### PR TITLE
[Merged by Bors] - Deal with short streams (open and closed) in the HTTP filter.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ### Fixed
 
 - crash when `getaddrinfo` is bypassed and libc tries to free our structure. Closes [#930](https://github.com/metalbear-co/mirrord/issues/930)
+- Stealer hangs on short streams left open and fails on short closed streams to filtered HTTP ports -
+ [#926](https://github.com/metalbear-co/mirrord/issues/926).
 
 ## 3.18.1
 
@@ -17,8 +19,6 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 - Issue when connect returns `libc::EINTR` or `libc::EINPROGRESS` causing outgoing connections to fail.
 - config: file config updated to fix simple pattern of IncomingConfig. [#933](https://github.com/metalbear-co/mirrord/pull/933)
-- Stealer hangs on short streams left open and fails on short closed streams to filtered HTTP ports -
- [#926](https://github.com/metalbear-co/mirrord/issues/926).
 
 ## 3.18.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 - Issue when connect returns `libc::EINTR` or `libc::EINPROGRESS` causing outgoing connections to fail.
 - config: file config updated to fix simple pattern of IncomingConfig. [#933](https://github.com/metalbear-co/mirrord/pull/933)
+- Stealer hangs on short streams left open and fails on short closed streams to filtered HTTP ports -
+ [#926](https://github.com/metalbear-co/mirrord/issues/926).
 
 ## 3.18.0
 

--- a/mirrord/agent/src/steal/connection.rs
+++ b/mirrord/agent/src/steal/connection.rs
@@ -370,7 +370,7 @@ impl TcpConnectionStealer {
                         connection_id,
                         self.http_connection_close_sender.clone(),
                     )
-                    .await?;
+                    .await;
 
                 Ok(())
             }

--- a/mirrord/agent/src/steal/http.rs
+++ b/mirrord/agent/src/steal/http.rs
@@ -38,7 +38,9 @@ impl HttpVersion {
     fn new(buffer: &[u8], h2_preface: &[u8]) -> Self {
         let mut empty_headers = [httparse::EMPTY_HEADER; 0];
 
-        if buffer == h2_preface {
+        if buffer.len() < MINIMAL_HEADER_SIZE {
+            Self::NotHttp
+        } else if buffer == h2_preface {
             Self::V2
         } else if matches!(
             httparse::Request::new(&mut empty_headers).parse(buffer),

--- a/mirrord/agent/src/steal/http/filter.rs
+++ b/mirrord/agent/src/steal/http/filter.rs
@@ -1,4 +1,4 @@
-use std::{net::SocketAddr, sync::Arc};
+use std::{net::SocketAddr, sync::Arc, time::Duration};
 
 use dashmap::DashMap;
 use fancy_regex::Regex;
@@ -16,6 +16,7 @@ use crate::{
 };
 
 const H2_PREFACE: &[u8] = b"PRI * HTTP/2.0";
+const DEFAULT_HTTP_VERSION_DETECTION_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Controls the amount of data we read when trying to detect if the stream's first message contains
 /// an HTTP request.
@@ -60,7 +61,7 @@ impl HttpFilterBuilder {
         matched_tx: Sender<HandlerHttpRequest>,
         connection_close_sender: Sender<ConnectionId>,
     ) -> Result<Self, HttpTrafficError> {
-        DefaultReversibleStream::read_header(stolen_stream)
+        DefaultReversibleStream::read_header(stolen_stream, DEFAULT_HTTP_VERSION_DETECTION_TIMEOUT)
             .await
             .map(|mut reversible_stream| {
                 let http_version = HttpVersion::new(

--- a/mirrord/agent/src/steal/http/filter.rs
+++ b/mirrord/agent/src/steal/http/filter.rs
@@ -5,15 +5,10 @@ use fancy_regex::Regex;
 use hyper::server::conn::http1;
 use mirrord_protocol::ConnectionId;
 use tokio::{io::copy_bidirectional, net::TcpStream, sync::mpsc::Sender};
-use tracing::error;
+use tracing::{error, trace};
 
-use super::{
-    error::HttpTrafficError, hyper_handler::HyperHandler, DefaultReversibleStream, HttpVersion,
-};
-use crate::{
-    steal::{http::error, HandlerHttpRequest},
-    util::ClientId,
-};
+use super::{hyper_handler::HyperHandler, DefaultReversibleStream, HttpVersion};
+use crate::{steal::HandlerHttpRequest, util::ClientId};
 
 const H2_PREFACE: &[u8] = b"PRI * HTTP/2.0";
 const DEFAULT_HTTP_VERSION_DETECTION_TIMEOUT: Duration = Duration::from_secs(10);
@@ -25,97 +20,40 @@ const DEFAULT_HTTP_VERSION_DETECTION_TIMEOUT: Duration = Duration::from_secs(10)
 /// requests.
 pub(super) const MINIMAL_HEADER_SIZE: usize = 10;
 
-/// Used to set up the creation of a [`HyperHandler`] task for the HTTP traffic stealer.
-#[derive(Debug)]
-pub(super) struct HttpFilterBuilder {
-    http_version: HttpVersion,
-    reversible_stream: DefaultReversibleStream,
+/// Read the start of the TCP stream, decide if it's HTTP (of a supported version), if it is, serve
+/// the connection with a [`HyperHandler`]. If it isn't, just forward the whole TCP connection to
+/// the original destination.
+#[tracing::instrument(
+    level = "trace",
+    skip(stolen_stream, matched_tx, connection_close_sender)
+)]
+pub(super) async fn filter_task(
+    stolen_stream: TcpStream,
     original_destination: SocketAddr,
     connection_id: ConnectionId,
-    client_filters: Arc<DashMap<ClientId, Regex>>,
+    filters: Arc<DashMap<ClientId, Regex>>,
     matched_tx: Sender<HandlerHttpRequest>,
-
-    /// For informing the stealer task that the connection was closed.
     connection_close_sender: Sender<ConnectionId>,
-}
-
-impl HttpFilterBuilder {
-    /// Does not consume bytes from the stream.
-    ///
-    /// Checks if the first available bytes in a stream could be of an http request.
-    ///
-    /// This is a best effort classification, not a guarantee that the stream is HTTP.
-    #[tracing::instrument(
-        level = "trace",
-        skip_all
-        fields(
-            local = ?stolen_stream.local_addr(),
-            peer = ?stolen_stream.peer_addr()
-        ),
-    )]
-    pub(super) async fn new(
-        stolen_stream: TcpStream,
-        original_destination: SocketAddr,
-        connection_id: ConnectionId,
-        filters: Arc<DashMap<ClientId, Regex>>,
-        matched_tx: Sender<HandlerHttpRequest>,
-        connection_close_sender: Sender<ConnectionId>,
-    ) -> Result<Self, HttpTrafficError> {
-        DefaultReversibleStream::read_header(stolen_stream, DEFAULT_HTTP_VERSION_DETECTION_TIMEOUT)
-            .await
-            .map(|mut reversible_stream| {
-                let http_version = HttpVersion::new(
-                    reversible_stream.get_header(),
-                    &H2_PREFACE[..MINIMAL_HEADER_SIZE],
-                );
-
-                Self {
-                    http_version,
-                    client_filters: filters,
-                    reversible_stream,
-                    original_destination,
-                    connection_id,
-                    matched_tx,
-                    connection_close_sender,
-                }
-            })
-            .inspect_err(|fail| error!("Something went wrong in http filter {fail:#?}"))
-    }
-
-    /// Creates the hyper task, and returns an [`HttpFilter`] that contains the channels we use to
-    /// pass the requests to the layer.
-    #[tracing::instrument(
-        level = "trace",
-        skip(self),
-        fields(
-            self.http_version = ?self.http_version,
-            self.client_filters = ?self.client_filters,
-            self.connection_id = ?self.connection_id,
-            self.original_destination = ?self.original_destination,
-        )
-    )]
-    pub(super) fn start(self) -> Result<(), HttpTrafficError> {
-        let Self {
-            http_version,
-            client_filters,
-            matched_tx,
-            mut reversible_stream,
-            connection_id,
-            original_destination,
-            connection_close_sender,
-        } = self;
-
-        let port = original_destination.port();
-
-        match http_version {
-            HttpVersion::V1 => {
-                tokio::task::spawn(async move {
+) {
+    let port = original_destination.port();
+    match DefaultReversibleStream::read_header(
+        stolen_stream,
+        DEFAULT_HTTP_VERSION_DETECTION_TIMEOUT,
+    )
+    .await
+    {
+        Ok(mut reversible_stream) => {
+            match HttpVersion::new(
+                reversible_stream.get_header(),
+                &H2_PREFACE[..MINIMAL_HEADER_SIZE],
+            ) {
+                HttpVersion::V1 => {
                     // TODO: do we need to do something with this result?
                     let _res = http1::Builder::new()
                         .serve_connection(
                             reversible_stream,
                             HyperHandler {
-                                filters: client_filters,
+                                filters,
                                 matched_tx,
                                 connection_id,
                                 port,
@@ -132,24 +70,52 @@ impl HttpFilterBuilder {
                             error!("Main TcpConnectionStealer dropped connection close channel while HTTP filter is still running. \
                             Cannot report the closing of connection {connection_id}.");
                         });
-                });
-                Ok(())
-            }
-            // TODO(alex): hyper handling of HTTP/2 requires a bit more work, as it takes an
-            // "executor" (just `tokio::spawn` in the `Builder::new` function is good enough), and
-            // some more effort to chase some missing implementations.
-            HttpVersion::V2 | HttpVersion::NotHttp => {
-                let _passhtrough_task = tokio::task::spawn(async move {
-                    let mut interceptor_to_original =
-                        TcpStream::connect(original_destination).await?;
+                }
 
-                    copy_bidirectional(&mut reversible_stream, &mut interceptor_to_original)
-                        .await?;
-                    Ok::<_, error::HttpTrafficError>(())
-                });
-
-                Ok(())
+                // TODO(alex): hyper handling of HTTP/2 requires a bit more work, as it takes an
+                // "executor" (just `tokio::spawn` in the `Builder::new` function is good enough),
+                // and some more effort to chase some missing implementations.
+                HttpVersion::V2 | HttpVersion::NotHttp => {
+                    trace!(
+                        "Got a connection with unsupported protocol version, passing it through \
+                        to its original destination."
+                    );
+                    match TcpStream::connect(original_destination).await {
+                        Ok(mut interceptor_to_original) => {
+                            match copy_bidirectional(
+                                &mut reversible_stream,
+                                &mut interceptor_to_original,
+                            )
+                            .await
+                            {
+                                Ok((incoming, outgoing)) => {
+                                    trace!(
+                                        "Forwarded {incoming} incoming bytes and {outgoing} \
+                                        outgoing bytes in passthrough connection"
+                                    )
+                                }
+                                Err(err) => {
+                                    error!(
+                                        "Encountered error while forwarding unsupported \
+                                    connection to its original destination: {err:?}"
+                                    )
+                                }
+                            };
+                        }
+                        Err(err) => {
+                            error!(
+                                "Could not connect to original destination {original_destination:?}\
+                                 . Received a connection with an unsupported protocol version to a \
+                                 filtered HTTP port, but cannot forward the connection because of \
+                                 the connection error: {err:?}");
+                        }
+                    }
+                }
             }
+        }
+
+        Err(read_error) => {
+            error!("Got error while trying to read first bytes of TCP stream: {read_error:?}");
         }
     }
 }

--- a/mirrord/agent/src/steal/http/reversible_stream.rs
+++ b/mirrord/agent/src/steal/http/reversible_stream.rs
@@ -28,7 +28,7 @@ pub(crate) struct ReversibleStream<const HEADER_SIZE: usize> {
     /// We could be writing less then `HEADER_SIZE` bytes into `header`, in two cases:
     /// 1. Got a timeout before reading as `HEADER_SIZE` bytes.
     /// 2. Read an EOF after less than `HEADER_SIZE` bytes.
-    /// So we need to always now how many bytes we actually have.
+    /// So we need to always know how many bytes we actually have.
     header_len: usize,
 
     /// How many bytes out of the `header` were already read by the owner of self.

--- a/mirrord/agent/src/steal/http/reversible_stream.rs
+++ b/mirrord/agent/src/steal/http/reversible_stream.rs
@@ -2,12 +2,15 @@ use pin_project::pin_project;
 use tokio::{
     io::{AsyncRead, AsyncReadExt, AsyncWrite},
     net::TcpStream,
+    time,
+    time::{Duration, Instant},
 };
+use tracing::{trace, warn};
 
-use super::error::HttpTrafficError;
+use crate::steal::http::error::HttpTrafficError;
 
-/// Wraps a [`TcpStream`] to allow a sort of _peek_ functionality, even though we're actually going
-/// to be calling [`TcpStream::read_exact`] on it.
+/// Wraps a [`TcpStream`] to allow a sort of _peek_ functionality, by reading the first bytes, but
+/// then keeping them for later reads.
 ///
 /// Very useful to the HTTP filter component on [`stealer`], where we have to look at the first
 /// message on a [`TcpStream`] to try and identify if this connection is _talking_ HTTP.
@@ -19,25 +22,79 @@ use super::error::HttpTrafficError;
 pub(crate) struct ReversibleStream<const HEADER_SIZE: usize> {
     #[pin]
     stream: TcpStream,
+
     header: [u8; HEADER_SIZE],
+
+    /// We could be writing less then `HEADER_SIZE` bytes into `header`, in two cases:
+    /// 1. Got a timeout before reading as `HEADER_SIZE` bytes.
+    /// 2. Read an EOF after less than `HEADER_SIZE` bytes.
+    /// So we need to always now how many bytes we actually have.
+    header_len: usize,
+
+    /// How many bytes out of the `header` were already read by the owner of self.
     num_forwarded: usize,
 }
 
 impl<const HEADER_SIZE: usize> ReversibleStream<HEADER_SIZE> {
-    pub(crate) async fn read_header(stream: TcpStream) -> Result<Self, HttpTrafficError> {
+    /// Build a Reversible stream from a TcpStream, move on if not done within given timeout.
+    /// Return an Error if there was an error while reading from the TCP Stream.
+    pub(crate) async fn read_header(
+        stream: TcpStream,
+        timeout: Duration,
+    ) -> Result<Self, HttpTrafficError> {
         let mut this = Self {
             stream,
             header: [0; HEADER_SIZE],
+            header_len: 0,
             num_forwarded: 0,
         };
 
-        this.stream.read_exact(&mut this.header).await?;
+        let mut mut_buf = &mut this.header[..];
 
+        let deadline = Instant::now() + timeout;
+
+        // I think we can't use `stream.take(...).read_to_end(...)` because `take` takes ownership
+        // of the stream and there is no `by_ref()` for `AsyncRead`.
+        // And I think we can't use `read_exact()` because that loses track of the read bytes in the
+        // case of an early EOF.
+        //
+        // Read bytes from the stream until the buffer is full, or until an EOF.
+        loop {
+            match time::timeout_at(deadline, this.stream.read_buf(&mut mut_buf)).await {
+                Ok(Ok(0)) => {
+                    if this.header_len != HEADER_SIZE {
+                        warn!(
+                            "Got early EOF after only {} bytes while creating reversible stream.",
+                            this.header_len
+                        );
+                    } else {
+                        trace!("\"Peeking\" into TCP stream start completed.")
+                    }
+                    break;
+                }
+                Ok(Ok(n)) => {
+                    this.header_len += n;
+                    trace!("Read {n} header bytes, {} total.", this.header_len);
+                }
+                Ok(Err(read_error)) => Err(read_error)?,
+                Err(_elapsed) => {
+                    warn!(
+                        "Got timeout while trying to read first {HEADER_SIZE} bytes of TCP stream."
+                    );
+                    break;
+                }
+            }
+        }
+        debug_assert!(this.header_len <= HEADER_SIZE);
+        trace!(
+            "created reversible stream with header: {}",
+            String::from_utf8_lossy(&this.header)
+        );
         Ok(this)
     }
 
-    pub(crate) fn get_header(&mut self) -> &[u8; HEADER_SIZE] {
-        &self.header
+    pub(crate) fn get_header(&mut self) -> &[u8] {
+        &self.header[..self.header_len]
     }
 }
 
@@ -49,8 +106,8 @@ impl<const HEADER_SIZE: usize> AsyncRead for ReversibleStream<HEADER_SIZE> {
     ) -> std::task::Poll<std::io::Result<()>> {
         let this = self.project();
 
-        if *this.num_forwarded < this.header.len() {
-            let leftover = &this.header[*this.num_forwarded..];
+        if this.num_forwarded < this.header_len {
+            let leftover = &this.header[*this.num_forwarded..*this.header_len];
 
             let num_forward_now = leftover.len().min(buf.remaining());
             let forward = &leftover[..num_forward_now];

--- a/mirrord/agent/src/steal/http/reversible_stream.rs
+++ b/mirrord/agent/src/steal/http/reversible_stream.rs
@@ -31,7 +31,11 @@ pub(crate) struct ReversibleStream<const HEADER_SIZE: usize> {
     /// So we need to always know how many bytes we actually have.
     header_len: usize,
 
-    /// How many bytes out of the `header` were already read by the owner of self.
+    /// How many bytes out of the [`header`] were already read by the reader of this
+    /// [`ReversibleStream`]. If the reader reads bytes into a buffer that is smaller than
+    /// `HEADER_SIZE`, it would not read the whole [`header`] on the first read, so this is the
+    /// amount of bytes that were already read. After all the bytes from the [`header`] were read,
+    /// by the user of this struct, further reads are forwarded to the underlying `TcpStream`.
     num_forwarded: usize,
 }
 

--- a/tests/src/traffic/steal.rs
+++ b/tests/src/traffic/steal.rs
@@ -171,6 +171,7 @@ mod steal {
         #[future] tcp_echo_service: KubeService,
         #[future] kube_client: Client,
         #[values(Agent::Job)] agent: Agent,
+        #[values("THIS IS NOT HTTP!\n", "short.\n")] tcp_data: &str,
     ) {
         let application = Application::NodeTcpEcho;
         let service = tcp_echo_service.await;
@@ -192,11 +193,13 @@ mod steal {
 
         let addr = SocketAddr::new(host.trim().parse().unwrap(), port as u16);
         let mut stream = TcpStream::connect(addr).unwrap();
-        stream.write(b"THIS IS NOT HTTP!\n").unwrap();
+        stream.write(tcp_data.as_bytes()).unwrap();
         let mut reader = BufReader::new(stream);
         let mut buf = String::new();
         reader.read_line(&mut buf).unwrap();
-        assert_eq!(&buf, "remote: THIS IS NOT HTTP!\n"); // Successful round trip with remote app.
+        println!("Got response: {buf}");
+        assert_eq!(&buf[..8], "remote: "); // The data was passed through to remote app.
+        assert_eq!(&buf[8..], tcp_data); // The correct data was sent there and back.
 
         // Verify the data was passed through and nothing was sent to the local app.
         let stdout_after = mirrorded_process.get_stdout();
@@ -216,11 +219,12 @@ mod steal {
         mirrorded_process.wait_for_line(Duration::from_secs(15), "daemon subscribed");
 
         let mut stream = TcpStream::connect(addr).unwrap();
-        stream.write(b"THIS IS NOT HTTP!\n").unwrap();
+        stream.write(tcp_data.as_bytes()).unwrap();
         let mut reader = BufReader::new(stream);
         let mut buf = String::new();
         reader.read_line(&mut buf).unwrap();
-        assert_eq!(&buf, "local: THIS IS NOT HTTP!\n"); // Successful round trip with local app.
+        assert_eq!(&buf[..7], "local: "); // The data was stolen to local app.
+        assert_eq!(&buf[7..], tcp_data); // The correct data was sent there and back.
 
         // Verify the data was sent to the local app.
         let stdout_after = mirrorded_process.get_stdout();


### PR DESCRIPTION
https://github.com/metalbear-co/mirrord/issues/926

Make reversible stream deal with short streams.

- Add timeout for reading first bytes, so that it does not hang if
 the client sends too few bytes and keeps the connection open.
- Change from `read_exact` to `read_buf` loop so that we don't get an
 error and lose bytes if the client closes the connection after
 too few bytes.
   
Move the stream-peeking into the filter task and simplify the filter task.

Since creating a reversible stream can wait for up to 10 seconds,
move that into the separate filter task.
This also has the effect of not the stealer not being able to
fail and stop because of an error in dealing with one HTTP
connection.
And since there's no more any logic in the HttpFilterBuilder,
just convert it to a function.

Add test: complete passthrough on short stream.

