### PR TITLE
In go-e2e, exit instead of sending SIGINT.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+### Changed
+- In `go-e2e` test, call `os.Exit` instead fo sending `SIGINT` to the process.
+
 ## 3.0.1-alpha
 
 ### Fixed

--- a/tests/go-e2e/main.go
+++ b/tests/go-e2e/main.go
@@ -5,7 +5,6 @@ import (
 	"math/rand"
 	"net/http"
 	"os"
-	"syscall"
 
 	"github.com/gin-gonic/gin"
 )
@@ -50,7 +49,7 @@ func main() {
 	r.DELETE("/", func(c *gin.Context) {
 		fmt.Println("DELETE: Request completed")
 		defer func() {
-			syscall.Kill(syscall.Getpid(), syscall.SIGINT)
+			os.Exit(0)
 		}()
 		c.String(http.StatusOK, "DELETE")
 	})


### PR DESCRIPTION
No CHANGELOG entry, since this is a minor and internal change to the tests, right?