### PR TITLE
[Merged by Bors] - Remove `unimplemented` for some IO cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+### Changed
+- Remove `unimplemented` for some IO cases, we now return `Unknown` instead. Also added warning logs for these cases to track.
+
 ## 3.10.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ## [Unreleased]
 
 ### Changed
+
 - Remove `unimplemented` for some IO cases, we now return `Unknown` instead. Also added warning logs for these cases to track.
 
 ## 3.10.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1779,6 +1779,7 @@ dependencies = [
  "bytes",
  "serde",
  "thiserror",
+ "tracing",
  "trust-dns-resolver",
 ]
 

--- a/mirrord/protocol/Cargo.toml
+++ b/mirrord/protocol/Cargo.toml
@@ -20,3 +20,4 @@ thiserror.workspace = true
 trust-dns-resolver.workspace = true
 serde = { version = "1", features = ["derive"] }
 bincode =  { version = "2.0.0-rc.2", features = ["serde"] }
+tracing.workspace = true


### PR DESCRIPTION
we now return `Unknown` instead. Also added warning logs for these cases to track.

Following a case in Discord where this happened and crashed.