### PR TITLE
[Merged by Bors] - cli: set canonical path for config file to avoid possible issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+### Changed
+
+- cli: set canonical path for config file to avoid possible issues when child processes change current working directory.
+
 ## 3.11.2
 
 ### Fixed

--- a/mirrord/cli/src/main.rs
+++ b/mirrord/cli/src/main.rs
@@ -203,7 +203,10 @@ fn exec(args: &ExecArgs, progress: &TaskProgress) -> Result<()> {
     }
 
     if let Some(config_file) = &args.config_file {
-        std::env::set_var("MIRRORD_CONFIG_FILE", config_file.clone());
+        // Set canoncialized path to config file, in case forks/children are in different
+        // working directories.
+        let full_path = std::fs::canonicalize(config_file)?;
+        std::env::set_var("MIRRORD_CONFIG_FILE", full_path);
     }
 
     if args.capture_error_trace {


### PR DESCRIPTION
cli: set canonical path for config file to avoid possible issues when child processes change current working directory.