### PR TITLE
Fix Environment parsing when value contained '='

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - mirrord-cli: Add random prefix to the generated shared lib to prevent Bus Error/EXC_BAD_ACCESS
 - Support for Go 1.19>= syscall hooking
 - Fix Python debugger crash in VS Code Extension. Closes [[#350](https://github.com/metalbear-co/mirrord/issues/350)].
-- Fix Environment parsing error when value containd '='
+- Fix Environment parsing error when value contained '='
 
 ## 2.13.0
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+### Fixed
+- Fix Environment parsing error when value contained '='
+
 ## 3.0.1-alpha
 
 ### Fixed
@@ -32,7 +35,6 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - mirrord-cli: Add random prefix to the generated shared lib to prevent Bus Error/EXC_BAD_ACCESS
 - Support for Go 1.19>= syscall hooking
 - Fix Python debugger crash in VS Code Extension. Closes [[#350](https://github.com/metalbear-co/mirrord/issues/350)].
-- Fix Environment parsing error when value contained '='
 
 ## 2.13.0
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - mirrord-cli: Add random prefix to the generated shared lib to prevent Bus Error/EXC_BAD_ACCESS
 - Support for Go 1.19>= syscall hooking
 - Fix Python debugger crash in VS Code Extension. Closes [[#350](https://github.com/metalbear-co/mirrord/issues/350)].
+- Fix Environment parsing error when value containd '='
 
 ## 2.13.0
 ### Added

--- a/mirrord-agent/src/main.rs
+++ b/mirrord-agent/src/main.rs
@@ -109,7 +109,7 @@ async fn select_env_vars(
         // "DB=foo.db\0PORT=99\0HOST=\0PATH=/fake\0"
         .split_terminator(char::from(0))
         // ["DB=foo.db", "PORT=99", "HOST=", "PATH=/fake"]
-        .map(|key_and_value| key_and_value.split_terminator('=').collect::<Vec<_>>())
+        .map(|key_and_value| key_and_value.splitn(2, '=').collect::<Vec<_>>())
         // [["DB", "foo.db"], ["PORT", "99"], ["HOST"], ["PATH", "/fake"]]
         .filter_map(
             |mut keys_and_values| match (keys_and_values.pop(), keys_and_values.pop()) {

--- a/tests/bash-e2e/env.sh
+++ b/tests/bash-e2e/env.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 case $1 in
-  include) first=1; second=0; third=0;
-  exclude) first=0; second=1; third=1;
-  *) first=1; second=1; third=1;
+  include) first=1; second=0; third=0;;
+  exclude) first=0; second=1; third=1;;
+  *) first=1; second=1; third=1;;
 esac
 
 if [ $MIRRORD_FAKE_VAR_FIRST ]; then

--- a/tests/bash-e2e/env.sh
+++ b/tests/bash-e2e/env.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 case $1 in
-  include) first=1; second=0;;
-  exclude) first=0; second=1;;
-  *) first=1; second=1;;
+  include) first=1; second=0; third=0;
+  exclude) first=0; second=1; third=1;
+  *) first=1; second=1; third=1;
 esac
 
 if [ $MIRRORD_FAKE_VAR_FIRST ]; then
@@ -38,6 +38,24 @@ if [ $MIRRORD_FAKE_VAR_SECOND ]; then
   fi
 elif [ $second == 1 ]; then
   echo "MIRRORD_FAKE_VAR_SECOND was not set";
+
+  exit -1
+fi
+
+if [ $MIRRORD_FAKE_VAR_THIRD ]; then
+  if [ $third == 0 ]; then
+    echo "MIRRORD_FAKE_VAR_THIRD should not be set";
+
+    exit -1
+  fi
+
+  if [[ $MIRRORD_FAKE_VAR_THIRD != "foo=bar" ]]; then
+    echo "MIRRORD_FAKE_VAR_THIRD wasn't of value foo=bar";
+
+    exit -1
+  fi
+elif [ $third == 1 ]; then
+  echo "MIRRORD_FAKE_VAR_THIRD was not set";
 
   exit -1
 fi

--- a/tests/go-e2e-env/main.go
+++ b/tests/go-e2e-env/main.go
@@ -16,4 +16,9 @@ func main() {
 		err := fmt.Errorf("missing env var MIRRORD_FAKE_VAR_SECOND")
 		panic(err)
 	}
+
+	if os.Getenv("MIRRORD_FAKE_VAR_THIRD") != "foo=bar" {
+		err := fmt.Errorf("missing env var MIRRORD_FAKE_VAR_THIRD")
+		panic(err)
+	}
 }

--- a/tests/node-e2e/remote_env/test_remote_env_vars_does_nothing_when_not_specified.mjs
+++ b/tests/node-e2e/remote_env/test_remote_env_vars_does_nothing_when_not_specified.mjs
@@ -1,6 +1,6 @@
 console.log(">> test_remote_env_vars_does_nothing_when_not_specified");
 
-if (process.env.MIRRORD_FAKE_VAR_FIRST || process.env.MIRRORD_FAKE_VAR_SECOND) {
+if (process.env.MIRRORD_FAKE_VAR_FIRST || process.env.MIRRORD_FAKE_VAR_SECOND || process.env.MIRRORD_FAKE_VAR_THIRD) {
   process.exit(-1);
 } else {
   process.exit(0);

--- a/tests/node-e2e/remote_env/test_remote_env_vars_exclude_works.mjs
+++ b/tests/node-e2e/remote_env/test_remote_env_vars_exclude_works.mjs
@@ -2,7 +2,8 @@ console.log(">> test_remote_env_vars_exclude_works");
 
 if (
   process.env.MIRRORD_FAKE_VAR_FIRST === undefined &&
-  process.env.MIRRORD_FAKE_VAR_SECOND === "7777"
+  process.env.MIRRORD_FAKE_VAR_SECOND === "7777" &&
+  process.env.MIRRORD_FAKE_VAR_THIRD === "foo=bar"
 ) {
   process.exit(0);
 } else {

--- a/tests/node-e2e/remote_env/test_remote_env_vars_include_works.mjs
+++ b/tests/node-e2e/remote_env/test_remote_env_vars_include_works.mjs
@@ -2,7 +2,8 @@ console.log(">> test_remote_env_vars_include_works");
 
 if (
   process.env.MIRRORD_FAKE_VAR_FIRST === "mirrord.is.running" &&
-  process.env.MIRRORD_FAKE_VAR_SECOND === undefined
+  process.env.MIRRORD_FAKE_VAR_SECOND === undefined &&
+  process.env.MIRRORD_FAKE_VAR_THIRD === undefined
 ) {
   process.exit(0);
 } else {

--- a/tests/node-e2e/remote_env/test_remote_env_vars_panics_when_both_filters_are_specified.mjs
+++ b/tests/node-e2e/remote_env/test_remote_env_vars_panics_when_both_filters_are_specified.mjs
@@ -1,6 +1,6 @@
 console.log(">> test_remote_env_vars_panics_when_both_filters_are_specified");
 
-if (process.env.MIRRORD_FAKE_VAR_SECOND) {
+if (process.env.MIRRORD_FAKE_VAR_FIRST || process.env.MIRRORD_FAKE_VAR_SECOND || process.env.MIRRORD_FAKE_VAR_THIRD) {
   process.exit(-1);
 } else {
   process.exit(0);

--- a/tests/src/sanity.rs
+++ b/tests/src/sanity.rs
@@ -419,6 +419,10 @@ mod tests {
                                     {
                                       "name": "MIRRORD_FAKE_VAR_SECOND",
                                       "value": "7777"
+                                    },
+                                    {
+                                        "name": "MIRRORD_FAKE_VAR_THIRD",
+                                        "value": "foo=bar"
                                     }
                                   ]
                             }


### PR DESCRIPTION
If env variable contains '=' in it's value then the GetEnvVarsResponse is completely messed up with the key being the last env variable

Example:
```
PG_CONNECTION=postgres://localhost/?ssl_mode=disable
```
generates response 

```
DaemonMessage::GetEnvVarsResponse {
    ...
    "postgres://localhost/?ssl_mode": "disable",
    ...
}!
```
