### PR TITLE
remove ephemeral containers feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+### Removed
+- Removed Ephemeral Containers until they become better supported.
+
 ## 2.5.0
 
 ### Added

--- a/mirrord-cli/src/config.rs
+++ b/mirrord-cli/src/config.rs
@@ -77,8 +77,4 @@ pub(super) struct ExecArgs {
     /// Where to extract the library to (defaults to a temp dir)
     #[clap(long, value_parser)]
     pub extract_path: Option<String>,
-
-    /// Use an Ephemeral Container to mirror traffic.
-    #[clap(short, long, value_parser)]
-    pub ephemeral_container: bool,
 }

--- a/mirrord-cli/src/main.rs
+++ b/mirrord-cli/src/main.rs
@@ -134,10 +134,6 @@ fn exec(args: &ExecArgs) -> Result<()> {
         std::env::set_var("MIRRORD_ACCEPT_INVALID_CERTIFICATES", "true");
     }
 
-    if args.ephemeral_container {
-        std::env::set_var("MIRRORD_EPHEMERAL_CONTAINER", "true");
-    };
-
     let library_path = extract_library(args.extract_path.clone())?;
     add_to_preload(library_path.to_str().unwrap()).unwrap();
 

--- a/mirrord-layer/src/config.rs
+++ b/mirrord-layer/src/config.rs
@@ -40,9 +40,6 @@ pub struct LayerConfig {
     #[envconfig(from = "MIRRORD_OVERRIDE_ENV_VARS_INCLUDE", default = "")]
     pub override_env_vars_include: String,
 
-    #[envconfig(from = "MIRRORD_EPHEMERAL_CONTAINER", default = "false")]
-    pub ephemeral_container: bool,
-
     /// Enables resolving a remote DNS.
     #[envconfig(from = "MIRRORD_REMOTE_DNS", default = "false")]
     pub remote_dns: bool,

--- a/mirrord-layer/src/pod_api.rs
+++ b/mirrord-layer/src/pod_api.rs
@@ -8,8 +8,8 @@ use kube::{
     Client, Config,
 };
 use rand::distributions::{Alphanumeric, DistString};
-use serde_json::{json, to_vec};
-use tracing::{debug, error, info, warn};
+use serde_json::json;
+use tracing::{error, info, warn};
 
 use crate::{config::LayerConfig, error::LayerError};
 

--- a/mirrord-layer/src/pod_api.rs
+++ b/mirrord-layer/src/pod_api.rs
@@ -1,9 +1,6 @@
 use anyhow::{Context, Result};
 use futures::{StreamExt, TryStreamExt};
-use k8s_openapi::api::{
-    batch::v1::Job,
-    core::v1::{EphemeralContainer, Pod},
-};
+use k8s_openapi::api::{batch::v1::Job, core::v1::Pod};
 use kube::{
     api::{Api, ListParams, Portforwarder, PostParams},
     core::WatchEvent,
@@ -81,7 +78,6 @@ pub async fn create_agent(config: LayerConfig) -> Result<Portforwarder, LayerErr
         impersonated_pod_name,
         impersonated_pod_namespace,
         impersonated_container_name,
-        ephemeral_container,
         accept_invalid_certificates,
         ..
     } = config.clone();
@@ -101,20 +97,17 @@ pub async fn create_agent(config: LayerConfig) -> Result<Portforwarder, LayerErr
         concat!("ghcr.io/metalbear-co/mirrord:", env!("CARGO_PKG_VERSION")).to_string()
     });
 
-    let pod_name = if ephemeral_container {
-        create_ephemeral_container_agent(&config, agent_image, &pods_api).await?
-    } else {
-        let runtime_data = RuntimeData::from_k8s(
-            client.clone(),
-            &impersonated_pod_name,
-            &impersonated_pod_namespace,
-            &impersonated_container_name,
-        )
-        .await;
-        let jobs_api: Api<Job> = Api::namespaced(client.clone(), &agent_namespace);
+    let runtime_data = RuntimeData::from_k8s(
+        client.clone(),
+        &impersonated_pod_name,
+        &impersonated_pod_namespace,
+        &impersonated_container_name,
+    )
+    .await;
+    let jobs_api: Api<Job> = Api::namespaced(client.clone(), &agent_namespace);
 
-        create_job_pod_agent(&config, agent_image, &pods_api, runtime_data, &jobs_api).await?
-    };
+    let pod_name =
+        create_job_pod_agent(&config, agent_image, &pods_api, runtime_data, &jobs_api).await?;
     pods_api
         .portforward(&pod_name, &[61337])
         .await
@@ -129,82 +122,6 @@ fn get_agent_name() -> String {
             .to_lowercase()
     );
     agent_name
-}
-
-async fn create_ephemeral_container_agent(
-    config: &LayerConfig,
-    agent_image: String,
-    pods_api: &Api<Pod>,
-) -> Result<String, LayerError> {
-    warn!("Ephemeral Containers is an experimental feature
-              >> Refer https://kubernetes.io/docs/concepts/workloads/pods/ephemeral-containers/ for more info");
-
-    let mirrord_agent_name = get_agent_name();
-
-    let ephemeral_container: EphemeralContainer = serde_json::from_value(json!({
-        "name": mirrord_agent_name,
-        "image": agent_image,
-        "imagePullPolicy": config.image_pull_policy,
-        "target_container_name": config.impersonated_container_name,
-        "env": [{"name": "RUST_LOG", "value": config.agent_rust_log}],
-        "command": [
-            "./mirrord-agent",
-            "-t",
-            "30",
-        ],
-    }))?;
-    debug!("Requesting ephemeral_containers_subresource");
-
-    let mut ephemeral_containers_subresource = pods_api
-        .get_subresource("ephemeralcontainers", &config.impersonated_pod_name)
-        .await
-        .map_err(LayerError::KubeError)?;
-
-    let mut spec = ephemeral_containers_subresource
-        .spec
-        .as_mut()
-        .ok_or_else(|| LayerError::PodSpecNotFound(config.impersonated_pod_name.clone()))?;
-
-    spec.ephemeral_containers = match spec.ephemeral_containers.clone() {
-        Some(mut ephemeral_containers) => {
-            ephemeral_containers.push(ephemeral_container);
-            Some(ephemeral_containers)
-        }
-        None => Some(vec![ephemeral_container]),
-    };
-
-    pods_api
-        .replace_subresource(
-            "ephemeralcontainers",
-            &config.impersonated_pod_name,
-            &PostParams::default(),
-            to_vec(&ephemeral_containers_subresource).unwrap(),
-        )
-        .await
-        .map_err(LayerError::KubeError)?;
-
-    let params = ListParams::default()
-        .fields(&format!("metadata.name={}", "mirrord_agent"))
-        .timeout(10);
-
-    let mut stream = pods_api
-        .watch(&params, "0")
-        .await
-        .map_err(LayerError::KubeError)?
-        .boxed();
-
-    while let Some(status) = stream.try_next().await? {
-        match status {
-            WatchEvent::Added(_) => break,
-            WatchEvent::Error(s) => {
-                error!("Error watching pod: {:?}", s);
-                break;
-            }
-            _ => {}
-        }
-    }
-
-    Ok(config.impersonated_pod_name.clone())
 }
 
 async fn create_job_pod_agent(

--- a/tests/src/sanity.rs
+++ b/tests/src/sanity.rs
@@ -76,9 +76,6 @@ mod tests {
         #[cfg(target_os = "macos")]
         GoHTTP,
     }
-    pub enum Agent {
-        Job,
-    }
 
     struct TestProcess {
         pub child: Child,
@@ -180,14 +177,6 @@ mod tests {
                 Application::GoHTTP => vec!["go-e2e/go-e2e"],
             };
             run(process_cmd, pod_name, namespace, args).await
-        }
-    }
-
-    impl Agent {
-        fn flag(&self) -> Option<Vec<&str>> {
-            match self {
-                Agent::Job => None,
-            }
         }
     }
 
@@ -513,13 +502,12 @@ mod tests {
         #[future] service: EchoService,
         #[future] kube_client: Client,
         #[values(Application::PythonHTTP, Application::NodeHTTP)] application: Application,
-        #[values(Agent::Job)] agent: Agent,
     ) {
         let service = service.await;
         let kube_client = kube_client.await;
         let url = get_service_url(kube_client.clone(), &service).await;
         let mut process = application
-            .run(&service.pod_name, Some(&service.namespace), agent.flag())
+            .run(&service.pod_name, Some(&service.namespace), None)
             .await;
         process.wait_for_line(Duration::from_secs(30), "real_port: 80");
         send_requests(&url).await;
@@ -548,13 +536,12 @@ mod tests {
         #[future] service: EchoService,
         #[future] kube_client: Client,
         #[values(Application::PythonHTTP, Application::NodeHTTP, Application::GoHTTP)] application: Application,
-        #[values(Agent::Job)] agent: Agent,
     ) {
         let service = service.await;
         let kube_client = kube_client.await;
         let url = get_service_url(kube_client.clone(), &service).await;
         let mut process = application
-            .run(&service.pod_name, Some(&service.namespace), agent.flag())
+            .run(&service.pod_name, Some(&service.namespace), None)
             .await;
         process.wait_for_line(Duration::from_secs(30), "real_port: 80");
         send_requests(&url).await;
@@ -568,7 +555,7 @@ mod tests {
     #[cfg(target_os = "linux")]
     #[rstest]
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    pub async fn test_file_ops(#[future] service: EchoService, #[values(Agent::Job)] agent: Agent) {
+    pub async fn test_file_ops(#[future] service: EchoService) {
         let service = service.await;
         let _ = std::fs::create_dir(std::path::Path::new("/tmp/fs"));
         let python_command = vec!["python3", "python-e2e/ops.py"];
@@ -592,14 +579,14 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[rstest]
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    pub async fn test_file_ops(#[future] service: EchoService, #[values(Agent::Job)] agent: Agent) {
+    pub async fn test_file_ops(#[future] service: EchoService) {
         let service = service.await;
         let _ = std::fs::create_dir(std::path::Path::new("/tmp/fs"));
         let python_command = vec!["python3", "python-e2e/ops.py"];
 
         let shared_lib_path = get_shared_lib_path();
 
-        let mut args = vec!["--enable-fs", "--extract-path", &shared_lib_path];
+        let args = vec!["--enable-fs", "--extract-path", &shared_lib_path];
 
         let mut process = run(
             python_command,


### PR DESCRIPTION
Few reasons we decided to remove for now:

1. spec cluttering
2. can't support all features (filesystem, traffic stealing) using current feature
