### PR TITLE
Add context to job/agent creation errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - Don't fail environment variable request if none exists.
 - E2E: Don't assert jobs and pods length, to allow better debugging and less flakiness.
 - Refactor(agent) - Main loop doesn't pass messages around but instead spawned peers interact directly with tcp sniffer. Renamed Peer -> Client and ClientID.
+- Add context to agent/job creation errors (Fixes #112)
 
 ## 2.3.0
 

--- a/mirrord-layer/src/pod_api.rs
+++ b/mirrord-layer/src/pod_api.rs
@@ -69,14 +69,14 @@ pub async fn create_agent(config: LayerConfig) -> Result<Portforwarder> {
     let client = if env_config.accept_invalid_certificates {
         let mut config = Config::infer()
             .await
-            .with_context(|| format!("Failed to load kube-config"))?;
+            .with_context(|| "Failed to load kube-config")?;
         config.accept_invalid_certs = true;
         warn!("Accepting invalid certificates");
-        Client::try_from(config).with_context(|| format!("Failed to create client"))?
+        Client::try_from(config).with_context(|| "Failed to create client")?
     } else {
         Client::try_default()
             .await
-            .with_context(|| format!("Failed to create client"))?
+            .with_context(|| "Failed to create client")?
     };
 
     let runtime_data = RuntimeData::from_k8s(

--- a/mirrord-layer/src/pod_api.rs
+++ b/mirrord-layer/src/pod_api.rs
@@ -67,12 +67,17 @@ pub async fn create_agent(config: LayerConfig) -> Result<Portforwarder> {
     let env_config = LayerConfig::init_from_env().unwrap();
 
     let client = if env_config.accept_invalid_certificates {
-        let mut config = Config::infer().await.unwrap();
+        let mut config = Config::infer()
+            .await
+            .with_context(|| format!("Failed to load kubec-config"))?;
         config.accept_invalid_certs = true;
         warn!("Accepting invalid certificates");
-        Client::try_from(config).unwrap()
+        Client::try_from(config)
+            .with_context(|| format!("Failed to create kubec-config with invalid certs"))?
     } else {
-        Client::try_default().await.unwrap()
+        Client::try_default()
+            .await
+            .with_context(|| format!("Failed to kubec-create config"))?
     };
 
     let runtime_data = RuntimeData::from_k8s(
@@ -154,7 +159,12 @@ pub async fn create_agent(config: LayerConfig) -> Result<Portforwarder> {
     jobs_api
         .create(&PostParams::default(), &agent_pod)
         .await
-        .unwrap();
+        .with_context(|| {
+            format!(
+                "Failed to create jobs api with agent pod {}",
+                &agent_job_name
+            )
+        })?;
 
     let pods_api: Api<Pod> = Api::namespaced(client.clone(), &agent_namespace);
     let params = ListParams::default()
@@ -176,7 +186,7 @@ pub async fn create_agent(config: LayerConfig) -> Result<Portforwarder> {
     let pods = pods_api
         .list(&ListParams::default().labels(&format!("job-name={}", agent_job_name)))
         .await
-        .unwrap();
+        .with_context(|| format!("Failed to list pods for job agent {}", &agent_job_name))?;
     let pod = pods.items.first().unwrap();
     let pod_name = pod.metadata.name.clone().unwrap();
     let running = await_condition(pods_api.clone(), &pod_name, is_pod_running());

--- a/mirrord-layer/src/pod_api.rs
+++ b/mirrord-layer/src/pod_api.rs
@@ -72,8 +72,7 @@ pub async fn create_agent(config: LayerConfig) -> Result<Portforwarder> {
             .with_context(|| format!("Failed to load kube-config"))?;
         config.accept_invalid_certs = true;
         warn!("Accepting invalid certificates");
-        Client::try_from(config)
-            .with_context(|| format!("Failed to create client"))?
+        Client::try_from(config).with_context(|| format!("Failed to create client"))?
     } else {
         Client::try_default()
             .await

--- a/mirrord-layer/src/pod_api.rs
+++ b/mirrord-layer/src/pod_api.rs
@@ -69,15 +69,15 @@ pub async fn create_agent(config: LayerConfig) -> Result<Portforwarder> {
     let client = if env_config.accept_invalid_certificates {
         let mut config = Config::infer()
             .await
-            .with_context(|| format!("Failed to load kubec-config"))?;
+            .with_context(|| format!("Failed to load kube-config"))?;
         config.accept_invalid_certs = true;
         warn!("Accepting invalid certificates");
         Client::try_from(config)
-            .with_context(|| format!("Failed to create kubec-config with invalid certs"))?
+            .with_context(|| format!("Failed to create client"))?
     } else {
         Client::try_default()
             .await
-            .with_context(|| format!("Failed to kubec-create config"))?
+            .with_context(|| format!("Failed to create client"))?
     };
 
     let runtime_data = RuntimeData::from_k8s(


### PR DESCRIPTION
Marked as draft since this is changing same file as `#168` and wanted to check for feedback on this, if more changes were intended.

#### Changes Made

1. added context to kube errors during agent  creation in mirrord-layer
2. updated CHANGELOG.md

---

Finally submitting changes to handle errors for #112. Please let me know if more was intended when handling the possible `kube::Error` cases.

I considered creating a separate error enum for these cases in `mirrord-layer/src/error.rs`. Would this be more useful/idiomatic? I think this was already discussed and in `#144`, or might be overkill for these create agent errors.

Thanks!