### PR TITLE
Initial work on resizing deployments with replicas > 1

### DIFF
--- a/mirrord-cli/src/main.rs
+++ b/mirrord-cli/src/main.rs
@@ -100,7 +100,7 @@ fn add_to_preload(path: &str) -> Result<()> {
 
 #[cfg(target_os = "macos")]
 fn sip_check(binary_path: &str) -> Result<()> {
-    let sip_set = RegexSet::new(&[
+    let sip_set = RegexSet::new([
         r"/System/.*",
         r"/bin/.*",
         r"/sbin/.*",

--- a/tests/app.yaml
+++ b/tests/app.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: py-serv
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       app: py-serv


### PR DESCRIPTION
This is just an initial draft:
I want to discuss:
- what are the scenarios where on Dropping/Exiting mirrord should resize the replicas back to its original number, for example when when the connection is dropped, or when the library constructor exits
- how do we go about doing the above when a simple call to exit() happens, do we hook exit()?
- do we install signal handlers for signals like SIGINT
- what kind of patch strategy are we looking to follow: https://docs.rs/kube/latest/kube/api/enum.Patch.html

