### PR TITLE
Add MIRRORD_IMPERSONATED_CONTAINER_NAME var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ## [Unreleased]
 ### Added
 - mirrord-cli `exec` subcommand accepts `--extract-path` argument to set the directory to extract the library to. Used for tests mainly.
+- mirrord-layer provides `MIRRORD_IMPERSONATED_CONTAINER_NAME` environment variable to specify container name to impersonate. mirrord-cli accepts argument to set variable.
 
 ### Changed
 - Refactor e2e, enable only Node HTTP mirroring test.

--- a/mirrord-cli/src/config.rs
+++ b/mirrord-cli/src/config.rs
@@ -58,6 +58,10 @@ pub(super) struct ExecArgs {
     #[clap(long, value_parser)]
     pub agent_ttl: Option<u16>,
 
+    /// Select container name to impersonate. Default is first container.
+    #[clap(long, value_parser)]
+    pub impersonate_container_name: Option<String>,
+
     /// Accept/reject invalid certificates.
     #[clap(short = 'c', long, value_parser)]
     pub accept_invalid_certificates: bool,

--- a/mirrord-cli/src/main.rs
+++ b/mirrord-cli/src/main.rs
@@ -89,6 +89,13 @@ fn exec(args: &ExecArgs) -> Result<()> {
         std::env::set_var("MIRRORD_AGENT_NAMESPACE", namespace.clone());
     }
 
+    if let Some(impersonate_container_name) = &args.impersonate_container_name {
+        std::env::set_var(
+            "MIRRORD_IMPERSONATED_CONTAINER_NAME",
+            impersonate_container_name,
+        );
+    }
+
     if let Some(log_level) = &args.agent_log_level {
         std::env::set_var("MIRRORD_AGENT_RUST_LOG", log_level.clone());
     }

--- a/mirrord-layer/src/config.rs
+++ b/mirrord-layer/src/config.rs
@@ -20,6 +20,9 @@ pub struct LayerConfig {
     #[envconfig(from = "MIRRORD_AGENT_IMPERSONATED_POD_NAMESPACE", default = "default")]
     pub impersonated_pod_namespace: String,
 
+    #[envconfig(from = "MIRRORD_IMPERSONATED_CONTAINER_NAME")]
+    pub impersonated_container_name: Option<String>,
+
     #[envconfig(from = "MIRRORD_ACCEPT_INVALID_CERTIFICATES", default = "false")]
     pub accept_invalid_certificates: bool,
 

--- a/tests/src/sanity.rs
+++ b/tests/src/sanity.rs
@@ -199,6 +199,7 @@ mod tests {
         env.insert("MIRRORD_AGENT_IMAGE", "test");
         env.insert("MIRRORD_CHECK_VERSION", "false");
         env.insert("MIRRORD_AGENT_RUST_LOG", "debug");
+        env.insert("MIRRORD_IMPERSONATED_CONTAINER_NAME", "test");
         env.insert("RUST_LOG", "debug");
         let server = Command::new(path)
             .args(args.clone())


### PR DESCRIPTION
### Details

This CR adds an optional `MIRRORD_IMPERSONATED_CONTAINER_NAME` to specify container name within pod for #100.

This doesn't implement ignoring linkerd/envoy pods yet. Can iterate on this draft based on feedback. I suppose the best way to ignore containers like this is to filter out common container names for linkerd/envoy within a pod?

A couple things that are missing, I'll convert to draft if these are blockers.

1. add ability to set this variable in VSCode extension
2. Ignore linkerd/envoy container names

### Testing

These are low effort tests and not really best practice since they won't be in CI. I can try this weekend adding a mock failure run to [sanity.rs](https://github.com/metalbear-co/mirrord/blob/main/tests/src/sanity.rs#L203-L209).

1. local GH action run manually setting `MIRRORD_IMPERSONATED_CONTAINER_NAME=test` ([link](https://github.com/camerondurham/mirrord/runs/7167446938?check_suite_focus=true))
2. local GH action run not setting `MIRRORD_IMPERSONATED_CONTAINER_NAME` ([link](https://github.com/camerondurham/mirrord/actions/runs/2604311840))
3. local GH action sanity check failed when setting `MIRRORD_IMPERSONATED_CONTAINER_NAME=testgarbage` ([link](https://github.com/camerondurham/mirrord/runs/7167505799?check_suite_focus=true#step:15:76))

Example failure:

https://github.com/camerondurham/mirrord/runs/7167505799?check_suite_focus=true#step:15:76

```
stderr 7282: thread '<unnamed>' panicked at 'called `Result::unwrap()` on an `Err` value: no container named testgarbage found in namespace=default, pod=http-echo-gw7u7b2-59cdf9cf46-pfqwp', mirrord-layer/src/pod_api.rs:49:18
```


Thanks!