### PR TITLE
Add Docker cache to Docker build-push action to reduce build duration.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,6 +66,8 @@ jobs:
           tag: test
           file: mirrord-agent/Dockerfile
           outputs: type=docker,dest=/tmp/test.tar
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
       - name: upload image
         uses: actions/upload-artifact@v2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ### Changed
 - Speed up agent container image building by using a more specific base image.
 - CI: Remove building agent before building & running tests (duplicate)
+- CI: Add Docker cache to Docker build-push action to reduce build duration.
 
 ## 2.2.1
 ### Changed


### PR DESCRIPTION
CI: Add Docker cache to Docker build-push action to reduce build duration.