### PR TITLE
[Merged by Bors] - Pass on to the layer the --pod-namespace argument.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - Don't ignore passed `--pod-namespace` argument, closes
   [[#605](https://github.com/metalbear-co/mirrord/issues/605)]
 
+### Deprecated
+- `--impersonated-container-name` and `MIRRORD_IMPERSONATED_CONTAINER_NAME` are
+  deprecated in favor of `--target` or `MIRRORD_IMPERSONATED_TARGET`
+- `--pod-namespace` and `MIRRORD_AGENT_IMPERSONATED_POD_NAMESPACE` are deprecated in
+  favor of `--target-namespace` and `MIRRORD_TARGET_NAMESPACE`
+
 ## 3.1.3
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ### Changed
 - Extended support for both `-s` and `-x` wildcard matching, now supports `PREFIX_*`, `*_SUFFIX`, ect.
 
+### Fixed
+- Don't ignore passed `--pod-namespace` argument, closes
+  [[#605](https://github.com/metalbear-co/mirrord/issues/605)]
+
 ## 3.1.3
 
 ### Changed

--- a/mirrord-cli/src/config.rs
+++ b/mirrord-cli/src/config.rs
@@ -36,6 +36,7 @@ pub(super) struct ExecArgs {
     #[clap(long, value_parser)]
     pub target_namespace: Option<String>,
 
+    // START | To be removed after deprecated functionality is removed
     /// Target name to mirror.
     /// WARNING: [DEPRECATED] Consider using `--target` instead.
     #[clap(short, long, group = "pod", value_parser)]
@@ -52,6 +53,12 @@ pub(super) struct ExecArgs {
     )]
     pub pod_namespace: Option<String>,
 
+    /// Select container name to impersonate. Default is first container.
+    /// WARNING: [DEPRECATED] Consider using `--target` instead.
+    #[clap(long, requires = "pod", conflicts_with = "target", value_parser)]
+    pub impersonated_container_name: Option<String>,
+
+    // END
     /// Namespace to place agent in.
     #[clap(short = 'a', long, value_parser)]
     pub agent_namespace: Option<String>,
@@ -95,10 +102,6 @@ pub(super) struct ExecArgs {
     /// Agent TTL
     #[clap(long, value_parser)]
     pub agent_ttl: Option<u16>,
-
-    /// Select container name to impersonate. Default is first container.
-    #[clap(long, requires = "pod", conflicts_with = "target", value_parser)]
-    pub impersonated_container_name: Option<String>,
 
     /// Accept/reject invalid certificates.
     #[clap(short = 'c', long, value_parser)]

--- a/mirrord-cli/src/main.rs
+++ b/mirrord-cli/src/main.rs
@@ -142,17 +142,25 @@ fn exec(args: &ExecArgs) -> Result<()> {
         std::env::set_var("MIRRORD_IMPERSONATED_TARGET", target);
     }
 
+    // START | To be removed after deprecated functionality is removed
     if let Some(pod) = &args.pod_name {
-        println!("[WARNING]: DEPRECATED - `--pod-name` is deprecated, consider using `--target instead.\nDeprecated since: [28/09/2022] | Scheduled removal: [28/10/2022]");
+        println!("[WARNING]: DEPRECATED - `--pod-name` is deprecated, consider using `--target` instead.\nDeprecated since: [28/09/2022] | Scheduled removal: [28/10/2022]");
         std::env::set_var("MIRRORD_AGENT_IMPERSONATED_POD_NAME", pod);
     }
 
+    if let Some(pod_namespace) = &args.pod_namespace {
+        println!("[WARNING]: DEPRECATED - `--pod-namespace` is deprecated, consider using `--target-namespace` instead.\nDeprecated since: [28/09/2022] | Scheduled removal: [28/10/2022]");
+        std::env::set_var("MIRRORD_AGENT_IMPERSONATED_POD_NAMESPACE", pod_namespace);
+    }
+
     if let Some(impersonated_container_name) = &args.impersonated_container_name {
+        println!("[WARNING]: DEPRECATED - `--impersonated-container-name` is deprecated, consider using `--target` instead.\nDeprecated since: [28/09/2022] | Scheduled removal: [28/10/2022]");
         std::env::set_var(
             "MIRRORD_IMPERSONATED_CONTAINER_NAME",
             impersonated_container_name,
         );
     }
+    // END
 
     if let Some(skip_processes) = &args.skip_processes {
         std::env::set_var("MIRRORD_SKIP_PROCESSES", skip_processes.clone());


### PR DESCRIPTION
- Also document deprecation for container name arg.
- Some places have deprecation code comments, so add them where they were missing.

Fixes #605.