### PR TITLE
[Merged by Bors] - remove --no-fs and --rw from cli args.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ### Fixed
 
 - Go crash in some scenarios [#834](https://github.com/metalbear-co/mirrord/issues/834).
+- Remove already deprecated `--no-fs` and `--rw` options, that do not do anything anymore, but were still listed in the
+  help message.
 
 ## 3.19.2
 

--- a/mirrord/cli/src/config.rs
+++ b/mirrord/cli/src/config.rs
@@ -88,14 +88,6 @@ pub(super) struct ExecArgs {
     #[arg(short = 'i', long)]
     pub agent_image: Option<String>,
 
-    /// Disable file read only
-    #[arg(long)]
-    pub no_fs: bool,
-
-    /// Enable file hooking (Both R/W)
-    #[arg(long = "rw")]
-    pub enable_rw_fs: bool,
-
     /// Default file system behavior: read, write, local
     #[arg(long)]
     pub fs_mode: Option<FsMode>,

--- a/mirrord/cli/src/main.rs
+++ b/mirrord/cli/src/main.rs
@@ -95,11 +95,6 @@ async fn exec(args: &ExecArgs, progress: &TaskProgress) -> Result<()> {
         );
     }
 
-    if args.enable_rw_fs && args.no_fs {
-        warn!("use --fs-mode=write or --fs-mode=readonly please");
-        warn!("fs was both enabled and disabled - disabling will take precedence.");
-    }
-
     if let Some(fs_mode) = args.fs_mode {
         std::env::set_var("MIRRORD_FILE_MODE", fs_mode.to_string());
     }


### PR DESCRIPTION
They were already deprecated and their functionality was removed, but the arguments were not deleted from the cli and so they still appear in the help message.