### PR TITLE
Use selected namespace in IntelliJ.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ### Added
 - Release arm64 agent image.
 
+### Fixed
+- Use selected namespace in IntelliJ plugin instead of always using default namespace.
+
 ## 2.12.1
 ### Fixed
 - Fix bug where VS Code extension would crash on startup due to new configuration values not being the correct type.

--- a/intellij-ext/src/main/kotlin/com/metalbear/mirrord/MirrordListener.kt
+++ b/intellij-ext/src/main/kotlin/com/metalbear/mirrord/MirrordListener.kt
@@ -69,6 +69,7 @@ class MirrordListener : ExecutionListener {
                 // SUCCESS: set the respective environment variables
                 if (dialogBuilder.show() == DialogWrapper.OK_EXIT_CODE && !pods.isSelectionEmpty) {
                     mirrordEnv["MIRRORD_AGENT_IMPERSONATED_POD_NAME"] = pods.selectedValue as String
+                    mirrordEnv["MIRRORD_AGENT_IMPERSONATED_POD_NAMESPACE"] = choseNamespace as String
                     mirrordEnv["MIRRORD_FILE_OPS"] = fileOpsCheckbox.isSelected.toString()
                     mirrordEnv["MIRRORD_EPHEMERAL_CONTAINER"] = ephemeralContainerCheckBox.isSelected.toString()
                     mirrordEnv["MIRRORD_REMOTE_DNS"] = remoteDnsCheckbox.isSelected.toString()


### PR DESCRIPTION
Currently the IntelliJ Plugin does not supply the selected namespace to the layer, but just uses it to fetch pods.
This means that if the user selected a non-default namespace, the mirrord layer will not find the given pod in the default namespace and will panic.