### PR TITLE
Fix go-e2e-dns module.

### DIFF
--- a/tests/go-e2e-dns/go.mod
+++ b/tests/go-e2e-dns/go.mod
@@ -1,3 +1,3 @@
-module go-e2e-outgoing
+module go-e2e-dns
 
 go 1.19


### PR DESCRIPTION
Missed the name for this go module, fixing.