### PR TITLE
Fix env-var name

### DIFF
--- a/mirrord-cli/src/main.rs
+++ b/mirrord-cli/src/main.rs
@@ -90,7 +90,7 @@ fn exec(args: &ExecArgs) -> Result<()> {
         "Launching {:?} with arguments {:?}",
         args.binary, args.binary_args
     );
-    std::env::set_var("MIRRORD_IMPERSONATED_POD_NAME", args.pod_name.clone());
+    std::env::set_var("MIRRORD_AGENT_IMPERSONATED_POD_NAME", args.pod_name.clone());
     if let Some(namespace) = &args.pod_namespace {
         std::env::set_var(
             "MIRRORD_AGENT_IMPERSONATED_POD_NAMESPACE",


### PR DESCRIPTION
Fixes the incorrect environment variable for the impersonated pod set in the CLI. 