### PR TITLE
validate log levels

### DIFF
--- a/mirrord-cli/src/main.rs
+++ b/mirrord-cli/src/main.rs
@@ -108,6 +108,12 @@ fn exec(args: &ExecArgs) -> Result<()> {
         std::env::set_var("MIRRORD_AGENT_NAMESPACE", namespace.clone());
     }
     if let Some(log_level) = &args.agent_log_level {
+        let levels = vec!["trace", "debug", "info", "warn", "error"];
+        if !levels.contains(&log_level.to_lowercase().as_str()) {
+            error!("Invalid log level: {}", log_level);
+            return Err(anyhow!("Invalid log level"));
+        }
+
         std::env::set_var("MIRRORD_AGENT_RUST_LOG", log_level.clone());
     }
     if let Some(image) = &args.agent_image {


### PR DESCRIPTION
Currently mirrord can accept any kind of arbitrary string for agent logs (-l/--agent-log-level <AGENT_LOG_LEVEL> ), which is not desirable as a simple typo in the log level can make it hard to determine why someone doesn't see the logs. Desirable behavior would be to error out on invalid log levels.
Valid log levels: trace, debug, info, warn, error (https://docs.rs/log/0.4.17/log/enum.Level.html)