### PR TITLE
Dev Container Update

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -30,7 +30,7 @@
 	"extensions": [
 		"vadimcn.vscode-lldb",
 		"mutantdino.resourcemonitor",
-		"matklad.rust-analyzer",
+		"rust-lang.rust-analyzer",
 		"tamasfe.even-better-toml",
 		"serayuzgur.crates"
 	],


### PR DESCRIPTION
# Problem

`rust-analyzer` extension is failing to install when initializing development container. 

# Scenario

Extension is referencing user/org matklad. No such extension is currently available from this profile. 

# Solution

Updated reference to [rust-lang official analyzer](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer).

---

#### Additional Thoughts

I also checked the JetBrains extensions marketplace for this users hosting of the analyzer with no luck.

If this is a private hosting of the analyzer I believe it is still valuable for community contributors to have the publicly available extension applied by default.


> feedback welcome!