### PR TITLE
Go safer hooks

### DIFF
--- a/mirrord-layer/src/go_hooks.rs
+++ b/mirrord-layer/src/go_hooks.rs
@@ -1,7 +1,7 @@
 #[cfg(target_os = "linux")]
 #[cfg(target_arch = "x86_64")]
 pub(crate) mod go_socket_hooks {
-    use std::{arch::asm, ptr::{null_mut}};
+    use std::{arch::asm, ptr::null_mut};
 
     use errno::errno;
     use frida_gum::interceptor::Interceptor;
@@ -262,8 +262,6 @@ pub(crate) mod go_socket_hooks {
         );
     }
 
-
-
     /// Syscall & Rawsyscall handler - supports upto 4 params, used for socket,
     /// bind, listen, and accept
     /// Note: Depending on success/failure Syscall may or may not call this handler
@@ -377,17 +375,23 @@ pub(crate) mod go_socket_hooks {
     ///   - File zsyscall_linux_amd64.go generated using mksyscall.pl.
     ///   - https://cs.opensource.google/go/go/+/refs/tags/go1.18.5:src/syscall/syscall_unix.go
     pub(crate) fn enable_socket_hooks(interceptor: &mut Interceptor, binary: &str) {
-        if let Some(address) = frida_gum::Module::find_symbol_by_name(Some(binary), "runtime.exitsyscall.abi0") {
+        if let Some(address) =
+            frida_gum::Module::find_symbol_by_name(Some(binary), "runtime.exitsyscall.abi0")
+        {
             unsafe {
                 GO_EXIT_SYSCALL = address.0;
             }
         };
-        if let Some(address) = frida_gum::Module::find_symbol_by_name(Some(binary), "runtime.entersyscall.abi0") {
+        if let Some(address) =
+            frida_gum::Module::find_symbol_by_name(Some(binary), "runtime.entersyscall.abi0")
+        {
             unsafe {
                 GO_ENTER_SYSCALL = address.0;
             }
         };
-        if let Some(address) = frida_gum::Module::find_symbol_by_name(Some(binary), "gosave_systemstack_switch") {
+        if let Some(address) =
+            frida_gum::Module::find_symbol_by_name(Some(binary), "gosave_systemstack_switch")
+        {
             unsafe {
                 GO_SAVE_SYSTEMSTACK = address.0;
             }

--- a/mirrord-layer/src/go_hooks.rs
+++ b/mirrord-layer/src/go_hooks.rs
@@ -24,7 +24,7 @@ pub(crate) mod go_socket_hooks {
     #[naked]
     unsafe extern "C" fn go_rawsyscall_detour() {
         asm!(
-            "call GO_ENTER_SYSCALL",
+            "call [GO_ENTER_SYSCALL]",
             // push the arguments of Rawsyscall from the stack to preserved registers
             "mov rbx, QWORD PTR [rsp+0x10]",
             "mov r10, QWORD PTR [rsp+0x18]",
@@ -46,7 +46,7 @@ pub(crate) mod go_socket_hooks {
             "mov    rsi, QWORD PTR [r8]",
             "cmp    rdi, rsi",
             "je     2f",
-            "call   GO_SAVE_SYSTEMSTACK",
+            "call   [GO_SAVE_SYSTEMSTACK]",
             "mov    QWORD PTR fs:[0xfffffff8], rsi",
             "mov    rsp, QWORD PTR [rsi+0x38]",
             "sub    rsp, 0x40",
@@ -58,7 +58,7 @@ pub(crate) mod go_socket_hooks {
             "mov    rsi, rbx",
             "mov    rdx, r10",
             "mov    rdi, rax",
-            "call   c_abi_syscall_handler",
+            "call   [c_abi_syscall_handler]",
             "mov    rdi, QWORD PTR [rsp+0x30]",
             "mov    rsi, QWORD PTR [rdi+0x8]",
             "sub    rsi, QWORD PTR [rsp+0x28]",
@@ -69,7 +69,7 @@ pub(crate) mod go_socket_hooks {
             "mov    QWORD PTR [rsp+0x28], -0x1",
             "mov    QWORD PTR [rsp+0x30], 0x0",
             "neg    rax",
-            "call GO_EXIT_SYSCALL",
+            "call [GO_EXIT_SYSCALL]",
             "ret",
             // same as `nosave` in the asmcgocall.
             // calls the abi handler, when we have no g
@@ -91,14 +91,14 @@ pub(crate) mod go_socket_hooks {
             "mov    QWORD PTR [rsp+0x30], 0x0",
             "neg    rax",
             "mov    QWORD PTR [rsp+0x38], rax",
-            "call GO_EXIT_SYSCALL",
+            "call [GO_EXIT_SYSCALL]",
             "ret",
             // Failure: Setup the return values and restore the tls.
             "3:",
             "mov    QWORD PTR [rsp+0x28], rax",
             "mov    QWORD PTR [rsp+0x30], 0x0",
             "mov    QWORD PTR [rsp+0x38], 0x0",
-            "call GO_EXIT_SYSCALL",
+            "call [GO_EXIT_SYSCALL]",
             "ret",
             options(noreturn)
         );
@@ -108,7 +108,7 @@ pub(crate) mod go_socket_hooks {
     #[naked]
     unsafe extern "C" fn go_syscall6_detour() {
         asm!(
-            "call GO_ENTER_SYSCALL",
+            "call [GO_ENTER_SYSCALL]",
             "mov rax, QWORD PTR [rsp+0x8]",
             "mov rbx, QWORD PTR [rsp+0x10]",
             "mov r10, QWORD PTR [rsp+0x18]",
@@ -127,7 +127,7 @@ pub(crate) mod go_socket_hooks {
             "mov    rsi, QWORD PTR [r8]",
             "cmp    rdi, rsi",
             "je     2f",
-            "call   GO_SAVE_SYSTEMSTACK",
+            "call   [GO_SAVE_SYSTEMSTACK]",
             "mov    QWORD PTR fs:[0xfffffff8], rsi",
             "mov    rsp, QWORD PTR [rsi+0x38]",
             "sub    rsp, 0x40",
@@ -154,7 +154,7 @@ pub(crate) mod go_socket_hooks {
             "mov    QWORD PTR [rsp+0x48], 0x0",
             "neg    rax",
             "mov    QWORD PTR [rsp+0x50], rax",
-            "call GO_EXIT_SYSCALL",
+            "call [GO_EXIT_SYSCALL]",
             "ret",
             "2:",
             "sub    rsp, 0x40",
@@ -176,13 +176,13 @@ pub(crate) mod go_socket_hooks {
             "mov    QWORD PTR [rsp+0x48], 0x0",
             "neg    rax",
             "mov    QWORD PTR [rsp+0x50], rax",
-            "call GO_EXIT_SYSCALL",
+            "call [GO_EXIT_SYSCALL]",
             "ret",
             "3:",
             "mov    QWORD PTR [rsp+0x40], rax",
             "mov    QWORD PTR [rsp+0x48], 0x0",
             "mov    QWORD PTR [rsp+0x50], 0x0",
-            "call GO_EXIT_SYSCALL",
+            "call [GO_EXIT_SYSCALL]",
             "ret",
             options(noreturn)
         );
@@ -192,7 +192,7 @@ pub(crate) mod go_socket_hooks {
     #[naked]
     unsafe extern "C" fn go_syscall_detour() {
         asm!(
-            "call GO_ENTER_SYSCALL",
+            "call [GO_ENTER_SYSCALL]",
             "mov rax, QWORD PTR [rsp+0x8]",
             "mov rbx, QWORD PTR [rsp+0x10]",
             "mov r10, QWORD PTR [rsp+0x18]",
@@ -208,7 +208,7 @@ pub(crate) mod go_socket_hooks {
             "mov    rsi, QWORD PTR [r8]",
             "cmp    rdi, rsi",
             "je     2f",
-            "call   GO_SAVE_SYSTEMSTACK",
+            "call   [GO_SAVE_SYSTEMSTACK]",
             "mov    QWORD PTR fs:[0xfffffff8], rsi",
             "mov    rsp, QWORD PTR [rsi+0x38]",
             "sub    rsp, 0x40",
@@ -232,7 +232,7 @@ pub(crate) mod go_socket_hooks {
             "mov    QWORD PTR [rsp+0x30], 0x0",
             "neg    rax",
             "mov    QWORD PTR [rsp+0x38], rax",
-            "call GO_EXIT_SYSCALL",
+            "call [GO_EXIT_SYSCALL]",
             "ret",
             "2:",
             "sub    rsp, 0x40",
@@ -253,13 +253,13 @@ pub(crate) mod go_socket_hooks {
             "mov    QWORD PTR [rsp+0x28], -0x1",
             "mov    QWORD PTR [rsp+0x30], 0x0",
             "neg    rax",
-            "call GO_EXIT_SYSCALL",
+            "call [GO_EXIT_SYSCALL]",
             "ret",
             "3:",
             "mov    QWORD PTR [rsp+0x28], rax",
             "mov    QWORD PTR [rsp+0x30], 0x0",
             "mov    QWORD PTR [rsp+0x38], 0x0",
-            "call GO_EXIT_SYSCALL",
+            "call [GO_EXIT_SYSCALL]",
             "ret",
             options(noreturn)
         );

--- a/mirrord-layer/src/go_hooks.rs
+++ b/mirrord-layer/src/go_hooks.rs
@@ -10,9 +10,9 @@ pub(crate) mod go_socket_hooks {
 
     use crate::{close_detour, macros::hook_symbol, socket::hooks::*};
 
-    static mut GO_ENTER_SYSCALL: *mut c_void = null_mut();
-    static mut GO_EXIT_SYSCALL: *mut c_void = null_mut();
-    static mut GO_SAVE_SYSTEMSTACK: *mut c_void = null_mut();
+    pub static mut GO_ENTER_SYSCALL: *mut c_void = null_mut();
+    pub static mut GO_EXIT_SYSCALL: *mut c_void = null_mut();
+    pub static mut GO_SAVE_SYSTEMSTACK: *mut c_void = null_mut();
     /// [Naked function] This detour is taken from `runtime.asmcgocall.abi0`
     /// Refer: https://go.googlesource.com/go/+/refs/tags/go1.19rc2/src/runtime/asm_amd64.s#806
     /// Golang's assembler - https://go.dev/doc/asm

--- a/mirrord-layer/src/go_hooks.rs
+++ b/mirrord-layer/src/go_hooks.rs
@@ -10,8 +10,11 @@ pub(crate) mod go_socket_hooks {
 
     use crate::{close_detour, macros::hook_symbol, socket::hooks::*};
 
+    #[no_mangle]
     pub static mut GO_ENTER_SYSCALL: *mut c_void = null_mut();
+    #[no_mangle]
     pub static mut GO_EXIT_SYSCALL: *mut c_void = null_mut();
+    #[no_mangle]
     pub static mut GO_SAVE_SYSTEMSTACK: *mut c_void = null_mut();
     /// [Naked function] This detour is taken from `runtime.asmcgocall.abi0`
     /// Refer: https://go.googlesource.com/go/+/refs/tags/go1.19rc2/src/runtime/asm_amd64.s#806


### PR DESCRIPTION
I found out that we're missing some of the flow that happens in Go's syscalls when we do our detour:
* Calling syscallenter at enter
* Calling syscallexit at exit
* Modified to use the binary's go system stack switch routine.