### PR TITLE
[Merged by Bors] - Print test process output while running in integration tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - Rename http mirroring tests from `integration` to `http_mirroring` since there are 
   now also integration tests in other files.
 - Delete useless `e2e_macos` CI job.
+- Integration tests also display test process output (with mirrord logs) when they 
+  time out.
 
 ### Fixed
 - Fix IntelliJ Extension artifact - use glob pattern

--- a/mirrord-layer/tests/common/mod.rs
+++ b/mirrord-layer/tests/common/mod.rs
@@ -1,7 +1,10 @@
 use std::{collections::HashMap, path::PathBuf, process::Stdio};
+use std::fmt::Debug;
+use std::sync::{Arc, Mutex};
 
 use actix_codec::Framed;
 use futures::{SinkExt, StreamExt};
+use k8s_openapi::chrono::Utc;
 use mirrord_protocol::{
     tcp::{DaemonTcp, LayerTcp, NewTcpConnection, TcpClose, TcpData},
     ClientMessage, DaemonCodec, DaemonMessage,
@@ -12,6 +15,100 @@ use tokio::{
     net::{TcpListener, TcpStream},
     process::Command,
 };
+use tokio::io::{AsyncReadExt, BufReader};
+use tokio::process::Child;
+
+pub struct TestProcess {
+    pub child: Child,
+    stderr: Arc<Mutex<String>>,
+    stdout: Arc<Mutex<String>>,
+}
+
+impl TestProcess {
+    pub fn get_stdout(&self) -> String {
+        self.stdout.lock().unwrap().clone()
+    }
+
+    pub fn assert_log_level(&self, stderr: bool, level: &str) {
+        if stderr {
+            assert!(!self.stderr.lock().unwrap().contains(level));
+        } else {
+            assert!(!self.stdout.lock().unwrap().contains(level));
+        }
+    }
+
+    fn from_child(mut child: Child) -> TestProcess {
+        let stderr_data = Arc::new(Mutex::new(String::new()));
+        let stdout_data = Arc::new(Mutex::new(String::new()));
+        let child_stderr = child.stderr.take().unwrap();
+        let child_stdout = child.stdout.take().unwrap();
+        let stderr_data_reader = stderr_data.clone();
+        let stdout_data_reader = stdout_data.clone();
+        let pid = child.id().unwrap();
+
+        tokio::spawn(async move {
+            let mut reader = BufReader::new(child_stderr);
+            let mut buf = [0; 1024];
+            loop {
+                let n = reader.read(&mut buf).await.unwrap();
+                if n == 0 {
+                    break;
+                }
+
+                let string = String::from_utf8_lossy(&buf[..n]);
+                eprintln!("stderr {:?} {pid}: {}", Utc::now(), string);
+                {
+                    stderr_data_reader.lock().unwrap().push_str(&string);
+                }
+            }
+        });
+        tokio::spawn(async move {
+            let mut reader = BufReader::new(child_stdout);
+            let mut buf = [0; 1024];
+            loop {
+                let n = reader.read(&mut buf).await.unwrap();
+                if n == 0 {
+                    break;
+                }
+                let string = String::from_utf8_lossy(&buf[..n]);
+                print!("stdout {:?} {pid}: {}", Utc::now(), string);
+                {
+                    stdout_data_reader.lock().unwrap().push_str(&string);
+                }
+            }
+        });
+        TestProcess {
+            child,
+            stderr: stderr_data,
+            stdout: stdout_data,
+        }
+    }
+
+    pub async fn start_process(executable: String, args: Vec<String>, env: HashMap<&str, &str>) -> TestProcess {
+        let child = Command::new(executable)
+            .args(args)
+            .envs(env)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .unwrap();
+        println!("Started application.");
+        TestProcess::from_child(child)
+    }
+
+    pub fn assert_stdout_contains(&self, string: &str) {
+        assert!(self.stdout.lock().unwrap().contains(string));
+    }
+
+    pub fn assert_no_error_in_stdout(&self) {
+        assert!(!self.stdout.lock().unwrap().to_lowercase().contains("error"));
+    }
+
+    pub fn assert_no_error_in_stderr(&self) {
+        assert!(!self.stderr.lock().unwrap().to_lowercase().contains("error"));
+    }
+
+}
 
 pub struct LayerConnection {
     codec: Framed<TcpStream, DaemonCodec>,

--- a/mirrord-layer/tests/common/mod.rs
+++ b/mirrord-layer/tests/common/mod.rs
@@ -1,6 +1,10 @@
-use std::{collections::HashMap, path::PathBuf, process::Stdio};
-use std::fmt::Debug;
-use std::sync::{Arc, Mutex};
+use std::{
+    collections::HashMap,
+    fmt::Debug,
+    path::PathBuf,
+    process::Stdio,
+    sync::{Arc, Mutex},
+};
 
 use actix_codec::Framed;
 use futures::{SinkExt, StreamExt};
@@ -11,12 +15,10 @@ use mirrord_protocol::{
 };
 use rstest::fixture;
 use tokio::{
-    io::AsyncWriteExt,
+    io::{AsyncReadExt, AsyncWriteExt, BufReader},
     net::{TcpListener, TcpStream},
-    process::Command,
+    process::{Child, Command},
 };
-use tokio::io::{AsyncReadExt, BufReader};
-use tokio::process::Child;
 
 pub struct TestProcess {
     pub child: Option<Child>,
@@ -88,7 +90,11 @@ impl TestProcess {
         }
     }
 
-    pub async fn start_process(executable: String, args: Vec<String>, env: HashMap<&str, &str>) -> TestProcess {
+    pub async fn start_process(
+        executable: String,
+        args: Vec<String>,
+        env: HashMap<&str, &str>,
+    ) -> TestProcess {
         let child = Command::new(executable)
             .args(args)
             .envs(env)
@@ -121,7 +127,6 @@ impl TestProcess {
     pub async fn wait(&mut self) {
         self.child.take().unwrap().wait().await.unwrap();
     }
-
 }
 
 pub struct LayerConnection {

--- a/mirrord-layer/tests/http_mirroring.rs
+++ b/mirrord-layer/tests/http_mirroring.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use rstest::rstest;
-use tokio::{net::TcpListener};
+use tokio::net::TcpListener;
 
 mod common;
 
@@ -50,7 +50,8 @@ async fn test_mirroring_with_http(
     let addr = listener.local_addr().unwrap().to_string();
     println!("Listening for messages from the layer on {addr}");
     let env = get_env(dylib_path.to_str().unwrap(), &addr);
-    let mut test_process = TestProcess::start_process(executable, application.get_args(), env).await;
+    let mut test_process =
+        TestProcess::start_process(executable, application.get_args(), env).await;
 
     // Accept the connection from the layer and verify initial messages.
     let mut layer_connection =

--- a/mirrord-layer/tests/http_mirroring.rs
+++ b/mirrord-layer/tests/http_mirroring.rs
@@ -2,7 +2,6 @@ use std::{
     env,
     path::{Path, PathBuf},
     process,
-    process::Stdio,
     time::Duration,
 };
 
@@ -70,7 +69,7 @@ async fn test_mirroring_with_http(
     layer_connection
         .send_connection_then_data("DELETE / HTTP/1.1\r\nHost: localhost\r\n\r\ndelete-data")
         .await;
-    test_process.child.wait().await.unwrap();
+    test_process.wait().await;
     test_process.assert_stdout_contains("GET: Request completed");
     test_process.assert_stdout_contains("POST: Request completed");
     test_process.assert_stdout_contains("PUT: Request completed");

--- a/mirrord-layer/tests/self_connect.rs
+++ b/mirrord-layer/tests/self_connect.rs
@@ -20,7 +20,8 @@ async fn test_self_connect(dylib_path: &PathBuf) {
     let addr = listener.local_addr().unwrap().to_string();
     println!("Listening for messages from the layer on {addr}");
     let env = get_env(dylib_path.to_str().unwrap(), &addr);
-    let mut test_process = TestProcess::start_process(executable, application.get_args(), env).await;
+    let mut test_process =
+        TestProcess::start_process(executable, application.get_args(), env).await;
 
     // Accept the connection from the layer and verify initial messages.
     let mut layer_connection =


### PR DESCRIPTION
That way, if the test times out, you can still read the mirrord logs.