### PR TITLE
Ignore unix sockets in hooks

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -37,10 +37,10 @@
       "args": ["${workspaceFolder}/sample/app.js"],
 
       "env": {
-          "DYLD_INSERT_LIBRARIES": "${workspaceFolder}/target/debug/libmirrord.dylib",
+          "DYLD_INSERT_LIBRARIES": "${workspaceFolder}/target/debug/libmirrord_layer.dylib",
           "LD_PRELOAD": "${workspaceFolder}/target/debug/libmirrord.so",
           "RUST_LOG": "trace",
-          "MIRRORD_AGENT_IMPERSONATED_POD_NAME": "nginx-deployment-66b6c48dd5-xg4rq",
+          "MIRRORD_AGENT_IMPERSONATED_POD_NAME": "nginx-deployment-66b6c48dd5-s2jbg",
           "MIRRORD_AGENT_RUST_LOG": "trace",
       },
   }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -15,6 +15,15 @@
 				"isDefault": true
 			},
 			"label": "rust: cargo build"
+		},
+		{
+			"type": "typescript",
+			"tsconfig": "vscode-ext/tsconfig.json",
+			"problemMatcher": [
+				"$tsc"
+			],
+			"group": "build",
+			"label": "tsc: build - vscode-ext/tsconfig.json"
 		}
 	]
 }

--- a/mirrord-layer/src/lib.rs
+++ b/mirrord-layer/src/lib.rs
@@ -7,7 +7,7 @@ use frida_gum::{interceptor::Interceptor, Error, Gum, Module, NativePointer};
 use futures::{SinkExt, StreamExt};
 use kube::api::Portforwarder;
 use lazy_static::lazy_static;
-use libc::{c_void, sockaddr, socklen_t};
+use libc::{c_int, c_void, fd_set, sockaddr, socklen_t, timeval};
 use mirrord_protocol::{ClientCodec, ClientMessage, DaemonMessage};
 use os_socketaddr::OsSocketAddr;
 use tokio::{
@@ -25,7 +25,7 @@ lazy_static! {
     static ref RUNTIME: Runtime = Runtime::new().unwrap();
     static ref SOCKETS: sockets::Sockets = sockets::Sockets::default();
     static ref NEW_CONNECTION_SENDER: Mutex<Option<Sender<i32>>> = Mutex::new(None);
-    static ref UNIX_FDS: Mutex<HashSet<i32>> = Mutex::new(HashSet::new());
+    static ref UNHOOKED_FDS: Mutex<HashSet<i32>> = Mutex::new(HashSet::new());
 }
 
 #[ctor]
@@ -42,33 +42,111 @@ fn init() {
     RUNTIME.spawn(poll_agent(pf, receiver));
 }
 
+unsafe extern "C" fn getsockname_detour(socket: c_int,
+    address: *mut sockaddr,
+    address_len: *mut socklen_t) -> c_int {
+
+        // debug!("GETSOCKNAME CALLED");
+        // debug!("address: {:?}", address);
+        // debug!("address_len: {:?}", address_len as usize);
+        // let before = OsSocketAddr::from_raw_parts(address as *const u8, address_len as usize)
+        // .into_addr()
+        // .unwrap();
+        let res = libc::getsockname(35, address, address_len);
+        // let after = OsSocketAddr::from_raw_parts(address as *const u8, address_len as usize)
+        // .into_addr()
+        // .unwrap();
+        // debug!("BEFORE: {:?}", before);
+        // debug!("AFTER: {:?}", after);
+        res
+
+}
+
 unsafe extern "C" fn socket_detour(domain: i32, socket_type: i32, protocol: i32) -> i32 {
     debug!("socket called");
-    if domain == 2 { // Unix socket
-        let fd = libc::socket(domain, socket_type, protocol);
-        UNIX_FDS.lock().unwrap().insert(fd);
-        return fd;
-    }
-    SOCKETS.create_socket()
+    debug!("domain: {}", domain);
+    debug!("socket_type: {}", socket_type);
+    debug!("protocol: {}", protocol);
+    // return libc::socket(domain, socket_type, protocol);
+    // if domain == 2 { // Unix socket
+    //     debug!("OVERRIDEN DOMAIN domain: {}", domain);
+
+    //     let fd = libc::socket(domain, socket_type, protocol);
+    //     UNIX_FDS.lock().unwrap().insert(fd);
+    //     return fd;
+    // }
+    let real_fd = libc::socket(domain, socket_type, protocol);
+    // return real_fd;
+    debug!("real_fd: {}", real_fd);
+    let fake_fd = SOCKETS.create_socket(real_fd);
+    debug!("fake_fd: {}", fake_fd);
+    return fake_fd;
+}
+unsafe extern "C" fn select_detour(
+    nfds: c_int,
+    readfds: *mut fd_set,
+    writefds: *mut fd_set,
+    exceptfds: *mut fd_set,
+    timeout: *mut timeval,
+) -> c_int {
+    debug!("select called");
+
+    libc::select(nfds, readfds, writefds, exceptfds, timeout)
+}
+
+unsafe extern "C" fn kqueue_detour() -> i32 {
+    debug!("kqueue called");
+    libc::kqueue()
 }
 
 unsafe extern "C" fn bind_detour(sockfd: i32, addr: *const sockaddr, addrlen: socklen_t) -> i32 {
     debug!("bind called");
-    if UNIX_FDS.lock().unwrap().contains(&sockfd) {
-        return libc::bind(sockfd, addr, addrlen);
-    }
+    // if UNIX_FDS.lock().unwrap().contains(&sockfd) {
+    return libc::bind(35, addr, addrlen);
+    // }
     let parsed_addr = OsSocketAddr::from_raw_parts(addr as *const u8, addrlen as usize)
         .into_addr()
         .unwrap();
 
-    SOCKETS.convert_to_connection_socket(sockfd, parsed_addr);
-    0
+    debug!("parsed_addr: {}", parsed_addr);
+    // return libc::bind(sockfd, addr, addrlen);
+    if parsed_addr.port() == 0 {
+        let real_fd = SOCKETS.create_real_connection(sockfd, parsed_addr);
+        UNHOOKED_FDS.lock().unwrap().insert(sockfd);
+        debug!("Unhooked fd on bind: {}", real_fd);
+        let res = libc::bind(real_fd, addr, addrlen);
+        debug!("BIND RESULT: {}", res);
+        res
+    } else {
+        SOCKETS.convert_to_connection_socket(sockfd, parsed_addr);
+        0
+    }
 }
 
 unsafe extern "C" fn listen_detour(sockfd: i32, backlog: i32) -> i32 {
     debug!("listen called");
-    if UNIX_FDS.lock().unwrap().contains(&sockfd) {
-        return libc::listen(sockfd, backlog);
+    // if UNIX_FDS.lock().unwrap().contains(&sockfd) {
+    //     return libc::listen(sockfd, backlog);
+    // }
+    
+    let _handle = thread::spawn(|| {
+        thread::sleep(Duration::from_millis(3000));
+        debug!("WRITING");
+        SOCKETS.write_to_socket(37);
+        debug!("WRITTEN");
+    });
+    debug!("LISTEN FD: {}", sockfd);
+    let res = libc::listen(35, backlog);
+    debug!("LISTEN RESULT: {}", res);
+    return res;
+    if UNHOOKED_FDS.lock().unwrap().contains(&sockfd) {
+        debug!("Unhooked fd on listen: {}", sockfd);
+
+        let real_fd = SOCKETS.get_real_fd(sockfd);
+        let res = libc::listen(real_fd, backlog);
+        debug!("AFTER LISTEN RESULT: {}", res);
+        debug!("AFTER LISTEN REALFD: {}", real_fd);
+        return res;
     }
     match SOCKETS.set_connection_state(sockfd, sockets::ConnectionState::Listening) {
         Ok(()) => {
@@ -88,9 +166,9 @@ unsafe extern "C" fn getpeername_detour(
     addr: *mut sockaddr,
     addrlen: *mut socklen_t,
 ) -> i32 {
-    if UNIX_FDS.lock().unwrap().contains(&sockfd) {
-        return libc::getpeername(sockfd, addr, addrlen);
-    }
+    // if UNIX_FDS.lock().unwrap().contains(&sockfd) {
+    //     return libc::getpeername(sockfd, addr, addrlen);
+    // }
     let socket_addr = SOCKETS.get_data_socket_address(sockfd).unwrap();
     let os_addr: OsSocketAddr = socket_addr.into();
     let len = std::cmp::min(*addrlen as usize, os_addr.len() as usize);
@@ -107,10 +185,20 @@ unsafe extern "C" fn setsockopt_detour(
     _optval: *mut c_void,
     _optlen: socklen_t,
 ) -> i32 {
-    if UNIX_FDS.lock().unwrap().contains(&_sockfd) {
-        return libc::setsockopt(_sockfd, _level, _optname, _optval, _optlen);
-    }
-    0
+    debug!("setsockopt called");
+    debug!("_sockfd: {}", _sockfd);
+    debug!("_level: {}", _level);
+    debug!("_optname: {}", _optname);
+    // debug!("_optval: {}", _optval);
+    debug!("_optlen: {}", _optlen);
+
+    // if UNIX_FDS.lock().unwrap().contains(&_sockfd) {
+    //     return libc::setsockopt(_sockfd, _level, _optname, _optval, _optlen);
+    // }
+
+    let res = libc::setsockopt(35, _level, _optname, _optval, _optlen);
+    debug!("SETSOCKOPT RESULT: {}", res);
+    res
 }
 
 unsafe extern "C" fn accept_detour(
@@ -118,13 +206,17 @@ unsafe extern "C" fn accept_detour(
     addr: *mut sockaddr,
     addrlen: *mut socklen_t,
 ) -> i32 {
-    if UNIX_FDS.lock().unwrap().contains(&sockfd) {
-        return libc::accept(sockfd, addr, addrlen);
-    }
+    // if UNIX_FDS.lock().unwrap().contains(&sockfd) {
+    //     return libc::accept(sockfd, addr, addrlen);
+    // }
     debug!(
         "Accept called with sockfd {:?}, addr {:?}, addrlen {:?}",
         &sockfd, &addr, &addrlen
     );
+    // return libc::accept(sockfd, addr, addrlen);
+    if UNHOOKED_FDS.lock().unwrap().contains(&sockfd) {
+        return libc::accept(sockfd, addr, addrlen);
+    }
     let socket_addr = SOCKETS.get_connection_socket_address(sockfd).unwrap();
 
     if !addr.is_null() {
@@ -232,6 +324,9 @@ fn enable_hooks() {
     hook!(interceptor, "listen", listen_detour);
     hook!(interceptor, "getpeername", getpeername_detour);
     hook!(interceptor, "setsockopt", setsockopt_detour);
+    hook!(interceptor, "select", select_detour);
+    hook!(interceptor, "getsockname", getsockname_detour);
+    hook!(interceptor, "kqueue", kqueue_detour);
     try_hook!(interceptor, "uv__accept4", accept4_detour);
     try_hook!(interceptor, "accept4", accept4_detour);
     try_hook!(interceptor, "accept", accept_detour);


### PR DESCRIPTION
Interfering with unix sockets broke our behavior when running in VSCode's debugger. This PR ignores unix sockets in hooks and instead maintains their default behavior.