### PR TITLE
[Merged by Bors] - Support Simple/Advanced Pattern for IncomingConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ### Fixed
 
 - Issue when connect returns `libc::EINTR` or `libc::EINPROGRESS` causing outgoing connections to fail.
+- config: file config updated to fix simple pattern of IncomingConfig. [#933](https://github.com/metalbear-co/mirrord/pull/933)
 
 ## 3.18.0
 

--- a/mirrord-schema.json
+++ b/mirrord-schema.json
@@ -431,8 +431,7 @@
       },
       "additionalProperties": false
     },
-    "IncomingFileConfig": {
-      "description": "Controls the incoming TCP traffic feature.\n\nSee the incoming [reference](https://mirrord.dev/docs/reference/traffic/#incoming) for more details.\n\nIncoming traffic supports 2 modes of operation:\n\n1. Mirror (**default**): Sniffs the TCP data from a port, and forwards a copy to the interested listeners;\n\n2. Steal: Captures the TCP data from a port, and forwards it (depending on how it's configured, see [`StealModeConfig`]);\n\n## Examples\n\n- Mirror any incoming traffic:\n\n```toml # mirrord-config.toml\n\n[feature.network] incoming = \"mirror\"    # for illustration purporses, it's the default ```\n\n- Steal incoming HTTP traffic, if the HTTP header matches \"Id: token.*\" (supports regex):\n\n```yaml # mirrord-config.yaml\n\n[feature.network.incoming] mode = \"steal\"\n\n[feature.network.incoming.http_header_filter] filter = \"Id: token.*\" ```",
+    "IncomingAdvancedFileConfig": {
       "type": "object",
       "properties": {
         "http_header_filter": {
@@ -457,8 +456,25 @@
             }
           ]
         }
-      },
-      "additionalProperties": false
+      }
+    },
+    "IncomingFileConfig": {
+      "description": "Controls the incoming TCP traffic feature.\n\nSee the incoming [reference](https://mirrord.dev/docs/reference/traffic/#incoming) for more details.\n\nIncoming traffic supports 2 modes of operation:\n\n1. Mirror (**default**): Sniffs the TCP data from a port, and forwards a copy to the interested listeners;\n\n2. Steal: Captures the TCP data from a port, and forwards it (depending on how it's configured, see [`StealModeConfig`]);\n\n## Examples\n\n- Mirror any incoming traffic:\n\n```toml # mirrord-config.toml\n\n[feature.network] incoming = \"mirror\"    # for illustration purporses, it's the default ```\n\n- Steal incoming HTTP traffic, if the HTTP header matches \"Id: token.*\" (supports regex):\n\n```yaml # mirrord-config.yaml\n\n[feature.network.incoming] mode = \"steal\"\n\n[feature.network.incoming.http_header_filter] filter = \"Id: token.*\" ```",
+      "anyOf": [
+        {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/IncomingMode"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        {
+          "$ref": "#/definitions/IncomingAdvancedFileConfig"
+        }
+      ]
     },
     "IncomingMode": {
       "description": "Mode of operation for the incoming TCP traffic feature.\n\nDefaults to [`IncomingMode::Mirror`].",

--- a/mirrord/config/src/lib.rs
+++ b/mirrord/config/src/lib.rs
@@ -162,7 +162,7 @@ mod tests {
         agent::AgentFileConfig,
         feature::FeatureFileConfig,
         fs::{FsModeConfig, FsUserConfig},
-        incoming::{IncomingFileConfig, IncomingMode},
+        incoming::{IncomingAdvancedFileConfig, IncomingFileConfig, IncomingMode},
         network::NetworkFileConfig,
         outgoing::OutgoingFileConfig,
         target::{PodTarget, Target, TargetFileConfig},
@@ -345,10 +345,12 @@ mod tests {
                 fs: ToggleableConfig::Config(FsUserConfig::Simple(FsModeConfig::Write)).into(),
                 network: Some(ToggleableConfig::Config(NetworkFileConfig {
                     dns: Some(false),
-                    incoming: Some(ToggleableConfig::Config(IncomingFileConfig {
-                        mode: Some(IncomingMode::Mirror),
-                        http_header_filter: None,
-                    })),
+                    incoming: Some(ToggleableConfig::Config(IncomingFileConfig::Advanced(
+                        IncomingAdvancedFileConfig {
+                            mode: Some(IncomingMode::Mirror),
+                            http_header_filter: None,
+                        },
+                    ))),
                     outgoing: Some(ToggleableConfig::Config(OutgoingFileConfig {
                         tcp: Some(true),
                         udp: Some(false),


### PR DESCRIPTION
Fix support simple format for network's incoming field

```yaml
feature:
    network:
        incoming: steal
```

```toml
[feature.network]
incoming = "steal"
```
