### PR TITLE
Bugfix: outgoing traffic with many requests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ### Fixed
 - Fix Environment parsing error when value contained '='
+- Fix bug in outgoing traffic with multiple requests in quick succession. 
+  Closes [[#331](https://github.com/metalbear-co/mirrord/issues/331)].
 
 ## 3.0.1-alpha
 

--- a/tests/node-e2e/outgoing/test_outgoing_traffic_many_requests.mjs
+++ b/tests/node-e2e/outgoing/test_outgoing_traffic_many_requests.mjs
@@ -1,0 +1,64 @@
+import https from "node:https";
+
+console.log(">> test_outgoing_traffic_many_requests");
+
+const hostList = [
+  "www.rust-lang.org",
+  "www.github.com",
+  "www.google.com",
+  "www.bing.com",
+  "www.yahoo.com",
+  "www.baidu.com",
+  "www.twitter.com",
+  "www.microsoft.com",
+  "www.youtube.com",
+  "www.live.com",
+  "www.msn.com",
+  "www.google.com.br",
+  "www.yahoo.co.jp",
+  "www.qq.com",
+];
+
+let requestIndex = 0;
+
+function makeRequests() {
+  hostList.forEach((host) => {
+    const options = {
+      hostname: host,
+      port: 443,
+      path: "/",
+      method: "GET",
+    };
+
+    console.log(`>> host ${host}`);
+
+    const request = https.request(options, (response) => {
+      requestIndex += 1;
+      console.log(
+        `>> ${requestIndex} ${host} statusCode ${response.statusCode}`
+      );
+
+      response.on("data", (data) => {
+        process.stdout.write(`>> received ${data.slice(0, 4)}`);
+      });
+
+      response.on("error", (fail) => {
+        process.stderr.write(`>> response from ${host} failed with ${fail}`);
+        throw fail;
+      });
+    });
+
+    request.on("error", (fail) => {
+      process.stderr.write(
+        `>> request to ${requestIndex} ${host} failed with ${fail}`
+      );
+      throw fail;
+    });
+
+    request.end();
+  });
+}
+
+for (let i = 0; i < 1; i++) {
+  makeRequests();
+}

--- a/tests/src/sanity.rs
+++ b/tests/src/sanity.rs
@@ -998,7 +998,39 @@ mod tests {
             "node",
             "node-e2e/outgoing/test_outgoing_traffic_single_request.mjs",
         ];
+        let mirrord_args = vec!["--no-outgoing"];
+        let mut process = run(node_command, &service.pod_name, None, Some(mirrord_args)).await;
+
+        let res = process.child.wait().await.unwrap();
+        assert!(res.success());
+        process.assert_stderr();
+    }
+
+    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    pub async fn test_outgoing_traffic_many_requests_enabled(#[future] service: EchoService) {
+        let service = service.await;
+        let node_command = vec![
+            "node",
+            "node-e2e/outgoing/test_outgoing_traffic_many_requests.mjs",
+        ];
         let mut process = run(node_command, &service.pod_name, None, None).await;
+
+        let res = process.child.wait().await.unwrap();
+        assert!(res.success());
+        process.assert_stderr();
+    }
+
+    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    pub async fn test_outgoing_traffic_many_requests_disabled(#[future] service: EchoService) {
+        let service = service.await;
+        let node_command = vec![
+            "node",
+            "node-e2e/outgoing/test_outgoing_traffic_many_requests.mjs",
+        ];
+        let mirrord_args = vec!["--no-outgoing"];
+        let mut process = run(node_command, &service.pod_name, None, Some(mirrord_args)).await;
 
         let res = process.child.wait().await.unwrap();
         assert!(res.success());


### PR DESCRIPTION
- Keep reading open streams until BOTH are done.
- Add meowjesty's many-requests test.
- Fix single-request, outgoing-disabled node test.

https://github.com/metalbear-co/mirrord/issues/331

https://github.com/metalbear-co/mirrord/pull/394 solves this bug by sleeping, as implemented in tcp_mirror.rs already. This PR suggests a different approach with less uncertainty.