### PR TITLE
Don't proxy connections that will just connect to our process anyway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+### Changed
+- mirrord-layer: When handling an outgoing connection to localhost, check first if it's a socket we intercept/mirror, then just let it connect normally.
+
 ## 3.0.11-alpha
 
 ### Added

--- a/mirrord-layer/src/socket/ops.rs
+++ b/mirrord-layer/src/socket/ops.rs
@@ -288,6 +288,23 @@ pub(super) fn connect(sockfd: RawFd, remote_address: SocketAddr) -> HookResult<i
         }
     };
 
+    // if it's loopback, check if it's a port we're listening to and if so, just let it connect
+    // locally.
+    if remote_address.ip().is_loopback() {
+        if SOCKETS.lock()?.values().any(|socket| {
+            if let SocketState::Listening(Bound { requested_port, .. }) = socket.state {
+                requested_port == remote_address.port()
+                    && socket.protocol == user_socket_info.protocol // added this line even though
+                                                                    // listen is only tcp for
+                                                                    // future..
+            } else {
+                false
+            }
+        }) {
+            return raw_connect(remote_address);
+        }
+    }
+
     match user_socket_info.kind {
         SocketKind::Udp(_) if enabled_udp_outgoing => {
             connect_outgoing::<UDP>(sockfd, remote_address, user_socket_info)

--- a/mirrord-layer/src/socket/ops.rs
+++ b/mirrord-layer/src/socket/ops.rs
@@ -290,8 +290,8 @@ pub(super) fn connect(sockfd: RawFd, remote_address: SocketAddr) -> HookResult<i
 
     // if it's loopback, check if it's a port we're listening to and if so, just let it connect
     // locally.
-    if remote_address.ip().is_loopback() {
-        if SOCKETS.lock()?.values().any(|socket| {
+    if remote_address.ip().is_loopback()
+        && SOCKETS.lock()?.values().any(|socket| {
             if let SocketState::Listening(Bound { requested_port, .. }) = socket.state {
                 requested_port == remote_address.port()
                     && socket.protocol == user_socket_info.protocol // added this line even though
@@ -300,9 +300,9 @@ pub(super) fn connect(sockfd: RawFd, remote_address: SocketAddr) -> HookResult<i
             } else {
                 false
             }
-        }) {
-            return raw_connect(remote_address);
-        }
+        })
+    {
+        return raw_connect(remote_address);
     }
 
     match user_socket_info.kind {


### PR DESCRIPTION
When handling an outgoing connection to localhost, check first if it's a socket we intercept/mirror, then just let it connect normally.