### PR TITLE
[Merged by Bors] - Fix errors when setting envars when debugging Kotlin app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ### Fixed
 - Don't ignore passed `--pod-namespace` argument, closes
   [[#605](https://github.com/metalbear-co/mirrord/issues/605)]
+- Issues with IntelliJ extension when debugging Kotlin applications
 
 ### Deprecated
 - `--impersonated-container-name` and `MIRRORD_IMPERSONATED_CONTAINER_NAME` are

--- a/intellij-ext/src/main/kotlin/com/metalbear/mirrord/MirrordListener.kt
+++ b/intellij-ext/src/main/kotlin/com/metalbear/mirrord/MirrordListener.kt
@@ -29,12 +29,14 @@ class MirrordListener : ExecutionListener {
 
     companion object {
         var enabled: Boolean = false
+        var id: String = ""
         var envSet: Boolean = false
         var mirrordEnv: LinkedHashMap<String, String> = LinkedHashMap()
     }
 
     override fun processStartScheduled(executorId: String, env: ExecutionEnvironment) {
-        if (enabled) {
+        if (enabled && id.isEmpty()) {
+            id = executorId
             ApplicationManager.getApplication().invokeLater {
                 val customDialogBuilder = MirrordDialogBuilder()
                 val kubeDataProvider = KubeDataProvider()
@@ -130,7 +132,8 @@ class MirrordListener : ExecutionListener {
         // NOTE: If the option was enabled, and we actually set the env, i.e. cancel was not clicked on the dialog,
         // we clear up the Environment, because we don't want mirrord to run again if the user hits debug again
         // with mirrord toggled off.
-        if (enabled and envSet) {
+        if (enabled && envSet && executorId == id) {
+            id = ""
             if (env.runProfile::class.simpleName == "GoApplicationConfiguration") {
                 GoRunConfig.clearGoEnv()
                 return super.processTerminating(executorId, env, handler)


### PR DESCRIPTION
Fix double showing of `MirrordKubeDialog` and errors occurring when setting envars when debug a Kotlin app.
<img width="372" alt="image" src="https://user-images.githubusercontent.com/29158537/197261427-c3a589f5-27ba-4a19-a37d-e59abb6a546e.png">
