### PR TITLE
[Merged by Bors] - Start e2e tests in parallel to integration tests.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -363,7 +363,7 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     name: e2e
-    needs: [build_mirrord, test_agent_image, integration_tests, changed_files]
+    needs: [build_mirrord, test_agent_image, changed_files]
     if: ${{needs.changed_files.outputs.rs_changed == 'true'}}
     env:
       MIRRORD_AGENT_RUST_LOG: "warn,mirrord=debug"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
   the agent itself ("global"). Got rid of `steal_worker` in favor of a similar abstraction to what
   we have in `sniffer.rs` (`TcpConnectionStealer` that acts as the traffic stealing task, and
   `TcpStealerApi` which bridges the communication between the agent and the stealer task).
+- Tests CI: don't wait for integration tests to start testing E2E tests.
 
 ## 3.13.2
 


### PR DESCRIPTION
Currently the e2e tests depend on the integration tests, so that they are only run if integration tests are successful. Sometimes (but not always) the integration tests finish after the other dependencies of the e2e tests, so by removing the dependency the e2e tests would start earlier in those cases and the whole github action would end earlier.