### PR TITLE
Support accessing Kubernetes cluster with IP as CNAME

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ### Fixed
 - mirrord-layer: Return errors from agent when `connect` fails back to the hook (previously we were handling these as errors in layer, so `connect` had slightly wrong behavior).
+- mirrord-layer: workaround for `presented server name type wasn't supported` error when Kubernetes server has IP for CN in certificate. [[#388](https://github.com/metalbear-co/mirrord/issues/388)]
+
 ### Changed
 - mirrord-layer: Use `tracing::instrument` to improve logs.
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2400,12 +2400,12 @@ dependencies = [
 [[package]]
 name = "rustls"
 version = "0.20.6"
-source = "git+https://github.com/rustls/rustls#a2802e69c4ba181a3fa0a313938db38d67249e87"
+source = "git+https://github.com/metalbear-co/rustls?branch=feat-ip-address#c706a865b99b7f1743342060178b28aed0257682"
 dependencies = [
  "log",
  "ring",
  "sct",
- "webpki",
+ "webpki 0.21.4",
 ]
 
 [[package]]
@@ -2953,7 +2953,7 @@ checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
 dependencies = [
  "rustls",
  "tokio",
- "webpki",
+ "webpki 0.22.0",
 ]
 
 [[package]]
@@ -3432,6 +3432,15 @@ dependencies = [
  "web-sys",
  "widestring",
  "winapi",
+]
+
+[[package]]
+name = "webpki"
+version = "0.21.4"
+source = "git+https://github.com/metalbear-co/webpki?branch=feat-ip-address#53a0215d998ec4bef37e55a5b7eed7d41f20e8ac"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,10 @@ streammap-ext = "0.1"
 # so we patch crates.io to use the latest commits from rustls
 # this should be changed once a newer version of rustls is ou
 [patch.crates-io]
-rustls = { git = 'https://github.com/rustls/rustls' }
+rustls = { git = "https://github.com/metalbear-co/rustls", branch = "feat-ip-address" }
+
+[patch."https://github.com/ctz/webpki"]
+webpki = { git = "https://github.com/metalbear-co/webpki", branch = "feat-ip-address" }
 
 [profile.release]
 strip = "debuginfo"


### PR DESCRIPTION
Workaround patch for supporting Kubernetes cluster that has IP as CNAME in it's certificate due to rustls/rustls#184

workaround for #388 and #39