### PR TITLE
Fix random crash on macOS on launch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,7 @@ jobs:
   test_mirrord_protocol:
     strategy:
       matrix:
-        os: [ubuntu-latest, ubuntu-18.04, macos-12, macos-11, macos-10.15]
+        os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -34,6 +34,7 @@ jobs:
         with:
           profile: minimal
           toolchain: nightly
+          target: ${{matrix.target}}
       - uses: Swatinem/rust-cache@v1
         with:
           key: ${{matrix.os}}
@@ -74,10 +75,23 @@ jobs:
           name: test
           path: /tmp/test.tar
 
-  test_mirrord_layer:
+  test_mirrord_layer_cli:
     strategy:
       matrix:
         os: [ubuntu-latest, ubuntu-18.04, macos-12, macos-11, macos-10.15]
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - os: ubuntu-18.04
+            target: x86_64-unknown-linux-gnu
+          - os: macos-12
+            target: x86_64-apple-darwin
+          - os: macos-12
+            target: aarch64-apple-darwin
+          - os: macos-11
+            target: x86_64-apple-darwin
+          - os: macos-10/15
+            target: x86_64-apple-darwin
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -85,11 +99,12 @@ jobs:
         with:
           profile: minimal
           toolchain: nightly
+          target: ${{matrix.target}}
       - uses: Swatinem/rust-cache@v1
         with:
           key: ${{matrix.os}}
-      # For now, just evrify it compiles.
-      - run: cargo +nightly build --manifest-path=mirrord-layer/Cargo.toml
+      # For now, just verify it compiles.
+      - run: cargo +nightly build -p mirrord-layer -p mirrord-cli --target=${{matrix.target}}
 
   build_mirrord:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - Update bug report template to apply to the latest version of mirrord.
 - Chang release profile to strip debuginfo and enable LTO.
 - VS Code extension - update dependencies.
+- CLI & macOS: Extract to `/tmp/` instead of `$TMPDIR` as the executed process is getting killed for some reason.
 
 ### Fixed
 

--- a/mirrord-cli/src/main.rs
+++ b/mirrord-cli/src/main.rs
@@ -1,4 +1,4 @@
-use std::{env::temp_dir, fs::File, io::Write, path::PathBuf, time::Duration};
+use std::{fs::File, io::Write, path::PathBuf, time::Duration};
 
 use anyhow::{anyhow, Context, Result};
 use clap::{Args, Parser, Subcommand};
@@ -73,14 +73,13 @@ mod mac_aarch {
     };
 
     use mach_object::{OFile, CPU_TYPE_X86_64};
-    use reqwest;
     use search_path::SearchPath;
     use tracing::warn;
 
     use super::*;
     pub fn is_binary_different_arch(binary_name: &String) -> bool {
         let search_path = SearchPath::new("PATH").unwrap();
-        let binary_name = match search_path.find(&Path::new(binary_name)) {
+        let binary_path = match search_path.find(Path::new(binary_name)) {
             Some(path) => path,
             None => {
                 warn!("Could not find binary in PATH");
@@ -141,6 +140,23 @@ mod mac_aarch {
 
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 use mac_aarch::*;
+
+/// For some reason loading dylib from $TMPDIR can get the process killed somehow..?
+mod mac {
+    use std::str::FromStr;
+
+    use super::*;
+
+    pub fn temp_dir() -> PathBuf {
+        PathBuf::from_str("/tmp/").unwrap()
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+use std::env::temp_dir;
+
+#[cfg(target_os = "macos")]
+use mac::temp_dir;
 
 fn extract_library(dest_dir: Option<String>) -> Result<PathBuf> {
     let library_file = env!("CARGO_CDYLIB_FILE_MIRRORD_LAYER");


### PR DESCRIPTION
Extract the dylib to `/tmp` instead of `$TMPDIR` seems to solve it? (change only on macOS)
Change CI to compile m1 binary