### PR TITLE
[Merged by Bors] - Improve error message when mirrord eats up program args.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+### Changed
+- mirrord-layer: Improve error message when user tries to run a program with args without `--`.
+
 ## 3.4.0
 
 ### Added

--- a/mirrord-layer/src/connection.rs
+++ b/mirrord-layer/src/connection.rs
@@ -10,7 +10,7 @@ use rand::Rng;
 use tokio::net::TcpStream;
 use tracing::log::info;
 
-use crate::{error::LayerError, pod_api::KubernetesAPI};
+use crate::{error::LayerError, pod_api::KubernetesAPI, FAIL_STILL_STUCK};
 
 pub(crate) enum AgentConnection<T>
 where
@@ -72,7 +72,7 @@ where
     }
 }
 
-const FAILED_TO_CREATE_AGENT: &str = r#"
+const FAIL_CREATE_AGENT: &str = r#"
 mirrord-layer failed while trying to establish connection with the agent pod!
 
 - Suggestions:
@@ -83,13 +83,6 @@ mirrord-layer failed while trying to establish connection with the agent pod!
 >> Check that you're using the correct kubernetes credentials (and configuration).
 
 >> Check your kubernetes context match where the agent should be spawned.
-
-- If you're still stuck and everything looks fine:
-
->> Please open a new bug report at https://github.com/metalbear-co/mirrord/issues/new/choose
-
->> Or join our discord https://discord.com/invite/J5YSrStDKD and request help in #mirrord-help.
-
 "#;
 
 fn handle_error(err: LayerError) -> ! {
@@ -102,7 +95,7 @@ fn handle_error(err: LayerError) -> ! {
                 None => panic!("mirrord got KubeError::HyperError"),
             }
         }
-        _ => panic!("{FAILED_TO_CREATE_AGENT}\nwith error {err:#?}"),
+        _ => panic!("{FAIL_CREATE_AGENT}{FAIL_STILL_STUCK}with error {err:#?}"),
     }
 }
 

--- a/mirrord-layer/src/lib.rs
+++ b/mirrord-layer/src/lib.rs
@@ -464,7 +464,8 @@ async fn start_layer_thread(
                     }
                 }
             } else {
-                graceful_exit!("unexpected response - expected env vars response {msg:?}");
+                let raw_issue = format!("Expected env vars response, but got {msg:?}");
+                graceful_exit!("{}{FAIL_STILL_STUCK}{}", FAIL_UNEXPECTED_RESPONSE, raw_issue);
             }
           },
           _ = sleep(Duration::from_secs(config.agent.communication_timeout.unwrap_or(30).into())) => {
@@ -553,6 +554,24 @@ pub(crate) unsafe extern "C" fn close_detour(fd: c_int) -> c_int {
 pub(crate) unsafe extern "C" fn close_nocancel_detour(fd: c_int) -> c_int {
     close_detour(fd)
 }
+
+pub(crate) const FAIL_STILL_STUCK: &str = r#"
+- If you're still stuck and everything looks fine:
+
+>> Please open a new bug report at https://github.com/metalbear-co/mirrord/issues/new/choose
+
+>> Or join our discord https://discord.com/invite/J5YSrStDKD and request help in #mirrord-help.
+
+"#;
+
+const FAIL_UNEXPECTED_RESPONSE: &str = r#"
+mirrord-layer received an unexpected response from the agent pod!
+
+- Suggestions:
+
+>> When trying to run a program with arguments in the form of `app -arg value`, run it as
+   `app -- -arg value` instead.
+"#;
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
- Improve error message when user runs something like `mirrord exec java -classpath /path app` #648 ;