### PR TITLE
remove macOS 10.15, deprecate

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,7 +77,7 @@ jobs:
   test_mirrord_layer_cli:
     strategy:
       matrix:
-        os: [ubuntu-latest, ubuntu-18.04, macos-12, macos-11, macos-10.15]
+        os: [ubuntu-latest, ubuntu-18.04, macos-12, macos-11]
         target:
           [x86_64-unknown-linux-gnu, x86_64-apple-darwin, aarch64-apple-darwin]
         exclude:
@@ -94,10 +94,6 @@ jobs:
           - os: macos-11
             target: aarch64-apple-darwin
           - os: macos-11
-            target: x86_64-unknown-linux-gnu
-          - os: macos-10.15
-            target: aarch64-apple-darwin
-          - os: macos-10.15
             target: x86_64-unknown-linux-gnu
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
https://github.blog/changelog/2022-0)7-20-github-actions-the-macos-10-15-actions-runner-image-is-being-deprecated-and-will-be-removed-by-8-30-22/