### PR TITLE
e2e macOS - reduce to one test only

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -199,19 +199,9 @@ jobs:
         with:
           key: macos-latest
           cache-on-failure: true
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 14
       - run: npm install express
       - uses: actions/setup-python@v3
       - run: pip3 install flask
-      - uses: actions/setup-go@v3
-        with:
-          go-version: "1.18.0"
-      - run: |
-          cd tests/go-e2e
-          go build
-          cd ../..
       - name: setup cluster requirements
         run: brew install docker colima kubectl
       - name: create cluster
@@ -224,7 +214,7 @@ jobs:
       - name: load image
         run: docker load --input /tmp/test.tar
       - name: cargo test
-        run: cargo test -p tests
+        run: cargo test -p tests test_mirror_http_traffic
       - name: Collect container logs
         if: ${{ failure() }}
         run: for CONTAINER in $(docker ps --format "{{.ID}}"); do docker logs $CONTAINER; done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - E2E - Increase agent communication timeout to reduce flakiness.
 - mirrord-layer - add `DetourGuard` to prevent unwanted calls to detours from our code.
 - mirrord-layer - extract reused detours to seperate logic functions
+- E2E - macOS run only sanity http mirror traffic with Python
+
 
 ## 2.6.0
 

--- a/tests/src/sanity.rs
+++ b/tests/src/sanity.rs
@@ -539,7 +539,7 @@ mod tests {
         #[future]
         #[notrace]
         kube_client: Client,
-        #[values(Application::PythonHTTP, Application::NodeHTTP, Application::GoHTTP)] application: Application,
+        #[values(Application::PythonHTTP)] application: Application,
         #[values(Agent::Job)] agent: Agent,
     ) {
         let service = service.await;


### PR DESCRIPTION
#248 fighting this with my life - I think the e2e for macOS is a real overkill and we just need sanity for now.
We should add tests for `layer` and `cli` specifically to cover better though.