### PR TITLE
E2E - Unify node host resolution with WSL support (for better windows development experience)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ node_modules
 .DS_Store
 **/.DS_Store
 target
-./tests/go-e2e/go-e2e
+tests/go-e2e/go-e2e
 
 ### VSCode ###
 .vscode/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - mirrord-layer - increase agent creation timeout (to reduce e2e flakiness on macOS)
 - E2E - Don't do file stuff on http traffic to reduce flakiness (doesn't add any coverage value..)
 - mirrord-layer - Change tcp mirror tunnel `select` to be biased so it flushes all data before closing it (better testing, reduces e2e flakiness)
+- E2E - unify resolve_node_host for linux and macOS with support for wsl provided Docker & Kubernetes
 
 ## 2.6.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2597,6 +2597,7 @@ dependencies = [
  "tempdir",
  "tokio",
  "tokio-util 0.7.3",
+ "wsl",
 ]
 
 [[package]]
@@ -3272,6 +3273,12 @@ checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "wsl"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dab7ac864710bdea6594becbea5b5050333cf34fefb0dc319567eb347950d4"
 
 [[package]]
 name = "xattr"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,4 @@
+edition = "2021"
 group_imports = "StdExternalCrate"
 comment_width = 100
 wrap_comments = true

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -22,3 +22,6 @@ tokio-util = "0.7"
 rand = "*"
 futures-util = "*"
 tempdir = "*"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+wsl = "0.1.0"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -22,6 +22,4 @@ tokio-util = "0.7"
 rand = "*"
 futures-util = "*"
 tempdir = "*"
-
-[target.'cfg(target_os = "linux")'.dependencies]
-wsl = "0.1.0"
+wsl = "0.1"

--- a/tests/src/sanity.rs
+++ b/tests/src/sanity.rs
@@ -418,22 +418,6 @@ mod tests {
         }
     }
 
-    #[cfg(target_os = "macos")]
-    fn resolve_node_host() -> String {
-        if std::env::var("USE_MINIKUBE").is_ok() {
-            let output = std::process::Command::new("minikube")
-                .arg("ip")
-                .output()
-                .unwrap()
-                .stdout;
-            String::from_utf8_lossy(&output).to_string()
-        } else {
-            // We assume it's Docker for Mac
-            "127.0.0.1".to_string()
-        }
-    }
-
-    #[cfg(target_os = "linux")]
     fn resolve_node_host() -> String {
         if !wsl::is_wsl() || std::env::var("USE_MINIKUBE").is_ok() {
             let output = std::process::Command::new("minikube")
@@ -443,7 +427,7 @@ mod tests {
                 .stdout;
             String::from_utf8_lossy(&output).to_string()
         } else {
-            // Assume that the docker is passed via wsl-integran
+            // We assume it's ither Docker for Mac or passed via wsl integration
             "127.0.0.1".to_string()
         }
     }

--- a/tests/src/sanity.rs
+++ b/tests/src/sanity.rs
@@ -427,7 +427,7 @@ mod tests {
                 .stdout;
             String::from_utf8_lossy(&output).to_string()
         } else {
-            // We assume it's ither Docker for Mac or passed via wsl integration
+            // We assume it's either Docker for Mac or passed via wsl integration
             "127.0.0.1".to_string()
         }
     }

--- a/tests/src/sanity.rs
+++ b/tests/src/sanity.rs
@@ -435,12 +435,17 @@ mod tests {
 
     #[cfg(target_os = "linux")]
     fn resolve_node_host() -> String {
-        let output = std::process::Command::new("minikube")
-            .arg("ip")
-            .output()
-            .unwrap()
-            .stdout;
-        String::from_utf8_lossy(&output).to_string()
+        if !wsl::is_wsl() || std::env::var("USE_MINIKUBE").is_ok() {
+            let output = std::process::Command::new("minikube")
+                .arg("ip")
+                .output()
+                .unwrap()
+                .stdout;
+            String::from_utf8_lossy(&output).to_string()
+        } else {
+            // Assume that the docker is passed via wsl-integran
+            "127.0.0.1".to_string()
+        }
     }
 
     async fn get_service_url(kube_client: Client, service: &EchoService) -> String {

--- a/tests/src/sanity.rs
+++ b/tests/src/sanity.rs
@@ -419,7 +419,7 @@ mod tests {
     }
 
     fn resolve_node_host() -> String {
-        if !wsl::is_wsl() || std::env::var("USE_MINIKUBE").is_ok() {
+        if (cfg!(target_os = "linux") && !wsl::is_wsl()) || std::env::var("USE_MINIKUBE").is_ok() {
             let output = std::process::Command::new("minikube")
                 .arg("ip")
                 .output()


### PR DESCRIPTION
With the use of wsl detection remove the requirement to use minikube if there is another Kubernetes api provided (Support Docker for Windows just like Docker for Mac)

for better windows support:
- add matching to cargo version "edition" field to rustfmt.toml 
- remove ./ from ./tests/go-e2e/go-e2e for better windows git support