### PR TITLE
[Merged by Bors] - Add requests to job spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ### Fixed
 - Issue [#577](https://github.com/metalbear-co/mirrord/issues/577). Changed non-error logs from `error!` to `trace!`.
 
+### Changed
+- Agent pod definition now has `requests` specifications to avoid being defaulted to high values. See [#579](https://github.com/metalbear-co/mirrord/issues/579).
+
 ## 3.0.22-alpha
 
 ### Changed

--- a/mirrord-layer/src/pod_api.rs
+++ b/mirrord-layer/src/pod_api.rs
@@ -327,6 +327,14 @@ impl KubernetesAPI {
                                 ],
                                 "command": agent_command_line,
                                 "env": [{"name": "RUST_LOG", "value": self.config.agent.log_level}],
+                                "resources": // Add requests to avoid getting defaulted https://github.com/metalbear-co/mirrord/issues/579
+                                {
+                                    "requests":
+                                    {
+                                        "cpu": "10m",
+                                        "memory": "50Mi"
+                                    }
+                                }
                             }
                         ]
                     }


### PR DESCRIPTION
Agent pod definition now has `requests` specifications to avoid being defaulted to high values. See [#579](https://github.com/metalbear-co/mirrord/issues/579).