### PR TITLE
Create mirrord agent as job instead of pod

### DIFF
--- a/mirrord-layer/src/config.rs
+++ b/mirrord-layer/src/config.rs
@@ -22,4 +22,7 @@ pub struct Config {
 
     #[envconfig(from = "MIRRORD_ACCEPT_INVALID_CERTIFICATES", default = "false")]
     pub accept_invalid_certificates: bool,
+
+    #[envconfig(from = "MIRRORD_AGENT_TTL", default = "0")]
+    pub agent_ttl: u16,
 }


### PR DESCRIPTION
Create the mirrord agent as a Kubernetes Job instead of Pod, so that it can self-terminate after completion.