### PR TITLE
Apt get update

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -5,5 +5,5 @@ ARG VARIANT="buster"
 FROM mcr.microsoft.com/vscode/devcontainers/rust:0-${VARIANT}
 
 RUN rustup toolchain install nightly-x86_64-unknown-linux-gnu && rustup component add rustfmt --toolchain nightly-x86_64-unknown-linux-gnu && rustup component add clippy --toolchain nightly-x86_64-unknown-linux-gnu
-RUN apt-get install -y clang
+RUN apt-get update && apt-get install -y clang
 RUN curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.16.0/kind-linux-amd64 && chmod +x ./kind && mv ./kind /usr/local/bin/kind

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+### Fixed
+- Dev container failing to execute `apt-get install -y clang`
+
 ## 3.1.2
 
 ### Changed


### PR DESCRIPTION
Was working on integration tests and ran into this error when trying to rebuild my development container

```
ERROR: failed to solve: executor failed running [/bin/sh -c apt-get install -y clang]: exit code: 100
```
- - -


https://github.com/metalbear-co/mirrord/blob/93af076cfd4b4652101b1751dc2ecb7b98fdcd54/.devcontainer/Dockerfile#L8

was added #552 

after some googling I found [these instructions](https://www.linux.com/news/what-do-when-apt-get-fails/#:~:text=Run%20apt%2Dget%20update%20to,it%20and%20all%20its%20dependencies.) 

# Criticism Welcome ❗ 
I could be missing something obvious 😅
