### PR TITLE
Enable "blocking" feature for reqwest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - CI: Add sleep after local app finishes loading for agent to load filter make tests less flaky.
 - Handle relative paths for open, openat
 - Fix once cell renamings, PR [#98165](https://github.com/rust-lang/rust/pull/98165)
+- Enable the blocking feature of the `reqwest` library 
 
 ## 2.2.1
 ### Changed

--- a/mirrord-cli/Cargo.toml
+++ b/mirrord-cli/Cargo.toml
@@ -23,7 +23,7 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 exec = "0.3"
 anyhow.workspace = true
-reqwest = "0.11.10"
+reqwest = { version = "0.11.10", features = ["blocking"] }
 semver = "1.0.9"
 
 [build-dependencies]


### PR DESCRIPTION
Enabling the blocking feature of the reqwest library for now, so that mirrord compiles for everyone. But it's weird that mirrord compiles on some setups on which this feature is not enabled. 
Relevant issue on Cargo: https://github.com/rust-lang/cargo/issues/10775
Relevant issue on mirrord: #152 