### PR TITLE
Make Go test stable.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -160,7 +160,7 @@ jobs:
           profile: minimal
           toolchain: nightly
           components: rustfmt
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
         with:
           key: ubuntu-latest
       - run: cargo +nightly build --manifest-path=./Cargo.toml
@@ -183,7 +183,7 @@ jobs:
           profile: minimal
           toolchain: nightly
           target: x86_64-unknown-linux-gnu
-      - uses: Swatinem/rust-cache@v1          # Restore rust cache from earlier runs to avoid recompiling dependencies.
+      - uses: Swatinem/rust-cache@v2          # Restore rust cache from earlier runs to avoid recompiling dependencies.
         with:
           key: ubuntu-latest
           cache-on-failure: true
@@ -220,7 +220,7 @@ jobs:
           profile: minimal
           toolchain: nightly
           target: x86_64-apple-darwin
-      - uses: Swatinem/rust-cache@v1          # Restore rust cache from earlier runs to avoid recompiling dependencies.
+      - uses: Swatinem/rust-cache@v2          # Restore rust cache from earlier runs to avoid recompiling dependencies.
         with:
           key: macos-12
           cache-on-failure: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -187,13 +187,12 @@ jobs:
         with:
           key: ubuntu-latest
           cache-on-failure: true
-      # TODO: Uncomment when go is enabled.
-      # - uses: actions/setup-go@v3             # Install Go for http mirroring tests with a Go webserver.
-      #   with:
-      #     go-version: "1.19.0"
-      # - run: |                                # Build Go app to test http mirroring with.
-      #     cd mirrord-layer/tests/apps/app_go
-      #     go build -o 19
+      - uses: actions/setup-go@v3             # Install Go for http mirroring tests with a Go webserver.
+        with:
+          go-version: "1.19.0"
+      - run: |                                # Build Go app to test http mirroring with.
+          cd mirrord-layer/tests/apps/app_go
+          go build -o 19
       - uses: actions/setup-node@v3           # For http mirroring test.
         with:
           node-version: 14
@@ -225,13 +224,12 @@ jobs:
         with:
           key: macos-12
           cache-on-failure: true
-      # TODO: Uncomment when go is enabled.
-      # - uses: actions/setup-go@v3             # Install Go for http mirroring tests with a Go webserver.
-      #   with:
-      #     go-version: "1.19.0"
-      # - run: |                                # Build Go app to test http mirroring with.
-      #     cd mirrord-layer/tests/apps/app_go
-      #     go build -o 19
+      - uses: actions/setup-go@v3             # Install Go for http mirroring tests with a Go webserver.
+        with:
+          go-version: "1.19.0"
+      - run: |                                # Build Go app to test http mirroring with.
+          cd mirrord-layer/tests/apps/app_go
+          go build -o 19
       - uses: actions/setup-node@v3
         with:
           node-version: 14

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -185,7 +185,6 @@ jobs:
           target: x86_64-unknown-linux-gnu
       - uses: Swatinem/rust-cache@v2          # Restore rust cache from earlier runs to avoid recompiling dependencies.
         with:
-          key: ubuntu-latest
           cache-on-failure: true
       - uses: actions/setup-go@v3             # Install Go for http mirroring tests with a Go webserver.
         with:
@@ -222,7 +221,6 @@ jobs:
           target: x86_64-apple-darwin
       - uses: Swatinem/rust-cache@v2          # Restore rust cache from earlier runs to avoid recompiling dependencies.
         with:
-          key: macos-12
           cache-on-failure: true
       - uses: actions/setup-go@v3             # Install Go for http mirroring tests with a Go webserver.
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -186,12 +186,6 @@ jobs:
       - uses: Swatinem/rust-cache@v2          # Restore rust cache from earlier runs to avoid recompiling dependencies.
         with:
           cache-on-failure: true
-      - uses: actions/setup-go@v3             # Install Go for http mirroring tests with a Go webserver.
-        with:
-          go-version: "1.19.0"
-      - run: |                                # Build Go app to test http mirroring with.
-          cd mirrord-layer/tests/apps/app_go
-          go build -o 19
       - uses: actions/setup-node@v3           # For http mirroring test.
         with:
           node-version: 14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ## [Unreleased]
 
 ### Added
-- Layer integration tests for more apps. Closes
-  [[#472](https://github.com/metalbear-co/mirrord/issues/472)].
+- Layer integration tests with more apps (testing with Go only on MacOS because of
+  known crash on Linux - [[#380](https://github.com/metalbear-co/mirrord/issues/380)]).
+  Closes [[#472](https://github.com/metalbear-co/mirrord/issues/472)].
 
 ## Changed
 - Don't report InProgress io error as error (log as info)

--- a/mirrord-layer/tests/apps/app_go/main.go
+++ b/mirrord-layer/tests/apps/app_go/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"context"
+	"time"
 	"fmt"
 	"net/http"
 	"os"
@@ -17,26 +19,29 @@ func main() {
 	r := gin.Default()
     server := &http.Server{Addr: ":80", Handler: r}
 
+    var wg sync.WaitGroup
+    var mut_done sync.Mutex
     done := make(map[string]bool)
     done["GET"] = false
     done["POST"] = false
     done["PUT"] = false
     done["DELETE"] = false
+
+    wg.Add(len(done))
+
     get_handler := func (method string) func(c *gin.Context) {
         return func(c *gin.Context) {
             fmt.Printf("%s: Request completed\n", method)
             c.String(http.StatusOK, method)
-            defer func() {
-                done[method] = true;
-                for _, isDone := range done {
-                    if !isDone {
-                        return
-                    }
-                }
-                fmt.Printf("All done after %s.\n", method)
-                fmt.Println("done map:", done)
-                server.Shutdown(c)
-            }()
+
+            mut_done.Lock()
+            first := !done[method]  // Is this the first request of this method.
+            done[method] = true
+            mut_done.Unlock()
+
+            if (first) {   // So that methods don't get counted more than once if they're sent multiple times.
+                defer wg.Done() // Tell main we're done.
+            }
         }
     }
 
@@ -45,16 +50,29 @@ func main() {
 	r.PUT("/", get_handler("PUT"))
 	r.DELETE("/", get_handler("DELETE"))
 
-	fmt.Println("Server listening on port 80")
-
-    serverDone := &sync.WaitGroup{}
-    serverDone.Add(1)
     go func() {
-        defer serverDone.Done()
-        if err := server.ListenAndServe(); err != http.ErrServerClosed {
-            fmt.Println("Error: Go app can't start listening.")
+        fmt.Println("Server listening on port 80")
+        if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+            fmt.Println("Error: listen: %s\n", err)
             os.Exit(1)
         }
     }()
-    serverDone.Wait()
+
+
+    fmt.Println("Main: waiting for all unique requests to be done.")
+    wg.Wait() // Wait for all methods to be done for the first time before shutting down server.
+    fmt.Println("Main: all done, shutting server down.")
+
+    // Shutdown server gracefully. If graceful shutdown is not done in 2 seconds just cancel.
+    ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+    defer cancel()
+    if err := server.Shutdown(ctx); err != nil {
+        fmt.Println("Error: Server Shutdown:", err)
+        os.Exit(1)
+    }
+    // catching ctx.Done(). timeout of 2 seconds.
+    select {
+    case <-ctx.Done():
+        fmt.Println("Server exiting")
+    }
 }

--- a/mirrord-layer/tests/apps/app_go/main.go
+++ b/mirrord-layer/tests/apps/app_go/main.go
@@ -2,77 +2,74 @@ package main
 
 import (
 	"context"
-	"time"
 	"fmt"
 	"net/http"
 	"os"
-    "sync"
+	"sync"
+	"time"
 
 	"github.com/gin-gonic/gin"
 )
-
-
 
 func main() {
 	fmt.Println(os.Environ())
 	gin.SetMode(gin.ReleaseMode)
 	r := gin.Default()
-    server := &http.Server{Addr: ":80", Handler: r}
+	server := &http.Server{Addr: ":80", Handler: r}
 
-    var wg sync.WaitGroup
-    var mut_done sync.Mutex
-    done := make(map[string]bool)
-    done["GET"] = false
-    done["POST"] = false
-    done["PUT"] = false
-    done["DELETE"] = false
+	var wg sync.WaitGroup
+	var mut_done sync.Mutex
+	done := make(map[string]bool)
+	done["GET"] = false
+	done["POST"] = false
+	done["PUT"] = false
+	done["DELETE"] = false
 
-    wg.Add(len(done))
+	wg.Add(len(done))
 
-    get_handler := func (method string) func(c *gin.Context) {
-        return func(c *gin.Context) {
-            fmt.Printf("%s: Request completed\n", method)
-            c.String(http.StatusOK, method)
+	get_handler := func(method string) func(c *gin.Context) {
+		return func(c *gin.Context) {
+			fmt.Printf("%s: Request completed\n", method)
+			c.String(http.StatusOK, method)
 
-            mut_done.Lock()
-            first := !done[method]  // Is this the first request of this method.
-            done[method] = true
-            mut_done.Unlock()
+			mut_done.Lock()
+			first := !done[method] // Is this the first request of this method.
+			done[method] = true
+			mut_done.Unlock()
 
-            if (first) {   // So that methods don't get counted more than once if they're sent multiple times.
-                defer wg.Done() // Tell main we're done.
-            }
-        }
-    }
+			if first { // So that methods don't get counted more than once if they're sent multiple times.
+				defer wg.Done() // Tell main we're done.
+			}
+		}
+	}
 
 	r.GET("/", get_handler("GET"))
 	r.POST("/", get_handler("POST"))
 	r.PUT("/", get_handler("PUT"))
 	r.DELETE("/", get_handler("DELETE"))
 
-    go func() {
-        fmt.Println("Server listening on port 80")
-        if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-            fmt.Println("Error: listen: %s\n", err)
-            os.Exit(1)
-        }
-    }()
+	go func() {
+		fmt.Println("Server listening on port 80")
+		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			fmt.Println("Error: listen: %s\n", err)
+			os.Exit(1)
+		}
+	}()
 
+	fmt.Println("Main: waiting for all unique requests to be done.")
+	wg.Wait() // Wait for all methods to be done for the first time before shutting down server.
+	fmt.Println("Main: all done, shutting server down.")
 
-    fmt.Println("Main: waiting for all unique requests to be done.")
-    wg.Wait() // Wait for all methods to be done for the first time before shutting down server.
-    fmt.Println("Main: all done, shutting server down.")
-
-    // Shutdown server gracefully. If graceful shutdown is not done in 2 seconds just cancel.
-    ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-    defer cancel()
-    if err := server.Shutdown(ctx); err != nil {
-        fmt.Println("Error: Server Shutdown:", err)
-        os.Exit(1)
-    }
-    // catching ctx.Done(). timeout of 2 seconds.
-    select {
-    case <-ctx.Done():
-        fmt.Println("Server exiting")
-    }
+	// Shutdown server gracefully. If graceful shutdown is not done in 2 seconds just cancel.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := server.Shutdown(ctx); err != nil {
+		fmt.Println("Error: Server Shutdown:", err)
+		os.Exit(1)
+	}
+	// catching ctx.Done(). timeout of 2 seconds.
+	select {
+	case <-ctx.Done():
+		fmt.Println("Server exiting")
+	}
 }

--- a/mirrord-layer/tests/http_mirroring.rs
+++ b/mirrord-layer/tests/http_mirroring.rs
@@ -190,18 +190,18 @@ impl Application {
 
 /// For running locally, so that new developers don't have the extra step of building the go app
 /// before running the tests.
-// #[ctor::ctor]
-// fn build_go_app() {
-//     let original_dir = env::current_dir().unwrap();
-//     let go_app_path = Path::new("tests/apps/app_go");
-//     env::set_current_dir(go_app_path).unwrap();
-//     let output = process::Command::new("go")
-//         .args(vec!["build", "-o", "19"])
-//         .output()
-//         .expect("Failed to build Go test app.");
-//     assert!(output.status.success(), "Building Go test app failed.");
-//     env::set_current_dir(original_dir).unwrap();
-// }
+#[ctor::ctor]
+fn build_go_app() {
+    let original_dir = env::current_dir().unwrap();
+    let go_app_path = Path::new("tests/apps/app_go");
+    env::set_current_dir(go_app_path).unwrap();
+    let output = process::Command::new("go")
+        .args(vec!["build", "-o", "19"])
+        .output()
+        .expect("Failed to build Go test app.");
+    assert!(output.status.success(), "Building Go test app failed.");
+    env::set_current_dir(original_dir).unwrap();
+}
 
 /// Return the path to the existing layer lib, or build it first and return the path, according to
 /// whether the environment variable MIRRORD_TEST_USE_EXISTING_LIB is set.
@@ -239,7 +239,7 @@ async fn test_mirroring_with_http(
         Application::PythonFlaskHTTP,
         Application::PythonFastApiHTTP,
         Application::NodeHTTP,
-        // Application::Go19HTTP
+        Application::Go19HTTP
     )]
     application: Application,
     dylib_path: &PathBuf,

--- a/mirrord-layer/tests/http_mirroring.rs
+++ b/mirrord-layer/tests/http_mirroring.rs
@@ -239,7 +239,7 @@ async fn test_mirroring_with_http(
     #[values(
         Application::PythonFlaskHTTP,
         Application::PythonFastApiHTTP,
-        Application::NodeHTTP,
+        Application::NodeHTTP
     )]
     application: Application,
     dylib_path: &PathBuf,

--- a/mirrord-layer/tests/http_mirroring.rs
+++ b/mirrord-layer/tests/http_mirroring.rs
@@ -288,12 +288,12 @@ async fn test_mirroring_with_http(
     let output = server.wait_with_output().await.unwrap();
     let stdout_str = String::from_utf8_lossy(&output.stdout).to_string();
     println!("{stdout_str}");
+    let stderr_str = String::from_utf8_lossy(&output.stderr).to_string();
+    println!("stderr:\n{stderr_str}");
     assert!(stdout_str.contains("GET: Request completed"));
     assert!(stdout_str.contains("POST: Request completed"));
     assert!(stdout_str.contains("PUT: Request completed"));
     assert!(stdout_str.contains("DELETE: Request completed"));
     assert!(!&stdout_str.to_lowercase().contains("error"));
-    let stderr_str = String::from_utf8_lossy(&output.stderr).to_string();
-    println!("stderr:\n{stderr_str}");
     assert!(!&stderr_str.to_lowercase().contains("error"));
 }

--- a/mirrord-layer/tests/http_mirroring.rs
+++ b/mirrord-layer/tests/http_mirroring.rs
@@ -190,6 +190,7 @@ impl Application {
 
 /// For running locally, so that new developers don't have the extra step of building the go app
 /// before running the tests.
+#[cfg(target_os = "macos")]
 #[ctor::ctor]
 fn build_go_app() {
     let original_dir = env::current_dir().unwrap();
@@ -239,7 +240,6 @@ async fn test_mirroring_with_http(
         Application::PythonFlaskHTTP,
         Application::PythonFastApiHTTP,
         Application::NodeHTTP,
-        Application::Go19HTTP
     )]
     application: Application,
     dylib_path: &PathBuf,
@@ -296,4 +296,13 @@ async fn test_mirroring_with_http(
     assert!(stdout_str.contains("DELETE: Request completed"));
     assert!(!&stdout_str.to_lowercase().contains("error"));
     assert!(!&stderr_str.to_lowercase().contains("error"));
+}
+
+/// Run the http mirroring test only on MacOS, because of a known crash on Linux.
+#[cfg(target_os = "macos")]
+#[rstest]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[timeout(Duration::from_secs(20))]
+async fn test_mirroring_with_http_go(dylib_path: &PathBuf) {
+    test_mirroring_with_http(Application::Go19HTTP, dylib_path).await;
 }


### PR DESCRIPTION
Wait for all unique methods to be done once, using a wait group. Synchronize done map with a mutex so that the same http method does not report it's done twice, if e.g. two GETs are sent.