### PR TITLE
[Merged by Bors] - Intercept argv and remove mirrord's temp dir

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,6 +252,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
 
 [[package]]
+name = "byte-strings-proc_macros"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e78e8673d97234c7a07636474b02c92fad06a0f26f70581aa46aee124c508e5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1762,6 +1773,7 @@ dependencies = [
  "mirrord-protocol",
  "mirrord-sip",
  "nix 0.24.2",
+ "null-terminated",
  "os_info",
  "rand 0.8.5",
  "rstest",
@@ -1982,6 +1994,17 @@ checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
  "overload",
  "winapi",
+]
+
+[[package]]
+name = "null-terminated"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db3ab2c625aa6bd21571b3599f3c4318b4456ec89efc62c0b47c1a8de14e30bf"
+dependencies = [
+ "byte-strings-proc_macros",
+ "unreachable",
+ "utf",
 ]
 
 [[package]]
@@ -3764,6 +3787,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
+name = "unreachable"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
+dependencies = [
+ "void",
+]
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3794,6 +3826,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8db7427f936968176eaa7cdf81b7f98b980b18495ec28f1b5791ac3bfe3eea9"
 
 [[package]]
+name = "utf"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8704f91734e57e97633bff5afe5c2893e5aca5bd83fac44736460deca2611a76"
+
+[[package]]
 name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3816,6 +3854,12 @@ name = "virtue"
 version = "0.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b60dcd6a64dd45abf9bd426970c9843726da7fc08f44cd6fcebf68c21220a63"
+
+[[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "walkdir"

--- a/mirrord/cli/src/main.rs
+++ b/mirrord/cli/src/main.rs
@@ -207,7 +207,7 @@ fn exec(args: &ExecArgs) -> Result<()> {
     let binary = args.binary.clone();
 
     let mut binary_args = args.binary_args.clone();
-    binary_args.insert(0, binary.clone());
+    binary_args.insert(0, args.binary.clone());
 
     // The execve hook is not yet active and does not hijack this call.
     let err = execvp(binary, binary_args);

--- a/mirrord/layer/Cargo.toml
+++ b/mirrord/layer/Cargo.toml
@@ -54,6 +54,7 @@ os_info = "3"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 mirrord-sip = { path = "../sip" }
+null-terminated = "0.3"
 
 [dev-dependencies]
 base64 = "0.13"

--- a/mirrord/layer/src/detour.rs
+++ b/mirrord/layer/src/detour.rs
@@ -82,6 +82,12 @@ pub(crate) enum Bypass {
     NoSipDetected(String),
     #[cfg(target_os = "macos")]
     ExecOnNonExistingFile(String),
+    #[cfg(target_os = "macos")]
+    NoTempDirInArgv,
+    #[cfg(target_os = "macos")]
+    TempDirEnvVarNotSet,
+    #[cfg(target_os = "macos")]
+    TooManyArgs,
 }
 
 /// `ControlFlow`-like enum to be used by hooks.

--- a/mirrord/layer/src/exec.rs
+++ b/mirrord/layer/src/exec.rs
@@ -1,16 +1,22 @@
 #![cfg(target_os = "macos")]
 
-use std::ffi::{CStr, CString};
+use std::{
+    env,
+    ffi::{CStr, CString},
+};
 
 use frida_gum::interceptor::Interceptor;
 use libc::{c_char, c_int};
 use mirrord_layer_macro::hook_guard_fn;
-use mirrord_sip::{sip_patch, SipError};
-use tracing::{trace, warn};
+use mirrord_sip::{sip_patch, SipError, TMP_DIR_ENV_VAR_NAME};
+use null_terminated::Nul;
+use tracing::{debug, log::error, warn};
 
 use crate::{
     detour::{
-        Bypass::{ExecOnNonExistingFile, NoSipDetected},
+        Bypass::{
+            ExecOnNonExistingFile, NoSipDetected, NoTempDirInArgv, TempDirEnvVarNotSet, TooManyArgs,
+        },
         Detour,
         Detour::{Bypass, Error, Success},
     },
@@ -18,6 +24,8 @@ use crate::{
     file::ops::str_from_rawish,
     replace,
 };
+
+static MAX_ARGC: usize = 16;
 
 pub(crate) unsafe fn enable_execve_hook(interceptor: &mut Interceptor) {
     let _ = replace!(interceptor, "execve", execve_detour, FnExecve, FN_EXECVE);
@@ -31,10 +39,11 @@ pub(super) fn patch_if_sip(rawish_path: Option<&CStr>) -> Detour<String> {
         Ok(None) => Bypass(NoSipDetected(path.to_string())),
         Ok(Some(new_path)) => Success(new_path),
         Err(SipError::FileNotFound(non_existing_bin)) => {
-            trace!(
-                "The application wants to execute {}, SIP check got FileNotFound. If the file \
-                actually exists, make sure it is excluded from FS ops.",
-                non_existing_bin
+            debug!(
+                "The application wants to execute {}, SIP check got FileNotFound for {}. \
+                If the file actually exists and should have been found, make sure it is excluded \
+                from FS ops.",
+                path, non_existing_bin
             );
             Bypass(ExecOnNonExistingFile(non_existing_bin))
         }
@@ -51,10 +60,64 @@ pub(super) fn patch_if_sip(rawish_path: Option<&CStr>) -> Detour<String> {
     }
 }
 
+fn raw_to_str(raw_str: &*const c_char) -> Detour<&str> {
+    let rawish_str = (!raw_str.is_null()).then(|| unsafe { CStr::from_ptr(raw_str.to_owned()) });
+    str_from_rawish(rawish_str)
+}
+
+/// Check if the arguments to the new executable contain paths to mirrord's temp dir.
+/// If they do, create a new array with the original paths instead of the patched paths.
+fn intercept_tmp_dir(argv_arr: &Nul<*const c_char>) -> Detour<Vec<*const c_char>> {
+    if let Ok(tmp_dir) = env::var(TMP_DIR_ENV_VAR_NAME) {
+        let mut ptr_vec: Vec<*const c_char> = Vec::new();
+        let mut changed = false; // Did we change any of the args?
+
+        // Iterate through args, if an argument is a path inside our temp dir, save pointer to
+        // after that prefix instead.
+        // Example:
+        //                                           "/path-to-mirrord-temp/file1"
+        // If argv[1] is a pointer to a string ptr: --^                    ^
+        // Then save a pointer to after the temp dir prefix instead:  -----|
+        for (i, arg) in argv_arr.iter().enumerate() {
+            if i > MAX_ARGC {
+                // the iterator will go until there is a null pointer, so stop after MAX_ARGC so
+                // that we don't just keep going indefinitely if a bad argv was passed.
+                return Bypass(TooManyArgs);
+            }
+            let arg_str = raw_to_str(arg)?;
+            ptr_vec.push(
+                    arg_str
+                        .strip_prefix(&tmp_dir)
+                        .map_or_else(
+                            || arg_str.as_ptr() as *const c_char, // No temp dir, use arg as is.
+                            |original_path| {
+                                debug!("Intercepted mirrord's temp dir in argv: {}. Replacing with original path: {}.", arg_str, original_path);
+                                changed = true;
+                                original_path.as_ptr() as *const c_char
+                            })
+            );
+        }
+        return if changed {
+            ptr_vec.push(0 as *const c_char); // Terminate with null.
+            Success(ptr_vec)
+        } else {
+            Bypass(NoTempDirInArgv)
+        };
+    }
+    error!(
+        "mirrord internal error: environment variable {} not set.",
+        TMP_DIR_ENV_VAR_NAME
+    );
+    Bypass(TempDirEnvVarNotSet) // Temp dir was not set. Cannot intercept. Should not happen.
+}
+
 /// Hook for `libc::execve`.
 ///
-/// Patch file if it is SIPed, then call normal execve (on the patched file if patched, otherwise
-/// on original file)
+/// Patch file if it is SIPed, used new path if patched.
+/// If any args in argv are paths to mirrord's temp directory, strip the temp dir part.
+/// So if argv[1] is "/var/folders/1337/mirrord-bin/opt/homebrew/bin/npx"
+/// Switch it to "/opt/homebrew/bin/npx"
+/// then call normal execve with the possibly updated path and argv and the original envp.
 #[hook_guard_fn]
 pub(crate) unsafe extern "C" fn execve_detour(
     path: *const c_char,
@@ -74,5 +137,18 @@ pub(crate) unsafe extern "C" fn execve_detour(
         })
         .unwrap_or(path); // Continue even if there were errors - just run without patching.
 
-    FN_EXECVE(final_path, argv, envp)
+    let argv_arr = Nul::new_unchecked(argv);
+
+    // If we intercept args, we create a new array.
+    // execve takes a null terminated array of char pointers.
+    // ptr_vec will own the vector that will be passed to execve as an array.
+    let mut ptr_vec: Vec<*const c_char> = Vec::new();
+    let final_argv = intercept_tmp_dir(argv_arr)
+        .map(|new_vec| {
+            ptr_vec = new_vec; // Make sure vector still lives when we pass the pointer to execve.
+            ptr_vec.as_ptr()
+        })
+        .unwrap_or(argv);
+
+    FN_EXECVE(final_path, final_argv, envp)
 }

--- a/mirrord/layer/src/exec.rs
+++ b/mirrord/layer/src/exec.rs
@@ -25,7 +25,7 @@ use crate::{
     replace,
 };
 
-static MAX_ARGC: usize = 16;
+const MAX_ARGC: usize = 254;
 
 pub(crate) unsafe fn enable_execve_hook(interceptor: &mut Interceptor) {
     let _ = replace!(interceptor, "execve", execve_detour, FnExecve, FN_EXECVE);

--- a/mirrord/sip/src/lib.rs
+++ b/mirrord/sip/src/lib.rs
@@ -29,7 +29,7 @@ mod main {
     };
 
     static EXCLUDE_ENV_VAR_NAME: &str = "MIRRORD_FILE_FILTER_EXCLUDE";
-    static TMP_DIR_ENV_VAR_NAME: &str = "MIRRORD_TMP_DIR";
+    pub static TMP_DIR_ENV_VAR_NAME: &str = "MIRRORD_TMP_DIR";
 
     fn is_fat_x64_arch(arch: &&impl FatArch) -> bool {
         matches!(arch.architecture(), Architecture::X86_64)

--- a/mirrord/sip/src/lib.rs
+++ b/mirrord/sip/src/lib.rs
@@ -28,8 +28,8 @@ mod main {
         SipError::{CyclicShebangs, FileNotFound, UnlikelyError},
     };
 
-    static EXCLUDE_ENV_VAR_NAME: &str = "MIRRORD_FILE_FILTER_EXCLUDE";
-    pub static TMP_DIR_ENV_VAR_NAME: &str = "MIRRORD_TMP_DIR";
+    const EXCLUDE_ENV_VAR_NAME: &str = "MIRRORD_FILE_FILTER_EXCLUDE";
+    pub const TMP_DIR_ENV_VAR_NAME: &str = "MIRRORD_TMP_DIR";
 
     fn is_fat_x64_arch(arch: &&impl FatArch) -> bool {
         matches!(arch.architecture(), Architecture::X86_64)


### PR DESCRIPTION
When an executable script `my_script` with a shebang `#!/usr/bin/env some_interpreter` is executed, it resolves to 
```bash
/usr/bin/env some_interpreter my_script
```
So currently if we patch it and save a patch version in `mirrord-tmp/`, running `/mirrord-tmp/my_script` resolves to 
```bash
/usr/bin/env some_interpreter /mirrord-temp/my_script
```
so what then happens when we run `my_script` with the mirrord CLI (if `some_interpreter` is a binary executable that does not have SIP):
1. We read `my_script` and its shebang.
2. We create a version of `my_script` in `/mirrrord-tmp/path/to/my_script` with the shebang `#!/mirrord-tmp/usr/bin/env some_interpreter`, and create a SIP-free version of `env` in `/mirrord-tmp/usr/bin/env`.
3. We execute `/mirrrord-tmp/path/to/my_script` which resolves to `/mirrord-tmp/usr/bin/env my_interpreter /mirrrord-tmp/path/to/my_script`
4. patched `env` is executed with loaded layer.
5. `env` calls `execve` with path `my_interpreter` and argv: `["my_interpreter", "/mirrrord-tmp/path/to/my_script"]`.

This is a problem when running `node` as the interpreter (`#!/usr/bin/env node`), since node determines the location of modules relatively to the executed file, which it receives as an argument (here argv[1]). In our example node would search for modules relative to `/mirrrord-tmp/path/to/my_script`, instead of relative to `/path/to/my_script`.
This PR suggests a mitigation that problem: 
In the `execve` hook: go over the arguments in `argv` and strip the path to our temp directory from them if it's there.

That way node reads the original script, not the patched one, and can find the required modules.