### PR TITLE
Restore ephemeral containers feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 
 ### Added
-- Add a flag for the agent, `--ephemeral`, to correctly refer to the filesystem i.e. refer to filesystem path as `/proc/1/root` when the flag is on, otherwise `/`.
+- Add a flag for the agent, `--ephemeral-container`, to correctly refer to the filesystem i.e. refer to root path as `/proc/1/root` when the flag is on, otherwise `/`.
 
 ### Changed
 - Assign a random port number instead of `61337`. (Reason: A forking process creates multiple agents sending traffic on the same port, causing addrinuse error.)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,12 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ### Added
 - Add a flag for the agent, `--ephemeral`, to correctly refer to the filesystem i.e. refer to filesystem path as `/proc/1/root` when the flag is on, otherwise `/`.
 
+### Changed
+- Assign a random port number instead of `61337`. (Reason: A forking process creates multiple agents sending traffic on the same port, causing addrinuse error.)
+
 ### Fixed
 - Fix filesystem tests to only run if the default path exists.
+
 
 ## 2.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+## Added
+- Refer to filesystem path as `/proc/1/root` when there is no container pid.
+
+## Fixed
+- Fix filesystem tests to only run if the default path exists.
+
 ## 2.5.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,6 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
-### Removed
-- Removed Ephemeral Containers until they become better supported.
-
 ## 2.5.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,11 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
-## Added
-- Refer to filesystem path as `/proc/1/root` when there is no container pid.
 
-## Fixed
+### Added
+- Add a flag for the agent, `--ephemeral`, to correctly refer to the filesystem i.e. refer to filesystem path as `/proc/1/root` when the flag is on, otherwise `/`.
+
+### Fixed
 - Fix filesystem tests to only run if the default path exists.
 
 ## 2.5.0

--- a/mirrord-agent/src/cli.rs
+++ b/mirrord-agent/src/cli.rs
@@ -27,7 +27,7 @@ pub struct Args {
     pub interface: String,
 
     /// Inform agent to use /proc/1/root as rootpath
-    #[clap(short = 'e', long, value_parser)]
+    #[clap(short = 'e', long, value_parser, default_value = "false")]
     pub ephemeral: bool,
 }
 

--- a/mirrord-agent/src/cli.rs
+++ b/mirrord-agent/src/cli.rs
@@ -25,6 +25,10 @@ pub struct Args {
     /// Interface to use
     #[clap(short = 'i', long, default_value = "eth0", value_parser)]
     pub interface: String,
+
+    /// Inform agent to use /proc/1/root as rootpath
+    #[clap(short = 'e', long, value_parser)]
+    pub ephemeral: bool,
 }
 
 const DEFAULT_RUNTIME: &str = "containerd";

--- a/mirrord-agent/src/cli.rs
+++ b/mirrord-agent/src/cli.rs
@@ -25,10 +25,6 @@ pub struct Args {
     /// Interface to use
     #[clap(short = 'i', long, default_value = "eth0", value_parser)]
     pub interface: String,
-
-    /// Inform agent to use /proc/1/root as rootpath
-    #[clap(short = 'e', long, value_parser, default_value = "false")]
-    pub ephemeral: bool,
 }
 
 const DEFAULT_RUNTIME: &str = "containerd";

--- a/mirrord-agent/src/cli.rs
+++ b/mirrord-agent/src/cli.rs
@@ -25,6 +25,10 @@ pub struct Args {
     /// Interface to use
     #[clap(short = 'i', long, default_value = "eth0", value_parser)]
     pub interface: String,
+
+    /// Inform the agent to use `proc/1/root` as the root directory.
+    #[clap(short = 'e', long, default_value_t = false, value_parser)]
+    pub ephemeral_container: bool,
 }
 
 const DEFAULT_RUNTIME: &str = "containerd";

--- a/mirrord-agent/src/file.rs
+++ b/mirrord-agent/src/file.rs
@@ -73,7 +73,8 @@ impl FileManager {
         }
     }
 
-    pub fn new(pid: Option<u64>) -> Self {
+    pub fn new(pid: Option<u64>, ephemeral: bool) -> Self {
+        let pid = pid.map(|pid| if ephemeral { 1 } else { pid });
         let root_path = match pid {
             Some(pid) => PathBuf::from("/proc").join(pid.to_string()).join("root"),
             None => PathBuf::from("/"),

--- a/mirrord-agent/src/file.rs
+++ b/mirrord-agent/src/file.rs
@@ -73,8 +73,7 @@ impl FileManager {
         }
     }
 
-    pub fn new(pid: Option<u64>, ephemeral: bool) -> Self {
-        let pid = pid.map(|pid| if ephemeral { 1 } else { pid });
+    pub fn new(pid: Option<u64>) -> Self {
         let root_path = match pid {
             Some(pid) => PathBuf::from("/proc").join(pid.to_string()).join("root"),
             None => PathBuf::from("/"),

--- a/mirrord-agent/src/file.rs
+++ b/mirrord-agent/src/file.rs
@@ -86,7 +86,7 @@ impl FileManager {
             }
         };
         debug!("Using root path: {}", root_path.display());
-        let ls = std::fs::read_dir("/").unwrap();
+        let ls = std::fs::read_dir("/proc/1/root").unwrap();
         let _ = ls.map(|x| debug!("dir = {:?}", x.unwrap()));
         Self {
             open_files: HashMap::new(),

--- a/mirrord-agent/src/file.rs
+++ b/mirrord-agent/src/file.rs
@@ -12,7 +12,7 @@ use mirrord_protocol::{
     ReadFileResponse, RemoteResult, ResponseError, SeekFileRequest, SeekFileResponse,
     WriteFileRequest, WriteFileResponse,
 };
-use tracing::{error, trace};
+use tracing::{error, trace, debug};
 
 use crate::{error::AgentError, util::IndexAllocator};
 
@@ -74,6 +74,7 @@ impl FileManager {
     }
 
     pub fn new(pid: Option<u64>, ephemeral: bool) -> Self {
+        debug!("Using ephemeral containers: {}", ephemeral);
         let root_path = match pid {
             Some(pid) => PathBuf::from("/proc").join(pid.to_string()).join("root"),
             None => {
@@ -84,6 +85,9 @@ impl FileManager {
                 }
             }
         };
+        debug!("Using root path: {}", root_path.display());
+        let ls = std::fs::read_dir("/").unwrap();
+        let _ = ls.map(|x| println!("{:?}", x.unwrap()));
         Self {
             open_files: HashMap::new(),
             root_path,

--- a/mirrord-agent/src/file.rs
+++ b/mirrord-agent/src/file.rs
@@ -73,10 +73,16 @@ impl FileManager {
         }
     }
 
-    pub fn new(pid: Option<u64>) -> Self {
+    pub fn new(pid: Option<u64>, ephemeral: bool) -> Self {
         let root_path = match pid {
             Some(pid) => PathBuf::from("/proc").join(pid.to_string()).join("root"),
-            None => PathBuf::from("/proc").join("1").join("root"),
+            None => {
+                if ephemeral {
+                    PathBuf::from("/proc").join("1").join("root")
+                } else {
+                    PathBuf::from("/")
+                }
+            }
         };
         Self {
             open_files: HashMap::new(),

--- a/mirrord-agent/src/file.rs
+++ b/mirrord-agent/src/file.rs
@@ -76,7 +76,7 @@ impl FileManager {
     pub fn new(pid: Option<u64>) -> Self {
         let root_path = match pid {
             Some(pid) => PathBuf::from("/proc").join(pid.to_string()).join("root"),
-            None => PathBuf::from("/"),
+            None => PathBuf::from("/proc").join("1").join("root"),
         };
         Self {
             open_files: HashMap::new(),

--- a/mirrord-agent/src/file.rs
+++ b/mirrord-agent/src/file.rs
@@ -12,7 +12,7 @@ use mirrord_protocol::{
     ReadFileResponse, RemoteResult, ResponseError, SeekFileRequest, SeekFileResponse,
     WriteFileRequest, WriteFileResponse,
 };
-use tracing::{error, trace, debug};
+use tracing::{error, trace};
 
 use crate::{error::AgentError, util::IndexAllocator};
 
@@ -73,21 +73,11 @@ impl FileManager {
         }
     }
 
-    pub fn new(pid: Option<u64>, ephemeral: bool) -> Self {
-        debug!("Using ephemeral containers: {}", ephemeral);
+    pub fn new(pid: Option<u64>) -> Self {
         let root_path = match pid {
             Some(pid) => PathBuf::from("/proc").join(pid.to_string()).join("root"),
-            None => {
-                if ephemeral {
-                    PathBuf::from("/proc").join("1").join("root")
-                } else {
-                    PathBuf::from("/")
-                }
-            }
+            None => PathBuf::from("/"),
         };
-        debug!("Using root path: {}", root_path.display());
-        let ls = std::fs::read_dir("/proc/1/root").unwrap();
-        let _ = ls.map(|x| debug!("dir = {:?}", x.unwrap()));
         Self {
             open_files: HashMap::new(),
             root_path,

--- a/mirrord-agent/src/file.rs
+++ b/mirrord-agent/src/file.rs
@@ -73,10 +73,16 @@ impl FileManager {
         }
     }
 
-    pub fn new(pid: Option<u64>) -> Self {
+    pub fn new(pid: Option<u64>, ephemeral: bool) -> Self {
         let root_path = match pid {
             Some(pid) => PathBuf::from("/proc").join(pid.to_string()).join("root"),
-            None => PathBuf::from("/"),
+            None => {
+                if ephemeral {
+                    PathBuf::from("/proc").join("1".to_string()).join("root")
+                } else {
+                    PathBuf::from("/")
+                }
+            }
         };
         Self {
             open_files: HashMap::new(),

--- a/mirrord-agent/src/file.rs
+++ b/mirrord-agent/src/file.rs
@@ -78,7 +78,7 @@ impl FileManager {
             Some(pid) => PathBuf::from("/proc").join(pid.to_string()).join("root"),
             None => {
                 if ephemeral {
-                    PathBuf::from("/proc").join("1".to_string()).join("root")
+                    PathBuf::from("/proc").join("1").join("root")
                 } else {
                     PathBuf::from("/")
                 }

--- a/mirrord-agent/src/file.rs
+++ b/mirrord-agent/src/file.rs
@@ -12,7 +12,7 @@ use mirrord_protocol::{
     ReadFileResponse, RemoteResult, ResponseError, SeekFileRequest, SeekFileResponse,
     WriteFileRequest, WriteFileResponse,
 };
-use tracing::{error, trace};
+use tracing::{debug, error, trace};
 
 use crate::{error::AgentError, util::IndexAllocator};
 
@@ -73,17 +73,12 @@ impl FileManager {
         }
     }
 
-    pub fn new(pid: Option<u64>, ephemeral: bool) -> Self {
+    pub fn new(pid: Option<u64>) -> Self {
         let root_path = match pid {
             Some(pid) => PathBuf::from("/proc").join(pid.to_string()).join("root"),
-            None => {
-                if ephemeral {
-                    PathBuf::from("/proc").join("1").join("root")
-                } else {
-                    PathBuf::from("/")
-                }
-            }
+            None => PathBuf::from("/"),
         };
+        debug!("Agent root path >> {root_path:?}");
         Self {
             open_files: HashMap::new(),
             root_path,

--- a/mirrord-agent/src/file.rs
+++ b/mirrord-agent/src/file.rs
@@ -87,7 +87,7 @@ impl FileManager {
         };
         debug!("Using root path: {}", root_path.display());
         let ls = std::fs::read_dir("/").unwrap();
-        let _ = ls.map(|x| println!("{:?}", x.unwrap()));
+        let _ = ls.map(|x| debug!("dir = {:?}", x.unwrap()));
         Self {
             open_files: HashMap::new(),
             root_path,

--- a/mirrord-agent/src/main.rs
+++ b/mirrord-agent/src/main.rs
@@ -311,9 +311,9 @@ async fn start_agent() -> Result<(), AgentError> {
         }
         _ => {
             if args.ephemeral_container {
-                None
-            } else {
                 Some(1)
+            } else {
+                None
             }
         }
     };

--- a/mirrord-agent/src/main.rs
+++ b/mirrord-agent/src/main.rs
@@ -183,11 +183,10 @@ impl ClientConnectionHandler {
         id: ClientID,
         stream: TcpStream,
         pid: Option<u64>,
-        ephemeral: bool,
         sniffer_command_sender: Sender<SnifferCommand>,
         cancel_token: CancellationToken,
     ) -> Result<(), AgentError> {
-        let file_manager = FileManager::new(pid, ephemeral);
+        let file_manager = FileManager::new(pid);
         let stream = actix_codec::Framed::new(stream, DaemonCodec::new());
 
         let (tcp_sender, tcp_receiver) = mpsc::channel(CHANNEL_SIZE);
@@ -310,7 +309,13 @@ async fn start_agent() -> Result<(), AgentError> {
         (Some(container_id), Some(container_runtime)) => {
             Some(get_container_pid(&container_id, &container_runtime).await?)
         }
-        _ => None,
+        _ => {
+            if args.ephemeral_container {
+                None
+            } else {
+                Some(1)
+            }
+        }
     };
 
     let mut state = State::new();
@@ -338,7 +343,7 @@ async fn start_agent() -> Result<(), AgentError> {
                     let sniffer_command_tx = sniffer_command_tx.clone();
                     let cancellation_token = cancellation_token.clone();
                     let client = tokio::spawn(async move {
-                        match ClientConnectionHandler::start(client_id, stream, pid, args.ephemeral_container, sniffer_command_tx, cancellation_token).await {
+                        match ClientConnectionHandler::start(client_id, stream, pid, sniffer_command_tx, cancellation_token).await {
                             Ok(_) => {
                                 debug!("ClientConnectionHandler::start -> Client {} disconnected", client_id);
                             }

--- a/mirrord-agent/src/main.rs
+++ b/mirrord-agent/src/main.rs
@@ -337,10 +337,10 @@ async fn start_agent() -> Result<(), AgentError> {
                     let sniffer_command_tx = sniffer_command_tx.clone();
                     let cancellation_token = cancellation_token.clone();
                     let client = tokio::spawn(async move {
-                    pid = pid.and_then(|pid| if args.ephemeral_container {
-                            Some(1)
+                    pid = pid.map(|pid| if args.ephemeral_container {
+                            1
                         } else {
-                            Some(pid)
+                            pid
                         });
                         match ClientConnectionHandler::start(client_id, stream, pid, sniffer_command_tx, cancellation_token).await {
                             Ok(_) => {

--- a/mirrord-agent/src/main.rs
+++ b/mirrord-agent/src/main.rs
@@ -183,11 +183,10 @@ impl ClientConnectionHandler {
         id: ClientID,
         stream: TcpStream,
         pid: Option<u64>,
-        ephemeral: bool,
         sniffer_command_sender: Sender<SnifferCommand>,
         cancel_token: CancellationToken,
     ) -> Result<(), AgentError> {
-        let file_manager = FileManager::new(pid, ephemeral);
+        let file_manager = FileManager::new(pid);
         let stream = actix_codec::Framed::new(stream, DaemonCodec::new());
 
         let (tcp_sender, tcp_receiver) = mpsc::channel(CHANNEL_SIZE);
@@ -338,7 +337,7 @@ async fn start_agent() -> Result<(), AgentError> {
                     let sniffer_command_tx = sniffer_command_tx.clone();
                     let cancellation_token = cancellation_token.clone();
                     let client = tokio::spawn(async move {
-                        match ClientConnectionHandler::start(client_id, stream, pid, args.ephemeral, sniffer_command_tx, cancellation_token).await {
+                        match ClientConnectionHandler::start(client_id, stream, pid, sniffer_command_tx, cancellation_token).await {
                             Ok(_) => {
                                 debug!("ClientConnectionHandler::start -> Client {} disconnected", client_id);
                             }

--- a/mirrord-agent/src/main.rs
+++ b/mirrord-agent/src/main.rs
@@ -183,10 +183,11 @@ impl ClientConnectionHandler {
         id: ClientID,
         stream: TcpStream,
         pid: Option<u64>,
+        ephemeral: bool,
         sniffer_command_sender: Sender<SnifferCommand>,
         cancel_token: CancellationToken,
     ) -> Result<(), AgentError> {
-        let file_manager = FileManager::new(pid);
+        let file_manager = FileManager::new(pid, ephemeral);
         let stream = actix_codec::Framed::new(stream, DaemonCodec::new());
 
         let (tcp_sender, tcp_receiver) = mpsc::channel(CHANNEL_SIZE);
@@ -337,7 +338,7 @@ async fn start_agent() -> Result<(), AgentError> {
                     let sniffer_command_tx = sniffer_command_tx.clone();
                     let cancellation_token = cancellation_token.clone();
                     let client = tokio::spawn(async move {
-                        match ClientConnectionHandler::start(client_id, stream, pid, sniffer_command_tx, cancellation_token).await {
+                        match ClientConnectionHandler::start(client_id, stream, pid, args.ephemeral, sniffer_command_tx, cancellation_token).await {
                             Ok(_) => {
                                 debug!("ClientConnectionHandler::start -> Client {} disconnected", client_id);
                             }

--- a/mirrord-agent/src/main.rs
+++ b/mirrord-agent/src/main.rs
@@ -189,13 +189,8 @@ impl ClientConnectionHandler {
     ) -> Result<(), AgentError> {
         let file_manager = match pid {
             Some(_) => FileManager::new(pid),
-            None => {
-                if ephemeral {
-                    FileManager::new(Some(1))
-                } else {
-                    FileManager::new(None)
-                }
-            }
+            None if ephemeral => FileManager::new(Some(1)),
+            None => FileManager::new(None),
         };
         let stream = actix_codec::Framed::new(stream, DaemonCodec::new());
 

--- a/mirrord-agent/src/main.rs
+++ b/mirrord-agent/src/main.rs
@@ -183,10 +183,11 @@ impl ClientConnectionHandler {
         id: ClientID,
         stream: TcpStream,
         pid: Option<u64>,
+        ephemeral: bool,
         sniffer_command_sender: Sender<SnifferCommand>,
         cancel_token: CancellationToken,
     ) -> Result<(), AgentError> {
-        let file_manager = FileManager::new(pid);
+        let file_manager = FileManager::new(pid, ephemeral);
         let stream = actix_codec::Framed::new(stream, DaemonCodec::new());
 
         let (tcp_sender, tcp_receiver) = mpsc::channel(CHANNEL_SIZE);
@@ -337,7 +338,7 @@ async fn start_agent() -> Result<(), AgentError> {
                     let sniffer_command_tx = sniffer_command_tx.clone();
                     let cancellation_token = cancellation_token.clone();
                     let client = tokio::spawn(async move {
-                        match ClientConnectionHandler::start(client_id, stream, pid, sniffer_command_tx, cancellation_token).await {
+                        match ClientConnectionHandler::start(client_id, stream, pid, args.ephemeral_container, sniffer_command_tx, cancellation_token).await {
                             Ok(_) => {
                                 debug!("ClientConnectionHandler::start -> Client {} disconnected", client_id);
                             }

--- a/mirrord-agent/src/main.rs
+++ b/mirrord-agent/src/main.rs
@@ -187,7 +187,16 @@ impl ClientConnectionHandler {
         sniffer_command_sender: Sender<SnifferCommand>,
         cancel_token: CancellationToken,
     ) -> Result<(), AgentError> {
-        let file_manager = FileManager::new(pid, ephemeral);
+        let file_manager = match pid {
+            Some(_) => FileManager::new(pid),
+            None => {
+                if ephemeral {
+                    FileManager::new(Some(1))
+                } else {
+                    FileManager::new(None)
+                }
+            }
+        };
         let stream = actix_codec::Framed::new(stream, DaemonCodec::new());
 
         let (tcp_sender, tcp_receiver) = mpsc::channel(CHANNEL_SIZE);

--- a/mirrord-agent/src/main.rs
+++ b/mirrord-agent/src/main.rs
@@ -187,8 +187,7 @@ impl ClientConnectionHandler {
         sniffer_command_sender: Sender<SnifferCommand>,
         cancel_token: CancellationToken,
     ) -> Result<(), AgentError> {
-        let pid = pid.map(|pid| if ephemeral { 1 } else { pid });
-        let file_manager = FileManager::new(pid);
+        let file_manager = FileManager::new(pid, ephemeral);
         let stream = actix_codec::Framed::new(stream, DaemonCodec::new());
 
         let (tcp_sender, tcp_receiver) = mpsc::channel(CHANNEL_SIZE);
@@ -307,7 +306,7 @@ async fn start_agent() -> Result<(), AgentError> {
     ))
     .await?;
 
-    let mut pid = match (args.container_id, args.container_runtime) {
+    let pid = match (args.container_id, args.container_runtime) {
         (Some(container_id), Some(container_runtime)) => {
             Some(get_container_pid(&container_id, &container_runtime).await?)
         }

--- a/mirrord-cli/src/config.rs
+++ b/mirrord-cli/src/config.rs
@@ -77,4 +77,8 @@ pub(super) struct ExecArgs {
     /// Where to extract the library to (defaults to a temp dir)
     #[clap(long, value_parser)]
     pub extract_path: Option<String>,
+
+    /// Use an Ephemeral Container to mirror traffic.
+    #[clap(short, long, value_parser)]
+    pub ephemeral_container: bool,
 }

--- a/mirrord-cli/src/main.rs
+++ b/mirrord-cli/src/main.rs
@@ -134,6 +134,10 @@ fn exec(args: &ExecArgs) -> Result<()> {
         std::env::set_var("MIRRORD_ACCEPT_INVALID_CERTIFICATES", "true");
     }
 
+    if args.ephemeral_container {
+        std::env::set_var("MIRRORD_EPHEMERAL_CONTAINER", "true");
+    };
+
     let library_path = extract_library(args.extract_path.clone())?;
     add_to_preload(library_path.to_str().unwrap()).unwrap();
 

--- a/mirrord-layer/src/config.rs
+++ b/mirrord-layer/src/config.rs
@@ -40,6 +40,9 @@ pub struct LayerConfig {
     #[envconfig(from = "MIRRORD_OVERRIDE_ENV_VARS_INCLUDE", default = "")]
     pub override_env_vars_include: String,
 
+    #[envconfig(from = "MIRRORD_EPHEMERAL_CONTAINER", default = "false")]
+    pub ephemeral_container: bool,
+
     /// Enables resolving a remote DNS.
     #[envconfig(from = "MIRRORD_REMOTE_DNS", default = "false")]
     pub remote_dns: bool,

--- a/mirrord-layer/src/lib.rs
+++ b/mirrord-layer/src/lib.rs
@@ -52,10 +52,8 @@ pub static mut HOOK_SENDER: Option<Sender<HookMessage>> = None;
 
 pub static ENABLED_FILE_OPS: OnceLock<bool> = OnceLock::new();
 
-pub static CONNECTION_PORT: LazyLock<u16> = LazyLock::new(|| {
-    let num = rand::thread_rng().gen_range(30000..=65535);
-    num
-});
+pub static CONNECTION_PORT: LazyLock<u16> =
+    LazyLock::new(|| rand::thread_rng().gen_range(30000..=65535));
 
 #[ctor]
 fn init() {

--- a/mirrord-layer/src/lib.rs
+++ b/mirrord-layer/src/lib.rs
@@ -63,6 +63,9 @@ fn init() {
 
     let config = LayerConfig::init_from_env().unwrap();
     let connection_port: u16 = rand::thread_rng().gen_range(30000..=65535);
+
+    info!("Using port `{connection_port:?}` for communication");
+
     let port_forwarder = RUNTIME
         .block_on(pod_api::create_agent(config.clone(), connection_port))
         .unwrap_or_else(|e| {

--- a/mirrord-layer/src/pod_api.rs
+++ b/mirrord-layer/src/pod_api.rs
@@ -145,13 +145,13 @@ async fn create_ephemeral_container_agent(
         "name": mirrord_agent_name,
         "image": agent_image,
         "imagePullPolicy": config.image_pull_policy,
-        "target_container_name": config.impersonated_container_name,
+        "targetContainerName": config.impersonated_container_name,
+        "workingDir": "/proc/1/root",
         "env": [{"name": "RUST_LOG", "value": config.agent_rust_log}],
         "command": [
             "./mirrord-agent",
             "-t",
             "30",
-            "--ephemeral",
         ],
     }))?;
     debug!("Requesting ephemeral_containers_subresource");

--- a/mirrord-layer/src/pod_api.rs
+++ b/mirrord-layer/src/pod_api.rs
@@ -126,7 +126,6 @@ pub async fn create_agent(
         )
         .await?
     };
-    debug!("Creating portforwarder for port {}", connection_port);
     pods_api
         .portforward(&pod_name, &[connection_port])
         .await

--- a/mirrord-layer/src/pod_api.rs
+++ b/mirrord-layer/src/pod_api.rs
@@ -151,6 +151,7 @@ async fn create_ephemeral_container_agent(
             "./mirrord-agent",
             "-t",
             "30",
+            "--ephemeral",
         ],
     }))?;
     debug!("Requesting ephemeral_containers_subresource");

--- a/mirrord-layer/src/pod_api.rs
+++ b/mirrord-layer/src/pod_api.rs
@@ -280,7 +280,6 @@ async fn create_job_pod_agent(
                                 "30",
                                 "-l",
                                 connection_port.to_string(),
-                                "-e",
                             ],
                             "env": [{"name": "RUST_LOG", "value": config.agent_rust_log}],
                         }

--- a/mirrord-layer/src/pod_api.rs
+++ b/mirrord-layer/src/pod_api.rs
@@ -159,7 +159,6 @@ async fn create_ephemeral_container_agent(
         "image": agent_image,
         "imagePullPolicy": config.image_pull_policy,
         "targetContainerName": config.impersonated_container_name,
-        "workingDir": "/proc/1/root",
         "env": [{"name": "RUST_LOG", "value": config.agent_rust_log}],
         "command": [
             "./mirrord-agent",
@@ -167,6 +166,7 @@ async fn create_ephemeral_container_agent(
             "30",
             "-l",
             format!("{}", connection_port),
+            "-e",
         ],
     }))?;
     debug!("Requesting ephemeral_containers_subresource");
@@ -281,6 +281,7 @@ async fn create_job_pod_agent(
                                 "30",
                                 "-l",
                                 format!("{}", connection_port),
+                                "-e",
                             ],
                             "env": [{"name": "RUST_LOG", "value": config.agent_rust_log}],
                         }

--- a/mirrord-layer/src/pod_api.rs
+++ b/mirrord-layer/src/pod_api.rs
@@ -165,7 +165,7 @@ async fn create_ephemeral_container_agent(
             "-t",
             "30",
             "-l",
-            format!("{}", connection_port),
+            connection_port.to_string(),
             "-e",
         ],
     }))?;
@@ -280,7 +280,7 @@ async fn create_job_pod_agent(
                                 "-t",
                                 "30",
                                 "-l",
-                                format!("{}", connection_port),
+                                connection_port.to_string(),
                                 "-e",
                             ],
                             "env": [{"name": "RUST_LOG", "value": config.agent_rust_log}],

--- a/tests/python-e2e/ops.py
+++ b/tests/python-e2e/ops.py
@@ -9,8 +9,7 @@ class FileOpsTest(unittest.TestCase):
     def setUp(self):
         """
         Check if the default file exists.
-        """
-        self.assertTrue(os.path.exists("/app/test.txt"))
+        """        
         with open("/app/test.txt", "r") as f:
             f.seek(0)
             self.assertEqual(f.readline(), TEXT)

--- a/tests/python-e2e/ops.py
+++ b/tests/python-e2e/ops.py
@@ -9,8 +9,11 @@ class FileOpsTest(unittest.TestCase):
     def setUp(self):
         """
         Check if the default file exists.
-        """        
-        self.assertTrue(os.path.exists("/app/test.txt"))        
+        """
+        self.assertTrue(os.path.exists("/app/test.txt"))
+        with open("/app/test.txt", "r") as f:
+            f.seek(0)
+            self.assertEqual(f.readline(), TEXT)
 
     def test_read_write_family(self):
         """
@@ -22,7 +25,6 @@ class FileOpsTest(unittest.TestCase):
             rw_file.seek(0)
             read_text = rw_file.readline()
             self.assertEqual(read_text, TEXT)
-            rw_file.close()
 
     def test_lseek(self):
         """

--- a/tests/python-e2e/ops.py
+++ b/tests/python-e2e/ops.py
@@ -8,12 +8,9 @@ TEXT = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod 
 class FileOpsTest(unittest.TestCase):
     def setUp(self):
         """
-        Skip and raise an exception if the default file does not exist.
-        """
-        try:
-            self.assertTrue(os.path.exists("/app/test.txt"))
-        except AssertionError:
-            self.skipTest("Default file does not exist")
+        Check if the default file exists.
+        """        
+        self.assertTrue(os.path.exists("/app/test.txt"))        
 
     def test_read_write_family(self):
         """

--- a/tests/python-e2e/ops.py
+++ b/tests/python-e2e/ops.py
@@ -6,6 +6,15 @@ TEXT = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod 
 
 
 class FileOpsTest(unittest.TestCase):
+    def setUp(self):
+        """
+        Skip and raise an exception if the default file does not exist.
+        """
+        try:
+            self.assertTrue(os.path.exists("/app/test.txt"))
+        except AssertionError:
+            self.skipTest("Default file does not exist")
+
     def test_read_write_family(self):
         """
         Reads data from a file in "/tmp" and verifies the text expected is the same as the text written.
@@ -39,8 +48,7 @@ class FileOpsTest(unittest.TestCase):
         dir = os.open(
             "/tmp", os.O_RDONLY | os.O_NONBLOCK | os.O_CLOEXEC | os.O_DIRECTORY
         )
-        file = os.open(file_name, os.O_RDWR | os.O_NONBLOCK |
-                       os.O_CLOEXEC, dir_fd=dir)
+        file = os.open(file_name, os.O_RDWR | os.O_NONBLOCK | os.O_CLOEXEC, dir_fd=dir)
         self.assertFalse(self._check_path_exists_on_host(file_path))
         read = os.read(file, len(TEXT) + 1)
         self.assertEqual(read.decode("utf-8"), TEXT)

--- a/tests/src/sanity.rs
+++ b/tests/src/sanity.rs
@@ -578,7 +578,7 @@ mod tests {
     ) {
         let service = service.await;
         let _ = std::fs::create_dir(std::path::Path::new("/tmp/fs"));
-        let python_command = vec!["python3", "python-e2e/ops.py"];
+        let mut python_command = vec![];
 
         let shared_lib_path = get_shared_lib_path();
 
@@ -586,6 +586,9 @@ mod tests {
 
         if let Some(ephemeral_flag) = agent.flag() {
             args.extend(ephemeral_flag);
+            python_command = vec!["python3", "-B", "-m", "unittest", "-f", "python-e2e/ops.py"]
+        } else {
+            python_command = vec!["python3", "python-e2e/ops.py"]
         }
 
         let mut process = run(
@@ -606,7 +609,7 @@ mod tests {
     pub async fn test_file_ops(#[future] service: EchoService, #[values(Agent::Job)] agent: Agent) {
         let service = service.await;
         let _ = std::fs::create_dir(std::path::Path::new("/tmp/fs"));
-        let python_command = vec!["python3", "python-e2e/ops.py"];
+        let mut python_command = vec![];
 
         let shared_lib_path = get_shared_lib_path();
 
@@ -614,6 +617,9 @@ mod tests {
 
         if let Some(ephemeral_flag) = agent.flag() {
             args.extend(ephemeral_flag);
+            python_command = vec!["python3", "-B", "-m", "unittest", "-f", "python-e2e/ops.py"]
+        } else {
+            python_command = vec!["python3", "python-e2e/ops.py"]
         }
 
         let mut process = run(

--- a/tests/src/sanity.rs
+++ b/tests/src/sanity.rs
@@ -76,6 +76,11 @@ mod tests {
         #[cfg(target_os = "macos")]
         GoHTTP,
     }
+    pub enum Agent {
+        #[cfg(target_os = "linux")]
+        Ephemeral,
+        Job,
+    }
 
     struct TestProcess {
         pub child: Child,
@@ -177,6 +182,16 @@ mod tests {
                 Application::GoHTTP => vec!["go-e2e/go-e2e"],
             };
             run(process_cmd, pod_name, namespace, args).await
+        }
+    }
+
+    impl Agent {
+        fn flag(&self) -> Option<Vec<&str>> {
+            match self {
+                #[cfg(target_os = "linux")]
+                Agent::Ephemeral => Some(vec!["--ephemeral-container"]),
+                Agent::Job => None,
+            }
         }
     }
 
@@ -502,12 +517,13 @@ mod tests {
         #[future] service: EchoService,
         #[future] kube_client: Client,
         #[values(Application::PythonHTTP, Application::NodeHTTP)] application: Application,
+        #[values(Agent::Ephemeral, Agent::Job)] agent: Agent,
     ) {
         let service = service.await;
         let kube_client = kube_client.await;
         let url = get_service_url(kube_client.clone(), &service).await;
         let mut process = application
-            .run(&service.pod_name, Some(&service.namespace), None)
+            .run(&service.pod_name, Some(&service.namespace), agent.flag())
             .await;
         process.wait_for_line(Duration::from_secs(30), "real_port: 80");
         send_requests(&url).await;
@@ -536,12 +552,13 @@ mod tests {
         #[future] service: EchoService,
         #[future] kube_client: Client,
         #[values(Application::PythonHTTP, Application::NodeHTTP, Application::GoHTTP)] application: Application,
+        #[values(Agent::Job)] agent: Agent,
     ) {
         let service = service.await;
         let kube_client = kube_client.await;
         let url = get_service_url(kube_client.clone(), &service).await;
         let mut process = application
-            .run(&service.pod_name, Some(&service.namespace), None)
+            .run(&service.pod_name, Some(&service.namespace), agent.flag())
             .await;
         process.wait_for_line(Duration::from_secs(30), "real_port: 80");
         send_requests(&url).await;
@@ -555,7 +572,10 @@ mod tests {
     #[cfg(target_os = "linux")]
     #[rstest]
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    pub async fn test_file_ops(#[future] service: EchoService) {
+    pub async fn test_file_ops(
+        #[future] service: EchoService,
+        #[values(Agent::Ephemeral, Agent::Job)] agent: Agent,
+    ) {
         let service = service.await;
         let _ = std::fs::create_dir(std::path::Path::new("/tmp/fs"));
         let python_command = vec!["python3", "python-e2e/ops.py"];
@@ -563,6 +583,10 @@ mod tests {
         let shared_lib_path = get_shared_lib_path();
 
         let mut args = vec!["--enable-fs", "--extract-path", &shared_lib_path];
+
+        if let Some(ephemeral_flag) = agent.flag() {
+            args.extend(ephemeral_flag);
+        }
 
         let mut process = run(
             python_command,
@@ -579,14 +603,18 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[rstest]
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    pub async fn test_file_ops(#[future] service: EchoService) {
+    pub async fn test_file_ops(#[future] service: EchoService, #[values(Agent::Job)] agent: Agent) {
         let service = service.await;
         let _ = std::fs::create_dir(std::path::Path::new("/tmp/fs"));
         let python_command = vec!["python3", "python-e2e/ops.py"];
 
         let shared_lib_path = get_shared_lib_path();
 
-        let args = vec!["--enable-fs", "--extract-path", &shared_lib_path];
+        let mut args = vec!["--enable-fs", "--extract-path", &shared_lib_path];
+
+        if let Some(ephemeral_flag) = agent.flag() {
+            args.extend(ephemeral_flag);
+        }
 
         let mut process = run(
             python_command,

--- a/tests/src/sanity.rs
+++ b/tests/src/sanity.rs
@@ -578,7 +578,7 @@ mod tests {
     ) {
         let service = service.await;
         let _ = std::fs::create_dir(std::path::Path::new("/tmp/fs"));
-        let mut python_command = vec![];
+        let python_command = vec!["python3", "-B", "-m", "unittest", "-f", "python-e2e/ops.py"];
 
         let shared_lib_path = get_shared_lib_path();
 
@@ -586,9 +586,6 @@ mod tests {
 
         if let Some(ephemeral_flag) = agent.flag() {
             args.extend(ephemeral_flag);
-            python_command = vec!["python3", "-B", "-m", "unittest", "-f", "python-e2e/ops.py"]
-        } else {
-            python_command = vec!["python3", "python-e2e/ops.py"]
         }
 
         let mut process = run(
@@ -609,7 +606,7 @@ mod tests {
     pub async fn test_file_ops(#[future] service: EchoService, #[values(Agent::Job)] agent: Agent) {
         let service = service.await;
         let _ = std::fs::create_dir(std::path::Path::new("/tmp/fs"));
-        let mut python_command = vec![];
+        let python_command = vec!["python3", "-B", "-m", "unittest", "-f", "python-e2e/ops.py"];
 
         let shared_lib_path = get_shared_lib_path();
 
@@ -617,9 +614,6 @@ mod tests {
 
         if let Some(ephemeral_flag) = agent.flag() {
             args.extend(ephemeral_flag);
-            python_command = vec!["python3", "-B", "-m", "unittest", "-f", "python-e2e/ops.py"]
-        } else {
-            python_command = vec!["python3", "python-e2e/ops.py"]
         }
 
         let mut process = run(


### PR DESCRIPTION
- revert the previous commit that removed the feature 
- change path to `proc/pic/root` for fs access when pid is None
- allow fs tests to run if the default path exists