### PR TITLE
Support impersonating deployments

### DIFF
--- a/mirrord-cli/src/config.rs
+++ b/mirrord-cli/src/config.rs
@@ -23,6 +23,10 @@ pub(super) struct ExecArgs {
     #[clap(short, long, value_parser)]
     pub pod_name: String,
 
+    /// Deployment name to mirror.
+    #[clap(short, long, value_parser)]
+    pub deployment_name: Option<String>,
+
     /// Namespace of the pod to mirror. Defaults to "default".
     #[clap(short = 'n', long, value_parser)]
     pub pod_namespace: Option<String>,

--- a/mirrord-cli/src/main.rs
+++ b/mirrord-cli/src/main.rs
@@ -105,10 +105,7 @@ fn exec(args: &ExecArgs) -> Result<()> {
     std::env::set_var("MIRRORD_AGENT_IMPERSONATED_POD_NAME", args.pod_name.clone());
 
     if let Some(deployment) = &args.deployment_name {
-        std::env::set_var(
-            "MIRRORD_IMPERSONATED_DEPLOYMENT_NAME",
-            deployment_name.clone(),
-        );
+        std::env::set_var("MIRRORD_IMPERSONATED_DEPLOYMENT_NAME", deployment.clone());
     }
 
     if let Some(namespace) = &args.pod_namespace {

--- a/mirrord-cli/src/main.rs
+++ b/mirrord-cli/src/main.rs
@@ -104,6 +104,13 @@ fn exec(args: &ExecArgs) -> Result<()> {
 
     std::env::set_var("MIRRORD_AGENT_IMPERSONATED_POD_NAME", args.pod_name.clone());
 
+    if let Some(deployment) = &args.deployment_name {
+        std::env::set_var(
+            "MIRRORD_IMPERSONATED_DEPLOYMENT_NAME",
+            deployment_name.clone(),
+        );
+    }
+
     if let Some(namespace) = &args.pod_namespace {
         std::env::set_var(
             "MIRRORD_AGENT_IMPERSONATED_POD_NAMESPACE",

--- a/mirrord-layer/src/config.rs
+++ b/mirrord-layer/src/config.rs
@@ -17,6 +17,9 @@ pub struct LayerConfig {
     #[envconfig(from = "MIRRORD_AGENT_IMPERSONATED_POD_NAME")]
     pub impersonated_pod_name: String,
 
+    #[envconfig(from = "MIRRORD_IMPERSONATED_DEPLOYMENT_NAME")]
+    pub impersonated_deployment_name: Option<String>,
+
     #[envconfig(from = "MIRRORD_AGENT_IMPERSONATED_POD_NAMESPACE", default = "default")]
     pub impersonated_pod_namespace: String,
 


### PR DESCRIPTION
closes https://github.com/metalbear-co/mirrord/issues/293

WIP - donot review:
- keep the mandatory `--pod-name` flag
- if `--deployment-name` is provided then pod name is picked from the deployment and matched with the given mandatory pod name, else pod name from the deployment is picked.
- container logic remains the same

TODO: is there a way to make clap only one of target-name or pod-name