### PR TITLE
[Merged by Bors] - refactor pod api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ## Changed
 - Print exit message when terminating application due to an unhandled error in the layer.
 - mirrord-layer: refactored `pod_api.rs` to be more maintainble.
+- Use kube config namespace by default.
 
 ## 3.0.20-alpha
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ Previous versions had CHANGELOG per component, we decided to combine all reposit
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
 ## [Unreleased]
+### Added
+- mirrord-layer: support `-target deployment/deployment_name/container/container_name` flag to run on a specific container.
 
+### Changed
+- mirrord-layer: refactored `pod_api.rs` to be more maintainble.
 ## 3.0.20-alpha
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ## [Unreleased]
 
 ### Added
+- Skip istio/linkerd-proxy/init container when mirroring a pod without a specific container name.
+- Add "linkerd.io/inject": "disabled" annotation to pod created by mirrord to avoid linkerd auto inject.
 - mirrord-layer: support `-target deployment/deployment_name/container/container_name` flag to run on a specific container.
 - `/nix/*` path is now ignored for file operations to support NixOS.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - Add "linkerd.io/inject": "disabled" annotation to pod created by mirrord to avoid linkerd auto inject.
 - mirrord-layer: support `-target deployment/deployment_name/container/container_name` flag to run on a specific container.
 - `/nix/*` path is now ignored for file operations to support NixOS.
+- Shortcut `deploy` for `deployment` in target argument.
+
 
 ## Changed
 - Print exit message when terminating application due to an unhandled error in the layer.

--- a/mirrord-config/src/lib.rs
+++ b/mirrord-config/src/lib.rs
@@ -37,7 +37,7 @@ pub struct LayerFileConfig {
     #[config(env = "MIRRORD_IMPERSONATED_TARGET")]
     pub target: Option<String>,
 
-    #[config(env = "MIRRORD_TARGET_NAMESPACE", default = "default")]
+    #[config(env = "MIRRORD_TARGET_NAMESPACE")]
     pub target_namespace: Option<String>,
 
     /// IP:PORT to connect to instead of using k8s api, for testing purposes.

--- a/mirrord-config/src/pod.rs
+++ b/mirrord-config/src/pod.rs
@@ -12,7 +12,7 @@ pub struct PodFileConfig {
     #[config(env = "MIRRORD_AGENT_IMPERSONATED_POD_NAME")]
     pub name: Option<String>,
 
-    #[config(env = "MIRRORD_AGENT_IMPERSONATED_POD_NAMESPACE", default = "default")]
+    #[config(env = "MIRRORD_AGENT_IMPERSONATED_POD_NAMESPACE")]
     pub namespace: Option<String>,
 
     #[config(env = "MIRRORD_IMPERSONATED_CONTAINER_NAME")]
@@ -29,9 +29,9 @@ mod tests {
     #[rstest]
     fn default(
         #[values((Some("pod"), Some("pod".to_string())))] name: (Option<&str>, Option<String>),
-        #[values((None, "default"), (Some("namespace"), "namespace"))] namespace: (
+        #[values((None, None), (Some("namespace"), Some("namespace".to_string())))] namespace: (
             Option<&str>,
-            &str,
+            Option<String>,
         ),
         #[values((None, None), (Some("container"), Some("container")))] container: (
             Option<&str>,

--- a/mirrord-layer/src/error.rs
+++ b/mirrord-layer/src/error.rs
@@ -105,8 +105,8 @@ pub(crate) enum LayerError {
     #[error("mirrord-layer: Failed to get `KubeConfig`!")]
     KubeConfigError(#[from] InferConfigError),
 
-    #[error("mirrord-layer: Failed to get `Spec` for Pod `{0}`!")]
-    PodSpecNotFound(String),
+    #[error("mirrord-layer: Failed to get `Spec` for Pod!")]
+    PodSpecNotFound,
 
     #[error("mirrord-layer: Failed to get Pod for Job `{0}`!")]
     JobPodNotFound(String),
@@ -120,8 +120,8 @@ pub(crate) enum LayerError {
     #[error("mirrord-layer: Container not found: `{0}`")]
     ContainerNotFound(String),
 
-    #[error("mirrord-layer: Node not found for: `{0}`")]
-    NodeNotFound(String),
+    #[error("mirrord-layer: Node name wasn't found in pod spec")]
+    NodeNotFound,
 
     #[error("mirrord-layer: Deployment: `{0} not found!`")]
     DeploymentNotFound(String),
@@ -131,6 +131,18 @@ pub(crate) enum LayerError {
 
     #[error("mirrord-layer: Failed to get Container runtime data for `{0}`!")]
     ContainerRuntimeParseError(String),
+
+    #[error("mirrord-layer: Pod name not found in response from kube API")]
+    PodNameNotFound,
+
+    #[error("mirrord-layer: Pod status not found in response from kube API")]
+    PodStatusNotFound,
+
+    #[error("mirrord-layer: Container status not found in response from kube API")]
+    ContainerStatusNotFound,
+
+    #[error("mirrord-layer: Container ID not found in response from kube API")]
+    ContainerIdNotFound,
 }
 
 // Cannot have a generic From<T> implementation for this error, so explicitly implemented here.

--- a/mirrord-layer/src/lib.rs
+++ b/mirrord-layer/src/lib.rs
@@ -522,7 +522,6 @@ mod tests {
     use rstest::rstest;
 
     use super::*;
-    use crate::pod_api::*;
 
     #[rstest]
     #[case("test", Some(vec!["foo".to_string()]))]
@@ -543,30 +542,5 @@ mod tests {
         #[case] skip_processes: Option<Vec<String>>,
     ) {
         assert!(!should_load(given_process, skip_processes));
-    }
-
-    #[rstest]
-    #[case("pod/foobaz", Target::Pod(PodData {pod_name: "foobaz".to_string(), container_name: None}))]
-    #[case("deployment/foobaz", Target::Deployment(DeploymentData {deployment: "foobaz".to_string()}))]
-    #[case("deployment/nginx-deployment", Target::Deployment(DeploymentData {deployment: "nginx-deployment".to_string()}))]
-    #[case("pod/foo/container/baz", Target::Pod(PodData { pod_name: "foo".to_string(), container_name: Some("baz".to_string()) }))]
-    fn test_target_parses(#[case] target: &str, #[case] expected: Target) {
-        let target = target.parse::<Target>().unwrap();
-        assert_eq!(target, expected)
-    }
-
-    #[rstest]
-    #[should_panic(expected = "InvalidTarget")]
-    #[case::panic("deployment/foobaz/blah")]
-    #[should_panic(expected = "InvalidTarget")]
-    #[case::panic("pod/foo/baz")]
-    fn test_target_parse_fails(#[case] target: &str) {
-        let target = target.parse::<pod_api::Target>().unwrap();
-        assert_eq!(
-            target,
-            Target::Deployment(DeploymentData {
-                deployment: "foobaz".to_string()
-            })
-        )
     }
 }

--- a/mirrord-layer/src/pod_api.rs
+++ b/mirrord-layer/src/pod_api.rs
@@ -681,7 +681,7 @@ impl FromStr for Target {
     fn from_str(target: &str) -> Result<Target> {
         let mut split = target.split('/');
         match split.next() {
-            Some("deployment") => DeploymentTarget::from_split(&mut split).map(Target::Deployment),
+            Some("deployment") | Some("deploy") => DeploymentTarget::from_split(&mut split).map(Target::Deployment),
             Some("pod") => PodTarget::from_split(&mut split).map(Target::Pod),
             _ => Err(LayerError::InvalidTarget(format!(
                 "Provided target: {:?} is neither a pod or a deployment.",

--- a/mirrord-layer/src/pod_api.rs
+++ b/mirrord-layer/src/pod_api.rs
@@ -526,9 +526,7 @@ impl RuntimeData {
 
         let container_id = split
             .next()
-            .ok_or(LayerError::ContainerRuntimeParseError(
-                container_id_full.to_string(),
-            ))?
+            .ok_or_else(|| LayerError::ContainerRuntimeParseError(container_id_full.to_string()))?
             .to_owned();
 
         let container_runtime = container_runtime.to_string();


### PR DESCRIPTION
### Added
- Skip istio/linkerd-proxy/init container when mirroring a pod without a specific container name. Closes #556 
- Add "linkerd.io/inject": "disabled" annotation to pod created by mirrord to avoid linkerd auto inject.
- mirrord-layer: support `-target deployment/deployment_name/container/container_name` flag to run on a specific container. 

## Changed
- mirrord-layer: refactored `pod_api.rs` to be more maintainble.
- Use kube config namespace by default. Closes #557 