### PR TITLE
Refactor sockets

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+*/target*
+*/.vscode*
+*/.git*
+*/.github*
+*/.devcontainer*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1311,7 +1311,7 @@ dependencies = [
 
 [[package]]
 name = "mirrord-agent"
-version = "2.0.0-alpha-3"
+version = "2.0.0-alpha-4"
 dependencies = [
  "actix-codec",
  "anyhow",
@@ -1342,6 +1342,7 @@ dependencies = [
  "ctor",
  "env_logger 0.9.0",
  "envconfig",
+ "errno",
  "frida-gum",
  "futures",
  "k8s-openapi",
@@ -1355,7 +1356,6 @@ dependencies = [
  "os_socketaddr",
  "queues",
  "rand 0.8.5",
- "redhook",
  "serde_json",
  "socketpair",
  "tempdir",
@@ -1990,15 +1990,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 dependencies = [
  "rand_core 0.3.1",
-]
-
-[[package]]
-name = "redhook"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6e109b8469dbbe6d7cbe18e5ebd65d4a134e2f4b91304ad9213984cad1d70a6"
-dependencies = [
- "libc",
 ]
 
 [[package]]

--- a/mirrord-agent/.dockerignore
+++ b/mirrord-agent/.dockerignore
@@ -1,0 +1,5 @@
+*/target*
+*/.vscode*
+*/.git*
+*/.github*
+*/.devcontainer*

--- a/mirrord-agent/CHANGELOG.md
+++ b/mirrord-agent/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## [Unreleased]
+## 2.0.0-alpha-4 - 5/11/2022
+### Changed
+* Add `source_port` to `NewTCPConnection` and change `port` to `destination_port`
 ## 2.0.0-alpha-3 - 1/5/2022
 ### Changed
 * Change behavior of namespace change - set the namespace only in the packet sniffing, in a new thread so "command" socket will listen on the original network namespace

--- a/mirrord-agent/Cargo.toml
+++ b/mirrord-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mirrord-agent"
-version = "2.0.0-alpha-3"
+version = "2.0.0-alpha-4"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/mirrord-agent/Dockerfile
+++ b/mirrord-agent/Dockerfile
@@ -2,8 +2,13 @@ FROM rust:latest as build-env
 RUN apt update && apt install -y libpcap-dev cmake
 RUN rustup toolchain install nightly --component rustfmt
 WORKDIR /app
-COPY . /app
-RUN cargo build --manifest-path mirrord-agent/Cargo.toml --release
+COPY Cargo.toml Cargo.lock CHANGELOG.md README.md LICENSE rust-toolchain.toml /app/
+COPY mirrord-protocol /app/mirrord-protocol
+COPY mirrord-agent /app/mirrord-agent
+COPY mirrord-layer /app/mirrord-layer
+COPY mirrord-cli /app/mirrord-cli
+COPY .cargo /app/.cargo
+RUN cargo +nightly build -Z bindeps --manifest-path /app/mirrord-agent/Cargo.toml --release
 
 FROM debian:stable
 RUN apt update && apt install -y libpcap-dev

--- a/mirrord-agent/src/main.rs
+++ b/mirrord-agent/src/main.rs
@@ -204,7 +204,7 @@ async fn start() -> Result<()> {
                     Some(message) => {
                         match message {
                             SnifferOutput::NewTCPConnection(conn) => {
-                                let peer_ids = state.port_subscriptions.get_topic_subscribers(conn.port);
+                                let peer_ids = state.port_subscriptions.get_topic_subscribers(conn.destination_port);
                                 for peer_id in peer_ids {
                                     state.connections_subscriptions.subscribe(peer_id, conn.connection_id);
                                     if let Some(peer) = state.peers.get(&peer_id) {

--- a/mirrord-agent/src/sniffer.rs
+++ b/mirrord-agent/src/sniffer.rs
@@ -143,10 +143,11 @@ impl ConnectionManager {
         };
         let dest_port = tcp_packet.get_destination();
         let tcp_flags = tcp_packet.get_flags();
+        let source_port = tcp_packet.get_source();
         let identifier = TCPSessionIdentifier {
             source_addr: ip_packet.get_source(),
             dest_addr: ip_packet.get_destination(),
-            source_port: tcp_packet.get_source(),
+            source_port,
             dest_port,
         };
         let is_client_packet = self.qualified_port(dest_port);
@@ -165,7 +166,8 @@ impl ConnectionManager {
                     None
                 })?;
                 messages.push(SnifferOutput::NewTCPConnection(NewTCPConnection {
-                    port: dest_port,
+                    destination_port: dest_port,
+                    source_port,
                     connection_id: id,
                     address: IpAddr::V4(identifier.source_addr),
                 }));

--- a/mirrord-agent/tests/blackbox.rs
+++ b/mirrord-agent/tests/blackbox.rs
@@ -74,6 +74,7 @@ mod tests {
         let mut test_conn = TcpStream::connect("127.0.0.1:1337")
             .await
             .expect("connection to dummy failed");
+        let port = test_conn.local_addr().unwrap().port();
         let test_data = [0, 3, 5];
         test_conn
             .write(&test_data)
@@ -100,7 +101,8 @@ mod tests {
             DaemonMessage::NewTCPConnection(NewTCPConnection {
                 connection_id: 0,
                 address: IpAddr::V4("127.0.0.1".parse().unwrap()),
-                port: 1337
+                destination_port: 1337,
+                source_port: port
             })
         );
 

--- a/mirrord-layer/Cargo.toml
+++ b/mirrord-layer/Cargo.toml
@@ -11,7 +11,6 @@ lazy_static = "1.4.0"
 libc = "0.2.121"
 nix = "0.23.1"
 os_socketaddr = "0.2.0"
-redhook = "2.0.0"
 socketpair = "0.15.0"
 tempdir = "0.3.7"
 tracing = "0.1"
@@ -34,6 +33,7 @@ queues = "1.1.0"
 rand = "0.8.5"
 multi-map = "1.3.0"
 envconfig = "0.10.0"
+errno = "0.2.8"
 
 [lib]
 crate_type = ["cdylib"]

--- a/mirrord-layer/src/common.rs
+++ b/mirrord-layer/src/common.rs
@@ -1,0 +1,16 @@
+use std::os::unix::io::RawFd;
+
+pub type Port = u16;
+
+#[derive(Debug)]
+pub struct Listen {
+    pub fake_port: Port,
+    pub real_port: Port,
+    pub ipv6: bool,
+    pub fd: RawFd,
+}
+
+#[derive(Debug)]
+pub enum HookMessage {
+    Listen(Listen),
+}

--- a/mirrord-layer/src/config.rs
+++ b/mirrord-layer/src/config.rs
@@ -10,7 +10,7 @@ pub struct Config {
 
     #[envconfig(
         from = "MIRRORD_AGENT_IMAGE",
-        default = "ghcr.io/metalbear-co/mirrord-agent:2.0.0-alpha-3"
+        default = "ghcr.io/metalbear-co/mirrord:2.0.0-alpha-4"
     )]
     pub agent_image: String,
 

--- a/mirrord-layer/src/lib.rs
+++ b/mirrord-layer/src/lib.rs
@@ -1,33 +1,93 @@
 // #![feature(c_variadic)]
 
-use std::{sync::Mutex, thread, time::Duration};
+use std::{
+    collections::HashMap,
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
+    os::unix::io::RawFd,
+    thread,
+    time::Duration,
+};
 
 use ctor::ctor;
 use envconfig::Envconfig;
-use frida_gum::{interceptor::Interceptor, Error, Gum, Module, NativePointer};
+use frida_gum::{interceptor::Interceptor, Gum};
 use futures::{SinkExt, StreamExt};
 use kube::api::Portforwarder;
 use lazy_static::lazy_static;
 use mirrord_protocol::{ClientCodec, ClientMessage, DaemonMessage};
 use tokio::{
+    io::AsyncWriteExt,
+    net::TcpStream,
     runtime::Runtime,
     select,
     sync::mpsc::{channel, Receiver, Sender},
+    task,
 };
 use tracing::{debug, error};
 
+mod common;
 mod config;
 mod macros;
 mod pod_api;
 mod sockets;
-use config::Config;
 use tracing_subscriber::prelude::*;
+
+use crate::{
+    common::{HookMessage, Port},
+    config::Config,
+    sockets::{SocketInformation, CONNECTION_QUEUE},
+};
 
 lazy_static! {
     static ref GUM: Gum = unsafe { Gum::obtain() };
     static ref RUNTIME: Runtime = Runtime::new().unwrap();
-    static ref SOCKETS: sockets::Sockets = sockets::Sockets::default();
-    static ref NEW_CONNECTION_SENDER: Mutex<Option<Sender<i32>>> = Mutex::new(None);
+}
+
+pub static mut HOOK_SENDER: Option<Sender<HookMessage>> = None;
+
+#[derive(Debug)]
+enum TcpTunnelMessages {
+    Data(Vec<u8>),
+    Close,
+}
+
+#[derive(Debug, Clone)]
+struct ListenData {
+    ipv6: bool,
+    port: Port,
+    fd: RawFd,
+}
+
+async fn tcp_tunnel(mut local_stream: TcpStream, mut receiver: Receiver<TcpTunnelMessages>) {
+    loop {
+        select! {
+            message = receiver.recv() => {
+                match message {
+                    Some(TcpTunnelMessages::Data(data)) => {
+                        local_stream.write_all(&data).await.unwrap()
+                    },
+                    Some(TcpTunnelMessages::Close) => break,
+                    None => break
+                };
+            },
+            _ = local_stream.readable() => {
+                let mut data = vec![0; 1024];
+                match local_stream.try_read(&mut data) {
+                    Err(ref err) if err.kind() == std::io::ErrorKind::WouldBlock => {
+                        continue
+                        },
+                    Err(err) => {
+                        debug!("local stream ended with err {:?}", err);
+                        break;
+                    }
+                    Ok(n) if n == 0 => break,
+                    Ok(_) => {}
+                }
+
+            }
+        }
+    }
+    debug!("exiting tcp tunnel");
 }
 
 #[ctor]
@@ -46,23 +106,27 @@ fn init() {
         config.agent_rust_log,
         config.agent_image,
     ));
-    let (sender, receiver) = channel::<i32>(1000);
-    *NEW_CONNECTION_SENDER.lock().unwrap() = Some(sender);
+    let (sender, receiver) = channel::<HookMessage>(1000);
+    unsafe {
+        HOOK_SENDER = Some(sender);
+    };
     enable_hooks();
     RUNTIME.spawn(poll_agent(pf, receiver));
 }
 
-async fn poll_agent(mut pf: Portforwarder, mut receiver: Receiver<i32>) {
+async fn poll_agent(mut pf: Portforwarder, mut receiver: Receiver<HookMessage>) {
     let port = pf.take_stream(61337).unwrap(); // TODO: Make port configurable
     let mut codec = actix_codec::Framed::new(port, ClientCodec::new());
+    let mut port_mapping: HashMap<Port, ListenData> = HashMap::new();
+    let mut active_connections = HashMap::new();
     loop {
         select! {
             message = receiver.recv() => {
                 match message {
-                    Some(sockfd) => {
-                        let port = SOCKETS.get_connection_socket_address(sockfd).unwrap().port();
-                        debug!("send message to client {:?}", port);
-                        codec.send(ClientMessage::PortSubscribe(vec![port])).await.unwrap();
+                    Some(HookMessage::Listen(msg)) => {
+                        debug!("received message from hook {:?}", msg);
+                        codec.send(ClientMessage::PortSubscribe(vec![msg.real_port])).await.unwrap();
+                        port_mapping.insert(msg.real_port, ListenData{port: msg.fake_port, ipv6: msg.ipv6, fd: msg.fd});
                     }
                     None => {
                         debug!("NONE in recv");
@@ -73,14 +137,59 @@ async fn poll_agent(mut pf: Portforwarder, mut receiver: Receiver<i32>) {
             message = codec.next() => {
                 match message {
                     Some(Ok(DaemonMessage::NewTCPConnection(conn))) => {
-                        SOCKETS.open_connection(conn.connection_id, conn.port);
+                        debug!("new connection {:?}", conn);
+                        let listen_data = match port_mapping.get(&conn.destination_port) {
+                            Some(listen_data) => (*listen_data).clone(),
+                            None => {
+                                debug!("no listen_data for {:?}", conn.destination_port);
+                                continue;
+                            }
+                        };
+                        let addr = match listen_data.ipv6 {
+                            false => SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), listen_data.port),
+                            true => SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), listen_data.port),
+                        };
+                        let info = SocketInformation::new(SocketAddr::new(conn.address, conn.source_port));
+                        {
+                            CONNECTION_QUEUE.lock().unwrap().add(&listen_data.fd, info);
+                        }
+                        let stream = match TcpStream::connect(addr).await {
+                            Ok(stream) => stream,
+                            Err(err) => {
+                                error!("failed to connect to port {:?}", err);
+                                continue;
+                            }
+                        };
+                        let (sender, receiver) = channel::<TcpTunnelMessages>(1000);
+                        active_connections.insert(conn.connection_id, sender);
+                        task::spawn(async move {
+                            tcp_tunnel(stream, receiver).await
+                        });
                     }
-                    Some(Ok(DaemonMessage::TCPData(d))) => {
-                        // Write to socket - need to find it in OPEN_CONNECTION_SOCKETS by conn_id
-                        SOCKETS.write_data(d.connection_id, d.data);
-                    }
-                    Some(Ok(DaemonMessage::TCPClose(d))) => {
-                        SOCKETS.close_connection(d.connection_id)
+                    Some(Ok(DaemonMessage::TCPData(msg))) => {
+                        let sender = match active_connections.get(&msg.connection_id) {
+                            Some(sender) => sender,
+                            None => {
+                                debug!("no sender for {:?}", msg.connection_id);
+                                continue;
+                            }
+                        };
+                        if let Err(err) = sender.send(TcpTunnelMessages::Data(msg.data)).await {
+                                debug!("sender error {:?}", err);
+                                active_connections.remove(&msg.connection_id);
+                        }
+                    },
+                    Some(Ok(DaemonMessage::TCPClose(msg))) => {
+                        let sender = match active_connections.remove(&msg.connection_id) {
+                            Some(sender) => sender,
+                            None => {
+                                debug!("no sender for {:?}", msg.connection_id);
+                                continue;
+                            }
+                        };
+                        if let Err(err) = sender.send(TcpTunnelMessages::Close).await {
+                                debug!("sender error {:?}", err);
+                        }
                     }
                     Some(_) => {
                         debug!("NONE in some");
@@ -98,6 +207,6 @@ async fn poll_agent(mut pf: Portforwarder, mut receiver: Receiver<i32>) {
 }
 
 fn enable_hooks() {
-    let mut interceptor = Interceptor::obtain(&GUM);
+    let interceptor = Interceptor::obtain(&GUM);
     sockets::enable_hooks(interceptor)
 }

--- a/mirrord-layer/src/lib.rs
+++ b/mirrord-layer/src/lib.rs
@@ -8,9 +8,7 @@ use frida_gum::{interceptor::Interceptor, Error, Gum, Module, NativePointer};
 use futures::{SinkExt, StreamExt};
 use kube::api::Portforwarder;
 use lazy_static::lazy_static;
-use libc::{c_char, c_void, sockaddr, socklen_t};
 use mirrord_protocol::{ClientCodec, ClientMessage, DaemonMessage};
-use os_socketaddr::OsSocketAddr;
 use tokio::{
     runtime::Runtime,
     select,
@@ -19,6 +17,7 @@ use tokio::{
 use tracing::{debug, error};
 
 mod config;
+mod macros;
 mod pod_api;
 mod sockets;
 use config::Config;
@@ -51,91 +50,6 @@ fn init() {
     *NEW_CONNECTION_SENDER.lock().unwrap() = Some(sender);
     enable_hooks();
     RUNTIME.spawn(poll_agent(pf, receiver));
-}
-
-unsafe extern "C" fn socket_detour(_domain: i32, _socket_type: i32, _protocol: i32) -> i32 {
-    debug!("socket called");
-    SOCKETS.create_socket()
-}
-
-unsafe extern "C" fn bind_detour(sockfd: i32, addr: *const sockaddr, addrlen: socklen_t) -> i32 {
-    debug!("bind called");
-    let parsed_addr = OsSocketAddr::from_raw_parts(addr as *const u8, addrlen as usize)
-        .into_addr()
-        .unwrap();
-
-    SOCKETS.convert_to_connection_socket(sockfd, parsed_addr);
-    0
-}
-
-unsafe extern "C" fn listen_detour(sockfd: i32, _backlog: i32) -> i32 {
-    debug!("listen called");
-
-    match SOCKETS.set_connection_state(sockfd, sockets::ConnectionState::Listening) {
-        Ok(()) => {
-            let sender = NEW_CONNECTION_SENDER.lock().unwrap();
-            sender.as_ref().unwrap().blocking_send(sockfd).unwrap(); // Tell main thread to subscribe to agent
-            0
-        }
-        Err(()) => {
-            error!("Failed to set connection state to listening");
-            -1
-        }
-    }
-}
-
-unsafe extern "C" fn getpeername_detour(
-    sockfd: i32,
-    addr: *mut sockaddr,
-    addrlen: *mut socklen_t,
-) -> i32 {
-    let socket_addr = SOCKETS.get_data_socket_address(sockfd).unwrap();
-    let os_addr: OsSocketAddr = socket_addr.into();
-    let len = std::cmp::min(*addrlen as usize, os_addr.len() as usize);
-    std::ptr::copy_nonoverlapping(os_addr.as_ptr() as *const u8, addr as *mut u8, len);
-
-    *addrlen = os_addr.len();
-    0
-}
-
-unsafe extern "C" fn setsockopt_detour(
-    _sockfd: i32,
-    _level: i32,
-    _optname: i32,
-    _optval: *mut c_char,
-    _optlen: socklen_t,
-) -> i32 {
-    0
-}
-
-unsafe extern "C" fn accept_detour(
-    sockfd: i32,
-    addr: *mut sockaddr,
-    addrlen: *mut socklen_t,
-) -> i32 {
-    debug!(
-        "Accept called with sockfd {:?}, addr {:?}, addrlen {:?}",
-        &sockfd, &addr, &addrlen
-    );
-    let socket_addr = SOCKETS.get_connection_socket_address(sockfd).unwrap();
-
-    if !addr.is_null() {
-        debug!("received non-null address in accept");
-        let os_addr: OsSocketAddr = socket_addr.into();
-        std::ptr::copy_nonoverlapping(os_addr.as_ptr(), addr, os_addr.len() as usize);
-    }
-
-    let connection_id = SOCKETS.read_single_connection(sockfd);
-    SOCKETS.create_data_socket(connection_id, socket_addr)
-}
-
-unsafe extern "C" fn accept4_detour(
-    sockfd: i32,
-    addr: *mut sockaddr,
-    addrlen: *mut socklen_t,
-    _flags: i32,
-) -> i32 {
-    accept_detour(sockfd, addr, addrlen)
 }
 
 async fn poll_agent(mut pf: Portforwarder, mut receiver: Receiver<i32>) {
@@ -183,48 +97,7 @@ async fn poll_agent(mut pf: Portforwarder, mut receiver: Receiver<i32>) {
     }
 }
 
-macro_rules! hook {
-    ($interceptor:expr, $func:expr, $detour_name:expr) => {
-        $interceptor
-            .replace(
-                Module::find_export_by_name(None, $func).unwrap(),
-                NativePointer($detour_name as *mut c_void),
-                NativePointer(std::ptr::null_mut::<c_void>()),
-            )
-            .unwrap();
-    };
-}
-
-macro_rules! try_hook {
-    ($interceptor:expr, $func:expr, $detour_name:expr) => {
-        if let Some(addr) = Module::find_export_by_name(None, $func) {
-            match $interceptor.replace(
-                addr,
-                NativePointer($detour_name as *mut c_void),
-                NativePointer(std::ptr::null_mut::<c_void>()),
-            ) {
-                Err(Error::InterceptorAlreadyReplaced) => {
-                    debug!("{} already replaced", $func);
-                }
-                Err(e) => {
-                    debug!("{} error: {:?}", $func, e);
-                }
-                Ok(_) => {
-                    debug!("{} hooked", $func);
-                }
-            }
-        }
-    };
-}
-
 fn enable_hooks() {
     let mut interceptor = Interceptor::obtain(&GUM);
-    hook!(interceptor, "socket", socket_detour);
-    hook!(interceptor, "bind", bind_detour);
-    hook!(interceptor, "listen", listen_detour);
-    hook!(interceptor, "getpeername", getpeername_detour);
-    hook!(interceptor, "setsockopt", setsockopt_detour);
-    try_hook!(interceptor, "uv__accept4", accept4_detour);
-    try_hook!(interceptor, "accept4", accept4_detour);
-    try_hook!(interceptor, "accept", accept_detour);
+    sockets::enable_hooks(interceptor)
 }

--- a/mirrord-layer/src/macros.rs
+++ b/mirrord-layer/src/macros.rs
@@ -1,0 +1,36 @@
+macro_rules! hook {
+    ($interceptor:expr, $func:expr, $detour_name:expr) => {
+        $interceptor
+            .replace(
+                frida_gum::Module::find_export_by_name(None, $func).unwrap(),
+                frida_gum::NativePointer($detour_name as *mut libc::c_void),
+                frida_gum::NativePointer(std::ptr::null_mut::<libc::c_void>()),
+            )
+            .unwrap();
+    };
+}
+
+macro_rules! try_hook {
+    ($interceptor:expr, $func:expr, $detour_name:expr) => {
+        if let Some(addr) = frida_gum::Module::find_export_by_name(None, $func) {
+            match $interceptor.replace(
+                addr,
+                frida_gum::NativePointer($detour_name as *mut libc::c_void),
+                frida_gum::NativePointer(std::ptr::null_mut::<libc::c_void>()),
+            ) {
+                Err(frida_gum::Error::InterceptorAlreadyReplaced) => {
+                    debug!("{} already replaced", $func);
+                }
+                Err(e) => {
+                    debug!("{} error: {:?}", $func, e);
+                }
+                Ok(_) => {
+                    debug!("{} hooked", $func);
+                }
+            }
+        }
+    };
+}
+
+pub(crate) use hook;
+pub(crate) use try_hook;

--- a/mirrord-layer/src/sockets.rs
+++ b/mirrord-layer/src/sockets.rs
@@ -6,10 +6,18 @@ use std::{
     sync::Mutex,
 };
 
+use frida_gum::interceptor::Interceptor;
+use libc::{c_char, sockaddr, socklen_t};
 use multi_map::MultiMap;
+use os_socketaddr::OsSocketAddr;
 use queues::{IsQueue, Queue};
 use socketpair::{socketpair_stream, SocketpairStream};
 use tracing::{debug, error};
+
+use crate::{
+    macros::{hook, try_hook},
+    NEW_CONNECTION_SENDER, SOCKETS,
+};
 
 pub struct Socket {
     pub read_fd: SockFd,
@@ -237,4 +245,100 @@ fn clear_data(socket: &mut SocketpairStream) {
         .take(num_ready_bytes)
         .read_to_end(&mut buffer)
         .unwrap();
+}
+
+unsafe extern "C" fn socket_detour(_domain: i32, _socket_type: i32, _protocol: i32) -> i32 {
+    debug!("socket called");
+    SOCKETS.create_socket()
+}
+
+unsafe extern "C" fn bind_detour(sockfd: i32, addr: *const sockaddr, addrlen: socklen_t) -> i32 {
+    debug!("bind called");
+    let parsed_addr = OsSocketAddr::from_raw_parts(addr as *const u8, addrlen as usize)
+        .into_addr()
+        .unwrap();
+
+    SOCKETS.convert_to_connection_socket(sockfd, parsed_addr);
+    0
+}
+
+unsafe extern "C" fn listen_detour(sockfd: i32, _backlog: i32) -> i32 {
+    debug!("listen called");
+
+    match SOCKETS.set_connection_state(sockfd, ConnectionState::Listening) {
+        Ok(()) => {
+            let sender = NEW_CONNECTION_SENDER.lock().unwrap();
+            sender.as_ref().unwrap().blocking_send(sockfd).unwrap(); // Tell main thread to subscribe to agent
+            0
+        }
+        Err(()) => {
+            error!("Failed to set connection state to listening");
+            -1
+        }
+    }
+}
+
+unsafe extern "C" fn getpeername_detour(
+    sockfd: i32,
+    addr: *mut sockaddr,
+    addrlen: *mut socklen_t,
+) -> i32 {
+    let socket_addr = SOCKETS.get_data_socket_address(sockfd).unwrap();
+    let os_addr: OsSocketAddr = socket_addr.into();
+    let len = std::cmp::min(*addrlen as usize, os_addr.len() as usize);
+    std::ptr::copy_nonoverlapping(os_addr.as_ptr() as *const u8, addr as *mut u8, len);
+
+    *addrlen = os_addr.len();
+    0
+}
+
+unsafe extern "C" fn setsockopt_detour(
+    _sockfd: i32,
+    _level: i32,
+    _optname: i32,
+    _optval: *mut c_char,
+    _optlen: socklen_t,
+) -> i32 {
+    0
+}
+
+unsafe extern "C" fn accept_detour(
+    sockfd: i32,
+    addr: *mut sockaddr,
+    addrlen: *mut socklen_t,
+) -> i32 {
+    debug!(
+        "Accept called with sockfd {:?}, addr {:?}, addrlen {:?}",
+        &sockfd, &addr, &addrlen
+    );
+    let socket_addr = SOCKETS.get_connection_socket_address(sockfd).unwrap();
+
+    if !addr.is_null() {
+        debug!("received non-null address in accept");
+        let os_addr: OsSocketAddr = socket_addr.into();
+        std::ptr::copy_nonoverlapping(os_addr.as_ptr(), addr, os_addr.len() as usize);
+    }
+
+    let connection_id = SOCKETS.read_single_connection(sockfd);
+    SOCKETS.create_data_socket(connection_id, socket_addr)
+}
+
+unsafe extern "C" fn accept4_detour(
+    sockfd: i32,
+    addr: *mut sockaddr,
+    addrlen: *mut socklen_t,
+    _flags: i32,
+) -> i32 {
+    accept_detour(sockfd, addr, addrlen)
+}
+
+pub fn enable_hooks(mut interceptor: Interceptor) {
+    hook!(interceptor, "socket", socket_detour);
+    hook!(interceptor, "bind", bind_detour);
+    hook!(interceptor, "listen", listen_detour);
+    hook!(interceptor, "getpeername", getpeername_detour);
+    hook!(interceptor, "setsockopt", setsockopt_detour);
+    try_hook!(interceptor, "uv__accept4", accept4_detour);
+    try_hook!(interceptor, "accept4", accept4_detour);
+    try_hook!(interceptor, "accept", accept_detour);
 }

--- a/mirrord-layer/src/sockets.rs
+++ b/mirrord-layer/src/sockets.rs
@@ -1,344 +1,556 @@
+//! We implement each hook function in a safe function as much as possible, having the unsafe do the
+//! absolute minimum
 use std::{
-    collections::HashMap,
-    io::{Read, Write},
-    net::SocketAddr,
-    os::unix::io::AsRawFd,
+    borrow::Borrow,
+    collections::{HashMap, HashSet, VecDeque},
+    hash::{Hash, Hasher},
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
+    os::unix::io::RawFd,
     sync::Mutex,
 };
 
+use errno::{errno, set_errno, Errno};
 use frida_gum::interceptor::Interceptor;
-use libc::{c_char, sockaddr, socklen_t};
-use multi_map::MultiMap;
+use lazy_static::lazy_static;
+use libc::{c_int, sockaddr, socklen_t};
 use os_socketaddr::OsSocketAddr;
-use queues::{IsQueue, Queue};
-use socketpair::{socketpair_stream, SocketpairStream};
 use tracing::{debug, error};
 
 use crate::{
+    common::{HookMessage, Listen, Port},
     macros::{hook, try_hook},
-    NEW_CONNECTION_SENDER, SOCKETS,
+    HOOK_SENDER,
 };
 
-pub struct Socket {
-    pub read_fd: SockFd,
-    pub read_socket: SocketpairStream,
-    pub write_socket: SocketpairStream,
+lazy_static! {
+    static ref SOCKETS: Mutex<HashSet<Socket>> = Mutex::new(HashSet::new());
+    pub static ref CONNECTION_QUEUE: Mutex<ConnectionQueue> =
+        Mutex::new(ConnectionQueue::default());
 }
 
-pub struct ConnectionSocket {
-    pub read_fd: SockFd,
-    pub read_socket: SocketpairStream,
-    pub write_socket: SocketpairStream,
-    pub address: SocketAddr,
-    pub state: ConnectionState,
-}
-
-#[derive(PartialEq)]
-pub enum ConnectionState {
-    Bound,
-    Listening,
-}
-
-pub struct DataSocket {
-    pub connection_id: ConnectionId,
-    #[allow(dead_code)]
-    pub read_socket: SocketpairStream, /* Though this is unread, it's necessary to keep the
-                                        * socket open */
-    pub write_socket: SocketpairStream,
+/// Struct sent over the socket once created to pass metadata to the hook
+#[derive(Debug)]
+pub struct SocketInformation {
     pub address: SocketAddr,
 }
 
-type SockFd = i32;
-type Port = u16;
-type ConnectionId = u16;
-type TCPBuffer = Vec<u8>;
-
-pub struct Sockets {
-    new_sockets: Mutex<HashMap<SockFd, Socket>>,
-    connections: Mutex<MultiMap<SockFd, Port, ConnectionSocket>>,
-    data: Mutex<MultiMap<SockFd, ConnectionId, DataSocket>>,
-    connection_queues: Mutex<HashMap<SockFd, Queue<ConnectionId>>>, /* Used to enqueue incoming
-                                                                     * connection
-                                                                     * ids from the
-                                                                     * agent, to be read in the
-                                                                     * 'accept'
-                                                                     * call */
-    pending_data: Mutex<HashMap<ConnectionId, TCPBuffer>>, /* Used to store data that arrived
-                                                            * before its
-                                                            * connection was opened. When the
-                                                            * connection is
-                                                            * later opened, pending_data is read
-                                                            * and
-                                                            * emptied. */
+/// poll_agent loop inserts connection data into this queue, and accept reads it.
+#[derive(Debug, Default)]
+pub struct ConnectionQueue {
+    connections: HashMap<RawFd, VecDeque<SocketInformation>>,
 }
 
-impl Default for Sockets {
+impl ConnectionQueue {
+    pub fn add(&mut self, fd: &RawFd, info: SocketInformation) {
+        self.connections.entry(*fd).or_default().push_back(info);
+    }
+    pub fn get(&mut self, fd: &RawFd) -> Option<SocketInformation> {
+        let mut queue = self.connections.remove(fd)?;
+        if let Some(info) = queue.pop_front() {
+            if !queue.is_empty() {
+                self.connections.insert(*fd, queue);
+            }
+            Some(info)
+        } else {
+            None
+        }
+    }
+}
+
+impl SocketInformation {
+    pub fn new(address: SocketAddr) -> Self {
+        Self { address }
+    }
+}
+
+trait GetPeerName {
+    fn get_peer_name(&self) -> SocketAddr;
+}
+
+#[derive(Debug)]
+pub struct Connected {
+    /// Remote address we're connected to
+    remote_address: SocketAddr,
+    /// Local address it's connected from
+    local_address: SocketAddr,
+}
+
+#[derive(Debug, Clone)]
+pub struct Bound {
+    address: SocketAddr,
+}
+
+#[derive(Debug)]
+pub enum SocketState {
+    Initialized,
+    Bound(Bound),
+    Listening(Bound),
+    Connected(Connected),
+}
+
+impl Default for SocketState {
     fn default() -> Self {
-        Self {
-            new_sockets: Mutex::new(HashMap::new()),
-            connections: Mutex::new(MultiMap::new()),
-            data: Mutex::new(MultiMap::new()),
-            connection_queues: Mutex::new(HashMap::new()),
-            pending_data: Mutex::new(HashMap::new()),
-        }
+        SocketState::Initialized
     }
 }
 
-impl Sockets {
-    pub fn create_socket(&self) -> SockFd {
-        let (write_socket, read_socket) = socketpair_stream().unwrap();
-        let read_fd = read_socket.as_raw_fd();
-        let socket = Socket {
-            read_fd,
-            read_socket,
-            write_socket,
-        };
+#[derive(Debug)]
+#[allow(dead_code)]
+struct Socket {
+    fd: RawFd,
+    domain: c_int,
+    type_: c_int,
+    protocol: c_int,
+    pub state: SocketState,
+}
 
-        self.new_sockets.lock().unwrap().insert(read_fd, socket);
-
-        read_fd
+impl PartialEq for Socket {
+    fn eq(&self, other: &Self) -> bool {
+        self.fd == other.fd
     }
+}
 
-    pub fn convert_to_connection_socket(&self, sockfd: SockFd, address: SocketAddr) {
-        let mut sockets = self.new_sockets.lock().unwrap();
+impl Eq for Socket {}
 
-        // let mut sockets = self.connections.lock().unwrap();
-        if let Some(socket) = sockets.remove(&sockfd) {
-            // socket.port = port;
-            self.connections.lock().unwrap().insert(
-                sockfd,
-                address.port(),
-                ConnectionSocket {
-                    read_fd: socket.read_fd,
-                    read_socket: socket.read_socket,
-                    write_socket: socket.write_socket,
-                    address,
-                    state: ConnectionState::Bound,
-                },
-            );
-        } else {
-            error!("No socket found for fd: {}", sockfd);
-        }
+impl Hash for Socket {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.fd.hash(state);
     }
+}
 
-    pub fn set_connection_state(&self, sockfd: SockFd, state: ConnectionState) -> Result<(), ()> {
-        let mut connections = self.connections.lock().unwrap();
-        if let Some(connection) = connections.get_mut(&sockfd) {
-            if connection.state != state {
-                connection.state = state;
-                Ok(())
-            } else {
-                error!("No connection found for fd: {}", sockfd);
-                Err(())
+impl Borrow<RawFd> for Socket {
+    fn borrow(&self) -> &RawFd {
+        &self.fd
+    }
+}
+
+#[inline]
+fn is_ignored_port(port: Port) -> bool {
+    port == 0 || (port > 50000 && port < 60000)
+}
+
+/// Create the socket, add it to SOCKETS if sucesssful and matching protocol and domain (TCPv4/v6)
+fn socket(domain: c_int, type_: c_int, protocol: c_int) -> RawFd {
+    debug!("socket called domain:{:?}, type:{:?}", domain, type_);
+    let fd = unsafe { libc::socket(domain, type_, protocol) };
+    if fd == -1 {
+        error!("socket failed");
+        return fd;
+    }
+    // We don't handle non TCPv4 sockets
+    if !((domain == libc::AF_INET) || (domain == libc::AF_INET6) && (type_ & libc::SOCK_STREAM) > 0)
+    {
+        debug!("non TCP socket domain:{:?}, type:{:?}", domain, type_);
+        return fd;
+    }
+    let mut sockets = SOCKETS.lock().unwrap();
+    sockets.insert(Socket {
+        fd,
+        domain,
+        type_,
+        protocol,
+        state: SocketState::default(),
+    });
+    fd
+}
+
+unsafe extern "C" fn socket_detour(domain: c_int, type_: c_int, protocol: c_int) -> c_int {
+    socket(domain, type_, protocol)
+}
+
+/// Check if the socket is managed by us, if it's managed by us and it's not an ignored port,
+/// update the socket state and don't call bind (will be called later). In any other case, we call
+/// regular bind.
+fn bind(sockfd: c_int, addr: *const sockaddr, addrlen: socklen_t) -> c_int {
+    debug!("bind called sockfd: {:?}", sockfd);
+    let mut socket = {
+        let mut sockets = SOCKETS.lock().unwrap();
+        match sockets.take(&sockfd) {
+            Some(socket) if !matches!(socket.state, SocketState::Initialized) => {
+                error!("socket is in invalid state for bind {:?}", socket.state);
+                return libc::EINVAL;
             }
-        } else {
-            error!("No connection found for fd: {}", sockfd);
-            Err(())
-        }
-    }
-
-    pub fn get_connection_socket_address(&self, sockfd: SockFd) -> Option<SocketAddr> {
-        let sockets = self.connections.lock().unwrap();
-        sockets.get(&sockfd).map(|socket| socket.address)
-    }
-
-    pub fn get_data_socket_address(&self, sockfd: SockFd) -> Option<SocketAddr> {
-        let sockets = self.data.lock().unwrap();
-        sockets.get(&sockfd).map(|socket| socket.address)
-    }
-
-    pub fn read_single_connection(&self, sockfd: SockFd) -> ConnectionId {
-        let mut sockets = self.connections.lock().unwrap();
-
-        if let Some(mut socket) = sockets.remove(&sockfd) {
-            let mut buffer = [0; 1];
-            socket.read_socket.read_exact(&mut buffer).unwrap();
-            sockets.insert(sockfd, socket.address.port(), socket);
-            let mut queues = self.connection_queues.lock().unwrap();
-            let queue = queues.get_mut(&sockfd).unwrap();
-            queue.remove().unwrap()
-        } else {
-            error!("No socket found for fd: {}", sockfd);
-            0
-        }
-    }
-
-    pub fn open_connection(&self, connection_id: ConnectionId, port: Port) {
-        let mut connections = self.connections.lock().unwrap();
-        if let Some(mut socket) = connections.remove_alt(&port) {
-            debug!("new connection id: {:?}", connection_id);
-            let mut queues = self.connection_queues.lock().unwrap();
-            match queues.get_mut(&socket.read_fd) {
-                Some(queue) => {
-                    queue.add(connection_id).unwrap();
-                }
-                None => {
-                    let mut queue = Queue::new();
-                    queue.add(connection_id).unwrap();
-                    queues.insert(socket.read_fd, queue);
-                }
+            Some(socket) => socket,
+            None => {
+                debug!("bind: no socket found for fd: {}", &sockfd);
+                return unsafe { libc::bind(sockfd, addr, addrlen) };
             }
-
-            write!(socket.write_socket, "a").unwrap(); // Need to write one byte per incoming connection, hence "a"
-            connections.insert(socket.read_fd, socket.address.port(), socket);
-        } else {
-            error!("No socket found for port: {}", port);
         }
-    }
+    };
 
-    pub fn create_data_socket(&self, connection_id: ConnectionId, address: SocketAddr) -> SockFd {
-        let (read_socket, mut write_socket) = socketpair_stream().unwrap();
-        let read_fd = read_socket.as_raw_fd();
-        debug!(
-            "Accepted connection from read_fd:{:?}, write_sock:{:?}",
-            read_fd, write_socket
-        );
-
-        if let Some(data) = self.pending_data.lock().unwrap().remove(&connection_id) {
-            debug!("writing pending data for connection_id: {}", connection_id);
-            write_socket.write_all(&data).unwrap();
+    let raw_addr = unsafe { OsSocketAddr::from_raw_parts(addr as *const u8, addrlen as usize) };
+    let parsed_addr = match raw_addr.into_addr() {
+        Some(addr) => addr,
+        None => {
+            error!("bind: failed to parse addr");
+            return libc::EINVAL;
         }
-        let read_fd = read_socket.as_raw_fd();
-        let data_socket = DataSocket {
-            connection_id,
-            read_socket,
-            write_socket,
-            address,
-        };
-        self.data
-            .lock()
-            .unwrap()
-            .insert(read_fd, connection_id, data_socket);
-        read_fd
+    };
+
+    debug!("bind:port: {}", parsed_addr.port());
+    if is_ignored_port(parsed_addr.port()) {
+        debug!("bind: ignoring port: {}", parsed_addr.port());
+        return unsafe { libc::bind(sockfd, addr, addrlen) };
     }
 
-    pub fn write_data(&self, connection_id: ConnectionId, data: TCPBuffer) {
-        let mut sockets = self.data.lock().unwrap();
-        if let Some(mut socket) = sockets.remove_alt(&connection_id) {
-            socket.write_socket.write_all(&data).unwrap();
-            clear_data(&mut socket.write_socket); // clear HTTP response data that the app wrote to this socket
-            sockets.insert(socket.read_socket.as_raw_fd(), socket.connection_id, socket);
-        } else {
-            // Not necessarily an error - sometime the TCPData message is handled before
-            // NewTcpConnection
-            debug!("No socket found for connection_id: {}", connection_id);
-            self.pending_data
-                .lock()
-                .unwrap()
-                .insert(connection_id, data);
-        }
-    }
+    socket.state = SocketState::Bound(Bound {
+        address: parsed_addr,
+    });
 
-    pub fn close_connection(&self, connection_id: ConnectionId) {
-        self.data
-            .lock()
-            .unwrap()
-            .remove_alt(&connection_id)
-            .unwrap();
-    }
-}
-
-fn clear_data(socket: &mut SocketpairStream) {
-    let num_ready_bytes = socket.num_ready_bytes().unwrap();
-    let mut buffer = Vec::with_capacity(num_ready_bytes as usize);
-    socket
-        .take(num_ready_bytes)
-        .read_to_end(&mut buffer)
-        .unwrap();
-}
-
-unsafe extern "C" fn socket_detour(_domain: i32, _socket_type: i32, _protocol: i32) -> i32 {
-    debug!("socket called");
-    SOCKETS.create_socket()
-}
-
-unsafe extern "C" fn bind_detour(sockfd: i32, addr: *const sockaddr, addrlen: socklen_t) -> i32 {
-    debug!("bind called");
-    let parsed_addr = OsSocketAddr::from_raw_parts(addr as *const u8, addrlen as usize)
-        .into_addr()
-        .unwrap();
-
-    SOCKETS.convert_to_connection_socket(sockfd, parsed_addr);
+    let mut sockets = SOCKETS.lock().unwrap();
+    sockets.insert(socket);
     0
 }
 
-unsafe extern "C" fn listen_detour(sockfd: i32, _backlog: i32) -> i32 {
-    debug!("listen called");
+unsafe extern "C" fn bind_detour(
+    sockfd: c_int,
+    addr: *const sockaddr,
+    addrlen: socklen_t,
+) -> c_int {
+    bind(sockfd, addr, addrlen)
+}
 
-    match SOCKETS.set_connection_state(sockfd, ConnectionState::Listening) {
-        Ok(()) => {
-            let sender = NEW_CONNECTION_SENDER.lock().unwrap();
-            sender.as_ref().unwrap().blocking_send(sockfd).unwrap(); // Tell main thread to subscribe to agent
-            0
+/// Bind the socket to a fake, local port, and subscribe to the agent on the real port.
+/// Messages received from the agent on the real port will later be routed to the fake local port.
+fn listen(sockfd: RawFd, _backlog: c_int) -> c_int {
+    debug!("listen called");
+    let mut socket = {
+        let mut sockets = SOCKETS.lock().unwrap();
+        match sockets.take(&sockfd) {
+            Some(socket) => socket,
+            None => {
+                debug!("listen: no socket found for fd: {}", &sockfd);
+                return unsafe { libc::listen(sockfd, _backlog) };
+            }
         }
-        Err(()) => {
-            error!("Failed to set connection state to listening");
-            -1
+    };
+    match socket.state {
+        SocketState::Bound(bound) => {
+            let real_port = bound.address.port();
+            socket.state = SocketState::Listening(bound);
+            let mut os_addr = match socket.domain {
+                libc::AF_INET => {
+                    OsSocketAddr::from(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0))
+                }
+                libc::AF_INET6 => {
+                    OsSocketAddr::from(SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0))
+                }
+                _ => {
+                    // shouldn't happen
+                    debug!("unsupported domain");
+                    return libc::EINVAL;
+                }
+            };
+
+            let ret = unsafe { libc::bind(sockfd, os_addr.as_ptr(), os_addr.len()) };
+            if ret != 0 {
+                error!(
+                    "listen: failed to bind socket ret: {:?}, addr: {:?}, sockfd: {:?}, errno: {:?}",
+                    ret, os_addr, sockfd, errno()
+                );
+                return ret;
+            }
+            let mut addr_len = os_addr.len();
+            // We need to find out what's the port we bound to, that'll be used by `poll_agent` to
+            // connect to.
+            let ret = unsafe { libc::getsockname(sockfd, os_addr.as_mut_ptr(), &mut addr_len) };
+            if ret != 0 {
+                error!(
+                    "listen: failed to get sockname ret: {:?}, addr: {:?}, sockfd: {:?}",
+                    ret, os_addr, sockfd
+                );
+                return ret;
+            }
+            let result_addr = match os_addr.into_addr() {
+                Some(addr) => addr,
+                None => {
+                    error!("listen: failed to parse addr");
+                    return libc::EINVAL;
+                }
+            };
+            let ret = unsafe { libc::listen(sockfd, _backlog) };
+            if ret != 0 {
+                error!(
+                    "listen: failed to listen ret: {:?}, addr: {:?}, sockfd: {:?}",
+                    ret, result_addr, sockfd
+                );
+                return ret;
+            }
+            let sender = unsafe { HOOK_SENDER.as_ref().unwrap() };
+            match sender.blocking_send(HookMessage::Listen(Listen {
+                fake_port: result_addr.port(),
+                real_port,
+                ipv6: result_addr.is_ipv6(),
+                fd: sockfd,
+            })) {
+                Ok(_) => {}
+                Err(e) => {
+                    error!("listen: failed to send listen message: {:?}", e);
+                    return libc::EFAULT;
+                }
+            };
+        }
+        _ => {
+            error!(
+                "listen: socket is not bound or already listening, state: {:?}",
+                socket.state
+            );
+            return libc::EINVAL;
         }
     }
+    debug!("listen: success");
+    let mut sockets = SOCKETS.lock().unwrap();
+    sockets.insert(socket);
+    0
+}
+
+unsafe extern "C" fn listen_detour(sockfd: RawFd, backlog: c_int) -> c_int {
+    listen(sockfd, backlog)
+}
+
+fn connect(sockfd: RawFd, address: *const sockaddr, len: socklen_t) -> c_int {
+    debug!("connect called");
+
+    let socket = {
+        let mut sockets = SOCKETS.lock().unwrap();
+        match sockets.take(&sockfd) {
+            Some(socket) => socket,
+            None => {
+                debug!("connect: no socket found for fd: {}", &sockfd);
+                return unsafe { libc::connect(sockfd, address, len) };
+            }
+        }
+    };
+
+    // We don't handle this socket, so restore state if there was any. (delay execute bind)
+    if let SocketState::Bound(bound) = socket.state {
+        let os_addr = OsSocketAddr::from(bound.address);
+        let ret = unsafe { libc::bind(sockfd, os_addr.as_ptr(), os_addr.len()) };
+        if ret != 0 {
+            error!(
+                "connect: failed to bind socket ret: {:?}, addr: {:?}, sockfd: {:?}",
+                ret, os_addr, sockfd
+            );
+            return ret;
+        }
+    };
+    unsafe { libc::connect(sockfd, address, len) }
+}
+
+unsafe extern "C" fn connect_detour(
+    sockfd: RawFd,
+    address: *const sockaddr,
+    len: socklen_t,
+) -> c_int {
+    connect(sockfd, address, len)
+}
+
+/// Resolve fake local address to real remote address. (IP & port of incoming traffic on the
+/// cluster)
+fn getpeername(sockfd: RawFd, address: *mut sockaddr, address_len: *mut socklen_t) -> c_int {
+    debug!("getpeername called");
+    let remote_address = {
+        let sockets = SOCKETS.lock().unwrap();
+        match sockets.get(&sockfd) {
+            Some(socket) => match &socket.state {
+                SocketState::Connected(connected) => connected.remote_address,
+                _ => {
+                    debug!(
+                        "getpeername: socket is not connected, state: {:?}",
+                        socket.state
+                    );
+                    set_errno(Errno(libc::ENOTCONN));
+                    return -1;
+                }
+            },
+            None => {
+                debug!("getpeername: no socket found for fd: {}", &sockfd);
+                return unsafe { libc::getpeername(sockfd, address, address_len) };
+            }
+        }
+    };
+    debug!("remote_address: {:?}", remote_address);
+    fill_address(address, address_len, remote_address)
 }
 
 unsafe extern "C" fn getpeername_detour(
-    sockfd: i32,
-    addr: *mut sockaddr,
-    addrlen: *mut socklen_t,
+    sockfd: RawFd,
+    address: *mut sockaddr,
+    address_len: *mut socklen_t,
 ) -> i32 {
-    let socket_addr = SOCKETS.get_data_socket_address(sockfd).unwrap();
-    let os_addr: OsSocketAddr = socket_addr.into();
-    let len = std::cmp::min(*addrlen as usize, os_addr.len() as usize);
-    std::ptr::copy_nonoverlapping(os_addr.as_ptr() as *const u8, addr as *mut u8, len);
+    getpeername(sockfd, address, address_len)
+}
 
-    *addrlen = os_addr.len();
+/// Resolve the fake local address to the real local address.
+fn getsockname(sockfd: RawFd, address: *mut sockaddr, address_len: *mut socklen_t) -> c_int {
+    debug!("getsockname called");
+    let local_address = {
+        let sockets = SOCKETS.lock().unwrap();
+        match sockets.get(&sockfd) {
+            Some(socket) => match &socket.state {
+                SocketState::Connected(connected) => connected.local_address,
+                SocketState::Bound(bound) => bound.address,
+                SocketState::Listening(bound) => bound.address,
+                _ => {
+                    debug!(
+                        "getsockname: socket is not bound or connected, state: {:?}",
+                        socket.state
+                    );
+                    return unsafe { libc::getsockname(sockfd, address, address_len) };
+                }
+            },
+            None => {
+                debug!("getsockname: no socket found for fd: {}", &sockfd);
+                return unsafe { libc::getsockname(sockfd, address, address_len) };
+            }
+        }
+    };
+    debug!("local_address: {:?}", local_address);
+    fill_address(address, address_len, local_address)
+}
+
+unsafe extern "C" fn getsockname_detour(
+    sockfd: RawFd,
+    address: *mut sockaddr,
+    address_len: *mut socklen_t,
+) -> i32 {
+    getsockname(sockfd, address, address_len)
+}
+
+// unsafe extern "C" fn setsockopt_detour(
+//     _sockfd: i32,
+//     _level: i32,
+//     _optname: i32,
+//     _optval: *mut c_char,
+//     _optlen: socklen_t,
+// ) -> i32 {
+//     0
+// }
+
+/// Fill in the sockaddr structure for the given address.
+#[inline]
+fn fill_address(
+    address: *mut sockaddr,
+    address_len: *mut socklen_t,
+    new_address: SocketAddr,
+) -> c_int {
+    if address.is_null() {
+        return 0;
+    }
+    if address_len.is_null() {
+        set_errno(Errno(libc::EINVAL));
+        return -1;
+    }
+    let os_address: OsSocketAddr = new_address.into();
+    unsafe {
+        let len = std::cmp::min(*address_len as usize, os_address.len() as usize);
+        std::ptr::copy_nonoverlapping(os_address.as_ptr() as *const u8, address as *mut u8, len);
+        *address_len = os_address.len();
+    }
     0
 }
 
-unsafe extern "C" fn setsockopt_detour(
-    _sockfd: i32,
-    _level: i32,
-    _optname: i32,
-    _optval: *mut c_char,
-    _optlen: socklen_t,
-) -> i32 {
-    0
+/// When the fd is "ours", we accept and recv the first bytes that contain metadata on the
+/// connection to be set in our lock This enables us to have a safe way to get "remote" information
+/// (remote ip, port, etc).
+fn accept(
+    sockfd: RawFd,
+    address: *mut sockaddr,
+    address_len: *mut socklen_t,
+    new_fd: RawFd,
+) -> RawFd {
+    let (origin_fd, local_address, domain, protocol, type_) = {
+        if let Some(socket) = SOCKETS.lock().unwrap().get(&sockfd) {
+            if let SocketState::Listening(bound) = &socket.state {
+                (
+                    socket.fd,
+                    bound.address,
+                    socket.domain,
+                    socket.protocol,
+                    socket.type_,
+                )
+            } else {
+                error!("original socket is not listening");
+                return new_fd;
+            }
+        } else {
+            debug!("origin socket not found");
+            return new_fd;
+        }
+    };
+    let socket_info = { CONNECTION_QUEUE.lock().unwrap().get(&origin_fd) };
+    let remote_address = match socket_info {
+        Some(socket_info) => socket_info,
+        None => {
+            debug!("accept: socketinformation not found, probably not ours");
+            return new_fd;
+        }
+    }
+    .address;
+    let new_socket = Socket {
+        fd: new_fd,
+        domain,
+        protocol,
+        type_,
+        state: SocketState::Connected(Connected {
+            remote_address,
+            local_address,
+        }),
+    };
+    fill_address(address, address_len, remote_address);
+
+    SOCKETS.lock().unwrap().insert(new_socket);
+    new_fd
 }
 
 unsafe extern "C" fn accept_detour(
-    sockfd: i32,
-    addr: *mut sockaddr,
-    addrlen: *mut socklen_t,
+    sockfd: c_int,
+    address: *mut sockaddr,
+    address_len: *mut socklen_t,
 ) -> i32 {
-    debug!(
-        "Accept called with sockfd {:?}, addr {:?}, addrlen {:?}",
-        &sockfd, &addr, &addrlen
-    );
-    let socket_addr = SOCKETS.get_connection_socket_address(sockfd).unwrap();
-
-    if !addr.is_null() {
-        debug!("received non-null address in accept");
-        let os_addr: OsSocketAddr = socket_addr.into();
-        std::ptr::copy_nonoverlapping(os_addr.as_ptr(), addr, os_addr.len() as usize);
+    let res = libc::accept(sockfd, address, address_len);
+    if res < 0 {
+        return res;
     }
+    accept(sockfd, address, address_len, res)
+    //     let socket_addr = SOCKETS.get_connection_socket_address(sockfd).unwrap();
 
-    let connection_id = SOCKETS.read_single_connection(sockfd);
-    SOCKETS.create_data_socket(connection_id, socket_addr)
+    //     if !addr.is_null() {
+    //         debug!("received non-null address in accept");
+    //         let os_addr: OsSocketAddr = socket_addr.into();
+    //         std::ptr::copy_nonoverlapping(os_addr.as_ptr(), addr, os_addr.len() as usize);
+    //     }
+
+    //     let connection_id = SOCKETS.read_single_connection(sockfd);
+    //     SOCKETS.create_data_socket(connection_id, socket_addr)
 }
 
+#[cfg(target_os = "linux")]
 unsafe extern "C" fn accept4_detour(
     sockfd: i32,
-    addr: *mut sockaddr,
-    addrlen: *mut socklen_t,
-    _flags: i32,
+    address: *mut sockaddr,
+    address_len: *mut socklen_t,
+    flags: i32,
 ) -> i32 {
-    accept_detour(sockfd, addr, addrlen)
+    let res = libc::accept4(sockfd, address, address_len, flags);
+    if res < 0 {
+        return res;
+    }
+    accept(sockfd, address, address_len, res)
 }
 
 pub fn enable_hooks(mut interceptor: Interceptor) {
     hook!(interceptor, "socket", socket_detour);
     hook!(interceptor, "bind", bind_detour);
     hook!(interceptor, "listen", listen_detour);
+    hook!(interceptor, "connect", connect_detour);
     hook!(interceptor, "getpeername", getpeername_detour);
-    hook!(interceptor, "setsockopt", setsockopt_detour);
-    try_hook!(interceptor, "uv__accept4", accept4_detour);
-    try_hook!(interceptor, "accept4", accept4_detour);
+    hook!(interceptor, "getsockname", getsockname_detour);
+    // hook!(interceptor, "setsockopt", setsockopt_detour);
+    #[cfg(target_os = "linux")]
+    {
+        try_hook!(interceptor, "uv__accept4", accept4_detour);
+        try_hook!(interceptor, "accept4", accept4_detour);
+    }
     try_hook!(interceptor, "accept", accept_detour);
 }

--- a/mirrord-protocol/src/codec.rs
+++ b/mirrord-protocol/src/codec.rs
@@ -11,7 +11,8 @@ pub type Port = u16;
 pub struct NewTCPConnection {
     pub connection_id: ConnectionID,
     pub address: IpAddr,
-    pub port: Port,
+    pub destination_port: Port,
+    pub source_port: Port,
 }
 
 #[derive(Encode, Decode, Debug, PartialEq, Clone)]


### PR DESCRIPTION
Refactor sockets - beforehand we created socketpair on each socket creation, now we only do it when necessary using delayed execution of bind,listen.

closes #41 closes #42