### PR TITLE
[Merged by Bors] - First e2e test for pause: http logger

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -378,7 +378,6 @@ jobs:
         with:
           key: ubuntu-latest
           cache-on-failure: true
-
       - uses: actions/setup-node@v3
         with:
           node-version: 14
@@ -387,6 +386,7 @@ jobs:
       - run: pip3 install flask
       - run: pip3 install fastapi
       - run: pip3 install uvicorn[standard]
+      - run: sudo apt-get update && sudo apt-get install -y curl
       - uses: actions/setup-go@v3
         with:
           go-version: "1.18.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+### Added
+
+- E2E test for pause feature with service that logs http requests and a service that makes requests.
+
 ## 3.12.0
 
 ### Added

--- a/mirrord/agent/src/main.rs
+++ b/mirrord/agent/src/main.rs
@@ -106,7 +106,7 @@ impl State {
                     // First client after no clients.
                     if self.should_pause {
                         self.container.as_ref().unwrap().pause().await?;
-                        debug!("First client connected - pausing container!")
+                        trace!("First client connected - pausing container.")
                     }
                 }
                 Ok(new_id)
@@ -127,7 +127,7 @@ impl State {
             // resume container (stop stopping).
             if self.should_pause {
                 self.container.as_ref().unwrap().unpause().await?;
-                debug!("last client disconnected - resuming container!")
+                trace!("Last client disconnected - resuming container.")
             }
         }
         Ok(())

--- a/mirrord/agent/src/main.rs
+++ b/mirrord/agent/src/main.rs
@@ -106,6 +106,7 @@ impl State {
                     // First client after no clients.
                     if self.should_pause {
                         self.container.as_ref().unwrap().pause().await?;
+                        debug!("First client connected - pausing container!")
                     }
                 }
                 Ok(new_id)
@@ -122,10 +123,11 @@ impl State {
     pub async fn remove_client(&mut self, client_id: ClientID) -> Result<()> {
         self.clients.remove(&client_id);
         self.index_allocator.free_index(client_id);
-        if self.clients.is_empty() {
+        if self.no_clients_left() {
             // resume container (stop stopping).
             if self.should_pause {
                 self.container.as_ref().unwrap().unpause().await?;
+                debug!("last client disconnected - resuming container!")
             }
         }
         Ok(())

--- a/tests/pause/send_reqs.sh
+++ b/tests/pause/send_reqs.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+curl mirrord-tests-http-logger/log/hi-from-local-app
+sleep 1 # if the deployed app was not paused, it will send requests while we're sleeping.
+curl mirrord-tests-http-logger/log/hi-again-from-local-app

--- a/tests/src/sanity.rs
+++ b/tests/src/sanity.rs
@@ -464,7 +464,13 @@ mod tests {
             }
         }))
         .unwrap();
-        let pod_guard = ResourceGuard::create(&deployment_api, name.to_string(), &deployment, delete_after_fail).await;
+        let pod_guard = ResourceGuard::create(
+            &deployment_api,
+            name.to_string(),
+            &deployment,
+            delete_after_fail,
+        )
+        .await;
         watch_resource_exists(&deployment_api, &name).await;
 
         let service: Service = serde_json::from_value(json!({
@@ -499,7 +505,9 @@ mod tests {
         }))
         .unwrap();
 
-        let service_guard = ResourceGuard::create(&service_api, name.to_string(), &service, delete_after_fail).await;
+        let service_guard =
+            ResourceGuard::create(&service_api, name.to_string(), &service, delete_after_fail)
+                .await;
         watch_resource_exists(&service_api, "default").await;
 
         let target = get_pod_instance(&kube_client, &name, namespace)

--- a/tests/src/sanity.rs
+++ b/tests/src/sanity.rs
@@ -13,7 +13,7 @@ mod tests {
 
     use bytes::Bytes;
     use chrono::Utc;
-    use futures::Future;
+    use futures::{Future, Stream};
     use futures_util::stream::{StreamExt, TryStreamExt};
     use k8s_openapi::api::{
         apps::v1::Deployment,
@@ -261,7 +261,10 @@ mod tests {
         namespace: Option<&str>,
         args: Option<Vec<&str>>,
     ) -> TestProcess {
-        let path = env!("CARGO_BIN_FILE_MIRRORD");
+        let path = match option_env!("MIRRORD_TESTS_USE_BINARY") {
+            None => env!("CARGO_BIN_FILE_MIRRORD"),
+            Some(binary_path) => binary_path,
+        };
         let temp_dir = tempdir::TempDir::new("test").unwrap();
         let mut mirrord_args = vec![
             "exec",
@@ -378,11 +381,27 @@ mod tests {
         #[default("default")] namespace: &str,
         #[default("NodePort")] service_type: &str,
         #[default("ghcr.io/metalbear-co/mirrord-pytest:latest")] image: &str,
+        #[default("http-echo")] service_name: &str,
+        #[default(true)] randomize_name: bool,
     ) -> KubeService {
         let kube_client = kube_client.await;
         let deployment_api: Api<Deployment> = Api::namespaced(kube_client.clone(), namespace);
-        let name = random_string();
-        let name = format!("http-echo-{}", name);
+        let service_api: Api<Service> = Api::namespaced(kube_client.clone(), namespace);
+        let name;
+        if randomize_name {
+            name = format!("{}-{}", service_name, random_string());
+        } else {
+            // if using non-random name, delete existing resources first.
+            // Just continue if they don't exist.
+            let _res = service_api
+                .delete(service_name, &DeleteParams::default())
+                .await;
+            let _res = deployment_api
+                .delete(service_name, &DeleteParams::default())
+                .await;
+            name = service_name.to_string();
+        }
+
         let deployment: Deployment = serde_json::from_value(json!({
             "apiVersion": "apps/v1",
             "kind": "Deployment",
@@ -410,6 +429,7 @@ mod tests {
                             {
                                 "name": &CONTAINER_NAME,
                                 "image": &image,
+                                "imagePullPolicy": "IfNotPresent", // TODO: is that ok?
                                 "ports": [
                                     {
                                         "containerPort": 80
@@ -439,7 +459,6 @@ mod tests {
         let pod_guard = ResourceGuard::create(&deployment_api, name.to_string(), &deployment).await;
         watch_resource_exists(&deployment_api, &name).await;
 
-        let service_api: Api<Service> = Api::namespaced(kube_client.clone(), namespace);
         let service: Service = serde_json::from_value(json!({
             "apiVersion": "v1",
             "kind": "Service",
@@ -502,6 +521,36 @@ mod tests {
             "default",
             "ClusterIP",
             "ghcr.io/metalbear-co/mirrord-node-udp-logger:latest",
+            "udp-logger",
+            true,
+        )
+        .await
+    }
+
+    #[fixture]
+    async fn http_logger_service(#[future] kube_client: Client) -> KubeService {
+        service(
+            kube_client,
+            "default",
+            "ClusterIP",
+            // "ghcr.io/metalbear-co/mirrord-http-logger:latest",
+            "mirrord-http-logger", // TODO: change to published image.
+            "mirrord-tests-http-logger",
+            false, // So that requester can reach logger by name.
+        )
+        .await
+    }
+
+    #[fixture]
+    async fn http_log_requester_service(#[future] kube_client: Client) -> KubeService {
+        service(
+            kube_client,
+            "default",
+            "ClusterIP",
+            // "ghcr.io/metalbear-co/mirrord-http-log-requester:latest",
+            "mirrord-http-log-requester", // TODO: change to published image.
+            "mirrord-http-log-requester",
+            true,
         )
         .await
     }
@@ -1258,5 +1307,113 @@ mod tests {
         let res = process.child.wait().await.unwrap();
         assert!(res.success());
         process.assert_stderr();
+    }
+
+    async fn get_next_log<T: Stream<Item = Result<Bytes, kube::Error>> + Unpin>(
+        stream: &mut T,
+    ) -> String {
+        String::from_utf8_lossy(&stream.try_next().await.unwrap().unwrap()).to_string()
+    }
+
+    /// http_logger_service is a service that logs strings from the uri of incoming http requests.
+    /// http_log_requester is a service that repeatedly sends a string over requests to the logger.
+    /// Deploy the services, the requester sends requests to the logger.
+    /// Run a requester with a different string with mirrord with --pause.
+    /// verify that the stdout of the logger looks like:
+    ///
+    /// <string-from-deployed-requester>
+    /// <string-from-deployed-requester>
+    ///              ...
+    /// <string-from-deployed-requester>
+    /// <string-from-mirrord-requester>
+    /// <string-from-mirrord-requester>
+    /// <string-from-deployed-requester>
+    /// <string-from-deployed-requester>
+    ///              ...
+    /// <string-from-deployed-requester>
+    ///
+    /// Which means the deployed requester was indeed paused while the local requester was running
+    /// with mirrord, because local requester waits between its two requests enough time for the
+    /// deployed requester to send more requests it were not paused.
+    ///
+    /// To run on mac, first build universal binary: (from repo root) `scripts/build_fat_mac.sh`
+    /// then run test with MIRRORD_TESTS_USE_BINARY=../target/universal-apple-darwin/debug/mirrord
+    /// Because the test runs a bash script with mirrord and that requires the universal binary.
+    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[timeout(Duration::from_secs(240))]
+    pub async fn pause_log_requests(
+        #[future] http_logger_service: KubeService,
+        #[future] http_log_requester_service: KubeService,
+        #[future] kube_client: Client,
+    ) {
+        let logger_service = http_logger_service.await;
+        let requester_service = http_log_requester_service.await; // Impersonate a pod of this service, to reach internal.
+        let kube_client = kube_client.await;
+        let pod_api: Api<Pod> = Api::namespaced(kube_client.clone(), &logger_service.namespace);
+
+        let target_parts = logger_service.target.split('/').collect::<Vec<&str>>();
+        let pod_name = target_parts[1];
+        let container_name = target_parts[3];
+        let lp = LogParams {
+            container: Some(container_name.to_string()), // Default to first, we only have 1.
+            follow: true,
+            limit_bytes: None,
+            pretty: false,
+            previous: false,
+            since_seconds: None,
+            tail_lines: None,
+            timestamps: false,
+        };
+
+        println!("getting log stream.");
+        let log_stream = pod_api.log_stream(pod_name, &lp).await.unwrap();
+
+        let command = vec!["pause/send_reqs.sh"];
+
+        let mirrord_pause_arg = vec!["--pause"];
+
+        println!("Waiting for 2 flask lines.");
+        let mut log_stream = log_stream.skip(2); // Skip flask prints.
+
+        let hi_from_deployed_app = "hi-from-deployed-app\n";
+        let hi_from_local_app = "hi-from-local-app\n";
+        let hi_again_from_local_app = "hi-again-from-local-app\n";
+
+        println!("Waiting for first log by deployed app.");
+        let first_log = get_next_log(&mut log_stream).await;
+
+        assert_eq!(first_log, hi_from_deployed_app);
+
+        println!("Running local app with mirrord.");
+        let mut process = run(
+            command.clone(),
+            &requester_service.target,
+            Some(&requester_service.namespace),
+            Some(mirrord_pause_arg),
+        )
+        .await;
+        let res = process.child.wait().await.unwrap();
+        println!("mirrord done running.");
+        assert!(res.success());
+
+        println!("Spooling logs forward to get to local app's first log.");
+        // Skip all the logs by the deployed app from before we ran local.
+        let mut next_log = get_next_log(&mut log_stream).await;
+        while next_log == hi_from_deployed_app {
+            next_log = get_next_log(&mut log_stream).await;
+        }
+
+        // Verify first log from local app.
+        assert_eq!(next_log, hi_from_local_app);
+
+        // Verify that the second log from local app comes right after it - the deployed requester
+        // was paused.
+        let log_from_local = get_next_log(&mut log_stream).await;
+        assert_eq!(log_from_local, hi_again_from_local_app);
+
+        // Verify that the deployed app resumes after the local app is done.
+        let log_from_deployed_after_resume = get_next_log(&mut log_stream).await;
+        assert_eq!(log_from_deployed_after_resume, hi_from_deployed_app);
     }
 }


### PR DESCRIPTION
Add a test that deploys two services, 1 that logs strings from http requests to stdout and 1 that sends requests.
Then we pause the requester with mirrord and verify it pauses.