### PR TITLE
[Merged by Bors] - Agent send error to layer on error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+## Added
+
+- Agent now sends error encountered back to layer for better UX when bad times happen. (This only applies to error happening on connection-level).
+
 ## Fixed
 
 - Update the setup-qemu-action action to remove a deprecation warning in the Release Workflow

--- a/mirrord/agent/src/main.rs
+++ b/mirrord/agent/src/main.rs
@@ -202,12 +202,20 @@ impl ClientConnectionHandler {
     /// Breaks upon receiver/sender drop.
     #[tracing::instrument(level = "trace", skip(self))]
     async fn start(mut self, cancellation_token: CancellationToken) -> Result<()> {
-        let mut running = true;
-        while running {
+        loop {
             select! {
                 message = self.stream.next() => {
                     if let Some(message) = message {
-                        running = self.handle_client_message(message?).await?;
+                        match self.handle_client_message(message?).await? {
+                            Ok(true) => {},
+                            Ok(false) => {
+                                break;
+                            }
+                            Err(e) => {
+                                self.respond(DaemonMessage::Close(format!("{:?}", e))).await?;
+                                break;
+                            }
+                        }
                     } else {
                         debug!("Client {} disconnected", self.id);
                         break;

--- a/mirrord/agent/src/main.rs
+++ b/mirrord/agent/src/main.rs
@@ -206,7 +206,7 @@ impl ClientConnectionHandler {
             select! {
                 message = self.stream.next() => {
                     if let Some(message) = message {
-                        match self.handle_client_message(message?).await? {
+                        match self.handle_client_message(message?).await {
                             Ok(true) => {},
                             Ok(false) => {
                                 break;

--- a/mirrord/layer/src/error.rs
+++ b/mirrord/layer/src/error.rs
@@ -143,6 +143,9 @@ pub(crate) enum LayerError {
 
     #[error("mirrord-layer: Got unexpected response error from agent: {0}")]
     UnexpectedResponseError(ResponseError),
+
+    #[error("mirrord-layer: Agent closed connection with error: {0}")]
+    AgentErrorClosed(String),
 }
 
 // Cannot have a generic From<T> implementation for this error, so explicitly implemented here.

--- a/mirrord/layer/src/lib.rs
+++ b/mirrord/layer/src/lib.rs
@@ -382,7 +382,7 @@ impl Layer {
                 .ok_or(LayerError::SendErrorGetAddrInfoResponse)?
                 .send(get_addr_info.0)
                 .map_err(|_| LayerError::SendErrorGetAddrInfoResponse),
-            DaemonMessage::Close => todo!(),
+            DaemonMessage::Close(error_message) => Err(LayerError::AgentErrorClosed(error_message)),
             DaemonMessage::LogMessage(_) => todo!(),
         }
     }

--- a/mirrord/protocol/src/codec.rs
+++ b/mirrord/protocol/src/codec.rs
@@ -258,7 +258,7 @@ pub enum FileResponse {
 /// `-agent` --> `-layer` messages.
 #[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
 pub enum DaemonMessage {
-    Close,
+    Close(String),
     Tcp(DaemonTcp),
     TcpSteal(DaemonTcp),
     TcpOutgoing(DaemonTcpOutgoing),


### PR DESCRIPTION
Agent now sends error encountered back to layer for better UX when bad times happen.

Part of #912 