### PR TITLE
Make getpeername and getsockame optional

### DIFF
--- a/mirrord-layer/src/sockets.rs
+++ b/mirrord-layer/src/sockets.rs
@@ -544,8 +544,8 @@ pub fn enable_hooks(mut interceptor: Interceptor) {
     hook!(interceptor, "bind", bind_detour);
     hook!(interceptor, "listen", listen_detour);
     hook!(interceptor, "connect", connect_detour);
-    hook!(interceptor, "getpeername", getpeername_detour);
-    hook!(interceptor, "getsockname", getsockname_detour);
+    try_hook!(interceptor, "getpeername", getpeername_detour);
+    try_hook!(interceptor, "getsockname", getsockname_detour);
     // hook!(interceptor, "setsockopt", setsockopt_detour);
     #[cfg(target_os = "linux")]
     {


### PR DESCRIPTION
Make getpeername and getsockname optional as frida sometimes doesn't recognize them - possibly due to this issue: https://github.com/frida/frida-gum/issues/273