### PR TITLE
[Merged by Bors] - macOS x64/SIP(arm): fix double hooking `fstatat$INODE64`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ### Fixed
 
 - tests: flaky passthrough fix. Avoid 2 agents running at the same time, add minimal sleep (1s)
+- macOS x64/SIP(arm): fix double hooking `fstatat$INODE64`. Possible crash and undefined behavior.
 
 ### Added
 

--- a/mirrord/layer/src/file/hooks.rs
+++ b/mirrord/layer/src/file/hooks.rs
@@ -703,13 +703,6 @@ pub(crate) unsafe fn enable_file_hooks(hook_manager: &mut HookManager) {
         );
         replace!(
             hook_manager,
-            "fstatat$INODE64",
-            fstatat_detour,
-            FnFstatat,
-            FN_FSTATAT
-        );
-        replace!(
-            hook_manager,
             "fdopendir$INODE64",
             fdopendir_detour,
             FnFdopendir,


### PR DESCRIPTION
Possible crash and undefined behavior.