### PR TITLE
[Merged by Bors] - Only set the env-override-option that is set, not both.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+### Fixed
+- IntelliJ plugin crashing on run because both include and exclude were being set for env vars.
+
 ## 3.1.0
 
 ### Added

--- a/intellij-ext/src/main/kotlin/com/metalbear/mirrord/MirrordListener.kt
+++ b/intellij-ext/src/main/kotlin/com/metalbear/mirrord/MirrordListener.kt
@@ -108,8 +108,12 @@ class MirrordListener : ExecutionListener {
                         mirrordEnv["MIRRORD_UDP_OUTGOING"] = outgoingTraffic.isSelected.toString()
                         mirrordEnv["RUST_LOG"] = rustLog.text.toString()
                         mirrordEnv["MIRRORD_AGENT_RUST_LOG"] = agentRustLog.text.toString()
-                        mirrordEnv["MIRRORD_OVERRIDE_ENV_VARS_EXCLUDE"] = excludeEnv.text.toString()
-                        mirrordEnv["MIRRORD_OVERRIDE_ENV_VARS_INCLUDE"] = includeEnv.text.toString()
+                        if (excludeEnv.text.toString().isNotEmpty()) {
+                            mirrordEnv["MIRRORD_OVERRIDE_ENV_VARS_EXCLUDE"] = excludeEnv.text.toString()
+                        }
+                        if (includeEnv.text.toString().isNotEmpty()) {
+                            mirrordEnv["MIRRORD_OVERRIDE_ENV_VARS_INCLUDE"] = includeEnv.text.toString()
+                        }
                         val envMap = getRunConfigEnv(env)
                         envMap?.putAll(mirrordEnv)
 


### PR DESCRIPTION
This solves a crash that would happen on running.

Co-authored-by: Eyal Bukchin <eyal@metalbear.co>