### PR TITLE
[Merged by Bors] - Ci on all branches

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,6 @@ name: CI
 on:
   workflow_dispatch:
   push:
-    branches: [main, staging, trying]
   pull_request:
     branches: [main, staging, trying]
 


### PR DESCRIPTION
Run the CI on a push to any branch, so that tests also run in the feature branches on our forks, without opening a PR.