### PR TITLE
feat(config): JSON schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1673,6 +1673,7 @@ dependencies = [
  "mirrord-config-derive",
  "mirrord-macro",
  "rstest",
+ "schemars",
  "serde",
  "serde_json",
  "serde_yaml 0.9.13",

--- a/mirrord-config/Cargo.toml
+++ b/mirrord-config/Cargo.toml
@@ -23,6 +23,10 @@ serde_json.workspace = true
 thiserror.workspace = true
 serde_yaml = "0.9"
 toml = "0.5"
+schemars = { version = "0.8.11", optional = true }
 
 [dev-dependencies]
 rstest = "*"
+
+[features]
+schema = ["dep:schemars"]

--- a/mirrord-config/src/agent.rs
+++ b/mirrord-config/src/agent.rs
@@ -4,6 +4,7 @@ use serde::Deserialize;
 use crate::config::source::MirrordConfigSource;
 
 #[derive(MirrordConfig, Deserialize, Default, PartialEq, Eq, Clone, Debug)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(deny_unknown_fields)]
 #[config(map_to = AgentConfig)]
 pub struct AgentFileConfig {

--- a/mirrord-config/src/env.rs
+++ b/mirrord-config/src/env.rs
@@ -7,6 +7,7 @@ use crate::{
 };
 
 #[derive(MirrordConfig, Default, Deserialize, PartialEq, Eq, Clone, Debug)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(deny_unknown_fields)]
 #[config(map_to = EnvConfig)]
 pub struct EnvFileConfig {

--- a/mirrord-config/src/feature.rs
+++ b/mirrord-config/src/feature.rs
@@ -7,6 +7,7 @@ use crate::{
 };
 
 #[derive(MirrordConfig, Deserialize, Default, PartialEq, Eq, Clone, Debug)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(deny_unknown_fields)]
 #[config(map_to = FeatureConfig)]
 pub struct FeatureFileConfig {

--- a/mirrord-config/src/fs.rs
+++ b/mirrord-config/src/fs.rs
@@ -6,6 +6,7 @@ use crate::{
 };
 
 #[derive(Deserialize, PartialEq, Eq, Clone, Debug)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "lowercase")]
 pub enum FsConfig {
     Disabled,

--- a/mirrord-config/src/incoming.rs
+++ b/mirrord-config/src/incoming.rs
@@ -4,6 +4,7 @@ use serde::Deserialize;
 use thiserror::Error;
 
 #[derive(Deserialize, PartialEq, Eq, Clone, Debug)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "lowercase")]
 pub enum IncomingConfig {
     Mirror,

--- a/mirrord-config/src/lib.rs
+++ b/mirrord-config/src/lib.rs
@@ -268,8 +268,9 @@ mod tests {
     }
 
     /// Helper for printing the config schema.
-    /// 
-    /// Run it with `cargo test -p mirrord-config --ignored print_schema --features schema -- --nocapture`
+    ///
+    /// Run it with `cargo test -p mirrord-config --ignored print_schema --features schema --
+    /// --nocapture`
     #[cfg(feature = "schema")]
     #[test]
     #[ignore]

--- a/mirrord-config/src/lib.rs
+++ b/mirrord-config/src/lib.rs
@@ -272,7 +272,7 @@ mod tests {
     /// Run it with:
     ///
     /// ```sh
-    /// cargo test -p mirrord-config --ignored print_schema --features schema -- --nocapture
+    /// cargo test -p mirrord-config print_schema --features schema -- --ignored --nocapture
     /// ```
     #[cfg(feature = "schema")]
     #[test]

--- a/mirrord-config/src/lib.rs
+++ b/mirrord-config/src/lib.rs
@@ -269,8 +269,11 @@ mod tests {
 
     /// Helper for printing the config schema.
     ///
-    /// Run it with `cargo test -p mirrord-config --ignored print_schema --features schema --
-    /// --nocapture`
+    /// Run it with:
+    ///
+    /// ```sh
+    /// cargo test -p mirrord-config --ignored print_schema --features schema -- --nocapture
+    /// ```
     #[cfg(feature = "schema")]
     #[test]
     #[ignore]

--- a/mirrord-config/src/lib.rs
+++ b/mirrord-config/src/lib.rs
@@ -24,6 +24,7 @@ use crate::{
 
 /// This is the root struct for mirrord-layer's configuration
 #[derive(MirrordConfig, Deserialize, Default, PartialEq, Eq, Clone, Debug)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(deny_unknown_fields)]
 #[config(map_to = LayerConfig)]
 pub struct LayerFileConfig {
@@ -264,5 +265,16 @@ mod tests {
         };
 
         assert_eq!(config, expect);
+    }
+
+    /// Helper for printing the config schema.
+    /// 
+    /// Run it with `cargo test -p mirrord-config --ignored print_schema --features schema -- --nocapture`
+    #[cfg(feature = "schema")]
+    #[test]
+    #[ignore]
+    fn print_schema() {
+        let schema = schemars::schema_for!(LayerFileConfig);
+        println!("{}", serde_json::to_string_pretty(&schema).unwrap());
     }
 }

--- a/mirrord-config/src/network.rs
+++ b/mirrord-config/src/network.rs
@@ -11,6 +11,7 @@ use crate::{
 };
 
 #[derive(MirrordConfig, Deserialize, Default, PartialEq, Eq, Clone, Debug)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(deny_unknown_fields)]
 #[config(map_to = NetworkConfig)]
 pub struct NetworkFileConfig {

--- a/mirrord-config/src/outgoing.rs
+++ b/mirrord-config/src/outgoing.rs
@@ -9,6 +9,7 @@ use crate::{
 };
 
 #[derive(MirrordConfig, Default, Deserialize, PartialEq, Eq, Clone, Debug)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(deny_unknown_fields)]
 #[config(map_to = OutgoingConfig)]
 pub struct OutgoingFileConfig {

--- a/mirrord-config/src/pod.rs
+++ b/mirrord-config/src/pod.rs
@@ -5,6 +5,7 @@ use serde::Deserialize;
 use crate::config::source::MirrordConfigSource;
 
 #[derive(MirrordConfig, Deserialize, Default, PartialEq, Eq, Clone, Debug)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(deny_unknown_fields)]
 #[config(map_to = PodConfig)]
 pub struct PodFileConfig {

--- a/mirrord-config/src/util.rs
+++ b/mirrord-config/src/util.rs
@@ -13,6 +13,7 @@ pub trait MirrordToggleableConfig: MirrordConfig + Default {
 }
 
 #[derive(Deserialize, PartialEq, Eq, Clone, Debug)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(untagged)]
 pub enum ToggleableConfig<T> {
     Enabled(bool),
@@ -41,6 +42,7 @@ where
 }
 
 #[derive(Deserialize, PartialEq, Eq, Clone, Debug)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(untagged)]
 pub enum VecOrSingle<T> {
     Single(T),


### PR DESCRIPTION
I took the liberty of implementing #538 as it took a few minutes only.

I added a test that is ignored by default that is used to generate the schema that can be submitted to schema store afterwards. I usually add the schema generation to my CLIs as well as a command but I don't ever recall actually using them.

Descriptions are generated from doc comments, so they are nonexistent, but completion and validation works:

![image](https://user-images.githubusercontent.com/25967296/195131181-3e16629b-99fc-494e-84d3-453f22412a45.png)
