### PR TITLE
Use local agent images

### DIFF
--- a/mirrord-layer/src/pod_api.rs
+++ b/mirrord-layer/src/pod_api.rs
@@ -88,7 +88,7 @@ pub async fn create_agent(
                         {
                             "name": "mirrord-agent",
                             "image": agent_image,
-                            "imagePullPolicy": "Always",
+                            "imagePullPolicy": "IfNotPresent",
                             "securityContext": {
                                 "privileged": true
                             },


### PR DESCRIPTION
Just a small change `"imagePullPolicy": "IfNotPresent"` as we should be able to use local images for mirrord-agent.
https://kubernetes.io/docs/concepts/containers/images/