### PR TITLE
bump to 2.0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1247,7 +1247,7 @@ dependencies = [
 
 [[package]]
 name = "mirrord"
-version = "2.0.0"
+version = "2.0.4"
 dependencies = [
  "anyhow",
  "clap 3.1.18",
@@ -1259,7 +1259,7 @@ dependencies = [
 
 [[package]]
 name = "mirrord-agent"
-version = "2.0.0"
+version = "2.0.4"
 dependencies = [
  "actix-codec",
  "anyhow",
@@ -1282,7 +1282,7 @@ dependencies = [
 
 [[package]]
 name = "mirrord-layer"
-version = "2.0.0"
+version = "2.0.4"
 dependencies = [
  "actix-codec",
  "bytes",
@@ -1312,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "mirrord-protocol"
-version = "2.0.0"
+version = "2.0.4"
 dependencies = [
  "actix-codec",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2.0.0"
+version = "2.0.4"
 edition = "2021"
 license = "MIT"
 readme = "README.md"


### PR DESCRIPTION
VSCode market place doesn't allow a pre release version to be overriden by a release version of same number, so we have to start from 2.0.4 :(