### PR TITLE
mirrord-layer add venv.cfg exclusion

### DIFF
--- a/mirrord-layer/src/file.rs
+++ b/mirrord-layer/src/file.rs
@@ -40,6 +40,7 @@ static IGNORE_FILES: LazyLock<RegexSet> = LazyLock::new(|| {
         r".*\.js",
         r".*\.pth",
         r".*\.plist",
+        r".*venv\.cfg",
         r"^/proc/.*",
         r"^/sys/.*",
         r"^/lib/.*",


### PR DESCRIPTION
Exclude fs calls to venv config files