### PR TITLE
Add E2E tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,3 +75,31 @@ jobs:
           key: ${{matrix.os}}
       # For now, just evrify it compiles.
       - run: cargo +nightly build --manifest-path=mirrord-layer/Cargo.toml
+
+  e2e:
+    runs-on: ubuntu-latest
+    name: e2e
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          components: rustfmt
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 14
+      - run: npm install express
+      - run: sudo apt-get update -y && sudo apt-get install -y libpcap-dev cmake
+      - name: start minikube
+        uses: medyagh/setup-minikube@master
+        with:
+          container-runtime: containerd
+      - run: docker build -t test . --file mirrord-agent/Dockerfile
+      - run: minikube image load test:latest
+      - name: setup nginx
+        run: kubectl apply -f tests/app.yaml
+      - name: build mirrord
+        run: cargo +nightly build --manifest-path=./Cargo.toml
+      - name: run node tests
+        run: cargo test --manifest-path ./tests/Cargo.toml  -- --test-threads 1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2337,6 +2337,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e7a7de15468c6e65dd7db81cf3822c1ec94c71b2a3c1a976ea8e4696c91115c"
 
 [[package]]
+name = "tests"
+version = "0.1.0"
+dependencies = [
+ "futures",
+ "k8s-openapi",
+ "kube",
+ "mirrord",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "mirrord-agent",
     "mirrord-layer",
     "mirrord-cli",
+    "tests"
 ]
 
 [workspace.package]

--- a/mirrord-agent/Dockerfile
+++ b/mirrord-agent/Dockerfile
@@ -7,6 +7,7 @@ COPY mirrord-protocol /app/mirrord-protocol
 COPY mirrord-agent /app/mirrord-agent
 COPY mirrord-layer /app/mirrord-layer
 COPY mirrord-cli /app/mirrord-cli
+COPY tests /app/tests
 COPY .cargo /app/.cargo
 RUN cargo +nightly build -Z bindeps --manifest-path /app/mirrord-agent/Cargo.toml --release
 

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "tests"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+name = "sanity"
+path = "src/sanity.rs"
+doctest = false
+
+[dependencies]
+k8s-openapi = { version = "0.14.0", features = ["v1_22"] }
+kube = { version = "0.71.0", default-features = false, features = ["runtime", "derive", "client", "ws", "rustls-tls"] }
+reqwest = "0.11.10"
+tokio = { version = "1", features = ["macros"] }
+serde_json = "1.0.79"
+mirrord = { artifact = "bin", bin = true, path = "../mirrord-cli" }
+serde = "1.0.137"
+futures = "0.3.21"

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,11 @@
+# How to Run the E2E tests
+
+To run the tests locally with the latest mirrord-agent image, run the following in the mirrord directory:
+- `docker build -t test . --file mirrord-agent/Dockerfile`
+- `minikube load image test`
+- `cargo test --package tests --lib -- tests --nocapture`
+
+The name "test" is hardcoded for the CI, and the tests will fail with an `Elapsed` error if the image named "test" is not found. 
+To use a different image change the environment variable `MIRRORD_AGENT_IMAGE` at `test_server_init` in `tests/src/utils.rs`.
+
+To use the latest release of mirrord-agent, comment out the line adding the `MIRRORD_AGENT_IMAGE` environment. 

--- a/tests/app.yaml
+++ b/tests/app.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  labels:
+    app: nginx
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.14.2
+          ports:
+            - containerPort: 80
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: nginx
+  name: nginx
+spec:
+  ports:
+    - port: 80
+      protocol: TCP
+      targetPort: 80
+  selector:
+    app: nginx
+  sessionAffinity: None
+  type: NodePort

--- a/tests/node-e2e/app.js
+++ b/tests/node-e2e/app.js
@@ -1,0 +1,47 @@
+const express = require('express');
+const process = require('process');
+const fs = require('fs');
+const app = express();
+const PORT = 80;
+
+const TEXT = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";
+var path = process.cwd() + "/test";
+
+app.get('/', (req, res) => {
+    res.send('Request received'); // Todo: validate responses 
+    console.log("GET: Request completed");
+});
+
+app.post('/', (req, res) => {
+    req.on('data', (data) => {
+        if (data.toString() == TEXT) {
+            console.log("POST: Request completed");
+        }
+    });
+});
+
+app.put('/', (req, res) => {
+    req.on('data', (data) => {
+        fs.writeFile(path, data.toString(), (err) => {
+            if (err) {
+                throw err;
+            }
+        });
+    });
+    console.log("PUT: Request completed");
+});
+
+app.delete('/', (req, res) => {
+    req.on('data', (data) => {
+        fs.unlink(path, (err) => {
+            if (err) {
+                throw err;
+            }
+        });
+    });
+    console.log("DELETE: Request completed");
+});
+
+app.listen(PORT, () => {
+    console.log(`Server listening on port ${PORT}`);
+});

--- a/tests/node-e2e/package-lock.json
+++ b/tests/node-e2e/package-lock.json
@@ -1,0 +1,430 @@
+{
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "requires": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      }
+    },
+    "array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
+    },
+    "body-parser": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.0.tgz",
+      "integrity": "sha512-DfJ+q6EPcGKZD1QWUjSpqp+Q7bDQTsQIF4zfUAtZ6qk+H/3/QRhg9CEp39ss+/T2vw0+HaidC0ecJj/DRLIaKg==",
+      "requires": {
+        "bytes": "3.1.2",
+        "content-type": "~1.0.4",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "on-finished": "2.4.1",
+        "qs": "6.10.3",
+        "raw-body": "2.5.1",
+        "type-is": "~1.6.18",
+        "unpipe": "1.0.0"
+      }
+    },
+    "bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="
+    },
+    "call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      }
+    },
+    "content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "requires": {
+        "safe-buffer": "5.2.1"
+      }
+    },
+    "content-type": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+    },
+    "cookie": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw=="
+    },
+    "cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
+    },
+    "destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg=="
+    },
+    "ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+    },
+    "encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+    },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+    },
+    "etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+    },
+    "express": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.18.1.tgz",
+      "integrity": "sha512-zZBcOX9TfehHQhtupq57OF8lFZ3UZi08Y97dwFCkD8p9d/d2Y3M+ykKcwaMDEL+4qyUolgBDX6AblpR3fL212Q==",
+      "requires": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.20.0",
+        "content-disposition": "0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "0.5.0",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.2.0",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~2.0.7",
+        "qs": "6.10.3",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "0.18.0",
+        "serve-static": "1.15.0",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      }
+    },
+    "finalhandler": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
+      "integrity": "sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==",
+      "requires": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "2.0.1",
+        "unpipe": "~1.0.0"
+      }
+    },
+    "forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="
+    },
+    "fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
+    "get-intrinsic": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
+      }
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
+    "has-symbols": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
+    },
+    "http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "requires": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      }
+    },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
+    },
+    "media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+    },
+    "merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+    },
+    "methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+    },
+    "mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+    },
+    "mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
+    },
+    "mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "requires": {
+        "mime-db": "1.52.0"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
+    },
+    "object-inspect": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
+      "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g=="
+    },
+    "on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "requires": {
+        "ee-first": "1.1.1"
+      }
+    },
+    "parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
+    },
+    "path-to-regexp": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+    },
+    "proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "requires": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      }
+    },
+    "qs": {
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
+      "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
+      "requires": {
+        "side-channel": "^1.0.4"
+      }
+    },
+    "range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
+    },
+    "raw-body": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
+      "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
+      "requires": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "send": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
+      "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
+      "requires": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "2.0.1"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+        }
+      }
+    },
+    "serve-static": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
+      "integrity": "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==",
+      "requires": {
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.18.0"
+      }
+    },
+    "setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+    },
+    "side-channel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "requires": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
+      }
+    },
+    "statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="
+    },
+    "toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
+    },
+    "type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "requires": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      }
+    },
+    "unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+    },
+    "utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+    },
+    "vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+    }
+  }
+}

--- a/tests/src/sanity.rs
+++ b/tests/src/sanity.rs
@@ -1,0 +1,291 @@
+pub mod utils;
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use k8s_openapi::api::{batch::v1::Job, core::v1::Pod};
+    use kube::{api::ListParams, Api};
+    use tokio::{
+        io::{AsyncBufReadExt, AsyncReadExt, BufReader},
+        time::{timeout, Duration},
+    };
+
+    use crate::utils::*;
+
+    #[tokio::test]
+    // starts the node(express.js) api server, sends four different requests, validates data,
+    // stops the server and validates if the agent job and pod are deleted
+    async fn test_complete_node_api() {
+        let client = setup_kube_client().await;
+
+        let pod_namespace = "default";
+        let env: HashMap<&str, &str> = HashMap::new(); // for adding more environment variables
+        let mut server = test_server_init(&client, pod_namespace, env).await;
+
+        let service_url = get_service_url(&client, pod_namespace).await.unwrap();
+
+        let mut stderr_reader = BufReader::new(server.stderr.take().unwrap());
+        let child_stdout = server.stdout.take().unwrap();
+
+        // Note: to run a task in the background, don't await on it.
+        // spawn returns a JoinHandle
+        tokio::spawn(async move {
+            loop {
+                let mut error_stream = String::new();
+                // the following is a blocking call, so we need to spawn a task to read the stderr
+                stderr_reader.read_line(&mut error_stream).await.unwrap();
+                // Todo(investigate): it looks like the task reaches the panic when not kept in a
+                // loop i.e. the buffer reads an empty string:  `thread 'main'
+                // panicked at 'Error: '`
+                if !error_stream.is_empty() {
+                    panic!("Error: {}", error_stream);
+                }
+            }
+        });
+
+        // since we are reading from the stdout, we could block at any point in case the server
+        // does not write to its stdout, so we need a timeout here
+        let validation_timeout = Duration::from_secs(20);
+        timeout(
+            validation_timeout,
+            validate_requests(child_stdout, service_url.as_str()),
+        )
+        .await
+        .unwrap();
+        server.kill().await.unwrap();
+
+        let jobs_api: Api<Job> = Api::namespaced(client.clone(), "default");
+        let jobs = jobs_api.list(&ListParams::default()).await.unwrap();
+        // assuming only one job is running
+        // to make the tests parallel we need to figure a way to get the exact job name when len() >
+        // 1
+        assert_eq!(jobs.items.len(), 1);
+
+        let pods_api: Api<Pod> = Api::namespaced(client.clone(), "default");
+        let pods = pods_api.list(&ListParams::default()).await.unwrap();
+        assert_eq!(pods.items.len(), 2);
+
+        let cleanup_timeout = Duration::from_secs(35);
+        timeout(
+            cleanup_timeout,
+            tokio::spawn(async move {
+                // verify cleanup
+                loop {
+                    let updated_jobs = jobs_api.list(&ListParams::default()).await.unwrap();
+                    let updated_pods = pods_api.list(&ListParams::default()).await.unwrap(); // only the nginx pod should exist
+                    if updated_pods.items.len() == 1 && updated_jobs.items.len() == 0 {
+                        let nginx_pod = updated_pods.items[0].metadata.name.clone().unwrap();
+                        assert!(nginx_pod.contains("nginx"));
+                        break;
+                    }
+                }
+            }),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+    }
+
+    #[tokio::test]
+    // we send a request to a different pod in the cluster (different namespace) and assert
+    // that no operation is performed as specified in the request by the server
+    // as the agent pod is impersonating the pod running in the default namespace
+    async fn test_different_pod_in_cluster() {
+        let client = setup_kube_client().await;
+
+        let test_namespace = "test-namespace";
+        let pod_namespace = "default";
+        let env: HashMap<&str, &str> = HashMap::new();
+        let mut server = test_server_init(&client, pod_namespace, env).await;
+
+        create_namespace(&client, test_namespace).await;
+        create_nginx_pod(&client, test_namespace).await;
+
+        let service_url = get_service_url(&client, test_namespace).await.unwrap();
+
+        let mut stderr_reader = BufReader::new(server.stderr.take().unwrap());
+        tokio::spawn(async move {
+            loop {
+                let mut error_stream = String::new();
+                stderr_reader.read_line(&mut error_stream).await.unwrap();
+                if !error_stream.is_empty() {
+                    panic!("Error: {}", error_stream);
+                }
+            }
+        });
+
+        let child_stdout = server.stdout.take().unwrap();
+        let timeout_duration = Duration::from_secs(10);
+        timeout(
+            timeout_duration,
+            validate_no_requests(child_stdout, service_url.as_str()),
+        )
+        .await
+        .unwrap();
+
+        server.kill().await.unwrap();
+        delete_namespace(&client, test_namespace).await;
+    }
+
+    // agent namespace tests
+    #[tokio::test]
+    // creates a new k8s namespace, starts the API server with env:
+    // MIRRORD_AGENT_NAMESPACE=namespace, asserts that the agent job and pod are created
+    // validate data through requests to the API server
+    async fn test_good_agent_namespace() {
+        let client = setup_kube_client().await;
+
+        let agent_namespace = "test-namespace-agent-good";
+        let pod_namespace = "default";
+        let env = HashMap::from([("MIRRORD_AGENT_NAMESPACE", agent_namespace)]);
+        let mut server = test_server_init(&client, pod_namespace, env).await;
+
+        create_namespace(&client, agent_namespace).await;
+
+        let service_url = get_service_url(&client, "default").await.unwrap();
+
+        let mut stderr_reader = BufReader::new(server.stderr.take().unwrap());
+        let child_stdout = server.stdout.take().unwrap();
+
+        tokio::spawn(async move {
+            loop {
+                let mut error_stream = String::new();
+                stderr_reader.read_line(&mut error_stream).await.unwrap();
+                if !error_stream.is_empty() {
+                    panic!("Error: {}", error_stream);
+                }
+            }
+        });
+
+        let validation_timeout = Duration::from_secs(20);
+        timeout(
+            validation_timeout,
+            validate_requests(child_stdout, service_url.as_str()),
+        )
+        .await
+        .unwrap();
+        server.kill().await.unwrap();
+
+        let jobs_api: Api<Job> = Api::namespaced(client.clone(), agent_namespace);
+        let jobs = jobs_api.list(&ListParams::default()).await.unwrap();
+        assert_eq!(jobs.items.len(), 1);
+
+        let pods_api: Api<Pod> = Api::namespaced(client.clone(), agent_namespace);
+        let pods = pods_api.list(&ListParams::default()).await.unwrap();
+        assert_eq!(pods.items.len(), 1);
+        delete_namespace(&client, agent_namespace).await;
+    }
+
+    #[tokio::test]
+    // starts the API server with env: MIRRORD_AGENT_NAMESPACE=namespace (nonexistent),
+    // asserts the process crashes: "NotFound" as the namespace does not exist
+    async fn test_nonexistent_agent_namespace() {
+        let client = setup_kube_client().await;
+        let agent_namespace = "nonexistent-namespace";
+        let pod_namespace = "default";
+        let env = HashMap::from([("MIRRORD_AGENT_NAMESPACE", agent_namespace)]);
+        let mut server = test_server_init(&client, pod_namespace, env).await;
+
+        let mut stderr_reader = BufReader::new(server.stderr.take().unwrap());
+
+        let timeout_duration = Duration::from_secs(5);
+        timeout(
+            timeout_duration,
+            tokio::spawn(async move {
+                loop {
+                    let mut error_stream = String::new();
+                    stderr_reader
+                        .read_to_string(&mut error_stream)
+                        .await
+                        .unwrap();
+                    if !error_stream.is_empty() {
+                        assert!(error_stream.contains("NotFound")); //Todo: fix this when unwraps are removed in pod_api.rs
+                        break;
+                    }
+                }
+            }),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+    }
+
+    // pod namespace tests
+    #[tokio::test]
+    // creates a new k8s namespace, starts the API server with env:
+    // MIRRORD_AGENT_IMPERSONATED_POD_NAMESPACE=namespace, validates data sent through
+    // requests
+    async fn test_good_pod_namespace() {
+        let client = setup_kube_client().await;
+
+        let pod_namespace = "test-pod-namespace";
+        create_namespace(&client, pod_namespace).await;
+        create_nginx_pod(&client, pod_namespace).await;
+
+        let env = HashMap::from([("MIRRORD_AGENT_IMPERSONATED_POD_NAMESPACE", pod_namespace)]);
+        let mut server = test_server_init(&client, pod_namespace, env).await;
+
+        let service_url = get_service_url(&client, pod_namespace).await.unwrap();
+
+        let mut stderr_reader = BufReader::new(server.stderr.take().unwrap());
+        tokio::spawn(async move {
+            loop {
+                let mut error_stream = String::new();
+                stderr_reader.read_line(&mut error_stream).await.unwrap();
+                if !error_stream.is_empty() {
+                    panic!("Error: {}", error_stream);
+                }
+            }
+        });
+
+        let child_stdout = server.stdout.take().unwrap();
+
+        let validation_timeout = Duration::from_secs(20);
+        timeout(
+            validation_timeout,
+            validate_requests(child_stdout, service_url.as_str()),
+        )
+        .await
+        .unwrap();
+        server.kill().await.unwrap();
+        delete_namespace(&client, pod_namespace).await;
+    }
+
+    #[tokio::test]
+    // starts the API server with env: MIRRORD_AGENT_IMPERSONATED_POD_NAMESPACE=namespace
+    // (nonexistent), asserts the process crashes: "NotFound" as the namespace does not
+    // exist
+    async fn test_bad_pod_namespace() {
+        let client = setup_kube_client().await;
+
+        let pod_namespace = "default";
+        let env = HashMap::from([(
+            "MIRRORD_AGENT_IMPERSONATED_POD_NAMESPACE",
+            "nonexistent-namespace",
+        )]);
+        let mut server = test_server_init(&client, pod_namespace, env).await;
+
+        let mut stderr_reader = BufReader::new(server.stderr.take().unwrap());
+        let timeout_duration = Duration::from_secs(5);
+        timeout(
+            timeout_duration,
+            tokio::spawn(async move {
+                loop {
+                    let mut error_stream = String::new();
+                    stderr_reader
+                        .read_to_string(&mut error_stream)
+                        .await
+                        .unwrap();
+                    if !error_stream.is_empty() {
+                        assert!(error_stream.contains("NotFound")); //Todo: fix this when unwraps are removed in pod_api.rs
+                        break;
+                    }
+                }
+            }),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+    }
+}

--- a/tests/src/utils.rs
+++ b/tests/src/utils.rs
@@ -1,0 +1,305 @@
+use std::{collections::HashMap, env, fmt::Debug, panic, process, process::Stdio};
+
+use futures::{StreamExt, TryStreamExt};
+use k8s_openapi::{
+    api::{
+        apps::v1::Deployment,
+        core::v1::{Namespace, Pod, Service},
+    },
+    apimachinery::pkg::apis::meta::v1::ObjectMeta,
+};
+use kube::{
+    api::{DeleteParams, ListParams, PostParams},
+    core::WatchEvent,
+    Api, Client, Config,
+};
+use reqwest::{Method, StatusCode};
+use serde::de::DeserializeOwned;
+use serde_json::json;
+use tokio::{
+    io::{AsyncBufReadExt, BufReader},
+    process::{Child, ChildStdout, Command},
+    time::{sleep, Duration},
+};
+
+static TEXT: &str = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";
+
+// target/debug/mirrord exec --pod-name pod_name  -c binary command
+pub fn start_node_server(pod_name: &str, command: Vec<&str>, env: HashMap<&str, &str>) -> Child {
+    let path = env!("CARGO_BIN_FILE_MIRRORD");
+    let args: Vec<&str> = vec!["exec", "--pod-name", pod_name, "-c"]
+        .into_iter()
+        .chain(command.into_iter())
+        .collect();
+    let server = Command::new(path)
+        .args(args)
+        .envs(&env)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    server
+}
+
+pub async fn setup_kube_client() -> Client {
+    let mut config = Config::infer().await.unwrap();
+    config.accept_invalid_certs = true;
+    Client::try_from(config).unwrap()
+}
+
+// minikube service nginx --url
+pub async fn get_service_url(client: &Client, namespace: &str) -> Option<String> {
+    let service_api: Api<Service> = Api::namespaced(client.clone(), namespace);
+    let services = service_api
+        .list(&ListParams::default().labels("app=nginx"))
+        .await
+        .unwrap();
+    let pod_api: Api<Pod> = Api::namespaced(client.clone(), namespace);
+    let pods = pod_api
+        .list(&ListParams::default().labels("app=nginx"))
+        .await
+        .unwrap();
+    let host_ip = pods
+        .into_iter()
+        .next()
+        .and_then(|pod| pod.status)
+        .and_then(|status| status.host_ip);
+    let port = services
+        .into_iter()
+        .next()
+        .and_then(|service| service.spec)
+        .and_then(|spec| spec.ports)
+        .and_then(|mut ports| ports.pop());
+    Some(format!(
+        "http://{}:{}",
+        host_ip.unwrap(),
+        port.unwrap().node_port.unwrap()
+    ))
+}
+
+// kubectl get pods | grep nginx
+pub async fn get_nginx_pod_name(client: &Client, namespace: &str) -> Option<String> {
+    let pod_api: Api<Pod> = Api::namespaced(client.clone(), namespace);
+    let pods = pod_api
+        .list(&ListParams::default().labels("app=nginx"))
+        .await
+        .unwrap();
+    let pod = pods.iter().next().and_then(|pod| pod.metadata.name.clone());
+    pod
+}
+
+// kubectl create namespace name
+pub async fn create_namespace(client: &Client, namespace: &str) {
+    let namespace_api: Api<Namespace> = Api::all(client.clone());
+    let new_namespace = Namespace {
+        metadata: ObjectMeta {
+            name: Some(namespace.to_string()),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    namespace_api
+        .create(&PostParams::default(), &new_namespace)
+        .await
+        .unwrap();
+    watch_resource_exists(namespace_api, namespace).await;
+}
+
+// kubectl delete namespace name
+pub async fn delete_namespace(client: &Client, namespace: &str) {
+    let namespace_api: Api<Namespace> = Api::all(client.clone());
+    namespace_api
+        .delete(namespace, &DeleteParams::default())
+        .await
+        .unwrap();
+}
+
+pub async fn http_request(url: &str, method: Method) {
+    let client = reqwest::Client::new();
+    let res = client
+        .request(method.clone(), url)
+        .body(TEXT)
+        .send()
+        .await
+        .unwrap();
+    match method {
+        Method::GET => assert_eq!(res.status(), StatusCode::OK),
+        Method::POST | Method::PUT | Method::DELETE => {
+            assert_eq!(res.status(), StatusCode::from_u16(405).unwrap())
+        }
+        _ => panic!("unexpected method"),
+    }
+}
+
+// kubectl apply -f tests/app.yaml -n name
+pub async fn create_nginx_pod(client: &Client, namespace: &str) {
+    let deployment_api: Api<Deployment> = Api::namespaced(client.clone(), namespace);
+    let deployment = serde_json::from_value(json!({
+        "apiVersion": "apps/v1",
+        "kind": "Deployment",
+        "metadata": {
+            "name": "nginx",
+            "labels": {
+                "app": "nginx"
+            }
+        },
+        "spec": {
+            "replicas": 1,
+            "selector": {
+                "matchLabels": {
+                    "app": "nginx"
+                }
+            },
+            "template": {
+                "metadata": {
+                    "labels": {
+                        "app": "nginx"
+                    }
+                },
+                "spec": {
+                    "containers": [
+                        {
+                            "name": "nginx",
+                            "image": "nginx:1.14.2",
+                            "ports": [
+                                {
+                                    "containerPort": 80
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        }
+    }))
+    .unwrap();
+
+    deployment_api
+        .create(&PostParams::default(), &deployment)
+        .await
+        .unwrap();
+    watch_resource_exists(deployment_api, "nginx").await;
+
+    let service_api: Api<Service> = Api::namespaced(client.clone(), namespace);
+    let service = serde_json::from_value(json!({
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {
+            "name": "nginx",
+            "labels": {
+                "app": "nginx"
+            }
+        },
+        "spec": {
+            "type": "NodePort",
+            "selector": {
+                "app": "nginx"
+            },
+            "sessionAffinity": "None",
+            "ports": [
+                {
+                    "protocol": "TCP",
+                    "port": 80,
+                    "targetPort": 80
+                }
+            ]
+        }
+    }))
+    .unwrap();
+
+    service_api
+        .create(&PostParams::default(), &service)
+        .await
+        .unwrap();
+    watch_resource_exists(service_api, "nginx").await;
+}
+
+// watch a resource until it exists
+pub async fn watch_resource_exists<K: Debug + Clone + DeserializeOwned>(api: Api<K>, name: &str) {
+    let params = ListParams::default()
+        .fields(&format!("metadata.name={}", name))
+        .timeout(10);
+    let mut stream = api.watch(&params, "0").await.unwrap().boxed();
+    while let Some(status) = stream.try_next().await.unwrap() {
+        match status {
+            WatchEvent::Modified(_) => break,
+            WatchEvent::Error(s) => {
+                panic!("Error watching namespaces: {:?}", s);
+            }
+            _ => {}
+        }
+    }
+}
+
+// to all requests, the express API prints {request_name}: Request completed
+// PUT - creates cwd/test, DELETE - deletes cwd/test
+// this is verified by reading the stdout of the server
+pub async fn validate_requests(stdout: ChildStdout, service_url: &str) {
+    let mut buffer = BufReader::new(stdout);
+    let mut stream = String::new();
+    buffer.read_line(&mut stream).await.unwrap();
+    assert!(stream.contains("Server listening on port 80"));
+
+    http_request(service_url, Method::GET).await;
+    buffer.read_line(&mut stream).await.unwrap();
+    assert!(stream.contains("GET: Request completed"));
+
+    http_request(service_url, Method::POST).await;
+    buffer.read_line(&mut stream).await.unwrap();
+    assert!(stream.contains("POST: Request completed"));
+
+    let cwd = env::current_dir().unwrap();
+    let path = cwd.join("test"); // 'test' is created in cwd, by PUT and deleted by DELETE
+
+    http_request(service_url, Method::PUT).await;
+    sleep(Duration::from_secs(2)).await; // Todo: remove this sleep and replace with a filesystem watcher
+    assert!(path.exists());
+    buffer.read_line(&mut stream).await.unwrap();
+    assert!(stream.contains("PUT: Request completed"));
+
+    http_request(service_url, Method::DELETE).await;
+    sleep(Duration::from_secs(2)).await;
+    assert!(!path.exists());
+    buffer.read_line(&mut stream).await.unwrap();
+    assert!(stream.contains("DELETE: Request completed"));
+}
+
+pub async fn validate_no_requests(stdout: ChildStdout, service_url: &str) {
+    let mut buffer = BufReader::new(stdout);
+    let mut stream = String::new();
+    buffer.read_line(&mut stream).await.unwrap();
+    assert!(stream.contains("Server listening on port 80"));
+
+    let cwd = env::current_dir().unwrap();
+    let path = cwd.join("test");
+
+    http_request(service_url, Method::PUT).await;
+    sleep(Duration::from_secs(2)).await;
+    assert!(!path.exists()); // the API creates a file called 'test' in cwd, which should not exist
+}
+
+// initializes the test/runs the node process
+pub async fn test_server_init(
+    client: &Client,
+    pod_namespace: &str,
+    mut env: HashMap<&str, &str>,
+) -> Child {
+    let pod_name = get_nginx_pod_name(client, pod_namespace).await.unwrap();
+    let command = vec!["node", "node-e2e/app.js"];
+    // used by the CI, to load the image locally:
+    // docker build -t test . -f mirrord-agent/Dockerfile
+    // minikube load image test:latest
+    env.insert("MIRRORD_AGENT_IMAGE", "test");
+    let server = start_node_server(&pod_name, command, env);
+    setup_panic_hook();
+    server
+}
+
+// can't panic from a task, this utility just exits the process with an error code
+pub fn setup_panic_hook() {
+    let orig_hook = panic::take_hook();
+    panic::set_hook(Box::new(move |panic_info| {
+        orig_hook(panic_info);
+        process::exit(1);
+    }));
+}


### PR DESCRIPTION
This PR adds the following E2E tests:

- built with the latest agent image 
`docker build -t test . --file mirrord-agent/Dockerfile`
`minikube load image test:latest`
- **test_complete_node_api**: sends four different requests to the node server present in node-e2e
`GET, POST, PUT, DELETE`. The node process writes to it's stdout which is then checked and verified by the test. Everything runs in the default namespace. The test also verifies the agent job and pod are cleaned up.
- **test_different_pod_in_cluster**: A `PUT` request is sent to a different pod in the cluster and asserted that no action corresponding to the request takes place.
- **test_good_agent_namespace**: A new namespace is created and it is specified as the agent's namespace and four different requests are sent to verify the server writes to its stdout. 
- **test_nonexistent_agent_namespace**: A nonexistent namespace is specified as agent's namespace and it is asserted that the process panics. 
- **test_good_pod_namespace**: A new namespace is created and it is specified as the pod's namespace and four different requests are sent to verify the server writes to its stdout. 
- **test_bad_pod_namespace**: A nonexistent namespace is specified as pod's namespace and it is asserted that the process panics. 
