### PR TITLE
Bugfix: crashing on connect with UDP sockets.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+### Fixed
+- mirrord-layer: Fix `connect` returning error when called on UDP sockets and the 
+  outgoing traffic feature of mirrord is disabled, by bypassing the detour in that 
+  case.
+
 ## 3.0.5-alpha
 
 ### Fixed

--- a/mirrord-layer/src/socket/hooks.rs
+++ b/mirrord-layer/src/socket/hooks.rs
@@ -103,6 +103,7 @@ pub(crate) unsafe extern "C" fn connect_detour(
                     .map_err(|fail| match fail {
                         HookError::LocalFDNotFound(_)
                         | HookError::SocketInvalidState(_)
+                        | HookError::BypassedType(_)
                         | HookError::BypassedPort(_) => {
                             warn!("connect_detour -> bypassed with {:#?}", fail);
                             FN_CONNECT(sockfd, raw_address, address_length)

--- a/tests/node-e2e/outgoing/test_outgoing_traffic_udp_client_with_connect.mjs
+++ b/tests/node-e2e/outgoing/test_outgoing_traffic_udp_client_with_connect.mjs
@@ -1,0 +1,41 @@
+import dgram from 'node:dgram';
+import { argv } from 'node:process';
+
+// Defaults
+let server_address = '127.0.0.1'
+let server_port = '31415';
+
+// Arguments override defaults if present.
+// First argument is port, second is address (so that you can override only port).
+if (argv.length >= 3) {
+    server_port = argv[2];
+    if (argv.length >= 4) {
+        server_address = argv[3];
+    }
+}
+
+const client_socket = dgram.createSocket('udp4');
+
+client_socket.on('error', (err) => {
+        client_socket.close();
+        if (err) {
+            throw err
+        }
+    }
+);
+console.log(`using port ${server_port} and host ${server_address}`);
+client_socket.bind('31413'); // Currently mirrord will ignore binding to port 0.
+client_socket.connect(server_port, server_address, (connect_err) => {
+    if (connect_err) {
+        client_socket.close();
+        throw connect_err
+    }
+    client_socket.send('Can I pass the test please?\n', (send_err) => {
+        if (send_err) {
+            client_socket.close();
+            throw send_err
+        }
+    });
+    client_socket.close();
+});
+


### PR DESCRIPTION
Currently, when called with `--no-outgoing` and the app calls `connect` on a UDP socket, the hook fails and `connect` returns an error to the app.