### PR TITLE
Add  support for golang fileops

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -154,7 +154,9 @@ jobs:
       - run: |
           cd tests/go-e2e
           go build
-          cd ../..
+      - run: |
+          cd tests/go-e2e-fileops
+          go build          
       - name: start minikube
         uses: medyagh/setup-minikube@master
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ node_modules
 **/.DS_Store
 target
 tests/go-e2e/go-e2e
-
+tests/go-e2e-fileops/go-e2e-fileops
 ### VSCode ###
 .vscode/*
 !.vscode/settings.json

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,18 +4,21 @@
   // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
   "version": "0.2.0",
   "configurations": [
-  {
-    "name": "Launch file",
-    "type": "go",
-    "request": "launch",
-    "mode": "debug",
-    "program": "${file}"
-  },
+    {
+      "name": "Launch golang file",
+      "type": "go",
+      "request": "launch",
+      "mode": "debug",
+      "program": "${file}"
+    },
     {
       "name": "Launch index.ts",
       "type": "node",
       "request": "launch",
-      "runtimeArgs": ["-r", "ts-node/register"],
+      "runtimeArgs": [
+        "-r",
+        "ts-node/register"
+      ],
       "args": [
         "${workspaceFolder}/cli/src/index.ts",
         "nginx-deployment-66b6c48dd5-zshg9"
@@ -23,9 +26,13 @@
       "cwd": "${workspaceFolder}/cli"
     },
     {
-      "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
+      "args": [
+        "--extensionDevelopmentPath=${workspaceFolder}"
+      ],
       "name": "Launch Extension",
-      "outFiles": ["${workspaceFolder}/vscode-ext/out/**/*.js"],
+      "outFiles": [
+        "${workspaceFolder}/vscode-ext/out/**/*.js"
+      ],
       "request": "launch",
       "type": "extensionHost"
     },
@@ -34,7 +41,9 @@
       "request": "launch",
       "name": "app.mjs: Debug mirrord-layer",
       "program": "node",
-      "args": ["${workspaceFolder}/sample/node/app.mjs"],
+      "args": [
+        "${workspaceFolder}/sample/node/app.mjs"
+      ],
       "sourceMap": {},
       "env": {
         "DYLD_INSERT_LIBRARIES": "${workspaceFolder}/target/debug/libmirrord_layer.dylib",
@@ -55,7 +64,9 @@
       "args": [],
       "cwd": "${workspaceFolder}",
       "sourceMap": {},
-      "sourceLanguages": ["rust"],
+      "sourceLanguages": [
+        "rust"
+      ],
       "env": {
         "DYLD_INSERT_LIBRARIES": "${workspaceFolder}/target/debug/libmirrord_layer.dylib",
         "LD_PRELOAD": "${workspaceFolder}/target/debug/libmirrord_layer.so",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,6 +4,13 @@
   // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
   "version": "0.2.0",
   "configurations": [
+  {
+    "name": "Launch file",
+    "type": "go",
+    "request": "launch",
+    "mode": "debug",
+    "program": "${file}"
+  },
     {
       "name": "Launch index.ts",
       "type": "node",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+### Added
+- Support for fileops for Golang
+
 
 ## 2.8.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ## [Unreleased]
 
 ### Added
-- Support for fileops for Golang
+- Support for Golang fileops
 
 
 ## 2.8.1

--- a/mirrord-layer/src/file/hooks.rs
+++ b/mirrord-layer/src/file/hooks.rs
@@ -125,7 +125,7 @@ pub(super) unsafe extern "C" fn fdopen_detour(fd: RawFd, raw_mode: *const c_char
 /// `open_detour`.
 /// `fd` for a file descriptor with the `O_DIRECTORY` flag.
 #[hook_guard_fn]
-pub(super) unsafe extern "C" fn openat_detour(
+pub(crate) unsafe extern "C" fn openat_detour(
     fd: RawFd,
     raw_path: *const c_char,
     open_flags: c_int,

--- a/mirrord-layer/src/file/hooks.rs
+++ b/mirrord-layer/src/file/hooks.rs
@@ -389,7 +389,7 @@ pub(crate) unsafe extern "C" fn faccessat_detour(
         flags
     );
 
-    if dirfd == AT_FDCWD && flags == AT_EACCESS {
+    if dirfd == AT_FDCWD && (flags == AT_EACCESS || flags == 0) {
         access_logic(pathname, mode)
     } else {
         FN_FACCESSAT(dirfd, pathname, mode, flags)

--- a/mirrord-layer/src/go_hooks.rs
+++ b/mirrord-layer/src/go_hooks.rs
@@ -1,6 +1,6 @@
 #[cfg(target_os = "linux")]
 #[cfg(target_arch = "x86_64")]
-pub(crate) mod go_hooks {
+pub(crate) mod hooks {
     use std::{arch::asm, sync::OnceLock};
 
     use errno::errno;
@@ -320,6 +320,18 @@ pub(crate) mod go_hooks {
                 libc::SYS_read => read_detour(param1 as _, param2 as _, param3 as _) as i64,
                 libc::SYS_write => write_detour(param1 as _, param2 as _, param3 as _) as i64,
                 libc::SYS_lseek => lseek_detour(param1 as _, param2 as _, param3 as _) as i64,
+                // Note(syscall_linux.go)
+                // if flags == 0 {
+                // 	return faccessat(dirfd, path, mode)
+                // }
+                // The Linux kernel faccessat system call does not take any flags.
+                // The glibc faccessat implements the flags itself; see
+                // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/faccessat.c;hb=HEAD
+                // Because people naturally expect syscall.Faccessat to act
+                // like C faccessat, we do the same.
+                libc::SYS_faccessat => {
+                    faccessat_detour(param1 as _, param2 as _, param3 as _, 0) as i64
+                }
                 _ => {
                     let syscall_res = syscall_3(syscall, param1, param2, param3);
                     return syscall_res;

--- a/mirrord-layer/src/go_hooks.rs
+++ b/mirrord-layer/src/go_hooks.rs
@@ -436,8 +436,8 @@ pub(crate) mod hooks {
     ) {
         ENABLED_FILE_OPS
             .set(enabled_file_ops)
-            .map_err(|e| {
-                error!("Error setting ENABLED_FILE_OPS: {}", e);
+            .map_err(|err| {
+                error!("Error setting ENABLED_FILE_OPS: {}", err);
             })
             .unwrap();
 

--- a/mirrord-layer/src/go_hooks.rs
+++ b/mirrord-layer/src/go_hooks.rs
@@ -5,7 +5,7 @@ pub(crate) mod hooks {
 
     use errno::errno;
     use frida_gum::interceptor::Interceptor;
-    use tracing::error;
+    use tracing::{debug, error, trace};
 
     use crate::{close_detour, file::hooks::*, macros::hook_symbol, socket::hooks::*};
     static ENABLED_FILE_OPS: OnceLock<bool> = OnceLock::new();
@@ -309,6 +309,13 @@ pub(crate) mod hooks {
         param2: i64,
         param3: i64,
     ) -> i64 {
+        trace!(
+            "c_abi_syscall_handler: syscall={} param1={} param2={} param3={}",
+            syscall,
+            param1,
+            param2,
+            param3
+        );
         let res = match syscall {
             libc::SYS_socket => socket_detour(param1 as _, param2 as _, param3 as _) as i64,
             libc::SYS_bind => bind_detour(param1 as _, param2 as _, param3 as _) as i64,
@@ -360,6 +367,10 @@ pub(crate) mod hooks {
         param5: i64,
         param6: i64,
     ) -> i64 {
+        trace!(
+            "c_abi_syscall6_handler: syscall={} param1={} param2={} param3={} param4={} param5={} param6={}",
+            syscall, param1, param2, param3, param4, param5, param6
+        );
         let res = match syscall {
             libc::SYS_accept4 => {
                 accept4_detour(param1 as _, param2 as _, param3 as _, param4 as _) as i64

--- a/mirrord-layer/src/go_hooks.rs
+++ b/mirrord-layer/src/go_hooks.rs
@@ -1,12 +1,18 @@
 #[cfg(target_os = "linux")]
 #[cfg(target_arch = "x86_64")]
-pub(crate) mod go_socket_hooks {
-    use std::arch::asm;
+pub(crate) mod go_hooks {
+    use std::{arch::asm, sync::OnceLock};
 
     use errno::errno;
     use frida_gum::interceptor::Interceptor;
+    use tracing::error;
 
-    use crate::{close_detour, macros::hook_symbol, socket::hooks::*};
+    use crate::{close_detour, file::hooks::*, macros::hook_symbol, socket::hooks::*};
+    static ENABLED_FILE_OPS: OnceLock<bool> = OnceLock::new();
+    /*
+     * Reference for which which syscall detours call file/socket detours:
+     *
+     */
 
     /// [Naked function] This detour is taken from `runtime.asmcgocall.abi0`
     /// Refer: https://go.googlesource.com/go/+/refs/tags/go1.19rc2/src/runtime/asm_amd64.s#806
@@ -309,6 +315,16 @@ pub(crate) mod go_socket_hooks {
             libc::SYS_listen => listen_detour(param1 as _, param2 as _) as i64,
             libc::SYS_accept => accept_detour(param1 as _, param2 as _, param3 as _) as i64,
             libc::SYS_close => close_detour(param1 as _) as i64,
+
+            _ if *ENABLED_FILE_OPS.get().unwrap() => match syscall {
+                libc::SYS_read => read_detour(param1 as _, param2 as _, param3 as _) as i64,
+                libc::SYS_write => write_detour(param1 as _, param2 as _, param3 as _) as i64,
+                libc::SYS_lseek => lseek_detour(param1 as _, param2 as _, param3 as _) as i64,
+                _ => {
+                    let syscall_res = syscall_3(syscall, param1, param2, param3);
+                    return syscall_res;
+                }
+            },
             _ => {
                 let syscall_res = syscall_3(syscall, param1, param2, param3);
                 return syscall_res;
@@ -336,6 +352,14 @@ pub(crate) mod go_socket_hooks {
             libc::SYS_accept4 => {
                 accept4_detour(param1 as _, param2 as _, param3 as _, param4 as _) as i64
             }
+            _ if *ENABLED_FILE_OPS.get().unwrap() => match syscall {
+                libc::SYS_openat => openat_detour(param1 as _, param2 as _, param3 as _) as i64,
+                _ => {
+                    let syscall_res =
+                        syscall_6(syscall, param1, param2, param3, param4, param5, param6);
+                    return syscall_res;
+                }
+            },
             _ => {
                 let syscall_res =
                     syscall_6(syscall, param1, param2, param3, param4, param5, param6);
@@ -393,7 +417,18 @@ pub(crate) mod go_socket_hooks {
     /// Refer:
     ///   - File zsyscall_linux_amd64.go generated using mksyscall.pl.
     ///   - https://cs.opensource.google/go/go/+/refs/tags/go1.18.5:src/syscall/syscall_unix.go
-    pub(crate) fn enable_socket_hooks(interceptor: &mut Interceptor, binary: &str) {
+    pub(crate) fn enable_socket_hooks(
+        interceptor: &mut Interceptor,
+        binary: &str,
+        enabled_file_ops: bool,
+    ) {
+        ENABLED_FILE_OPS
+            .set(enabled_file_ops)
+            .map_err(|e| {
+                error!("Error setting ENABLED_FILE_OPS: {}", e);
+            })
+            .unwrap();
+
         hook_symbol!(
             interceptor,
             "syscall.RawSyscall.abi0",

--- a/mirrord-layer/src/go_hooks.rs
+++ b/mirrord-layer/src/go_hooks.rs
@@ -5,13 +5,17 @@ pub(crate) mod hooks {
 
     use errno::errno;
     use frida_gum::interceptor::Interceptor;
-    use tracing::{debug, error, trace};
+    use tracing::{error, trace};
 
     use crate::{close_detour, file::hooks::*, macros::hook_symbol, socket::hooks::*};
     static ENABLED_FILE_OPS: OnceLock<bool> = OnceLock::new();
     /*
-     * Reference for which which syscall detours call file/socket detours:
+     * Reference for which syscalls are managed by the handlers:
+     * SYS_openat: Syscall6
+     * SYS_read, SYS_write, SYS_lseek, SYS_faccessat: Syscall
      *
+     * SYS_socket, SYS_bind, SYS_listen, SYS_accept, SYS_close: Syscall
+     * SYS_accept4: Syscall6
      */
 
     /// [Naked function] This detour is taken from `runtime.asmcgocall.abi0`

--- a/mirrord-layer/src/lib.rs
+++ b/mirrord-layer/src/lib.rs
@@ -384,7 +384,7 @@ fn enable_hooks(enabled_file_ops: bool, enabled_remote_dns: bool) {
     {
         let modules = frida_gum::Module::enumerate_modules();
         let binary = &modules.first().unwrap().name;
-        go_hooks::go_socket_hooks::enable_socket_hooks(&mut interceptor, binary);
+        go_hooks::go_hooks::enable_socket_hooks(&mut interceptor, binary, enabled_file_ops);
     }
     interceptor.end_transaction();
 }

--- a/mirrord-layer/src/lib.rs
+++ b/mirrord-layer/src/lib.rs
@@ -384,7 +384,7 @@ fn enable_hooks(enabled_file_ops: bool, enabled_remote_dns: bool) {
     {
         let modules = frida_gum::Module::enumerate_modules();
         let binary = &modules.first().unwrap().name;
-        go_hooks::go_hooks::enable_socket_hooks(&mut interceptor, binary, enabled_file_ops);
+        go_hooks::hooks::enable_socket_hooks(&mut interceptor, binary, enabled_file_ops);
     }
     interceptor.end_transaction();
 }

--- a/tests/go-e2e-fileops/go.mod
+++ b/tests/go-e2e-fileops/go.mod
@@ -1,0 +1,3 @@
+module go-e2e-fileops
+
+go 1.18

--- a/tests/go-e2e-fileops/main.go
+++ b/tests/go-e2e-fileops/main.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"C"
+	"fmt"
+	"os"
+)
+
+const TEXT = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+
+func TestRead() {
+	// Tests: SYS_read, SYS_openat
+	dat, err := os.ReadFile("/app/test.txt")
+	if err != nil {
+		panic(err)
+	}
+	if string(dat) != TEXT {
+		err := fmt.Errorf("Expected %s, got %s", TEXT, string(dat))
+		panic(err)
+	}
+}
+
+func TestWrite() {
+	// Tests: SYS_write
+	fileName := createTempFile()
+	checkFileExistsOnHost(fileName)
+	dat, err := os.ReadFile(fileName)
+	if err != nil {
+		panic(err)
+	}
+	if string(dat) != TEXT {
+		err := fmt.Errorf("Expected %s, got %s", TEXT, string(dat))
+		panic(err)
+	}
+}
+
+func TestLseek() {
+	// Tests: SYS_lseek
+	fileName := createTempFile()
+	checkFileExistsOnHost(fileName)
+	file, err := os.Open(fileName)
+	if err != nil {
+		panic(err)
+	}
+	buf := make([]byte, len(TEXT))
+	file.Seek(0, 1)
+	_, err = file.Read(buf)
+	if err != nil {
+		panic(err)
+	}
+	if string(buf) != TEXT {
+		err := fmt.Errorf("Expected %s, got %s", TEXT, string(buf))
+		panic(err)
+	}
+}
+
+func TestFaccessat() {
+	// Tests: SYS_faccessat
+	fileName := createTempFile()
+	checkFileExistsOnHost(fileName)
+	err := os.Chmod(fileName, 0666)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func createTempFile() string {
+	file, err := os.CreateTemp("/tmp", "test")
+	if err != nil {
+		panic(err)
+	}
+	file.WriteString(TEXT)
+	fileName := file.Name()
+	file.Close()
+	return fileName
+}
+
+func checkFileExistsOnHost(fileName string) {
+	_, err := os.Stat(fileName)
+	if err == nil {
+		panic("file exists on host")
+	}
+}
+
+func main() {
+	TestRead()
+	TestWrite()
+	TestLseek()
+	TestFaccessat()
+	TestLseek()
+}

--- a/tests/go-e2e-fileops/main.go
+++ b/tests/go-e2e-fileops/main.go
@@ -89,5 +89,4 @@ func main() {
 	TestWrite()
 	TestLseek()
 	TestFaccessat()
-	TestLseek()
 }

--- a/tests/go-e2e-fileops/main.go
+++ b/tests/go-e2e-fileops/main.go
@@ -4,6 +4,7 @@ import (
 	"C"
 	"fmt"
 	"os"
+	"syscall"
 )
 
 const TEXT = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
@@ -56,9 +57,10 @@ func TestLseek() {
 
 func TestFaccessat() {
 	// Tests: SYS_faccessat
+	// Access calls Faccess with _AT_FDCWD and flags set to 0
 	fileName := createTempFile()
 	checkFileExistsOnHost(fileName)
-	err := os.Chmod(fileName, 0666)
+	err := syscall.Access(fileName, syscall.O_RDWR)
 	if err != nil {
 		panic(err)
 	}

--- a/tests/python-e2e/ops.py
+++ b/tests/python-e2e/ops.py
@@ -8,21 +8,20 @@ TEXT = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod 
 class FileOpsTest(unittest.TestCase):
     def setUp(self):
         """
-        Check if the default file exists.
-        """        
+        Check if the default file exists and reads the text.
+        """
         with open("/app/test.txt", "r") as f:
             f.seek(0)
             self.assertEqual(f.readline(), TEXT)
 
-    def test_read_write_family(self):
+    def test_write(self):
         """
         Reads data from a file in "/tmp" and verifies the text expected is the same as the text written.
         """
         file_path, _ = self._create_new_tmp_file()
         self.assertFalse(self._check_path_exists_on_host(file_path))
-        with open(file_path, "r+") as rw_file:
-            rw_file.seek(0)
-            read_text = rw_file.readline()
+        with open(file_path, "r+") as file:
+            read_text = file.readline()
             self.assertEqual(read_text, TEXT)
 
     def test_lseek(self):
@@ -32,9 +31,9 @@ class FileOpsTest(unittest.TestCase):
         read_str = ""
         file_path, _ = self._create_new_tmp_file()
         self.assertFalse(self._check_path_exists_on_host(file_path))
-        with open(file_path, "r+") as rw_file:
+        with open(file_path, "r+") as file:
             while read_str != TEXT:
-                read_str += rw_file.read(1)
+                read_str += file.read(0, 1)
             self.assertEqual(read_str, TEXT)
 
     def test_openat(self):

--- a/tests/python-e2e/ops.py
+++ b/tests/python-e2e/ops.py
@@ -8,20 +8,21 @@ TEXT = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod 
 class FileOpsTest(unittest.TestCase):
     def setUp(self):
         """
-        Check if the default file exists and reads the text.
-        """
+        Check if the default file exists.
+        """        
         with open("/app/test.txt", "r") as f:
             f.seek(0)
             self.assertEqual(f.readline(), TEXT)
 
-    def test_write(self):
+    def test_read_write_family(self):
         """
         Reads data from a file in "/tmp" and verifies the text expected is the same as the text written.
         """
         file_path, _ = self._create_new_tmp_file()
         self.assertFalse(self._check_path_exists_on_host(file_path))
-        with open(file_path, "r+") as file:
-            read_text = file.readline()
+        with open(file_path, "r+") as rw_file:
+            rw_file.seek(0)
+            read_text = rw_file.readline()
             self.assertEqual(read_text, TEXT)
 
     def test_lseek(self):
@@ -31,9 +32,9 @@ class FileOpsTest(unittest.TestCase):
         read_str = ""
         file_path, _ = self._create_new_tmp_file()
         self.assertFalse(self._check_path_exists_on_host(file_path))
-        with open(file_path, "r+") as file:
+        with open(file_path, "r+") as rw_file:
             while read_str != TEXT:
-                read_str += file.read(0, 1)
+                read_str += rw_file.read(1)
             self.assertEqual(read_str, TEXT)
 
     def test_openat(self):
@@ -66,3 +67,4 @@ class FileOpsTest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+Footer

--- a/tests/python-e2e/ops.py
+++ b/tests/python-e2e/ops.py
@@ -67,4 +67,3 @@ class FileOpsTest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-Footer

--- a/tests/src/sanity.rs
+++ b/tests/src/sanity.rs
@@ -83,6 +83,7 @@ mod tests {
         Job,
     }
 
+    #[derive(Debug)]
     enum FileOps {
         Python,
         Go,

--- a/tests/src/sanity.rs
+++ b/tests/src/sanity.rs
@@ -84,7 +84,7 @@ mod tests {
     }
 
     #[derive(Debug)]
-    enum FileOps {
+    pub enum FileOps {
         Python,
         Go,
     }

--- a/tests/src/sanity.rs
+++ b/tests/src/sanity.rs
@@ -83,6 +83,11 @@ mod tests {
         Job,
     }
 
+    enum FileOps {
+        Python,
+        Go,
+    }
+
     struct TestProcess {
         pub child: Child,
         stderr: Arc<Mutex<String>>,
@@ -188,6 +193,24 @@ mod tests {
                 #[cfg(target_os = "linux")]
                 Agent::Ephemeral => Some(vec!["--ephemeral-container"]),
                 Agent::Job => None,
+            }
+        }
+    }
+
+    impl FileOps {
+        fn command(&self) -> Vec<&str> {
+            match self {
+                FileOps::Python => {
+                    vec!["python3", "-B", "-m", "unittest", "-f", "python-e2e/ops.py"]
+                }
+                FileOps::Go => vec!["go-e2e-fileops/go-e2e-fileops"],
+            }
+        }
+
+        fn assert(&self, process: TestProcess) {
+            match self {
+                FileOps::Python => process.assert_python_fileops_stderr(),
+                FileOps::Go => process.assert_stderr(),
             }
         }
     }
@@ -581,10 +604,11 @@ mod tests {
         #[notrace]
         service: EchoService,
         #[values(Agent::Ephemeral, Agent::Job)] agent: Agent,
+        #[values(FileOps::Python, FileOps::Go)] ops: FileOps,
     ) {
         let service = service.await;
         let _ = std::fs::create_dir(std::path::Path::new("/tmp/fs"));
-        let python_command = vec!["python3", "-B", "-m", "unittest", "-f", "python-e2e/ops.py"];
+        let command = ops.command();
 
         let mut args = vec!["--enable-fs"];
 
@@ -593,7 +617,7 @@ mod tests {
         }
 
         let mut process = run(
-            python_command,
+            command,
             &service.pod_name,
             Some(&service.namespace),
             Some(args),
@@ -601,7 +625,7 @@ mod tests {
         .await;
         let res = process.child.wait().await.unwrap();
         assert!(res.success());
-        process.assert_python_fileops_stderr();
+        ops.assert(process);
     }
 
     #[cfg(target_os = "macos")]


### PR DESCRIPTION
This PR adds support for golang fileops, closes #230 
- SYS_openat
- SYS_read
- SYS_write
- SYS_lseek
- SYS_faccessat