### PR TITLE
[Merged by Bors] - Make connection errors nicer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+### Changed
+
+- Only recommend `--accept-invalid-certificates` on connection errors if not already set.
+- Terminate user application on connection error instead of only stopping mirrord.
+
 ## 3.10.0
 
 ### Added

--- a/mirrord/layer/src/macros.rs
+++ b/mirrord/layer/src/macros.rs
@@ -91,17 +91,18 @@ macro_rules! hook_symbol {
 
 #[macro_export]
 macro_rules! graceful_exit {
-    ($($arg:tt)+) => {
+    ($($arg:tt)+) => {{
         eprintln!($($arg)+);
         graceful_exit!()
-    };
-    () => {
+    }};
+    () => {{
         nix::sys::signal::kill(
             nix::unistd::Pid::from_raw(std::process::id() as i32),
             nix::sys::signal::Signal::SIGTERM,
         )
-        .expect("unable to graceful exit")
-    };
+        .expect("unable to graceful exit");
+        panic!()
+    }};
 }
 
 #[cfg(all(target_os = "linux", not(target_arch = "aarch64")))]


### PR DESCRIPTION
  - Only recommend `--accept-invalid-certificates` if not already set.
  - Exit gracefully instead of `panic`king: this means also the user's
    application is terminated, not just mirrord's layer.
  - Wrap `graceful_exit` code in a block so that it can be used as a
    whole `match` arm, add (unreachable) `panic` at the end, so that it
    can be used where the return type is `!`.
