### PR TITLE
Downgrade es5-ext so we don't get flagged as malicious

### DIFF
--- a/vscode-ext/package-lock.json
+++ b/vscode-ext/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "2.3.1",
 			"dependencies": {
 				"@kubernetes/client-node": "^0.16.3",
+				"es5-ext": "<=0.10.53",
 				"ffi-napi": "^4.0.3",
 				"nan": "^2.15.0",
 				"node-go-require": "^2.0.0",
@@ -1474,17 +1475,13 @@
 			}
 		},
 		"node_modules/es5-ext": {
-			"version": "0.10.61",
-			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.61.tgz",
-			"integrity": "sha512-yFhIqQAzu2Ca2I4SE2Au3rxVfmohU9Y7wqGR+s7+H7krk26NXhIRAZDgqd6xqjCEFUomDEA3/Bo/7fKmIkW1kA==",
-			"hasInstallScript": true,
+			"version": "0.10.53",
+			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
+			"integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
 			"dependencies": {
-				"es6-iterator": "^2.0.3",
-				"es6-symbol": "^3.1.3",
-				"next-tick": "^1.1.0"
-			},
-			"engines": {
-				"node": ">=0.10"
+				"es6-iterator": "~2.0.3",
+				"es6-symbol": "~3.1.3",
+				"next-tick": "~1.0.0"
 			}
 		},
 		"node_modules/es6-iterator": {
@@ -3480,9 +3477,9 @@
 			"dev": true
 		},
 		"node_modules/next-tick": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-			"integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+			"integrity": "sha512-mc/caHeUcdjnC/boPWJefDr4KUIWQNv+tlnFnJd38QMou86QtxQzBJfxgGRzvx8jazYRqrVlaHarfO72uNxPOg=="
 		},
 		"node_modules/node-abi": {
 			"version": "3.22.0",
@@ -6256,13 +6253,13 @@
 			"dev": true
 		},
 		"es5-ext": {
-			"version": "0.10.61",
-			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.61.tgz",
-			"integrity": "sha512-yFhIqQAzu2Ca2I4SE2Au3rxVfmohU9Y7wqGR+s7+H7krk26NXhIRAZDgqd6xqjCEFUomDEA3/Bo/7fKmIkW1kA==",
+			"version": "0.10.53",
+			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
+			"integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
 			"requires": {
-				"es6-iterator": "^2.0.3",
-				"es6-symbol": "^3.1.3",
-				"next-tick": "^1.1.0"
+				"es6-iterator": "~2.0.3",
+				"es6-symbol": "~3.1.3",
+				"next-tick": "~1.0.0"
 			}
 		},
 		"es6-iterator": {
@@ -7676,9 +7673,9 @@
 			"dev": true
 		},
 		"next-tick": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-			"integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+			"integrity": "sha512-mc/caHeUcdjnC/boPWJefDr4KUIWQNv+tlnFnJd38QMou86QtxQzBJfxgGRzvx8jazYRqrVlaHarfO72uNxPOg=="
 		},
 		"node-abi": {
 			"version": "3.22.0",

--- a/vscode-ext/package.json
+++ b/vscode-ext/package.json
@@ -77,6 +77,7 @@
 		"ref-array-napi": "^1.2.2",
 		"ref-napi": "^3.0.3",
 		"ref-struct-napi": "^1.1.1",
-		"semver": "^7.3.7"
+		"semver": "^7.3.7",
+		"es5-ext": "<=0.10.53"
 	}
 }


### PR DESCRIPTION
es5-ext 10.54+ is contains [protestware](https://medium.com/checkmarx-security/new-protestware-found-lurking-in-highly-popular-npm-package-d46f8ba67e36) which is flagged as malicious by the VSCode marketplace. Downgrade the dependency so we don't get flagged.
![image](https://user-images.githubusercontent.com/41201924/178148924-e3a440f6-2dc1-4cf6-9e4c-0878415ababc.png)
