### PR TITLE
3.0.10-alpha - macOS binaries should be okay now.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,7 +33,7 @@ jobs:
             target/${{matrix.target}}/release/libmirrord_layer.${{matrix.extension}}
           if-no-files-found: error
   build_binaries_macos:
-    runs-on: macos-latest
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,17 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+## 3.0.10-alpha
+
 ### Added
 - Test that verifies that outgoing UDP traffic (only with a bind to non-0 port and a 
   call to `connect`) is successfully intercepted and forwarded.
+
+### Fixed
+- macOS binaries should be okay now.
+
+
+### Fixed
 
 ## 3.0.9-alpha
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1439,7 +1439,7 @@ dependencies = [
 
 [[package]]
 name = "mirrord"
-version = "3.0.9-alpha"
+version = "3.0.10-alpha"
 dependencies = [
  "anyhow",
  "clap 3.2.20",
@@ -1455,7 +1455,7 @@ dependencies = [
 
 [[package]]
 name = "mirrord-agent"
-version = "3.0.9-alpha"
+version = "3.0.10-alpha"
 dependencies = [
  "actix-codec",
  "bollard",
@@ -1489,7 +1489,7 @@ dependencies = [
 
 [[package]]
 name = "mirrord-auth"
-version = "3.0.9-alpha"
+version = "3.0.10-alpha"
 dependencies = [
  "lazy_static",
  "rand 0.8.5",
@@ -1502,7 +1502,7 @@ dependencies = [
 
 [[package]]
 name = "mirrord-layer"
-version = "3.0.9-alpha"
+version = "3.0.10-alpha"
 dependencies = [
  "actix-codec",
  "anyhow",
@@ -1537,7 +1537,7 @@ dependencies = [
 
 [[package]]
 name = "mirrord-macro"
-version = "3.0.9-alpha"
+version = "3.0.10-alpha"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1546,7 +1546,7 @@ dependencies = [
 
 [[package]]
 name = "mirrord-protocol"
-version = "3.0.9-alpha"
+version = "3.0.10-alpha"
 dependencies = [
  "actix-codec",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 
 # latest commits on rustls suppress certificate verification
 [workspace.package]
-version = "3.0.9-alpha"
+version = "3.0.10-alpha"
 edition = "2021"
 license = "MIT"
 readme = "README.md"

--- a/intellij-ext/gradle.properties
+++ b/intellij-ext/gradle.properties
@@ -4,7 +4,7 @@
 pluginGroup = com.metalbear.mirrord
 pluginName = mirrord
 # SemVer format -> https://semver.org
-pluginVersion = 3.0.9-alpha
+pluginVersion = 3.0.10-alpha
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.

--- a/vscode-ext/package-lock.json
+++ b/vscode-ext/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "mirrord",
-	"version": "3.0.9",
+	"version": "3.0.10",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "mirrord",
-			"version": "3.0.9",
+			"version": "3.0.10",
 			"dependencies": {
 				"@kubernetes/client-node": "^0.16.3",
 				"es5-ext": "<=0.10.53",

--- a/vscode-ext/package.json
+++ b/vscode-ext/package.json
@@ -3,7 +3,7 @@
 	"displayName": "mirrord",
 	"description": "Mirror live traffic from your Kubernetes cluster to your local debugged process.",
 	"publisher": "MetalBear",
-	"version": "3.0.9",
+	"version": "3.0.10",
 	"engines": {
 		"vscode": "^1.63.0"
 	},


### PR DESCRIPTION
Thank you for contributing to mirrord!

Please make sure you added a CHANGELOG entry & squashed your PR to one commit.