### PR TITLE
[Merged by Bors] - Move all file requests/responses into file.rs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+### Changed
+
+- Code refactor: moved all file request and response types into own file.
+
 ## 3.19.1
 
 ### Fixed

--- a/mirrord/agent/src/file.rs
+++ b/mirrord/agent/src/file.rs
@@ -11,14 +11,14 @@ use std::{
 use faccess::{AccessMode, PathExt};
 use mirrord_protocol::{
     file::{
-        CloseDirRequest, DirEntryInternal, FdOpenDirRequest, OpenDirResponse, ReadDirRequest,
-        ReadDirResponse, XstatRequest, XstatResponse,
+        AccessFileRequest, AccessFileResponse, CloseDirRequest, CloseFileRequest, DirEntryInternal,
+        FdOpenDirRequest, OpenDirResponse, OpenFileRequest, OpenFileResponse, OpenOptionsInternal,
+        OpenRelativeFileRequest, ReadDirRequest, ReadDirResponse, ReadFileRequest,
+        ReadFileResponse, ReadLimitedFileRequest, ReadLineFileRequest, SeekFileRequest,
+        SeekFileResponse, WriteFileRequest, WriteFileResponse, WriteLimitedFileRequest,
+        XstatRequest, XstatResponse,
     },
-    AccessFileRequest, AccessFileResponse, CloseFileRequest, FileRequest, FileResponse,
-    OpenFileRequest, OpenFileResponse, OpenOptionsInternal, OpenRelativeFileRequest,
-    ReadFileRequest, ReadFileResponse, ReadLimitedFileRequest, ReadLineFileRequest, RemoteResult,
-    ResponseError, SeekFileRequest, SeekFileResponse, WriteFileRequest, WriteFileResponse,
-    WriteLimitedFileRequest,
+    FileRequest, FileResponse, RemoteResult, ResponseError,
 };
 use tracing::{error, trace};
 

--- a/mirrord/layer/src/file.rs
+++ b/mirrord/layer/src/file.rs
@@ -19,14 +19,14 @@ use std::{
 use libc::{c_int, O_ACCMODE, O_APPEND, O_CREAT, O_RDONLY, O_RDWR, O_TRUNC, O_WRONLY};
 use mirrord_protocol::{
     file::{
-        CloseDirRequest, DirEntryInternal, FdOpenDirRequest, OpenDirResponse, ReadDirRequest,
-        ReadDirResponse, XstatRequest, XstatResponse,
+        AccessFileRequest, AccessFileResponse, CloseDirRequest, CloseFileRequest, DirEntryInternal,
+        FdOpenDirRequest, OpenDirResponse, OpenFileRequest, OpenFileResponse, OpenOptionsInternal,
+        OpenRelativeFileRequest, ReadDirRequest, ReadDirResponse, ReadFileRequest,
+        ReadFileResponse, ReadLimitedFileRequest, ReadLineFileRequest, SeekFileRequest,
+        SeekFileResponse, WriteFileRequest, WriteFileResponse, WriteLimitedFileRequest,
+        XstatRequest, XstatResponse,
     },
-    AccessFileRequest, AccessFileResponse, ClientMessage, CloseFileRequest, FileRequest,
-    FileResponse, OpenFileRequest, OpenFileResponse, OpenOptionsInternal, OpenRelativeFileRequest,
-    ReadFileRequest, ReadFileResponse, ReadLimitedFileRequest, ReadLineFileRequest, RemoteResult,
-    SeekFileRequest, SeekFileResponse, WriteFileRequest, WriteFileResponse,
-    WriteLimitedFileRequest,
+    ClientMessage, FileRequest, FileResponse, RemoteResult,
 };
 use tokio::sync::mpsc::Sender;
 use tracing::{error, trace, warn};

--- a/mirrord/layer/src/file/hooks.rs
+++ b/mirrord/layer/src/file/hooks.rs
@@ -15,9 +15,8 @@ use libc::{
     FILE,
 };
 use mirrord_layer_macro::{hook_fn, hook_guard_fn};
-use mirrord_protocol::{
-    file::{DirEntryInternal, MetadataInternal},
-    OpenOptionsInternal, ReadFileResponse, WriteFileResponse,
+use mirrord_protocol::file::{
+    DirEntryInternal, MetadataInternal, OpenOptionsInternal, ReadFileResponse, WriteFileResponse,
 };
 use num_traits::Bounded;
 use tracing::trace;

--- a/mirrord/layer/src/file/ops.rs
+++ b/mirrord/layer/src/file/ops.rs
@@ -2,9 +2,9 @@ use core::ffi::CStr;
 use std::{ffi::CString, io::SeekFrom, os::unix::io::RawFd, path::PathBuf};
 
 use libc::{c_int, c_uint, AT_FDCWD, FILE, O_CREAT, O_RDONLY, S_IRUSR, S_IWUSR, S_IXUSR};
-use mirrord_protocol::{
-    file::XstatResponse, OpenFileResponse, OpenOptionsInternal, ReadFileResponse, SeekFileResponse,
-    WriteFileResponse,
+use mirrord_protocol::file::{
+    OpenFileResponse, OpenOptionsInternal, ReadFileResponse, SeekFileResponse, WriteFileResponse,
+    XstatResponse,
 };
 use tokio::sync::oneshot;
 use tracing::{error, trace};

--- a/mirrord/layer/tests/common/mod.rs
+++ b/mirrord/layer/tests/common/mod.rs
@@ -254,9 +254,9 @@ impl LayerConnection {
         assert_eq!(
             self.codec.next().await.unwrap().unwrap(),
             ClientMessage::FileRequest(mirrord_protocol::FileRequest::Open(
-                mirrord_protocol::OpenFileRequest {
+                mirrord_protocol::file::OpenFileRequest {
                     path: file_name.to_string().into(),
-                    open_options: mirrord_protocol::OpenOptionsInternal {
+                    open_options: mirrord_protocol::file::OpenOptionsInternal {
                         read: true,
                         write: false,
                         append: false,
@@ -271,7 +271,7 @@ impl LayerConnection {
         // Answer open.
         self.codec
             .send(DaemonMessage::File(mirrord_protocol::FileResponse::Open(
-                Ok(mirrord_protocol::OpenFileResponse { fd }),
+                Ok(mirrord_protocol::file::OpenFileResponse { fd }),
             )))
             .await
             .unwrap();
@@ -281,7 +281,7 @@ impl LayerConnection {
     pub async fn expect_file_read(&mut self, expected_fd: u64) -> u64 {
         // Verify the app reads the file.
         if let ClientMessage::FileRequest(mirrord_protocol::FileRequest::Read(
-            mirrord_protocol::ReadFileRequest {
+            mirrord_protocol::file::ReadFileRequest {
                 remote_fd: requested_fd,
                 buffer_size,
             },
@@ -298,7 +298,7 @@ impl LayerConnection {
         let read_amount = contents.len();
         self.codec
             .send(DaemonMessage::File(mirrord_protocol::FileResponse::Read(
-                Ok(mirrord_protocol::ReadFileResponse {
+                Ok(mirrord_protocol::file::ReadFileResponse {
                     bytes: contents,
                     read_amount: read_amount as u64,
                 }),
@@ -324,7 +324,7 @@ impl LayerConnection {
         assert_eq!(
             self.codec.next().await.unwrap().unwrap(),
             ClientMessage::FileRequest(mirrord_protocol::FileRequest::Close(
-                mirrord_protocol::CloseFileRequest { fd }
+                mirrord_protocol::file::CloseFileRequest { fd }
             ))
         );
     }

--- a/mirrord/protocol/src/codec.rs
+++ b/mirrord/protocol/src/codec.rs
@@ -1,8 +1,6 @@
-use core::fmt;
 use std::{
     collections::{HashMap, HashSet},
-    io::{self, SeekFrom},
-    path::PathBuf,
+    io::{self},
 };
 
 use actix_codec::{Decoder, Encoder};
@@ -12,8 +10,11 @@ use bytes::{Buf, BufMut, BytesMut};
 use crate::{
     dns::{GetAddrInfoRequest, GetAddrInfoResponse},
     file::{
-        CloseDirRequest, FdOpenDirRequest, OpenDirResponse, ReadDirRequest, ReadDirResponse,
-        XstatRequest, XstatResponse,
+        AccessFileRequest, AccessFileResponse, CloseDirRequest, CloseFileRequest, FdOpenDirRequest,
+        OpenDirResponse, OpenFileRequest, OpenFileResponse, OpenRelativeFileRequest,
+        ReadDirRequest, ReadDirResponse, ReadFileRequest, ReadFileResponse, ReadLimitedFileRequest,
+        ReadLineFileRequest, SeekFileRequest, SeekFileResponse, WriteFileRequest,
+        WriteFileResponse, WriteLimitedFileRequest, XstatRequest, XstatResponse,
     },
     outgoing::{
         tcp::{DaemonTcpOutgoing, LayerTcpOutgoing},
@@ -26,150 +27,6 @@ use crate::{
 #[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
 pub struct LogMessage {
     pub message: String,
-}
-
-#[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
-pub struct ReadFileRequest {
-    pub remote_fd: u64,
-    pub buffer_size: u64,
-}
-
-#[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
-pub struct ReadLineFileRequest {
-    pub remote_fd: u64,
-    pub buffer_size: u64,
-}
-
-#[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
-pub struct ReadLimitedFileRequest {
-    pub remote_fd: u64,
-    pub buffer_size: u64,
-    pub start_from: u64,
-}
-
-// TODO: We're not handling `custom_flags` here, if we ever need to do so, add them here (it's an OS
-// specific thing).
-//
-// TODO: Should probably live in a separate place (same reasoning as `AddrInfoHint`).
-#[derive(Encode, Decode, Debug, PartialEq, Clone, Copy, Eq, Default)]
-pub struct OpenOptionsInternal {
-    pub read: bool,
-    pub write: bool,
-    pub append: bool,
-    pub truncate: bool,
-    pub create: bool,
-    pub create_new: bool,
-}
-
-impl OpenOptionsInternal {
-    pub fn is_read_only(&self) -> bool {
-        self.read && !(self.write || self.append || self.truncate || self.create || self.create_new)
-    }
-
-    pub fn is_write(&self) -> bool {
-        self.write || self.append || self.truncate || self.create || self.create_new
-    }
-}
-
-impl From<OpenOptionsInternal> for std::fs::OpenOptions {
-    fn from(internal: OpenOptionsInternal) -> Self {
-        let OpenOptionsInternal {
-            read,
-            write,
-            append,
-            truncate,
-            create,
-            create_new,
-        } = internal;
-
-        std::fs::OpenOptions::new()
-            .read(read)
-            .write(write)
-            .append(append)
-            .truncate(truncate)
-            .create(create)
-            .create_new(create_new)
-            .to_owned()
-    }
-}
-
-/// Alternative to `std::io::SeekFrom`, used to implement `bincode::Encode` and `bincode::Decode`.
-#[derive(Encode, Decode, Debug, PartialEq, Clone, Copy, Eq)]
-pub enum SeekFromInternal {
-    Start(u64),
-    End(i64),
-    Current(i64),
-}
-
-impl const From<SeekFromInternal> for SeekFrom {
-    fn from(seek_from: SeekFromInternal) -> Self {
-        match seek_from {
-            SeekFromInternal::Start(start) => SeekFrom::Start(start),
-            SeekFromInternal::End(end) => SeekFrom::End(end),
-            SeekFromInternal::Current(current) => SeekFrom::Current(current),
-        }
-    }
-}
-
-impl const From<SeekFrom> for SeekFromInternal {
-    fn from(seek_from: SeekFrom) -> Self {
-        match seek_from {
-            SeekFrom::Start(start) => SeekFromInternal::Start(start),
-            SeekFrom::End(end) => SeekFromInternal::End(end),
-            SeekFrom::Current(current) => SeekFromInternal::Current(current),
-        }
-    }
-}
-#[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
-pub struct OpenFileRequest {
-    pub path: PathBuf,
-    pub open_options: OpenOptionsInternal,
-}
-
-#[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
-pub struct OpenRelativeFileRequest {
-    pub relative_fd: u64,
-    pub path: PathBuf,
-    pub open_options: OpenOptionsInternal,
-}
-
-#[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
-pub struct SeekFileRequest {
-    pub fd: u64,
-    pub seek_from: SeekFromInternal,
-}
-
-#[derive(Encode, Decode, PartialEq, Eq, Clone)]
-pub struct WriteFileRequest {
-    pub fd: u64,
-    pub write_bytes: Vec<u8>,
-}
-
-#[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
-pub struct WriteLimitedFileRequest {
-    pub remote_fd: u64,
-    pub start_from: u64,
-    pub write_bytes: Vec<u8>,
-}
-
-impl fmt::Debug for WriteFileRequest {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("WriteFileRequest")
-            .field("fd", &self.fd)
-            .field("write_bytes (length)", &self.write_bytes.len())
-            .finish()
-    }
-}
-
-#[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
-pub struct CloseFileRequest {
-    pub fd: u64,
-}
-
-#[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
-pub struct AccessFileRequest {
-    pub pathname: PathBuf,
-    pub mode: u8,
 }
 
 #[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
@@ -209,39 +66,6 @@ pub enum ClientMessage {
     Ping,
     GetAddrInfoRequest(GetAddrInfoRequest),
 }
-
-#[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
-pub struct OpenFileResponse {
-    pub fd: u64,
-}
-
-#[derive(Encode, Decode, PartialEq, Eq, Clone)]
-pub struct ReadFileResponse {
-    pub bytes: Vec<u8>,
-    pub read_amount: u64,
-}
-
-impl fmt::Debug for ReadFileResponse {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("ReadFileResponse")
-            .field("bytes (length)", &self.bytes.len())
-            .field("read_amount", &self.read_amount)
-            .finish()
-    }
-}
-
-#[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
-pub struct SeekFileResponse {
-    pub result_offset: u64,
-}
-
-#[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
-pub struct WriteFileResponse {
-    pub written_amount: u64,
-}
-
-#[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
-pub struct AccessFileResponse;
 
 /// Type alias for `Result`s that should be returned from mirrord-agent to mirrord-layer.
 pub type RemoteResult<T> = Result<T, ResponseError>;


### PR DESCRIPTION
Currently some of the types used in the [`FileRequest`](https://github.com/metalbear-co/mirrord/blob/46f2d06038502bb2d77d430f97a81a859a334260/mirrord/protocol/src/codec.rs#L182) and [`FileResponse`](https://github.com/metalbear-co/mirrord/blob/46f2d06038502bb2d77d430f97a81a859a334260/mirrord/protocol/src/codec.rs#L250) enums are defined in the same file, and some are defined in [file.rs](https://github.com/metalbear-co/mirrord/blob/46f2d06038502bb2d77d430f97a81a859a334260/mirrord/protocol/src/file.rs).

This was a bit confusing to me, so if it's not intentional, I thought we could also move the rest of the types to the separate file.