### PR TITLE
CI Improvements

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -179,3 +179,6 @@ jobs:
         run: kubectl wait --for=condition=ready pod -l app=http-echo --timeout=20s
       - name: test with docker runtime
         run: cargo test --package tests --lib -- tests --nocapture --test-threads 1
+      - name: Collect logs
+        if: ${{ failure() }}
+        run: kubectl logs -l app=mirrord

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - CD release: Fix universal binary for macOS
 - Refactor: Change protocol + mirrord-layer to split messages into modules, so main module only handles general messages, passing down to the appropriate module for handling.
 - Add a CLI flag to specify `MIRRORD_AGENT_TTL`
+- CI: Collect mirrord-agent logs in case of failure in e2e.
+- Add "app" = "mirrord" label to the agent pod for log collection at ease.
+- CI: Add sleep after local app finishes loading for agent to load filter make tests less flaky.
 
 ## 2.2.1
 ### Changed

--- a/mirrord-layer/src/pod_api.rs
+++ b/mirrord-layer/src/pod_api.rs
@@ -79,7 +79,10 @@ pub async fn create_agent(
     let agent_pod: Job =
         serde_json::from_value(json!({ // Only Jobs support self deletion after completion
                 "metadata": {
-                    "name": agent_job_name
+                    "name": agent_job_name,
+                    "labels": {
+                        "app": "mirrord"
+                    }
                 },
                 "spec": {
                 "ttlSecondsAfterFinished": env_config.agent_ttl,

--- a/tests/src/sanity.rs
+++ b/tests/src/sanity.rs
@@ -12,7 +12,7 @@ mod tests {
     };
     use tokio::{
         io::{AsyncBufReadExt, AsyncReadExt, BufReader},
-        time::{timeout, Duration},
+        time::{timeout, Duration, sleep},
     };
 
     use crate::utils::*;
@@ -71,6 +71,9 @@ mod tests {
         .await
         .unwrap();
 
+        // agent takes a bit of time to set filter and start sending traffic, this should solve many race stuff until
+        // we watch the agent logs and start sending requests after we see it had set the new filter.
+        sleep(Duration::from_millis(100)).await;
         send_requests(service_url.as_str()).await;
 
         timeout(Duration::from_secs(5), async {
@@ -153,6 +156,9 @@ mod tests {
         .await
         .unwrap();
 
+        // agent takes a bit of time to set filter and start sending traffic, this should solve many race stuff until
+        // we watch the agent logs and start sending requests after we see it had set the new filter.
+        sleep(Duration::from_millis(100)).await;
         send_requests(service_url.as_str()).await;
 
         // Note: Sending a SIGTERM adds an EOF to the stdout stream, so we can read it without
@@ -213,6 +219,9 @@ mod tests {
         .await
         .unwrap();
 
+        // agent takes a bit of time to set filter and start sending traffic, this should solve many race stuff until
+        // we watch the agent logs and start sending requests after we see it had set the new filter.
+        sleep(Duration::from_millis(100)).await;
         send_requests(service_url.as_str()).await;
 
         timeout(Duration::from_secs(5), async {
@@ -310,6 +319,9 @@ mod tests {
         .await
         .unwrap();
 
+        // agent takes a bit of time to set filter and start sending traffic, this should solve many race stuff until
+        // we watch the agent logs and start sending requests after we see it had set the new filter.
+        sleep(Duration::from_millis(100)).await;
         send_requests(service_url.as_str()).await;
 
         timeout(Duration::from_secs(5), async {

--- a/tests/src/sanity.rs
+++ b/tests/src/sanity.rs
@@ -12,7 +12,7 @@ mod tests {
     };
     use tokio::{
         io::{AsyncBufReadExt, AsyncReadExt, BufReader},
-        time::{timeout, Duration, sleep},
+        time::{sleep, timeout, Duration},
     };
 
     use crate::utils::*;
@@ -71,8 +71,9 @@ mod tests {
         .await
         .unwrap();
 
-        // agent takes a bit of time to set filter and start sending traffic, this should solve many race stuff until
-        // we watch the agent logs and start sending requests after we see it had set the new filter.
+        // agent takes a bit of time to set filter and start sending traffic, this should solve many
+        // race stuff until we watch the agent logs and start sending requests after we see
+        // it had set the new filter.
         sleep(Duration::from_millis(100)).await;
         send_requests(service_url.as_str()).await;
 
@@ -156,8 +157,9 @@ mod tests {
         .await
         .unwrap();
 
-        // agent takes a bit of time to set filter and start sending traffic, this should solve many race stuff until
-        // we watch the agent logs and start sending requests after we see it had set the new filter.
+        // agent takes a bit of time to set filter and start sending traffic, this should solve many
+        // race stuff until we watch the agent logs and start sending requests after we see
+        // it had set the new filter.
         sleep(Duration::from_millis(100)).await;
         send_requests(service_url.as_str()).await;
 
@@ -219,8 +221,9 @@ mod tests {
         .await
         .unwrap();
 
-        // agent takes a bit of time to set filter and start sending traffic, this should solve many race stuff until
-        // we watch the agent logs and start sending requests after we see it had set the new filter.
+        // agent takes a bit of time to set filter and start sending traffic, this should solve many
+        // race stuff until we watch the agent logs and start sending requests after we see
+        // it had set the new filter.
         sleep(Duration::from_millis(100)).await;
         send_requests(service_url.as_str()).await;
 
@@ -319,8 +322,9 @@ mod tests {
         .await
         .unwrap();
 
-        // agent takes a bit of time to set filter and start sending traffic, this should solve many race stuff until
-        // we watch the agent logs and start sending requests after we see it had set the new filter.
+        // agent takes a bit of time to set filter and start sending traffic, this should solve many
+        // race stuff until we watch the agent logs and start sending requests after we see
+        // it had set the new filter.
         sleep(Duration::from_millis(100)).await;
         send_requests(service_url.as_str()).await;
 


### PR DESCRIPTION
- CI: Collect mirrord-agent logs in case of failure in e2e.
- Add "app" = "mirrord" label to the agent pod for log collection at ease.
- CI: Add sleep after local app finishes loading for agent to load filter make tests less flaky.