### PR TITLE
[Merged by Bors] - Bypass SIP on MacOS

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -111,6 +111,20 @@ jobs:
       - run: |
           cargo test -p mirrord-config
 
+  test_mirrord_sip:
+    runs-on: macos-latest
+    needs: changed_files
+    if: ${{needs.changed_files.outputs.rs_changed == 'true'}}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+      - uses: Swatinem/rust-cache@v1
+      - run: |
+          cargo test -p mirrord-sip
+
   test_mirrord_layer:
     strategy:
       matrix:
@@ -438,6 +452,7 @@ jobs:
         lint,
         test_mirrord_config,
         test_mirrord_protocol,
+        test_mirrord_sip,
         build_intellij_plugin,
         lint_markdown,
       ]
@@ -454,6 +469,7 @@ jobs:
       (needs.lint.result == 'success' || needs.lint.result == 'skipped') &&
       (needs.test_mirrord_config.result == 'success' || needs.test_mirrord_config.result == 'skipped') &&
       (needs.test_mirrord_protocol.result == 'success' || needs.test_mirrord_protocol.result == 'skipped') &&
+      (needs.test_mirrord_sip.result == 'success' || needs.test_mirrord_sip.result == 'skipped') &&
       (needs.build_intellij_plugin.result == 'success' || needs.build_intellij_plugin.result == 'skipped') &&
       (needs.lint_markdown.result == 'success' || needs.lint_markdown.result == 'skipped')
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+### Added
+
+- Bypass SIP on MacOS on the executed binary, (also via shebang).
+  See [[#649](https://github.com/metalbear-co/mirrord/issues/649)].
+  This does not yet include binaries that are executed by the first binary.
+
 ## 3.7.3
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,6 +20,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "ahash"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -441,6 +447,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -771,6 +786,16 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "flate2"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "float-cmp"
@@ -1220,9 +1245,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.5.0"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
+checksum = "f88c5561171189e69df9d98bcf18fd5f9558300f7ea7b801eb8a0fd748bd8745"
 
 [[package]]
 name = "ipnetwork"
@@ -1457,9 +1482,9 @@ checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
 
 [[package]]
 name = "libloading"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbc0f03f9a775e9f6aed295c6a1ba2253c5757a9e03d55c6caa46a681abcddd"
+checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
 dependencies = [
  "cfg-if",
  "winapi",
@@ -1568,6 +1593,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96590ba8f175222643a85693f33d26e9c8a015f599c216509b1a6894af675d34"
+dependencies = [
+ "adler",
+]
+
+[[package]]
 name = "mio"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1589,13 +1623,13 @@ dependencies = [
  "mirrord-auth",
  "mirrord-layer",
  "mirrord-progress",
+ "mirrord-sip",
  "rand 0.8.5",
  "regex",
  "reqwest",
  "semver 1.0.14",
  "tracing",
  "tracing-subscriber",
- "which",
 ]
 
 [[package]]
@@ -1696,6 +1730,7 @@ dependencies = [
  "mirrord-layer-macro",
  "mirrord-progress",
  "mirrord-protocol",
+ "mirrord-sip",
  "nix 0.24.2",
  "os_info",
  "rand 0.8.5",
@@ -1744,6 +1779,18 @@ dependencies = [
  "serde",
  "thiserror",
  "trust-dns-resolver",
+]
+
+[[package]]
+name = "mirrord-sip"
+version = "3.7.0"
+dependencies = [
+ "memchr",
+ "object",
+ "tempfile",
+ "thiserror",
+ "tracing",
+ "which",
 ]
 
 [[package]]
@@ -2025,12 +2072,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_threads"
-version = "0.1.6"
+name = "object"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+checksum = "21158b2c33aa6d4561f1c0a6ea283ca92bc54802a93b263e910746d679a7eb53"
 dependencies = [
- "libc",
+ "flate2",
+ "memchr",
 ]
 
 [[package]]
@@ -2536,9 +2584,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
+checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2556,9 +2604,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.27"
+version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
+checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
 name = "remove_dir_all"
@@ -3210,13 +3258,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fab5c8b9980850e06d92ddbe3ab839c062c801f3927c0fb8abd6fc8e918fbca"
+checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
 dependencies = [
  "itoa",
- "libc",
- "num_threads",
  "serde",
  "time-core",
  "time-macros",
@@ -3230,9 +3276,9 @@ checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
 
 [[package]]
 name = "time-macros"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bb801831d812c562ae7d2bfb531f26e66e4e1f6b17307ba4149c5064710e5b"
+checksum = "d967f99f534ca7e495c575c62638eebc2898a8c84c119b89e250477bc4ba16b2"
 dependencies = [
  "time-core",
 ]
@@ -3479,7 +3525,7 @@ source = "git+https://github.com/metalbear-co/tracing?branch=worker_options_non_
 dependencies = [
  "crossbeam-channel",
  "thiserror",
- "time 0.3.16",
+ "time 0.3.17",
  "tracing-subscriber",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1784,7 +1784,7 @@ dependencies = [
 
 [[package]]
 name = "mirrord-sip"
-version = "3.7.0"
+version = "3.7.3"
 dependencies = [
  "memchr",
  "object",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1619,6 +1619,7 @@ version = "3.7.0"
 dependencies = [
  "anyhow",
  "clap",
+ "errno",
  "exec",
  "mirrord-auth",
  "mirrord-layer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,6 @@ tokio-util = { version = "0.7", features = ["net", "codec"] }
 rand = "0.8"
 streammap-ext = "0.1"
 
-
 # latest commits on rustls suppress certificate verification
 # https://github.com/rustls/rustls/pull/1032
 # so we patch crates.io to use the latest commits from rustls

--- a/mirrord/cli/Cargo.toml
+++ b/mirrord/cli/Cargo.toml
@@ -25,6 +25,7 @@ tracing.workspace = true
 rand.workspace = true
 tracing-subscriber.workspace = true
 regex = "1.6.0"
+errno = "0.2"
 exec = "0.3"
 anyhow.workspace = true
 reqwest.workspace = true

--- a/mirrord/cli/Cargo.toml
+++ b/mirrord/cli/Cargo.toml
@@ -18,13 +18,13 @@ edition.workspace = true
 [dependencies]
 mirrord-auth = { path="../auth", features = ["webbrowser"] }
 mirrord-progress = { path = "../progress" }
+mirrord-sip = { path = "../sip" }
 
 clap.workspace = true
 tracing.workspace = true
 rand.workspace = true
 tracing-subscriber.workspace = true
 regex = "1.6.0"
-which = "4.3.0"
 exec = "0.3"
 anyhow.workspace = true
 reqwest.workspace = true

--- a/mirrord/cli/src/main.rs
+++ b/mirrord/cli/src/main.rs
@@ -8,10 +8,9 @@ use std::{
 use anyhow::{anyhow, Context, Result};
 use clap::Parser;
 use config::*;
-use exec::execvp;
-
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 use errno;
+use exec::execvp;
 use mirrord_auth::AuthConfig;
 use mirrord_progress::TaskProgress;
 #[cfg(target_os = "macos")]
@@ -223,8 +222,10 @@ fn exec(args: &ExecArgs) -> Result<()> {
     let err = execvp(binary, binary_args);
     error!("Couldn't execute {:?}", err);
     #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
-    if let exec::Error::Errno(errno::Errno(86)) = err { // "Bad CPU type in executable"
-        if did_sip_patch { // We did a SIP patch.
+    if let exec::Error::Errno(errno::Errno(86)) = err {
+        // "Bad CPU type in executable"
+        if did_sip_patch {
+            // We did a SIP patch.
             error!(
                 "The file you are trying to run, {}, is either SIP protected or a script with a
                 shebang that leads to a SIP protected binary. In order to bypass SIP protection,

--- a/mirrord/cli/src/main.rs
+++ b/mirrord/cli/src/main.rs
@@ -11,12 +11,12 @@ use config::*;
 use exec::execvp;
 use mirrord_auth::AuthConfig;
 use mirrord_progress::TaskProgress;
+#[cfg(target_os = "macos")]
+use mirrord_sip::sip_patch;
 use rand::distributions::{Alphanumeric, DistString};
 use semver::Version;
 use tracing::{debug, error, info, warn};
 use tracing_subscriber::{fmt, prelude::*, registry, EnvFilter};
-#[cfg(target_os = "macos")]
-use {regex::RegexSet, which::which};
 
 mod config;
 
@@ -98,33 +98,6 @@ fn add_to_preload(path: &str) -> Result<()> {
     }
 }
 
-#[cfg(target_os = "macos")]
-fn sip_check(binary_path: &str) -> Result<()> {
-    let sip_set = RegexSet::new([
-        r"/System/.*",
-        r"/bin/.*",
-        r"/sbin/.*",
-        r"/usr/.*",
-        r"/var/.*",
-        r"/Applications/.*",
-    ])?;
-    let complete_path = which(binary_path)?;
-
-    let sliced_path = complete_path.to_str().ok_or_else(|| {
-        anyhow!(
-            "Failed to convert path to a string slice: {}",
-            binary_path.to_string()
-        )
-    })?;
-
-    if sip_set.is_match(sliced_path) {
-        println!("[WARNING]: Provided binary: {:?} is located in a SIP directory. mirrord might fail to load into it.
-        >> for more info visit https://support.apple.com/en-us/HT204899", binary_path);
-    }
-
-    Ok(())
-}
-
 fn exec(args: &ExecArgs) -> Result<()> {
     if !args.no_telemetry {
         prompt_outdated_version();
@@ -135,7 +108,7 @@ fn exec(args: &ExecArgs) -> Result<()> {
     );
 
     #[cfg(target_os = "macos")]
-    sip_check(&args.binary)?;
+    sip_patch(&mut args.binary)?;
 
     if !(args.no_tcp_outgoing || args.no_udp_outgoing) && args.no_remote_dns {
         warn!("TCP/UDP outgoing enabled without remote DNS might cause issues when local machine has IPv6 enabled but remote cluster doesn't")
@@ -270,7 +243,7 @@ fn main() -> Result<()> {
 
     let cli = Cli::parse();
     match cli.commands {
-        Commands::Exec(args) => exec(&args)?,
+        Commands::Exec(mut args) => exec(&mut args)?,
         Commands::Extract { path } => {
             extract_library(Some(path))?;
         } // Commands::Login(args) => login(args)?,

--- a/mirrord/cli/src/main.rs
+++ b/mirrord/cli/src/main.rs
@@ -270,7 +270,7 @@ fn main() -> Result<()> {
 
     let cli = Cli::parse();
     match cli.commands {
-        Commands::Exec(mut args) => exec(&mut args)?,
+        Commands::Exec(args) => exec(&args)?,
         Commands::Extract { path } => {
             extract_library(Some(path))?;
         } // Commands::Login(args) => login(args)?,

--- a/mirrord/layer/Cargo.toml
+++ b/mirrord/layer/Cargo.toml
@@ -19,6 +19,7 @@ mirrord-config = { path = "../config"}
 mirrord-protocol = { path = "../protocol"}
 mirrord-layer-macro = { path = "./macro"}
 mirrord-progress = { path = "../progress" }
+mirrord-sip = { path = "../sip" }
 
 ctor = "0.1"
 libc = "0.2"

--- a/mirrord/sip/Cargo.toml
+++ b/mirrord/sip/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "mirrord-sip"
+version.workspace = true
+authors.workspace = true
+description.workspace = true
+documentation.workspace = true
+readme.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+publish.workspace = true
+edition.workspace = true
+
+[dependencies]
+object = "0.29"
+memchr = "2"
+which = "4.3.0"
+
+tracing.workspace = true
+thiserror.workspace = true
+
+
+[dev-dependencies]
+tempfile = "3.3.0"

--- a/mirrord/sip/src/codesign.rs
+++ b/mirrord/sip/src/codesign.rs
@@ -1,0 +1,21 @@
+use std::{path::Path, process::Command};
+
+use crate::error::{Result, SipError};
+
+pub(crate) fn sign<P: AsRef<Path>>(path: P) -> Result<()> {
+    let output = Command::new("codesign")
+        .arg("-s") // sign with identity
+        .arg("-") // adhoc identity
+        .arg("-f") // force (might have a signature already)
+        .arg(path.as_ref())
+        .output()?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        let code = output.status.code().unwrap(); // shuoldn't happen
+        Err(SipError::Sign(
+            code,
+            String::from_utf8_lossy(&output.stderr).to_string(),
+        ))
+    }
+}

--- a/mirrord/sip/src/error.rs
+++ b/mirrord/sip/src/error.rs
@@ -24,4 +24,7 @@ pub enum SipError {
 
     #[error("Unlikely error happened `{0}`")]
     UnlikelyError(String),
+
+    #[error("Can't perform SIP check - executable file not found at `{0}`")]
+    FileNotFound(String),
 }

--- a/mirrord/sip/src/error.rs
+++ b/mirrord/sip/src/error.rs
@@ -1,0 +1,27 @@
+use thiserror::Error;
+
+pub type Result<T> = std::result::Result<T, SipError>;
+
+#[derive(Debug, Error)]
+pub enum SipError {
+    #[error("IO failed with `{0}`")]
+    IO(#[from] std::io::Error),
+
+    #[error("Signing failed statuscode: `{0}`, output: `{1}`")]
+    Sign(i32, String),
+
+    #[error("Can't patch file format `{0}`")]
+    UnsupportedFileFormat(String),
+
+    #[error("No x64 architecture in file")]
+    NoX64Arch,
+
+    #[error("ObjectParse failed with `{0}`")]
+    ObjectParse(#[from] object::Error),
+
+    #[error("which failed with `{0}`")]
+    WhichFailed(#[from] which::Error),
+
+    #[error("Unlikely error happened `{0}`")]
+    UnlikelyError(String),
+}

--- a/mirrord/sip/src/error.rs
+++ b/mirrord/sip/src/error.rs
@@ -27,4 +27,7 @@ pub enum SipError {
 
     #[error("Can't perform SIP check - executable file not found at `{0}`")]
     FileNotFound(String),
+
+    #[error("Can't perform SIP check - there is a cycle in the shebang graph, found at `{0}`")]
+    CyclicShebangs(String),
 }

--- a/mirrord/sip/src/lib.rs
+++ b/mirrord/sip/src/lib.rs
@@ -248,7 +248,7 @@ mod main {
             SipError::UnlikelyError("Failed to get parent directory".to_string())
         })?)?;
 
-        return match shebang_target {
+        match shebang_target {
             None => {
                 // The file is a sip protected binary.
                 debug!(
@@ -283,7 +283,7 @@ mod main {
                     ))
                 }
             }
-        };
+        }
     }
 
     /// Check if the file that the user wants to execute is a SIP protected binary (or a script

--- a/mirrord/sip/src/lib.rs
+++ b/mirrord/sip/src/lib.rs
@@ -184,7 +184,7 @@ mod main {
         NoSIP,
     }
 
-    /// Determine status recursively, keep seen_paths, and return an error if there is a cycle.
+    /// Determine status recursively, keep seen_paths, and return an error if there is a cyclical reference.
     fn get_sip_status_rec(path: &str, seen_paths: &mut HashSet<PathBuf>) -> Result<SipStatus> {
         // If which fails, try using the given path as is.
         let complete_path = which(&path).unwrap_or(PathBuf::from(&path));

--- a/mirrord/sip/src/lib.rs
+++ b/mirrord/sip/src/lib.rs
@@ -1,0 +1,240 @@
+#[cfg(target_os = "macos")]
+mod codesign;
+#[cfg(target_os = "macos")]
+mod error;
+#[cfg(target_os = "macos")]
+mod whitespace;
+
+#[cfg(target_os = "macos")]
+mod main {
+    use std::{
+        env::temp_dir,
+        fs::Permissions,
+        io::{self, Read},
+        os::{macos::fs::MetadataExt, unix::prelude::PermissionsExt},
+        path::Path,
+    };
+
+    use object::{
+        macho::{FatHeader, MachHeader32, MachHeader64, CPU_TYPE_X86_64},
+        read::macho::{FatArch, MachHeader},
+        Architecture, Endianness, FileKind,
+    };
+    use which::which;
+
+    use super::*;
+    use crate::error::Result;
+    pub use crate::error::SipError;
+
+    fn is_fat_x64_arch(arch: &&impl FatArch) -> bool {
+        matches!(arch.architecture(), Architecture::X86_64)
+    }
+
+    struct BinaryInfo {
+        offset: usize,
+        size: usize,
+    }
+
+    impl BinaryInfo {
+        fn new(offset: usize, size: usize) -> Self {
+            Self { offset, size }
+        }
+
+        /// Gets x64 binary offset from a Mach-O fat binary or returns 0 if is x64 macho binary.
+        fn from_object_bytes(bytes: &[u8]) -> Result<Self> {
+            match FileKind::parse(bytes)? {
+                FileKind::MachO32 => {
+                    let header: &MachHeader32<Endianness> =
+                        MachHeader::parse(bytes, 0).map_err(|_| {
+                            SipError::UnsupportedFileFormat(
+                                "MachO 32 file parsing failed".to_string(),
+                            )
+                        })?;
+                    if header.cputype(Endianness::default()) == CPU_TYPE_X86_64 {
+                        Ok(Self::new(0, bytes.len()))
+                    } else {
+                        Err(SipError::NoX64Arch)
+                    }
+                }
+                FileKind::MachO64 => {
+                    let header: &MachHeader64<Endianness> =
+                        MachHeader::parse(bytes, 0).map_err(|_| {
+                            SipError::UnsupportedFileFormat(
+                                "MachO 64 file parsing failed".to_string(),
+                            )
+                        })?;
+                    if header.cputype(Endianness::default()) == CPU_TYPE_X86_64 {
+                        Ok(Self::new(0, bytes.len()))
+                    } else {
+                        Err(SipError::NoX64Arch)
+                    }
+                }
+                FileKind::MachOFat32 => FatHeader::parse_arch32(bytes)
+                    .map_err(|_| SipError::UnsupportedFileFormat("FatMach-O 32-bit".to_string()))?
+                    .iter()
+                    .find(is_fat_x64_arch)
+                    .map(|arch| Self::new(arch.offset() as usize, arch.size() as usize))
+                    .ok_or(SipError::NoX64Arch),
+                FileKind::MachOFat64 => FatHeader::parse_arch64(bytes)
+                    .map_err(|_| SipError::UnsupportedFileFormat("Mach-O 32-bit".to_string()))?
+                    .iter()
+                    .find(is_fat_x64_arch)
+                    .map(|arch| Self::new(arch.offset() as usize, arch.size() as usize))
+                    .ok_or(SipError::NoX64Arch),
+                other => Err(SipError::UnsupportedFileFormat(format!("{:?}", other))),
+            }
+        }
+    }
+
+    /// Patches a binary to disable SIP.
+    /// Right now it extracts x64 binary from fat/MachO binary and patches it.
+    fn patch_binary<P: AsRef<Path>, K: AsRef<Path>>(path: P, output: K) -> Result<()> {
+        let data = std::fs::read(path.as_ref())?;
+        let binary_info = BinaryInfo::from_object_bytes(&data)?;
+
+        let x64_binary = &data[binary_info.offset..binary_info.offset + binary_info.size];
+        std::fs::write(output.as_ref(), x64_binary)?;
+        std::fs::set_permissions(output.as_ref(), Permissions::from_mode(0o755))?;
+        codesign::sign(output)
+    }
+
+    const SF_RESTRICTED: u32 = 0x00080000; // entitlement required for writing, from stat.h (macos)
+
+    fn read_shebang<P: AsRef<Path>>(path: P) -> Result<Option<String>> {
+        let mut f = std::fs::File::open(path)?;
+        let mut buffer = String::new();
+        match f.read_to_string(&mut buffer) {
+            Ok(_) => {}
+            Err(e) if e.kind() == io::ErrorKind::InvalidData => return Ok(None),
+            Err(e) => return Err(SipError::IO(e)),
+        }
+
+        const BOM: &str = "\u{feff}";
+        let mut content: &str = &buffer;
+        if content.starts_with(BOM) {
+            content = &content[BOM.len()..];
+        }
+
+        let mut shebang = None;
+        if content.starts_with("#!") {
+            let rest = whitespace::skip(&content[2..]);
+            if !rest.starts_with('[') {
+                let full_shebang = if let Some(idx) = content.find('\n') {
+                    &content[..idx]
+                } else {
+                    content
+                };
+                shebang = full_shebang
+                    .split_whitespace()
+                    .next()
+                    .map(|s| s.to_string());
+            }
+        }
+        Ok(shebang)
+    }
+
+    enum BinaryType {
+        Executable,
+        Shebang(String),
+    }
+
+    /// Checks the SF_RESTRICTED flags on a file (there might be a better check, feel free to
+    /// suggest)
+    fn is_sip<P: AsRef<Path>>(path: P) -> Result<bool> {
+        let metadata = std::fs::metadata(&path)?;
+        if (metadata.st_flags() & SF_RESTRICTED) > 0 {
+            return Ok(true);
+        }
+        if let Some(path) = read_shebang(&path)? {
+            let full_path = which(&path)?;
+            is_sip(full_path)
+        } else {
+            return Ok(false);
+        }
+    }
+
+    pub fn sip_patch(binary_path: &mut String) -> Result<()> {
+        let complete_path = which(&binary_path)?;
+
+        if !is_sip(&complete_path)? {
+            return Ok(());
+        }
+
+        // Strip root path from binary path, as when joined it will clear the previous.
+        let output = temp_dir().join("mirrord-bin").join(
+            &complete_path
+                .strip_prefix("/")
+                .map_err(|e| SipError::UnlikelyError(e.to_string()))?,
+        );
+
+        // Patched version already exists
+        if output.exists() {
+            *binary_path = output
+                .to_str()
+                .ok_or_else(|| {
+                    SipError::UnlikelyError("Failed to convert path to string".to_string())
+                })?
+                .to_string();
+            return Ok(());
+        }
+
+        std::fs::create_dir_all(output.parent().ok_or_else(|| {
+            SipError::UnlikelyError("Failed to get parent directory".to_string())
+        })?)?;
+
+        if let Ok(()) = patch_binary(&complete_path, &output) {
+            *binary_path = output
+                .to_str()
+                .ok_or_else(|| {
+                    SipError::UnlikelyError("Failed to convert path to string".to_string())
+                })?
+                .to_string();
+        }
+        Ok(())
+    }
+
+    #[cfg(test)]
+    mod tests {
+
+        use std::io::Write;
+
+        use super::*;
+
+        #[test]
+        fn is_sip_true() {
+            assert!(is_sip("/bin/ls").unwrap());
+        }
+
+        #[test]
+        fn is_sip_false() {
+            let mut f = tempfile::NamedTempFile::new().unwrap();
+            let data = std::fs::read("/bin/ls").unwrap();
+            f.write(&data).unwrap();
+            f.flush().unwrap();
+            assert!(!is_sip(f.path().to_str().unwrap()).unwrap());
+        }
+
+        #[test]
+        fn is_sip_notfound() {
+            let err = is_sip("/donald/duck/was/a/duck/not/a/quack/a/duck").unwrap_err();
+            assert!(err.to_string().contains("No such file or directory"));
+        }
+
+        #[test]
+        fn patch_binary_fat() {
+            let path = "/bin/ls";
+            let output = "/tmp/ls_mirrord_test";
+            patch_binary(path, output).unwrap();
+            assert!(!is_sip(output).unwrap());
+            // Check DYLD_* features work on it:
+            let output = std::process::Command::new(output)
+                .env("DYLD_PRINT_LIBRARIES", "1")
+                .output()
+                .unwrap();
+            assert!(String::from_utf8_lossy(&output.stderr).contains("libsystem_kernel.dylib"));
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+pub use main::*;

--- a/mirrord/sip/src/lib.rs
+++ b/mirrord/sip/src/lib.rs
@@ -227,13 +227,13 @@ mod main {
         let output = temp_dir().join("mirrord-bin").join(
             &path
                 .strip_prefix("/")
-                .map_err(|e| SipError::UnlikelyError(e.to_string()))?,
+                .map_err(|e| UnlikelyError(e.to_string()))?,
         );
 
         // A string of the path of new created file to run instead of the SIPed file.
         let patched_path_string = output
             .to_str()
-            .ok_or_else(|| SipError::UnlikelyError("Failed to convert path to string".to_string()))?
+            .ok_or_else(|| UnlikelyError("Failed to convert path to string".to_string()))?
             .to_string();
 
         if output.exists() {
@@ -244,9 +244,11 @@ mod main {
             return Ok(patched_path_string);
         }
 
-        std::fs::create_dir_all(output.parent().ok_or_else(|| {
-            SipError::UnlikelyError("Failed to get parent directory".to_string())
-        })?)?;
+        std::fs::create_dir_all(
+            output
+                .parent()
+                .ok_or_else(|| UnlikelyError("Failed to get parent directory".to_string()))?,
+        )?;
 
         match shebang_target {
             None => {
@@ -278,9 +280,7 @@ mod main {
                     // This function should only be called on a file which has SomeSIP SipStatus.
                     // If the file has a shebang pointing to a file which is NoSIP, this file should
                     // not have SomeSIP status in the first place.
-                    Err(SipError::UnlikelyError(
-                        "Internal mirrord error.".to_string(),
-                    ))
+                    Err(UnlikelyError("Internal mirrord error.".to_string()))
                 }
             }
         }

--- a/mirrord/sip/src/lib.rs
+++ b/mirrord/sip/src/lib.rs
@@ -184,7 +184,8 @@ mod main {
         NoSIP,
     }
 
-    /// Determine status recursively, keep seen_paths, and return an error if there is a cyclical reference.
+    /// Determine status recursively, keep seen_paths, and return an error if there is a cyclical
+    /// reference.
     fn get_sip_status_rec(path: &str, seen_paths: &mut HashSet<PathBuf>) -> Result<SipStatus> {
         // If which fails, try using the given path as is.
         let complete_path = which(&path).unwrap_or(PathBuf::from(&path));

--- a/mirrord/sip/src/lib.rs
+++ b/mirrord/sip/src/lib.rs
@@ -132,12 +132,7 @@ mod main {
     const SF_RESTRICTED: u32 = 0x00080000; // entitlement required for writing, from stat.h (macos)
 
     /// Extract shebang from file contexts.
-    /// # Examples
-    ///
-    /// ```
-    /// let contents = "#!/usr/bin/env bash\n".to_string();
-    /// assert_eq!(get_shebang_from_string(contents), "#!/usr/bin/env")
-    /// ```
+    /// "#!/usr/bin/env bash\n..." -> Some("#!/usr/bin/env")
     fn get_shebang_from_string(file_contents: &str) -> Option<String> {
         const BOM: &str = "\u{feff}";
         let mut content: &str = &file_contents;
@@ -350,6 +345,12 @@ mod main {
             patch_script(original_file.path(), &patched_path, "/test/shebang").unwrap();
             let new_contents = std::fs::read(&patched_path).unwrap();
             assert_eq!(new_contents, "#!/test/shebang bash\n".as_bytes())
+        }
+
+        #[test]
+        fn shebang_from_string() {
+            let contents = "#!/usr/bin/env bash\n".to_string();
+            assert_eq!(get_shebang_from_string(&contents).unwrap(), "#!/usr/bin/env")
         }
     }
 }

--- a/mirrord/sip/src/whitespace.rs
+++ b/mirrord/sip/src/whitespace.rs
@@ -1,3 +1,29 @@
+/*
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+*/
+
 // source: https://github.com/dtolnay/syn/blob/master/src/whitespace.rs
 
 pub fn skip(mut s: &str) -> &str {

--- a/mirrord/sip/src/whitespace.rs
+++ b/mirrord/sip/src/whitespace.rs
@@ -1,0 +1,67 @@
+// source: https://github.com/dtolnay/syn/blob/master/src/whitespace.rs
+
+pub fn skip(mut s: &str) -> &str {
+    'skip: while !s.is_empty() {
+        let byte = s.as_bytes()[0];
+        if byte == b'/' {
+            if s.starts_with("//")
+                && (!s.starts_with("///") || s.starts_with("////"))
+                && !s.starts_with("//!")
+            {
+                if let Some(i) = s.find('\n') {
+                    s = &s[i + 1..];
+                    continue;
+                } else {
+                    return "";
+                }
+            } else if s.starts_with("/**/") {
+                s = &s[4..];
+                continue;
+            } else if s.starts_with("/*")
+                && (!s.starts_with("/**") || s.starts_with("/***"))
+                && !s.starts_with("/*!")
+            {
+                let mut depth = 0;
+                let bytes = s.as_bytes();
+                let mut i = 0;
+                let upper = bytes.len() - 1;
+                while i < upper {
+                    if bytes[i] == b'/' && bytes[i + 1] == b'*' {
+                        depth += 1;
+                        i += 1; // eat '*'
+                    } else if bytes[i] == b'*' && bytes[i + 1] == b'/' {
+                        depth -= 1;
+                        if depth == 0 {
+                            s = &s[i + 2..];
+                            continue 'skip;
+                        }
+                        i += 1; // eat '/'
+                    }
+                    i += 1;
+                }
+                return s;
+            }
+        }
+        match byte {
+            b' ' | 0x09..=0x0d => {
+                s = &s[1..];
+                continue;
+            }
+            b if b <= 0x7f => {}
+            _ => {
+                let ch = s.chars().next().unwrap();
+                if is_whitespace(ch) {
+                    s = &s[ch.len_utf8()..];
+                    continue;
+                }
+            }
+        }
+        return s;
+    }
+    s
+}
+
+fn is_whitespace(ch: char) -> bool {
+    // Rust treats left-to-right mark and right-to-left mark as whitespace
+    ch.is_whitespace() || ch == '\u{200e}' || ch == '\u{200f}'
+}

--- a/scripts/build_fat_mac.sh
+++ b/scripts/build_fat_mac.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+# This script builds a fat binary for Mac OS X.
+# Output will be in target/universal-apple-darwin/debug/mirrord
+set -e
+cargo +nightly build -p mirrord-layer --target=x86_64-apple-darwin
+cargo +nightly build -p mirrord-layer --target=aarch64-apple-darwin
+cp target/aarch64-apple-darwin/debug/libmirrord_layer.dylib target/aarch64-apple-darwin/debug/libmirrord_layer_arm64e.dylib
+printf '\x02' | dd of=target/aarch64-apple-darwin/debug/libmirrord_layer_arm64e.dylib bs=1 seek=8 count=1 conv=notrunc
+codesign -f -s - target/aarch64-apple-darwin/debug/libmirrord_layer_arm64e.dylib
+codesign -f -s - target/x86_64-apple-darwin/debug/libmirrord_layer.dylib
+mkdir -p target/universal-apple-darwin/debug
+lipo -create -output target/universal-apple-darwin/debug/libmirrord_layer.dylib target/aarch64-apple-darwin/debug/libmirrord_layer.dylib target/x86_64-apple-darwin/debug/libmirrord_layer.dylib target/aarch64-apple-darwin/debug/libmirrord_layer_arm64e.dylib
+codesign -f -s - target/universal-apple-darwin/debug/libmirrord_layer.dylib
+MIRRORD_LAYER_FILE=../../target/universal-apple-darwin/debug/libmirrord_layer.dylib cargo +nightly build -p mirrord --target=aarch64-apple-darwin
+MIRRORD_LAYER_FILE=../../target/universal-apple-darwin/debug/libmirrord_layer.dylib cargo +nightly build -p mirrord --target=x86_64-apple-darwin
+lipo -create -output target/universal-apple-darwin/debug/mirrord target/aarch64-apple-darwin/debug/mirrord target/x86_64-apple-darwin/debug/mirrord
+codesign -f -s - target/universal-apple-darwin/debug/mirrord

--- a/scripts/build_fat_mac.sh
+++ b/scripts/build_fat_mac.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 # This script builds a fat binary for Mac OS X.
 # Output will be in target/universal-apple-darwin/debug/mirrord
+# If compilation fails, try running:
+# rustup target add --toolchain nightly x86_64-apple-darwin
+
 set -e
 cargo +nightly build -p mirrord-layer --target=x86_64-apple-darwin
 cargo +nightly build -p mirrord-layer --target=aarch64-apple-darwin
@@ -11,7 +14,8 @@ codesign -f -s - target/x86_64-apple-darwin/debug/libmirrord_layer.dylib
 mkdir -p target/universal-apple-darwin/debug
 lipo -create -output target/universal-apple-darwin/debug/libmirrord_layer.dylib target/aarch64-apple-darwin/debug/libmirrord_layer.dylib target/x86_64-apple-darwin/debug/libmirrord_layer.dylib target/aarch64-apple-darwin/debug/libmirrord_layer_arm64e.dylib
 codesign -f -s - target/universal-apple-darwin/debug/libmirrord_layer.dylib
-MIRRORD_LAYER_FILE=../../target/universal-apple-darwin/debug/libmirrord_layer.dylib cargo +nightly build -p mirrord --target=aarch64-apple-darwin
-MIRRORD_LAYER_FILE=../../target/universal-apple-darwin/debug/libmirrord_layer.dylib cargo +nightly build -p mirrord --target=x86_64-apple-darwin
+MIRRORD_LAYER_FILE=../../../target/universal-apple-darwin/debug/libmirrord_layer.dylib cargo +nightly build -p mirrord --target=aarch64-apple-darwin
+MIRRORD_LAYER_FILE=../../../target/universal-apple-darwin/debug/libmirrord_layer.dylib cargo +nightly build -p mirrord --target=x86_64-apple-darwin
 lipo -create -output target/universal-apple-darwin/debug/mirrord target/aarch64-apple-darwin/debug/mirrord target/x86_64-apple-darwin/debug/mirrord
 codesign -f -s - target/universal-apple-darwin/debug/mirrord
+


### PR DESCRIPTION
Part of https://github.com/metalbear-co/mirrord/issues/649.

On MacOS, test if the file that the user specified to run is protected by SIP, or is a script with a shebang that leads to such a binary (also via multiple shebang scripts). If it is, create an unprotected version of the binary (and the shebang scripts that lead to it) and run that instead.

This does not yet bypass SIP on binaries that the executed application executes.