### PR TITLE
scripts/install.sh: improve message for non-writable install target

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -28,7 +28,7 @@ copy() {
       fi
       mv /tmp/mirrord "$HOME/.local/bin/mirrord"
   else
-      echo "/usr/local/bin which is write protected, installing it requires sudo"
+      echo "installation target directory is write protected, run as root to override"
       sudo mv /tmp/mirrord /usr/local/bin/mirrord
   fi
 }


### PR DESCRIPTION
Fixes non-grammatical message in the installation script