### PR TITLE
[Merged by Bors] - Pause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+### Added
+
+- `--pause` feature (unstable). See [#712](https://github.com/metalbear-co/mirrord/issues/712).
+
 ### Changed
 
 - CI: cancel previous runs of same PR.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -739,6 +739,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum_dispatch"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eb359f1476bf611266ac1f5355bc14aeca37b299d0ebccc038ee7058891c9cb"
+dependencies = [
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "errno"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1714,10 +1726,12 @@ name = "mirrord-agent"
 version = "3.11.2"
 dependencies = [
  "actix-codec",
+ "async-trait",
  "bollard",
  "bytes",
  "clap",
  "containerd-client",
+ "enum_dispatch",
  "faccess",
  "futures",
  "iptables",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ categories = ["development-tools", "backend", "devtool"]
 
 [workspace.dependencies]
 actix-codec = "0.5"
+async-trait = "0.1"
 bytes = "1"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "net", "macros"] }
 tokio-stream = "0.1"

--- a/mirrord-schema.json
+++ b/mirrord-schema.json
@@ -177,7 +177,7 @@
           ]
         },
         "pause": {
-          "description": "Controls target pause feature.\n\nWith this feature enabled, the deployed app is paused while clients are connected to the agent.",
+          "description": "Controls target pause feature.\n\nWith this feature enabled, the remote container is paused while clients are connected to the agent.",
           "type": [
             "boolean",
             "null"

--- a/mirrord-schema.json
+++ b/mirrord-schema.json
@@ -177,7 +177,7 @@
           ]
         },
         "pause": {
-          "description": "Controls target pause feature.\n\nWith this feature enabled, the remote container is paused while clients are connected to the agent.",
+          "description": "Controls target pause feature. Unstable.\n\nWith this feature enabled, the remote container is paused while clients are connected to the agent.",
           "type": [
             "boolean",
             "null"

--- a/mirrord-schema.json
+++ b/mirrord-schema.json
@@ -176,6 +176,13 @@
             "null"
           ]
         },
+        "pause": {
+          "description": "Controls target pause feature.\n\nWith this feature enabled, the deployed app is paused while clients are connected to the agent.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "startup_timeout": {
           "description": "Controls how long to wait for the agent to finish initialization.\n\nIf initialization takes longer than this value, mirrord exits.",
           "type": [

--- a/mirrord/agent/Cargo.toml
+++ b/mirrord/agent/Cargo.toml
@@ -43,6 +43,8 @@ regex = "1"
 socket2 = "0.4"
 rawsocket = {git = "https://github.com/metalbear-co/rawsocket.git"}
 wildmatch = "2"
+enum_dispatch = "0.3.8"
+async-trait = "0.1"
 
 [dev-dependencies]
 mockall = "0.11"

--- a/mirrord/agent/Cargo.toml
+++ b/mirrord/agent/Cargo.toml
@@ -44,7 +44,7 @@ socket2 = "0.4"
 rawsocket = {git = "https://github.com/metalbear-co/rawsocket.git"}
 wildmatch = "2"
 enum_dispatch = "0.3.8"
-async-trait = "0.1"
+async-trait.workspace = true
 
 [dev-dependencies]
 mockall = "0.11"

--- a/mirrord/agent/src/cli.rs
+++ b/mirrord/agent/src/cli.rs
@@ -31,6 +31,10 @@ pub struct Args {
     /// Inform the agent to use `proc/1/root` as the root directory.
     #[arg(short = 'e', long, default_value_t = false)]
     pub ephemeral_container: bool,
+
+    /// Pause the target container while clients are connected.
+    #[clap(short = 'p', long, default_value_t = false, value_parser)]
+    pub pause: bool,
 }
 
 const DEFAULT_RUNTIME: &str = "containerd";

--- a/mirrord/agent/src/cli.rs
+++ b/mirrord/agent/src/cli.rs
@@ -33,7 +33,7 @@ pub struct Args {
     pub ephemeral_container: bool,
 
     /// Pause the target container while clients are connected.
-    #[clap(short = 'p', long, default_value_t = false, value_parser)]
+    #[arg(short = 'p', long, default_value_t = false)]
     pub pause: bool,
 }
 

--- a/mirrord/agent/src/error.rs
+++ b/mirrord/agent/src/error.rs
@@ -90,6 +90,12 @@ pub enum AgentError {
 
     #[error("DNS response receive failed with `{0}`")]
     DnsResponseReceiveError(#[from] tokio::sync::oneshot::error::RecvError),
+
+    #[error("Pause was set, but container id or runtime is missing.")]
+    MissingContainerInfo,
+
+    #[error("start_client -> Ran out of connections, dropping new connection")]
+    ConnectionLimitReached,
 }
 
 pub(crate) type Result<T, E = AgentError> = std::result::Result<T, E>;

--- a/mirrord/agent/src/main.rs
+++ b/mirrord/agent/src/main.rs
@@ -3,13 +3,14 @@
 #![feature(once_cell)]
 
 use nix::unistd::Pid;
-use nix::sys::signal::{self, Signal};
+use nix::sys::signal::{kill, Signal};
 
 use std::{
     collections::HashSet,
     net::{Ipv4Addr, SocketAddrV4},
     path::PathBuf,
 };
+use std::time::Duration;
 
 use actix_codec::Framed;
 use cli::parse_args;
@@ -32,6 +33,8 @@ use tokio::{
     select,
     sync::mpsc::{self, Receiver, Sender},
 };
+use tokio::sync::mpsc::channel;
+use tokio::time::interval;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, trace};
 use tracing_subscriber::{fmt::format::FmtSpan, prelude::*};
@@ -55,27 +58,143 @@ mod util;
 
 const CHANNEL_SIZE: usize = 1024;
 
+/// An instance of Pauser is used to pause a container by sending periodic SIGSTOPs to its pid.
+/// Once the Pauser is dropped the SIGSTOPs will stop and the container will resume.
+/// But the Pauser itself can also be stopped and continued using its public methods.
 #[derive(Debug)]
-struct State {
-    pub clients: HashSet<ClientID>,
-    index_allocator: IndexAllocator<ClientID>,
+struct Pauser {
+    on_sender: Sender<()>,
+    off_sender: Sender<()>,
 }
 
-impl State {
-    pub fn new() -> State {
-        State {
-            clients: HashSet::new(),
-            index_allocator: IndexAllocator::new(),
+impl Pauser {
+    /// After calling new the stopper thread is started, but is blocked, waiting to be "turned on."
+    pub fn new(pid: u64, interval: Duration) -> Pauser {
+        let (on_sender, on_receiver) = channel(256);
+        let (off_sender, off_receiver) = channel(256);
+
+        tokio::spawn(Self::container_stopper(pid, interval, on_receiver, off_receiver));
+        Pauser {
+            on_sender,
+            off_sender,
         }
     }
 
-    pub fn generate_id(&mut self) -> Option<ClientID> {
+    /// Send SIGSTOP to `pid` every `dur`.
+    /// First SIGSTOP will be sent after first message received on `on_receiver`.
+    /// After that, will stop sending SIGSTOP when receiving a message in `off_receiver`, until
+    /// another message arrives in `on_receiver`.
+    async fn container_stopper(pid: u64, dur: Duration, mut on_receiver: Receiver<()>, mut off_receiver: Receiver<()>) {
+        info!("Container stopper started - will be pausing pid {pid}");
+        let mut ticker = interval(dur);
+        let pid = pid as pid_t;
+        // wait for first on to come.
+        if on_receiver.recv().await.is_none(){
+            return; // Other side dropped channel, exit.
+        }
+        loop {
+            select! {
+                _ = ticker.tick() => {
+                    kill(Pid::from_raw(pid), Signal::SIGSTOP).unwrap();
+                    // TODO: do we also need to stop children?
+                },
+                res = off_receiver.recv() => {
+                    match res {
+                        Some(()) => {
+                            info!("Resuming pid {}", pid);
+                            // Resume original container when agent is done.
+                            kill(Pid::from_raw(pid), Signal::SIGCONT).unwrap();
+                            // block until Pauser turned on again.
+                            if on_receiver.recv().await.is_none(){
+                                // channel dropped by other side, so exit.
+                                break;
+                            }
+                            // unblocked by "on", send SIGSTOPs again.
+                        }
+                        None => break // channel dropped by other side, so exit.
+                    }
+                }
+            }
+        }
+    }
+
+    /// Start sending SIGSTOPs periodically so that the container pauses.
+    pub async fn pause_container(&self) {
+        info!("Pausing container");
+        // Turning pauser on means pausing container.
+        self.on_sender.send(()).await.unwrap_or_else(|err| {
+            error!("pause failed with {:?}. container stopper dropped channel before main thread?", err);
+            // TODO: should we stop the agent?
+        });
+    }
+
+    /// Stop sending SIGSTOPs, send SIGCONT so that the container resumes its run.
+    pub async fn resume_container(&self) {
+        info!("Resuming container (all clients disconnected).");
+        // Turning pauser off means resuming container.
+        self.off_sender.send(()).await.unwrap_or_else(|err| {
+            error!("pause failed with {:?}. container stopper dropped channel before main thread?", err);
+            // TODO: should we stop the agent?
+        });
+    }
+}
+
+/// Keeps track of connected clients.
+/// If pausing target, also pauses and unpauses when number of clients changes from or to 0.
+#[derive(Debug)]
+struct State {
+    clients: HashSet<ClientID>,
+    index_allocator: IndexAllocator<ClientID>,
+    pauser: Option<Pauser>,
+}
+
+impl State {
+    /// If `pid` is some, will create a Pauser and pause that pid as long as there are clients
+    /// connected.
+    pub fn new(pid: Option<u64>) -> State {
+        State {
+            clients: HashSet::new(),
+            index_allocator: IndexAllocator::new(),
+            pauser: pid.map(|pid| Pauser::new(pid, Duration::from_secs(5))),
+        }
+    }
+
+    /// If there are clientIDs left, insert new one and return it.
+    /// If there were no clients before, and there is a Pauser, start pausing.
+    pub async fn new_client(&mut self) -> Option<ClientID> {
+        match self.generate_id() {
+            None => None,
+            Some(new_id) => {
+                self.clients.insert(new_id.to_owned());
+                if self.clients.len() == 1 { // First client after no clients.
+                    // Start sending SIGSTOP to pause container.
+                    if let Some(pauser) = self.pauser.as_ref() {
+                        pauser.pause_container().await;
+                    }
+                }
+                Some(new_id)
+            }
+        }
+    }
+
+    fn generate_id(&mut self) -> Option<ClientID> {
         self.index_allocator.next_index()
     }
 
-    pub fn remove_client(&mut self, client_id: ClientID) {
+    /// If that was the last client and we have a pauser, stop pausing.
+    pub async fn remove_client(&mut self, client_id: ClientID) {
         self.clients.remove(&client_id);
-        self.index_allocator.free_index(client_id)
+        self.index_allocator.free_index(client_id);
+        if self.clients.is_empty() {
+            // resume container (stop stopping).
+            if let Some(pauser) = self.pauser.as_ref() {
+                pauser.resume_container().await;
+            }
+        }
+    }
+
+    pub fn no_clients_left(&self) -> bool {
+        self.clients.is_empty()
     }
 }
 
@@ -298,7 +417,8 @@ async fn start_agent() -> Result<()> {
         _ => None,
     };
 
-    let mut state = State::new();
+    // Only pass pid if should pause it. otherwise None.
+    let mut state = State::new(args.pause.then_some(()).and(pid));
     let cancellation_token = CancellationToken::new();
     // Cancel all other tasks on exit
     let cancel_guard = cancellation_token.clone().drop_guard();
@@ -312,11 +432,6 @@ async fn start_agent() -> Result<()> {
             .and_then(|sniffer| sniffer.start(sniffer_cancellation_token)),
     );
 
-
-    pid.inspect(|pid| {
-        signal::kill(Pid::from_raw(pid.clone() as pid_t), Signal::SIGSTOP).unwrap();
-    });
-
     // WARNING: This exact string is expected to be read in `pod_api.rs`, more specifically in
     // `wait_for_agent_startup`. If you change this, or if this is not logged (i.e. user disables
     // `MIRRORD_AGENT_RUST_LOG`), then mirrord fails to initialize.
@@ -328,9 +443,7 @@ async fn start_agent() -> Result<()> {
             Ok((stream, addr)) = listener.accept() => {
                 trace!("start -> Connection accepted from {:?}", addr);
 
-                if let Some(client_id) = state.generate_id() {
-
-                    state.clients.insert(client_id);
+                if let Some(client_id) = state.new_client().await {
                     let sniffer_command_tx = sniffer_command_tx.clone();
                     let cancellation_token = cancellation_token.clone();
                     let dns_sender = dns_sender.clone();
@@ -370,23 +483,16 @@ async fn start_agent() -> Result<()> {
             },
             Some(client) = clients.next() => {
                 let client_id = client?;
-                state.remove_client(client_id);
+                state.remove_client(client_id).await;
             },
             _ = tokio::time::sleep(std::time::Duration::from_secs(args.communication_timeout.into())) => {
-                if state.clients.is_empty() {
+                if state.no_clients_left() {
                     trace!("Main thread timeout, no clients connected.");
                     break;
                 }
             }
         }
     }
-
-    // Resume original container when agent is done.
-    // TODO: remove first inspect
-    pid.inspect(|pid| info!("pid: {}", pid)).inspect(|pid| {
-        signal::kill(Pid::from_raw(pid.clone() as pid_t), Signal::SIGCONT).unwrap();
-    });
-
 
     trace!("Agent shutting down.");
     drop(cancel_guard);

--- a/mirrord/agent/src/runtime.rs
+++ b/mirrord/agent/src/runtime.rs
@@ -4,13 +4,15 @@ use std::{
     path::PathBuf,
 };
 
+use async_trait::async_trait;
 use bollard::{container::InspectContainerOptions, Docker};
 use containerd_client::{
     connect,
-    services::v1::{tasks_client::TasksClient, GetRequest},
-    tonic::Request,
+    services::v1::{tasks_client::TasksClient, GetRequest, PauseTaskRequest, ResumeTaskRequest},
+    tonic::{transport::Channel, Request},
     with_namespace,
 };
+use enum_dispatch::enum_dispatch;
 use nix::sched::setns;
 use tracing::debug;
 
@@ -21,51 +23,148 @@ const CONTAINERD_ALTERNATIVE_SOCK_PATH: &str = "/run/dockershim.sock";
 
 const DEFAULT_CONTAINERD_NAMESPACE: &str = "k8s.io";
 
-pub async fn get_container_pid(container_id: &str, container_runtime: &str) -> Result<u64> {
-    match container_runtime {
-        "docker" => get_docker_container_pid(container_id.to_string()).await,
-        "containerd" => get_containerd_container_pid(container_id.to_string()).await,
-        _ => Err(AgentError::NotFound(format!(
-            "Unknown runtime {:?}",
-            container_runtime
-        ))),
+#[async_trait]
+#[enum_dispatch]
+pub(crate) trait ContainerRuntime {
+    /// Get the external pid of the container.
+    async fn get_pid(&self) -> Result<u64>;
+    /// Pause the whole container (all processes).
+    async fn pause(&self) -> Result<()>;
+    /// Unpause the whole container (all processes).
+    async fn unpause(&self) -> Result<()>;
+}
+
+#[enum_dispatch(ContainerRuntime)]
+#[derive(Debug)]
+pub(crate) enum Container {
+    Docker(DockerContainer),
+    Containerd(ContainerdContainer),
+}
+
+/// get a container object according to args.
+pub(crate) async fn get_container(
+    container_id_opt: Option<&String>,
+    container_runtime_opt: Option<&String>,
+) -> Result<Option<Container>> {
+    if let (Some(container_id), Some(container_runtime)) = (container_id_opt, container_runtime_opt)
+    {
+        let container_id = container_id.to_string();
+        match container_runtime.as_str() {
+            "docker" => Ok(Some(Container::Docker(DockerContainer::from_id(
+                container_id,
+            )?))),
+            "containerd" => Ok(Some(Container::Containerd(ContainerdContainer {
+                container_id,
+            }))),
+            _ => Err(AgentError::NotFound(format!(
+                "Unknown runtime {:?}",
+                container_runtime
+            ))),
+        }
+    } else {
+        Ok(None)
     }
 }
 
-async fn get_docker_container_pid(container_id: String) -> Result<u64> {
-    let client = Docker::connect_with_local_defaults()?;
-    let inspect_options = Some(InspectContainerOptions { size: false });
-    let inspect_response = client
-        .inspect_container(&container_id, inspect_options)
-        .await?;
-
-    let pid = inspect_response
-        .state
-        .and_then(|state| state.pid)
-        .and_then(|pid| if pid > 0 { Some(pid as u64) } else { None })
-        .ok_or_else(|| AgentError::NotFound("No pid found!".to_string()))?;
-    Ok(pid)
+#[derive(Debug)]
+pub(crate) struct DockerContainer {
+    container_id: String,
+    client: Docker,
 }
 
-async fn get_containerd_container_pid(container_id: String) -> Result<u64> {
-    let channel = match connect(CONTAINERD_SOCK_PATH).await {
-        Ok(channel) => channel,
-        Err(_) => connect(CONTAINERD_ALTERNATIVE_SOCK_PATH).await?,
-    };
-    let mut client = TasksClient::new(channel);
-    let request = GetRequest {
-        container_id,
-        ..Default::default()
-    };
-    let request = with_namespace!(request, DEFAULT_CONTAINERD_NAMESPACE);
-    let response = client.get(request).await?;
-    let pid = response
-        .into_inner()
-        .process
-        .ok_or_else(|| AgentError::NotFound("No pid found!".to_string()))?
-        .pid;
+impl DockerContainer {
+    fn from_id(container_id: String) -> Result<Self> {
+        Ok(DockerContainer {
+            container_id,
+            client: Docker::connect_with_local_defaults()?,
+        })
+    }
+}
 
-    Ok(pid as u64)
+#[async_trait]
+impl ContainerRuntime for DockerContainer {
+    async fn get_pid(&self) -> Result<u64> {
+        let inspect_options = Some(InspectContainerOptions { size: false });
+        let inspect_response = self
+            .client
+            .inspect_container(&self.container_id, inspect_options)
+            .await?;
+
+        let pid = inspect_response
+            .state
+            .and_then(|state| state.pid)
+            .and_then(|pid| if pid > 0 { Some(pid as u64) } else { None })
+            .ok_or_else(|| AgentError::NotFound("No pid found!".to_string()))?;
+        Ok(pid)
+    }
+
+    async fn pause(&self) -> Result<()> {
+        self.client
+            .pause_container(&self.container_id)
+            .await
+            .map_err(From::from)
+    }
+
+    async fn unpause(&self) -> Result<()> {
+        self.client
+            .unpause_container(&self.container_id)
+            .await
+            .map_err(From::from)
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct ContainerdContainer {
+    container_id: String,
+}
+
+impl ContainerdContainer {
+    async fn get_client() -> Result<TasksClient<Channel>> {
+        let channel = match connect(CONTAINERD_SOCK_PATH).await {
+            Ok(channel) => channel,
+            Err(_) => connect(CONTAINERD_ALTERNATIVE_SOCK_PATH).await?,
+        };
+        Ok(TasksClient::new(channel))
+    }
+}
+
+#[async_trait]
+impl ContainerRuntime for ContainerdContainer {
+    async fn get_pid(&self) -> Result<u64> {
+        let mut client = Self::get_client().await?;
+        let container_id = self.container_id.to_string();
+        let request = GetRequest {
+            container_id,
+            ..Default::default()
+        };
+        let request = with_namespace!(request, DEFAULT_CONTAINERD_NAMESPACE);
+        let response = client.get(request).await?;
+        let pid = response
+            .into_inner()
+            .process
+            .ok_or_else(|| AgentError::NotFound("No pid found!".to_string()))?
+            .pid;
+
+        Ok(pid as u64)
+    }
+
+    async fn pause(&self) -> Result<()> {
+        let mut client = Self::get_client().await?;
+        let container_id = self.container_id.to_string();
+        let request = PauseTaskRequest { container_id };
+        let request = with_namespace!(request, DEFAULT_CONTAINERD_NAMESPACE);
+        client.pause(request).await?;
+        Ok(())
+    }
+
+    async fn unpause(&self) -> Result<()> {
+        let mut client = Self::get_client().await?;
+        let container_id = self.container_id.to_string();
+        let request = ResumeTaskRequest { container_id };
+        let request = with_namespace!(request, DEFAULT_CONTAINERD_NAMESPACE);
+        client.resume(request).await?;
+        Ok(())
+    }
 }
 
 pub fn set_namespace(ns_path: PathBuf) -> Result<()> {

--- a/mirrord/cli/src/config.rs
+++ b/mirrord/cli/src/config.rs
@@ -105,7 +105,7 @@ pub(super) struct ExecArgs {
     #[arg(long = "steal")]
     pub tcp_steal: bool,
 
-    /// Pause target pod(?TODO) while running.
+    /// Pause target container while running.
     #[arg(short, long)]
     pub pause: bool,
 
@@ -129,7 +129,7 @@ pub(super) struct ExecArgs {
     #[arg(short = 'f', long)]
     pub config_file: Option<PathBuf>,
 
-    // Create a trace file of errors for debugging.
+    /// Create a trace file of errors for debugging.
     #[arg(long)]
     pub capture_error_trace: bool,
 }

--- a/mirrord/cli/src/config.rs
+++ b/mirrord/cli/src/config.rs
@@ -74,7 +74,7 @@ pub(super) struct ExecArgs {
     /// Binary to execute and connect with the remote pod.
     pub binary: String,
 
-    /// Binary to execute and connect with the remote pod.
+    /// mirrord will not load into these processes, they will run completely locally.
     #[arg(long)]
     pub skip_processes: Option<String>,
 

--- a/mirrord/cli/src/config.rs
+++ b/mirrord/cli/src/config.rs
@@ -105,6 +105,10 @@ pub(super) struct ExecArgs {
     #[arg(long = "steal")]
     pub tcp_steal: bool,
 
+    /// Pause target pod(?TODO) while running.
+    #[arg(short, long)]
+    pub pause: bool,
+
     /// Disable tcp/udp outgoing traffic
     #[arg(long)]
     pub no_outgoing: bool,

--- a/mirrord/cli/src/main.rs
+++ b/mirrord/cli/src/main.rs
@@ -29,15 +29,16 @@ const INJECTION_ENV_VAR: &str = "LD_PRELOAD";
 const INJECTION_ENV_VAR: &str = "DYLD_INSERT_LIBRARIES";
 const PAUSE_WITHOUT_STEAL_WARNING: &str =
     "--pause specified without --steal: Incoming requests to the application will
-not be handled. The target container running the deployed application is paused,
-and responses from the local application are dropped.
+                                           not be handled. The target container running the deployed application is paused,
+                                           and responses from the local application are dropped.
 
-Attention: if network based liveness/readiness probes are defined for the
-target, they will fail under this configuration.
+                                           Attention: if network based liveness/readiness probes are defined for the
+                                           target, they will fail under this configuration.
 
-To have the local application handle incoming requests you can run again with
-`--steal`. To have the deployed application handle requests, run again without
-specifying `--pause`.";
+                                           To have the local application handle incoming requests you can run again with
+                                           `--steal`. To have the deployed application handle requests, run again without
+                                           specifying `--pause`.
+    ";
 
 /// For some reason loading dylib from $TMPDIR can get the process killed somehow..?
 #[cfg(target_os = "macos")]
@@ -109,7 +110,7 @@ async fn create_agent(progress: &TaskProgress) -> Result<()> {
             panic!("Mutually exclusive arguments `--pause` and `--ephemeral` passed together.");
         }
         if !config.feature.network.incoming.is_steal() {
-            warn!(PAUSE_WITHOUT_STEAL_WARNING);
+            warn!("{PAUSE_WITHOUT_STEAL_WARNING}");
         }
     }
     let kube_api = KubernetesAPI::create(&config).await?;

--- a/mirrord/cli/src/main.rs
+++ b/mirrord/cli/src/main.rs
@@ -107,7 +107,7 @@ async fn create_agent(progress: &TaskProgress) -> Result<()> {
     if config.agent.pause {
         if config.agent.ephemeral {
             error!("Pausing is not yet supported together with an ephemeral agent container.");
-            panic!("Mutually exclusive arguments `--pause` and `--ephemeral` passed together.");
+            panic!("Mutually exclusive arguments `--pause` and `--ephemeral-container` passed together.");
         }
         if !config.feature.network.incoming.is_steal() {
             warn!("{PAUSE_WITHOUT_STEAL_WARNING}");

--- a/mirrord/cli/src/main.rs
+++ b/mirrord/cli/src/main.rs
@@ -192,6 +192,10 @@ fn exec(args: &ExecArgs, progress: &TaskProgress) -> Result<()> {
         std::env::set_var("MIRRORD_AGENT_TCP_STEAL_TRAFFIC", "true");
     };
 
+    if args.pause {
+        std::env::set_var("MIRRORD_PAUSE", "true");
+    }
+
     if args.no_outgoing || args.no_tcp_outgoing {
         std::env::set_var("MIRRORD_TCP_OUTGOING", "false");
     }

--- a/mirrord/config/derive/src/config/field.rs
+++ b/mirrord/config/derive/src/config/field.rs
@@ -185,7 +185,7 @@ impl ConfigField {
         if layers.is_empty() {
             quote! { #ident: #impls .source_value().transpose()?#unwrapper }
         } else {
-            quote! { #ident: #impls (#(#layers),*) .source_value().transpose()?#unwrapper }
+            quote! { #ident: #impls #(#layers),* .source_value().transpose()?#unwrapper }
         }
     }
 }

--- a/mirrord/config/src/agent.rs
+++ b/mirrord/config/src/agent.rs
@@ -70,8 +70,8 @@ pub struct AgentConfig {
 
     /// Controls target pause feature.
     ///
-    /// With this feature enabled, the deployed app is paused while clients are connected to the
-    /// agent.
+    /// With this feature enabled, the remote container is paused while clients are connected to
+    /// the agent.
     #[config(env = "MIRRORD_PAUSE", default = false, unstable)]
     pub pause: bool,
 }

--- a/mirrord/config/src/agent.rs
+++ b/mirrord/config/src/agent.rs
@@ -67,6 +67,12 @@ pub struct AgentConfig {
     /// and if that fails it uses eth0.
     #[config(env = "MIRRORD_AGENT_NETWORK_INTERFACE")]
     pub network_interface: Option<String>,
+
+    /// Controls target pause feature.
+    ///
+    /// With this feature enabled, the target container is paused while agent is running.
+    #[config(env = "MIRRORD_PAUSE", default = "false")]
+    pub pause: bool,
 }
 
 #[cfg(test)]

--- a/mirrord/config/src/agent.rs
+++ b/mirrord/config/src/agent.rs
@@ -72,7 +72,7 @@ pub struct AgentConfig {
     ///
     /// With this feature enabled, the deployed app is paused while clients are connected to the
     /// agent.
-    #[config(env = "MIRRORD_PAUSE", default = "false", unstable)]
+    #[config(env = "MIRRORD_PAUSE", default = false, unstable)]
     pub pause: bool,
 }
 

--- a/mirrord/config/src/agent.rs
+++ b/mirrord/config/src/agent.rs
@@ -68,7 +68,7 @@ pub struct AgentConfig {
     #[config(env = "MIRRORD_AGENT_NETWORK_INTERFACE")]
     pub network_interface: Option<String>,
 
-    /// Controls target pause feature.
+    /// Controls target pause feature. Unstable.
     ///
     /// With this feature enabled, the remote container is paused while clients are connected to
     /// the agent.

--- a/mirrord/config/src/agent.rs
+++ b/mirrord/config/src/agent.rs
@@ -72,7 +72,7 @@ pub struct AgentConfig {
     ///
     /// With this feature enabled, the deployed app is paused while clients are connected to the
     /// agent.
-    #[config(env = "MIRRORD_PAUSE", default = false, unstable)]
+    #[config(env = "MIRRORD_PAUSE", default = false)]
     pub pause: bool,
 }
 

--- a/mirrord/config/src/agent.rs
+++ b/mirrord/config/src/agent.rs
@@ -72,7 +72,7 @@ pub struct AgentConfig {
     ///
     /// With this feature enabled, the deployed app is paused while clients are connected to the
     /// agent.
-    #[config(env = "MIRRORD_PAUSE", default = false)]
+    #[config(env = "MIRRORD_PAUSE", default = false, unstable)]
     pub pause: bool,
 }
 

--- a/mirrord/config/src/agent.rs
+++ b/mirrord/config/src/agent.rs
@@ -72,7 +72,7 @@ pub struct AgentConfig {
     ///
     /// With this feature enabled, the deployed app is paused while clients are connected to the
     /// agent.
-    #[config(env = "MIRRORD_PAUSE", default = "false")]
+    #[config(env = "MIRRORD_PAUSE", default = "false", unstable)]
     pub pause: bool,
 }
 

--- a/mirrord/config/src/agent.rs
+++ b/mirrord/config/src/agent.rs
@@ -70,7 +70,8 @@ pub struct AgentConfig {
 
     /// Controls target pause feature.
     ///
-    /// With this feature enabled, the target container is paused while agent is running.
+    /// With this feature enabled, the deployed app is paused while clients are connected to the
+    /// agent.
     #[config(env = "MIRRORD_PAUSE", default = "false")]
     pub pause: bool,
 }

--- a/mirrord/config/src/feature.rs
+++ b/mirrord/config/src/feature.rs
@@ -72,6 +72,12 @@ pub struct FeatureConfig {
     #[config(nested, toggleable)]
     pub network: NetworkConfig,
 
+    /// Controls target pause feature.
+    ///
+    /// With this feature enabled, the target pod(? TODO) is paused while agent is running.
+    #[config(env = "MIRRORD_PAUSE", default = "false")]
+    pub pause: bool,
+
     /// Controls the crash reporting feature.
     ///
     /// With this feature enabled, mirrord generates a nice crash report log.

--- a/mirrord/config/src/feature.rs
+++ b/mirrord/config/src/feature.rs
@@ -72,12 +72,6 @@ pub struct FeatureConfig {
     #[config(nested, toggleable)]
     pub network: NetworkConfig,
 
-    /// Controls target pause feature.
-    ///
-    /// With this feature enabled, the target pod(? TODO) is paused while agent is running.
-    #[config(env = "MIRRORD_PAUSE", default = "false")]
-    pub pause: bool,
-
     /// Controls the crash reporting feature.
     ///
     /// With this feature enabled, mirrord generates a nice crash report log.

--- a/mirrord/config/src/lib.rs
+++ b/mirrord/config/src/lib.rs
@@ -325,6 +325,7 @@ mod tests {
                 communication_timeout: None,
                 startup_timeout: None,
                 network_interface: None,
+                pause: Some(false),
             }),
             feature: Some(FeatureFileConfig {
                 env: ToggleableConfig::Enabled(true).into(),

--- a/mirrord/config/src/lib.rs
+++ b/mirrord/config/src/lib.rs
@@ -196,7 +196,8 @@ mod tests {
                             "image": "",
                             "image_pull_policy": "",
                             "ttl": 60,
-                            "ephemeral": false
+                            "ephemeral": false,
+                            "pause": false
                         },
                         "feature": {
                             "env": true,
@@ -228,6 +229,7 @@ mod tests {
                     image_pull_policy = ""
                     ttl = 60
                     ephemeral = false
+                    pause = false
 
                     [feature]
                     env = true
@@ -256,6 +258,7 @@ mod tests {
                         image_pull_policy: ""
                         ttl: 60
                         ephemeral: false
+                        pause: false
 
                     feature:
                         env: true

--- a/mirrord/kube/Cargo.toml
+++ b/mirrord/kube/Cargo.toml
@@ -23,7 +23,7 @@ mirrord-progress = { path = "../progress" }
 mirrord-protocol = { path = "../protocol" }
 
 actix-codec.workspace = true
-async-trait = "0.1"
+async-trait.workspace = true
 futures.workspace = true
 k8s-openapi.workspace = true
 kube.workspace = true

--- a/mirrord/kube/src/api/container.rs
+++ b/mirrord/kube/src/api/container.rs
@@ -152,6 +152,9 @@ impl ContainerApi for JobContainer {
             agent_command_line.push("-t".to_string());
             agent_command_line.push(timeout.to_string());
         }
+        if agent.pause {
+            agent_command_line.push("--pause".to_string());
+        }
 
         let agent_pod: Job =
             serde_json::from_value(json!({ // Only Jobs support self deletion after completion

--- a/mirrord/layer/Cargo.toml
+++ b/mirrord/layer/Cargo.toml
@@ -43,7 +43,7 @@ trust-dns-resolver.workspace = true
 rand = "0.8"
 fancy-regex = { version = "0.10" }
 errno = "0.2"
-async-trait = "0.1"
+async-trait.workspace = true
 socket2 = "0.4"
 anyhow.workspace = true
 streammap-ext.workspace = true

--- a/tests/node-app.yaml
+++ b/tests/node-app.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: node-http-deployment
+  labels:
+    app: node-http
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: node-http
+  template:
+    metadata:
+      labels:
+        app: node-http
+    spec:
+      containers:
+        - name: node-http
+          image: ghcr.io/metalbear-co/mirrord-node:latest
+          ports:
+            - containerPort: 80
+          env:
+            - name: MIRRORD_FAKE_VAR_FIRST
+              value: mirrord.is.running
+            - name: MIRRORD_FAKE_VAR_SECOND
+              value: "7777"
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: node-http
+  name: node-http
+spec:
+  ports:
+    - port: 80
+      protocol: TCP
+      targetPort: 80
+      nodePort: 30000
+  selector:
+    app: node-http
+  sessionAffinity: None
+  type: NodePort


### PR DESCRIPTION
https://github.com/metalbear-co/mirrord/issues/712

Add the `--pause` flag which pauses the target container while there are clients connected to the agent.
When the last client disconnects the container resumes.

Currently the pause behaviour is determined in the creation of the agent. So if clients from a different run want to reuse the same agent they will just get the existing pause behaviour of the agent.