### PR TITLE
Expand fs support with access & faccessat hooks for absolute paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ### Added
 - mirrord-layer: You can now pass `MIRRORD_AGENT_COMMUNICATION_TIMEOUT` as environment variable to control agent timeout.
+- Expand file system operations with `access` and `faccessat` hooks for absolute paths
 
 ### Fixed
 - Ephemeral Containers didn't wait for the right condition, leading to timeouts in many cases.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,6 +628,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "faccess"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ae66425802d6a903e268ae1a08b8c38ba143520f227a205edf4e9c7e3e26d5"
+dependencies = [
+ "bitflags",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "fastrand"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1406,6 +1417,7 @@ dependencies = [
  "clap 3.2.17",
  "containerd-client",
  "dns-lookup",
+ "faccess",
  "futures",
  "mirrord-protocol",
  "nix",

--- a/mirrord-agent/Cargo.toml
+++ b/mirrord-agent/Cargo.toml
@@ -34,6 +34,7 @@ dns-lookup.workspace = true
 num-traits = "0.2"
 bollard = "0.13"
 tokio-util = "0.7"
+faccess = "0.2"
 
 [dev-dependencies]
 test_bin = "0.4"

--- a/mirrord-agent/src/file.rs
+++ b/mirrord-agent/src/file.rs
@@ -278,8 +278,10 @@ impl FileManager {
             mode,
         );
 
-        let mode = AccessMode::from_bits(mode.rotate_right(4).reverse_bits() | 1)
-            .unwrap_or(AccessMode::EXISTS);
+        // Mirror bit representation of flags to support how the flags are represented in the
+        // faccess library
+        let mode =
+            AccessMode::from_bits((mode << 4).reverse_bits() | 1).unwrap_or(AccessMode::EXISTS);
 
         pathname
             .access(mode)

--- a/mirrord-agent/src/file.rs
+++ b/mirrord-agent/src/file.rs
@@ -7,10 +7,10 @@ use std::{
 };
 
 use mirrord_protocol::{
-    CloseFileRequest, CloseFileResponse, FileRequest, FileResponse, OpenFileRequest,
-    OpenFileResponse, OpenOptionsInternal, OpenRelativeFileRequest, ReadFileRequest,
-    ReadFileResponse, RemoteResult, ResponseError, SeekFileRequest, SeekFileResponse,
-    WriteFileRequest, WriteFileResponse,
+    CloseFileRequest, CloseFileResponse, FAccessAtFileRequest, FAccessAtFileResponse, FileRequest,
+    FileResponse, OpenFileRequest, OpenFileResponse, OpenOptionsInternal, OpenRelativeFileRequest,
+    ReadFileRequest, ReadFileResponse, RemoteResult, ResponseError, SeekFileRequest,
+    SeekFileResponse, WriteFileRequest, WriteFileResponse,
 };
 use tracing::{debug, error, trace};
 
@@ -69,6 +69,15 @@ impl FileManager {
             FileRequest::Close(CloseFileRequest { fd }) => {
                 let close_result = self.close(fd);
                 Ok(FileResponse::Close(close_result))
+            }
+            FileRequest::FAccessAt(FAccessAtFileRequest {
+                dirfd,
+                pathname,
+                mode,
+                flags,
+            }) => {
+                let faccessat2_result = self.faccessat2(dirfd, pathname, mode, flags);
+                Ok(FileResponse::FAccessAt(faccessat2_result))
             }
         }
     }
@@ -253,5 +262,15 @@ impl FileManager {
         self.index_allocator.free_index(fd);
 
         Ok(CloseFileResponse)
+    }
+
+    pub(crate) fn faccessat2(
+        &mut self,
+        _dirfd: usize,
+        _pathname: PathBuf,
+        _mode: usize,
+        _flags: usize,
+    ) -> RemoteResult<FAccessAtFileResponse> {
+        todo!("implement faccessat2")
     }
 }

--- a/mirrord-agent/src/file.rs
+++ b/mirrord-agent/src/file.rs
@@ -286,6 +286,6 @@ impl FileManager {
         pathname
             .access(mode)
             .map(|_| AccessFileResponse)
-            .map_err(|err| ResponseError::from(err))
+            .map_err(ResponseError::from)
     }
 }

--- a/mirrord-layer/src/file.rs
+++ b/mirrord-layer/src/file.rs
@@ -369,7 +369,7 @@ impl FileHandler {
 
     async fn handle_hook_access(
         &mut self,
-        acccess: Access,
+        access: Access,
         codec: &mut actix_codec::Framed<
             impl tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send,
             ClientCodec,
@@ -379,7 +379,7 @@ impl FileHandler {
             pathname,
             mode,
             file_channel_tx,
-        } = acccess;
+        } = access;
 
         debug!(
             "HookMessage::AccessFileHook pathname {:#?} | mode {:#?}",

--- a/mirrord-layer/src/file/hooks.rs
+++ b/mirrord-layer/src/file/hooks.rs
@@ -1,7 +1,7 @@
 use std::{ffi::CStr, io::SeekFrom, os::unix::io::RawFd, path::PathBuf, ptr, slice};
 
 use frida_gum::interceptor::Interceptor;
-use libc::{self, c_char, c_int, c_void, off_t, size_t, ssize_t, AT_FDCWD, FILE};
+use libc::{self, c_char, c_int, c_void, off_t, size_t, ssize_t, AT_EACCESS, AT_FDCWD, FILE};
 use mirrord_macro::hook_fn;
 use mirrord_protocol::ReadFileResponse;
 use tracing::{error, trace};
@@ -374,7 +374,7 @@ pub(crate) unsafe extern "C" fn faccessat_detour(
         flags
     );
 
-    if dirfd == AT_FDCWD {
+    if dirfd == AT_FDCWD && flags == AT_EACCESS {
         access_detour(pathname, mode)
     } else {
         FN_FACCESSAT(dirfd, pathname, mode, flags)

--- a/mirrord-layer/src/file/ops.rs
+++ b/mirrord-layer/src/file/ops.rs
@@ -12,7 +12,7 @@ use crate::{
     common::blocking_send_hook_message,
     error::LayerError,
     file::{
-        Close, FAccessAt, HookMessageFile, Open, OpenOptionsInternalExt, OpenRelative, Read, Seek,
+        Access, Close, HookMessageFile, Open, OpenOptionsInternalExt, OpenRelative, Read, Seek,
         Write, OPEN_FILES,
     },
     HookMessage,
@@ -269,31 +269,18 @@ pub(crate) fn close(fd: usize) -> Result<c_int, LayerError> {
     Ok(0)
 }
 
-pub(crate) fn faccessat(
-    dirfd: usize,
-    pathname: PathBuf,
-    mode: usize,
-    flags: usize,
-) -> Result<c_int, LayerError> {
-    trace!(
-        "faccessat -> dirfd {:?} | pathname {:#?} | mode {:?} | flags {:?}",
-        dirfd,
-        &pathname,
-        mode,
-        flags
-    );
+pub(crate) fn access(pathname: PathBuf, mode: u8) -> Result<c_int, LayerError> {
+    trace!("access -> pathname {:#?} | mode {:?}", pathname, mode,);
 
     let (file_channel_tx, file_channel_rx) = oneshot::channel();
 
-    let access_at = FAccessAt {
-        dirfd,
+    let access = Access {
         pathname,
         mode,
-        flags,
         file_channel_tx,
     };
 
-    blocking_send_file_message(HookMessageFile::FAccessAt(access_at))?;
+    blocking_send_file_message(HookMessageFile::Access(access))?;
 
     file_channel_rx.blocking_recv()??;
 

--- a/mirrord-protocol/src/codec.rs
+++ b/mirrord-protocol/src/codec.rs
@@ -128,6 +128,14 @@ pub struct CloseFileRequest {
 }
 
 #[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
+pub struct FAccessAtFileRequest {
+    pub dirfd: usize,
+    pub pathname: PathBuf,
+    pub mode: usize,
+    pub flags: usize,
+}
+
+#[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
 pub struct GetEnvVarsRequest {
     pub env_vars_filter: HashSet<String>,
     pub env_vars_select: HashSet<String>,
@@ -141,6 +149,7 @@ pub enum FileRequest {
     Seek(SeekFileRequest),
     Write(WriteFileRequest),
     Close(CloseFileRequest),
+    FAccessAt(FAccessAtFileRequest),
 }
 
 /// Triggered by the `mirrord-layer` hook of `getaddrinfo_detour`.
@@ -189,6 +198,9 @@ pub struct WriteFileResponse {
 #[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
 pub struct CloseFileResponse;
 
+#[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
+pub struct FAccessAtFileResponse;
+
 /// Type alias for `Result`s that should be returned from mirrord-agent to mirrord-layer.
 pub type RemoteResult<T> = Result<T, ResponseError>;
 
@@ -199,6 +211,7 @@ pub enum FileResponse {
     Seek(RemoteResult<SeekFileResponse>),
     Write(RemoteResult<WriteFileResponse>),
     Close(RemoteResult<CloseFileResponse>),
+    FAccessAt(RemoteResult<FAccessAtFileResponse>),
 }
 
 #[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]

--- a/mirrord-protocol/src/codec.rs
+++ b/mirrord-protocol/src/codec.rs
@@ -128,11 +128,9 @@ pub struct CloseFileRequest {
 }
 
 #[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
-pub struct FAccessAtFileRequest {
-    pub dirfd: usize,
+pub struct AccessFileRequest {
     pub pathname: PathBuf,
-    pub mode: usize,
-    pub flags: usize,
+    pub mode: u8,
 }
 
 #[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
@@ -149,7 +147,7 @@ pub enum FileRequest {
     Seek(SeekFileRequest),
     Write(WriteFileRequest),
     Close(CloseFileRequest),
-    FAccessAt(FAccessAtFileRequest),
+    Access(AccessFileRequest),
 }
 
 /// Triggered by the `mirrord-layer` hook of `getaddrinfo_detour`.
@@ -199,7 +197,7 @@ pub struct WriteFileResponse {
 pub struct CloseFileResponse;
 
 #[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
-pub struct FAccessAtFileResponse;
+pub struct AccessFileResponse;
 
 /// Type alias for `Result`s that should be returned from mirrord-agent to mirrord-layer.
 pub type RemoteResult<T> = Result<T, ResponseError>;
@@ -211,7 +209,7 @@ pub enum FileResponse {
     Seek(RemoteResult<SeekFileResponse>),
     Write(RemoteResult<WriteFileResponse>),
     Close(RemoteResult<CloseFileResponse>),
-    FAccessAt(RemoteResult<FAccessAtFileResponse>),
+    Access(RemoteResult<AccessFileResponse>),
 }
 
 #[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]


### PR DESCRIPTION
Support hooks for `access` & `faccessat` only for absolute paths

Relevant for #200 and #137