### PR TITLE
Accept invalid certificates optionally

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2130,8 +2130,7 @@ dependencies = [
 [[package]]
 name = "rustls"
 version = "0.20.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fbfeb8d0ddb84706bc597a5574ab8912817c52a397f819e5b614e2265206921"
+source = "git+https://github.com/rustls/rustls#093e88e7e180d44eb94b6f2c30b92a89f9f0cdbe"
 dependencies = [
  "log",
  "ring",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,11 @@ members = [
     "mirrord-layer",
     "mirrord-cli",
 ]
+
+# latest commits on rustls suppress certificate verification 
+# https://github.com/rustls/rustls/pull/1032
+# so we patch crates.io to use the latest commits from rustls
+# this should be changed once a newer version of rustls is out
+
+[patch.crates-io]
+rustls = { git = 'https://github.com/rustls/rustls' }

--- a/mirrord-cli/src/main.rs
+++ b/mirrord-cli/src/main.rs
@@ -45,6 +45,9 @@ struct ExecArgs {
     #[clap()]
     pub binary: String,
 
+    /// Accept/reject invalid certificates.
+    #[clap(parse(try_from_str), short = 'c', long)]
+    pub accept_invalid_certificates: Option<bool>,
     /// Arguments to pass to the binary.
     #[clap()]
     binary_args: Vec<String>,
@@ -109,6 +112,12 @@ fn exec(args: &ExecArgs) -> Result<()> {
     }
     if let Some(image) = &args.agent_image {
         std::env::set_var("MIRRORD_AGENT_IMAGE", image.clone());
+    }
+    if let Some(accept_invalid_certificates) = &args.accept_invalid_certificates {
+        std::env::set_var(
+            "MIRRORD_ACCEPT_INVALID_CERTIFICATES",
+            accept_invalid_certificates.to_string(),
+        );
     }
     let library_path = extract_library(None);
     add_to_preload(&library_path).unwrap();

--- a/mirrord-layer/src/config.rs
+++ b/mirrord-layer/src/config.rs
@@ -19,4 +19,7 @@ pub struct Config {
 
     #[envconfig(from = "MIRRORD_AGENT_IMPERSONATED_POD_NAMESPACE", default = "default")]
     pub impersonated_pod_namespace: String,
+
+    #[envconfig(from = "MIRRORD_ACCEPT_INVALID_CERTIFICATES", default = "false")]
+    pub accept_invalid_certificates: bool,
 }


### PR DESCRIPTION
Following changes have been made:
- Currently certificates can't be verified in the current version of rustls for IP addresses and this results in an `invalid dnsname` error. The latest commits on rustls suppress certificate verification https://github.com/rustls/rustls/pull/1032 and we use this by patching the dependencies. 
- Added a new CLI argument which accepts boolean value to accept/reject invalid certificates. This argument is directly related to the new `MIRRORD_ACCEPT_INVALID_CERTIFICATES` environment variable (default false)