### PR TITLE
Changed release profile to strip debuginfo and enable LTO.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - Refactor the CI by splitting the building of mirrord-agent in a separate job and caching the agent image for E2E tests.
 - File operations are now available behind the `MIRRORD_FILE_OPS` env variable, this means that mirrod now hooks into the following file functions: `open`, `fopen`, `fdopen`, `openat`, `read`, `fread`, `fileno`, `lseek`, and `write` to provide a mirrored file system.
 - Update bug report template to apply to the latest version of mirrord.
+- Changed release profile to strip debuginfo and enable LTO.
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,3 +44,7 @@ thiserror = "1"
 # this should be changed once a newer version of rustls is ou
 [patch.crates-io]
 rustls = { git = 'https://github.com/rustls/rustls' }
+
+[profile.release]
+strip = "debuginfo"
+lto = true


### PR DESCRIPTION
This reduces binary size and potentially can improve performance.