### PR TITLE
[Merged by Bors] - Goland bugfix.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+### Fixed
+
+- Add go to skipped processes in JetBrains plugin. Solving GoLand bug.
+
 ## 3.16.1
 
 ### Fixed

--- a/intellij-ext/modules/products/goland/src/main/kotlin/com/metalbear/mirrord/products/goland/GolandRunConfigurationExtension.kt
+++ b/intellij-ext/modules/products/goland/src/main/kotlin/com/metalbear/mirrord/products/goland/GolandRunConfigurationExtension.kt
@@ -49,7 +49,7 @@ class GolandRunConfigurationExtension : GoRunConfigurationExtension() {
                 for (entry in env.entries.iterator()) {
                     cmdLine.addEnvironmentVariable(entry.key, entry.value)
                 }
-                cmdLine.addEnvironmentVariable("MIRRORD_SKIP_PROCESSES", "dlv;debugserver")
+                cmdLine.addEnvironmentVariable("MIRRORD_SKIP_PROCESSES", "dlv;debugserver;go")
             }
 
         }


### PR DESCRIPTION
GoLand fails to run with mirrord. Add go to skipped processes.