### PR TITLE
Disable version check to false for e2e tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ## [Unreleased]
 ### Added
 - Prompt user to update if their version is outdated in the VS Code extension or CLI.
+- Set `MIRRORD_CHECK_VERSION` to false to make E2E tests not read update messages. 
 
 ## 2.0.0
 

--- a/tests/src/utils.rs
+++ b/tests/src/utils.rs
@@ -290,6 +290,7 @@ pub async fn test_server_init(
     // docker build -t test . -f mirrord-agent/Dockerfile
     // minikube load image test:latest
     env.insert("MIRRORD_AGENT_IMAGE", "test");
+    env.insert("MIRRORD_CHECK_VERSION", "false");
     let server = start_node_server(&pod_name, command, env);
     setup_panic_hook();
     server


### PR DESCRIPTION
If `MIRRORD_CHECK_VERSION` is not set to false then a version update message is printed and we can't `read_line` and check if the server is listening or not. 