### PR TITLE
Fix once cell renaimings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,8 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - CI: Collect mirrord-agent logs in case of failure in e2e.
 - Add "app" = "mirrord" label to the agent pod for log collection at ease.
 - CI: Add sleep after local app finishes loading for agent to load filter make tests less flaky.
-
 - Handle relative paths for open, openat
+- Fix once cell renamings, PR [#98165](https://github.com/rust-lang/rust/pull/98165)
 
 ## 2.2.1
 ### Changed

--- a/mirrord-layer/src/file.rs
+++ b/mirrord-layer/src/file.rs
@@ -1,4 +1,9 @@
-use std::{collections::HashMap, env, lazy::SyncLazy, os::unix::io::RawFd, sync::Mutex};
+use std::{
+    collections::HashMap,
+    env,
+    os::unix::io::RawFd,
+    sync::{LazyLock, Mutex},
+};
 
 use libc::{c_int, O_ACCMODE, O_APPEND, O_CREAT, O_RDONLY, O_RDWR, O_TRUNC, O_WRONLY};
 use mirrord_protocol::OpenOptionsInternal;
@@ -9,7 +14,7 @@ pub(crate) mod hooks;
 pub(crate) mod ops;
 
 /// Regex that ignores system files + files in the current working directory.
-static IGNORE_FILES: SyncLazy<RegexSet> = SyncLazy::new(|| {
+static IGNORE_FILES: LazyLock<RegexSet> = LazyLock::new(|| {
     // To handle the problem of injecting `open` and friends into project runners (like in a call to
     // `node app.js`, or `cargo run app`), we're ignoring files from the current working directory.
     let current_dir = env::current_dir().unwrap();
@@ -46,8 +51,8 @@ struct RemoteFile {
     fd: RawFd,
 }
 
-pub(crate) static OPEN_FILES: SyncLazy<Mutex<HashMap<LocalFd, RemoteFd>>> =
-    SyncLazy::new(|| Mutex::new(HashMap::with_capacity(4)));
+pub(crate) static OPEN_FILES: LazyLock<Mutex<HashMap<LocalFd, RemoteFd>>> =
+    LazyLock::new(|| Mutex::new(HashMap::with_capacity(4)));
 
 pub(crate) trait OpenOptionsInternalExt {
     fn from_flags(flags: c_int) -> Self;

--- a/mirrord-layer/src/lib.rs
+++ b/mirrord-layer/src/lib.rs
@@ -7,8 +7,7 @@
 
 use std::{
     env,
-    lazy::{SyncLazy, SyncOnceCell},
-    sync::Mutex,
+    sync::{LazyLock, Mutex, OnceLock},
 };
 
 use actix_codec::{AsyncRead, AsyncWrite};
@@ -54,11 +53,11 @@ mod tcp_mirror;
 
 use crate::{common::HookMessage, config::Config, macros::hook};
 
-static RUNTIME: SyncLazy<Runtime> = SyncLazy::new(|| Runtime::new().unwrap());
-static GUM: SyncLazy<Gum> = SyncLazy::new(|| unsafe { Gum::obtain() });
+static RUNTIME: LazyLock<Runtime> = LazyLock::new(|| Runtime::new().unwrap());
+static GUM: LazyLock<Gum> = LazyLock::new(|| unsafe { Gum::obtain() });
 
 pub static mut HOOK_SENDER: Option<Sender<HookMessage>> = None;
-pub static ENABLED_FILE_OPS: SyncOnceCell<bool> = SyncOnceCell::new();
+pub static ENABLED_FILE_OPS: OnceLock<bool> = OnceLock::new();
 
 #[ctor]
 fn init() {

--- a/mirrord-layer/src/sockets.rs
+++ b/mirrord-layer/src/sockets.rs
@@ -2,10 +2,9 @@
 //! absolute minimum
 use std::{
     collections::{HashMap, VecDeque},
-    lazy::SyncLazy,
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
     os::unix::io::RawFd,
-    sync::{Arc, Mutex},
+    sync::{Arc, LazyLock, Mutex},
 };
 
 use errno::{errno, set_errno, Errno};
@@ -22,11 +21,11 @@ use crate::{
     HOOK_SENDER,
 };
 
-pub(crate) static SOCKETS: SyncLazy<Mutex<HashMap<RawFd, Arc<Socket>>>> =
-    SyncLazy::new(|| Mutex::new(HashMap::new()));
+pub(crate) static SOCKETS: LazyLock<Mutex<HashMap<RawFd, Arc<Socket>>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
 
-pub static CONNECTION_QUEUE: SyncLazy<Mutex<ConnectionQueue>> =
-    SyncLazy::new(|| Mutex::new(ConnectionQueue::default()));
+pub static CONNECTION_QUEUE: LazyLock<Mutex<ConnectionQueue>> =
+    LazyLock::new(|| Mutex::new(ConnectionQueue::default()));
 
 /// Struct sent over the socket once created to pass metadata to the hook
 #[derive(Debug)]


### PR DESCRIPTION
This PR fixes the compilation issue as with the latest release of rust, the stdlib was updated to use better naming for once cell https://github.com/rust-lang/rust/pull/98165