### PR TITLE
[Merged by Bors] - improve error for packet ignore outgoing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 - Update the setup-qemu-action action to remove a deprecation warning in the Release Workflow
 
+## Changed
+
+- agent: Return better error message when failing to use `PACKET_IGNORE_OUTGOING` flag.
+
 ## 3.17.0
 
 ### Added

--- a/mirrord/agent/src/error.rs
+++ b/mirrord/agent/src/error.rs
@@ -106,7 +106,8 @@ pub enum AgentError {
     #[error("An internal invariant of the agent was violated, this should not happen.")]
     AgentInvariantViolated,
 
-    #[error("Failed to set socket flag PACKET_IGNORE_OUTGOING, this might be due to kernel version before 4.20")]
+    #[error(r#"Failed to set socket flag PACKET_IGNORE_OUTGOING, this might be due to kernel version before 4.20.
+    Original error `{0}`"#)]
     PacketIgnoreOutgoing(#[source] std::io::Error),
 }
 

--- a/mirrord/agent/src/error.rs
+++ b/mirrord/agent/src/error.rs
@@ -105,6 +105,9 @@ pub enum AgentError {
 
     #[error("An internal invariant of the agent was violated, this should not happen.")]
     AgentInvariantViolated,
+
+    #[error("Failed to set socket flag PACKET_IGNORE_OUTGOING, this might be due to kernel version before 4.20")]
+    PacketIgnoreOutgoing(#[source] std::io::Error),
 }
 
 pub(crate) type Result<T, E = AgentError> = std::result::Result<T, E>;

--- a/mirrord/agent/src/sniffer.rs
+++ b/mirrord/agent/src/sniffer.rs
@@ -138,7 +138,9 @@ async fn prepare_sniffer(network_interface: Option<String>) -> Result<RawCapture
     // we ofc could've done this when a layer connected, but I (A.H) thought it'd make more sense
     // to have this shared among layers (potentially, in the future) - fme.
     capture.set_filter(rawsocket::filter::build_drop_always())?;
-    capture.ignore_outgoing()?;
+    capture
+        .ignore_outgoing()
+        .map_err(AgentError::PacketIgnoreOutgoing)?;
     Ok(capture)
 }
 


### PR DESCRIPTION
agent: Return better error message when failing to use `PACKET_IGNORE_OUTGOING` flag.

Part of #912 