### PR TITLE
dotnet e2e

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,11 +9,21 @@ __pycache__
 target
 
 ### go tests ###
-tests/go-e2e/go-e2e
-tests/go-e2e-env/go-e2e-env
-tests/go-e2e-fileops/go-e2e-fileops
-tests/go-e2e-outgoing/go-e2e-outgoing
-tests/go-e2e-dns/go-e2e-dns
+tests/go-e2e/18
+tests/go-e2e-env/18
+tests/go-e2e-fileops/18
+tests/go-e2e-outgoing/18
+tests/go-e2e-dns/18
+
+tests/go-e2e/19
+tests/go-e2e-env/19
+tests/go-e2e-fileops/19
+tests/go-e2e-outgoing/19
+tests/go-e2e-dns/19
+
+### dotnet tests ###
+tests/dotnet-e2e/*/bin
+tests/dotnet-e2e/*/obj
 
 ### VSCode ###
 .vscode/*

--- a/tests/dotnet-e2e/dns/Program.cs
+++ b/tests/dotnet-e2e/dns/Program.cs
@@ -1,0 +1,6 @@
+using System.Net;
+
+var url = "https://google.com";
+Uri myUri = new Uri(url);
+var ip = (await Dns.GetHostAddressesAsync(myUri.Host))[0];
+Console.WriteLine(ip);

--- a/tests/dotnet-e2e/dns/dns.csproj
+++ b/tests/dotnet-e2e/dns/dns.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+</Project>

--- a/tests/dotnet-e2e/env/Program.cs
+++ b/tests/dotnet-e2e/env/Program.cs
@@ -1,0 +1,12 @@
+﻿Dictionary<string, string> environmentVariables = new()
+{
+    ["MIRRORD_FAKE_VAR_FIRST"] = "mirrord.is.running",
+    ["MIRRORD_FAKE_VAR_SECOND"] = "7777",
+    ["MIRRORD_FAKE_VAR_THIRD"] = "foo=bar",
+};
+
+foreach (var (key, value) in environmentVariables)
+{
+    if (Environment.GetEnvironmentVariable(key, EnvironmentVariableTarget.Process) != value)
+        throw new Exception($"missing env var {key}");
+}

--- a/tests/dotnet-e2e/env/env.csproj
+++ b/tests/dotnet-e2e/env/env.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/tests/dotnet-e2e/fileops/Program.cs
+++ b/tests/dotnet-e2e/fileops/Program.cs
@@ -1,0 +1,78 @@
+﻿var TEXT = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";
+
+// Read
+
+{
+    var dat = File.ReadAllText("/app/test.txt");
+
+    if (dat != TEXT)
+        throw new Exception($"Expected {TEXT}, got {dat}");
+}
+
+
+// Write
+
+{
+    var filePath = createTempFile();
+    checkFileExistsOnHost(filePath);
+
+    var dat = File.ReadAllText(filePath);
+
+    if (dat != TEXT)
+        throw new Exception($"Expected {TEXT}, got {dat}");
+
+    File.Delete(filePath);
+}
+
+
+// Lseek
+
+{
+    var filePath = createTempFile();
+    checkFileExistsOnHost(filePath);
+
+    var fileStream = File.Open(filePath, FileMode.Open);
+    var buf = new byte[TEXT.Length];
+
+    // https://learn.microsoft.com/en-us/dotnet/api/system.io.filestream.canseek?view=net-6.0
+    if (!fileStream.CanSeek)
+        throw new Exception("file stream CanSeek failure");
+
+    // Arg 2 specifies offset for stream
+    fileStream.Read(buf, 0, buf.Length);
+
+    if (System.Text.Encoding.Default.GetString(buf) != TEXT)
+        throw new Exception($"Expected {TEXT}, got {System.Text.Encoding.Default.GetString(buf)}");
+
+    fileStream.Close();
+    File.Delete(filePath);
+}
+
+
+// Faccessat
+// TODO: syscall limitations x-platform. Will revisit after discussion
+
+{
+    var filePath = createTempFile();
+    checkFileExistsOnHost(filePath);
+
+    var fileStream = File.Open(filePath, FileMode.Append);
+
+    fileStream.Close();
+    File.Delete(filePath);
+}
+
+// helpers
+
+string createTempFile()
+{
+    var filePath = $"/tmp/tmpF-{Guid.NewGuid()}.txt";
+    File.WriteAllText(filePath, TEXT);
+    return filePath;
+}
+
+void checkFileExistsOnHost(string fileName)
+{
+    if (File.Exists(fileName))
+        throw new Exception("file exists on host");
+}

--- a/tests/dotnet-e2e/fileops/fileops.csproj
+++ b/tests/dotnet-e2e/fileops/fileops.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/tests/dotnet-e2e/http/Program.cs
+++ b/tests/dotnet-e2e/http/Program.cs
@@ -1,0 +1,17 @@
+// https://learn.microsoft.com/en-us/aspnet/core/fundamentals/servers/kestrel?view=aspnetcore-6.0#get-started
+// "the WebApplication.CreateBuilder method calls UseKestrel internally"
+var builder = WebApplication.CreateBuilder(args);
+builder.WebHost.UseUrls("http://0.0.0.0:80");
+
+var app = builder.Build();
+
+app.MapGet("/", () => "GET");
+
+app.MapPost("/", () => "POST");
+
+app.MapPut("/", () => "PUT");
+
+app.MapDelete("/", () => "DELETE");
+
+Console.WriteLine("Kestrel server starting");
+app.Run();

--- a/tests/dotnet-e2e/http/http.csproj
+++ b/tests/dotnet-e2e/http/http.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+</Project>

--- a/tests/dotnet-e2e/outgoing/Program.cs
+++ b/tests/dotnet-e2e/outgoing/Program.cs
@@ -1,0 +1,8 @@
+﻿using Flurl.Http;
+
+var response = await "http://www.google.com/robots.txt".GetAsync();
+
+if (response.StatusCode > 299)
+    throw new Exception("Response failed with status code");
+
+Console.WriteLine(await response.GetStringAsync());

--- a/tests/dotnet-e2e/outgoing/outgoing.csproj
+++ b/tests/dotnet-e2e/outgoing/outgoing.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Flurl.Http" Version="3.2.4" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
# Summary

Extend e2e coverage to include net6.0 runtime and Kestrel web server.

# Coverage

I've been running the sanity tests against these environments

- [X] macos arm64 (local)
- [X] linux bullseye arm64 (container)
- [ ] linux buster x86_64 (container) [coming soon]

# Tasks

- [X] Make tests
- [ ] Get Feedback on work
- [ ] Update change log after feedback and code updates
- [ ] Update CI to run tests

---

# Criticism and feedback welcome 😄 

Drafting a pr for feedback. I will have all of the tasks above completed (including squashing and changelog as the guideline dictates) before I move from the draft state. 

I have a few questions about the code myself, but that can wait till tomorrow 😴 