### PR TITLE
[Merged by Bors] - only warn about invalid certs once per agent.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+### Changed
+
+- Only warn about invalid certificates once per agent.
+
 ### Fixed
 
 - CI: Fix regex for homebrew formula

--- a/mirrord/layer/src/pod_api.rs
+++ b/mirrord/layer/src/pod_api.rs
@@ -171,10 +171,13 @@ pub(crate) struct KubernetesAPI {
 impl KubernetesAPI {
     pub(crate) async fn create_kube_config(config: &LayerConfig) -> Result<Config> {
         if config.accept_invalid_certificates {
-            let mut config = Config::infer().await?;
-            config.accept_invalid_certs = true;
-            warn!("Accepting invalid certificates");
-            Ok(config)
+            let mut kube_config = Config::infer().await?;
+            kube_config.accept_invalid_certs = true;
+            // Only warn the first time connecting to the agent, not on child processes.
+            if config.connect_agent_name.is_none() {
+                warn!("Accepting invalid certificates");
+            }
+            Ok(kube_config)
         } else {
             Config::infer().await.map_err(|err| err.into())
         }


### PR DESCRIPTION
If the layer is not creating a new agent but using an existing one, don't warn again about invalid certificates.
This is especially relevant for running bash scripts, were many commands are binaries that then go through layer initialisation on execution. Currently we get a warning for each such command in a bash script.

Before:
```
t4lz ~/Documents/projects/mirrord % RUST_LOG=mirrord=warn target/universal-apple-darwin/debug/mirrord exec -c --target pod/py-serv-deployment-ff89b5974-wkl2t /tmp/bash_script.sh


✓ layer initialized
2022-11-17T11:18:39.806863Z  WARN ThreadId(09) mirrord_layer::pod_api: Accepting invalid certificates
✓ agent running
  ✓ agent pod created
  ✓ pod is ready
2022-11-17T11:18:40.935507Z  WARN ThreadId(09) mirrord_layer::pod_api: Accepting invalid certificates
2022-11-17T11:18:41.030515Z  WARN ThreadId(09) mirrord_layer::pod_api: Accepting invalid certificates
2022-11-17T11:18:41.134278Z  WARN ThreadId(09) mirrord_layer::pod_api: Accepting invalid certificates
2022-11-17T11:18:41.225709Z  WARN ThreadId(09) mirrord_layer::pod_api: Accepting invalid certificates
2022-11-17T11:18:41.322926Z  WARN ThreadId(09) mirrord_layer::pod_api: Accepting invalid certificates
2022-11-17T11:18:41.423296Z  WARN ThreadId(09) mirrord_layer::pod_api: Accepting invalid certificates
2022-11-17T11:18:41.497168Z  WARN ThreadId(09) mirrord_layer::pod_api: Accepting invalid certificates
2022-11-17T11:18:41.572503Z  WARN ThreadId(09) mirrord_layer::pod_api: Accepting invalid certificates
2022-11-17T11:18:41.647330Z  WARN ThreadId(09) mirrord_layer::pod_api: Accepting invalid certificates
2022-11-17T11:18:41.732043Z  WARN ThreadId(09) mirrord_layer::pod_api: Accepting invalid certificates
2022-11-17T11:18:41.809728Z  WARN ThreadId(09) mirrord_layer::pod_api: Accepting invalid certificates
2022-11-17T11:18:41.886884Z  WARN ThreadId(09) mirrord_layer::pod_api: Accepting invalid certificates
2022-11-17T11:18:41.962741Z  WARN ThreadId(09) mirrord_layer::pod_api: Accepting invalid certificates
2022-11-17T11:18:42.036310Z  WARN ThreadId(09) mirrord_layer::pod_api: Accepting invalid certificates
```

After:
```
t4lz ~/Documents/projects/mirrord % RUST_LOG=mirrord=warn target/universal-apple-darwin/debug/mirrord exec -c --target pod/py-serv-deployment-ff89b5974-wkl2t /tmp/bash_script.sh


✓ layer initialized
2022-11-17T11:17:41.915502Z  WARN ThreadId(09) mirrord_layer::pod_api: Accepting invalid certificates
✓ agent running
  ✓ agent pod created
  ✓ pod is ready
```