### PR TITLE
Fix fd leak

### DIFF
--- a/mirrord-layer/src/sockets.rs
+++ b/mirrord-layer/src/sockets.rs
@@ -540,13 +540,10 @@ unsafe extern "C" fn accept4_detour(
 }
 
 fn close(fd: c_int) {
-    let mut sockets = SOCKETS.lock().unwrap();
-    debug!("removing {fd:?}");
-    sockets.remove(&fd);
+    SOCKETS.lock().unwrap().remove(&fd);
 }
 
 unsafe extern "C" fn close_detour(fd: c_int) -> c_int {
-    debug!("close called");
     close(fd);
     libc::close(fd)
 }


### PR DESCRIPTION
We had fd leak because we didn't hook close, meaning that if a socket got closed we'd still hold it in our `SOCKETS` struct.
This adds a hook for close to add removal of a fd from our data.