### PR TITLE
[Merged by Bors] - Hook `posix_spawn` with same logic as `execve`.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -414,6 +414,10 @@ jobs:
       - run: pip3 install uvicorn[standard] # For http mirroring test with FastAPI.
       - run: cargo build -p mirrord-layer # Build layer lib. The tests load it into the apps.
       - run: cargo test -p mirrord-layer
+      - uses: actions/setup-node@v3 # version 19 spawns processes with `posix_spawn`, so test that also.
+        with:
+          node-version: 19
+      - run: cargo test -p mirrord-layer --test spawn
 
   e2e:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - mirrord-agent: Handle HTTP upgrade requests when the stealer feature is enabled
   (with HTTP traffic) PR [#973](https://github.com/metalbear-co/mirrord/pull/973).
 - E2E tests compile on MacOS.
+- mirrord could not load into some newer binaries of node -
+  [#987](https://github.com/metalbear-co/mirrord/issues/987). Now hooking also `posix_spawn`, since node now uses
+  `libuv`'s `uv_spawn` (which in turn calls `posix_spawn`) instead of libc's `execvp` (which calls `execve`).
 
 ## 3.20.0
 

--- a/mirrord/layer/src/detour.rs
+++ b/mirrord/layer/src/detour.rs
@@ -295,22 +295,11 @@ impl<S> Detour<S> {
     }
 
     /// Like Result's `ok()`.
+    #[cfg(target_os = "macos")] // Currently only used in macos, remove to use in linux code.
     pub(crate) fn success(self) -> Option<S> {
         match self {
             Detour::Success(s) => Some(s),
             _ => None,
-        }
-    }
-
-    /// Return the contained `Success` value or a provided default if `Bypass` or `Error`.
-    ///
-    /// To be used in hooks that are deemed non-essential, and the run should continue even if they
-    /// fail.
-    #[allow(dead_code)] // leaving it here in case it's useful in the future.
-    pub(crate) fn unwrap_or(self, default: S) -> S {
-        match self {
-            Detour::Success(s) => s,
-            _ => default,
         }
     }
 }

--- a/mirrord/layer/src/detour.rs
+++ b/mirrord/layer/src/detour.rs
@@ -294,17 +294,23 @@ impl<S> Detour<S> {
         }
     }
 
+    /// Like Result's `ok()`.
+    pub(crate) fn success(self) -> Option<S> {
+        match self {
+            Detour::Success(s) => Some(s),
+            _ => None,
+        }
+    }
+
     /// Return the contained `Success` value or a provided default if `Bypass` or `Error`.
     ///
     /// To be used in hooks that are deemed non-essential, and the run should continue even if they
     /// fail.
-    /// Currently defined only on macos because it is only used in macos-only code.
-    /// Remove the cfg attribute to enable using in other code.
-    #[cfg(target_os = "macos")]
+    #[allow(dead_code)] // leaving it here in case it's useful in the future.
     pub(crate) fn unwrap_or(self, default: S) -> S {
         match self {
             Detour::Success(s) => s,
-            Detour::Bypass(_) | Detour::Error(_) => default,
+            _ => default,
         }
     }
 }

--- a/mirrord/layer/src/exec.rs
+++ b/mirrord/layer/src/exec.rs
@@ -221,6 +221,7 @@ pub(crate) unsafe extern "C" fn execve_detour(
     FN_EXECVE(patched_args.get_path(), patched_args.get_argv(), envp)
 }
 
+// TODO: do we also need to hook posix_spawnp?
 #[hook_guard_fn]
 pub(crate) unsafe extern "C" fn posix_spawn_detour(
     pid: *const pid_t,

--- a/mirrord/layer/src/lib.rs
+++ b/mirrord/layer/src/lib.rs
@@ -363,6 +363,14 @@ fn layer_start(config: LayerConfig) {
     };
 
     info!("Initializing mirrord-layer!");
+    let exe_path = std::env::current_exe()
+        .map(|path| path.to_string_lossy().to_string())
+        .unwrap_or_default();
+    trace!(
+        "Loaded into executable: {}, with args: {:?}",
+        &exe_path,
+        std::env::args()
+    );
 
     let (tx, rx) = RUNTIME.block_on(connection::connect(&config));
 

--- a/mirrord/layer/tests/apps/node_spawn.js
+++ b/mirrord/layer/tests/apps/node_spawn.js
@@ -1,0 +1,17 @@
+const { exec } = require('child_process');
+const process = require("process");
+
+// Echo is a built-in, so we will get a new process for the shell, but not a new one for echo.
+// This starts: ["/bin/sh", "-c", "echo \"Hello over shell\""]
+exec('echo "Hello over shell"', (err, stdout, stderr) => {
+  if (err) {
+    // node couldn't execute the command
+    process.exit(1)
+  }
+
+  // the *entire* stdout and stderr (buffered)
+  console.log(stdout);
+  if (stderr) {
+    console.error(stderr);
+  }
+});

--- a/mirrord/layer/tests/common/mod.rs
+++ b/mirrord/layer/tests/common/mod.rs
@@ -34,6 +34,10 @@ impl TestProcess {
         self.stdout.lock().unwrap().clone()
     }
 
+    pub fn get_stderr(&self) -> String {
+        self.stderr.lock().unwrap().clone()
+    }
+
     pub fn assert_log_level(&self, stderr: bool, level: &str) {
         if stderr {
             assert!(!self.stderr.lock().unwrap().contains(level));
@@ -347,6 +351,7 @@ pub enum Application {
     Go20Issue834,
     Go19Issue834,
     Go18Issue834,
+    NodeSpawn,
 }
 
 impl Application {
@@ -397,6 +402,7 @@ impl Application {
             Application::Go18Issue834 => String::from("tests/apps/issue834/18"),
             Application::Go19DirBypass => String::from("tests/apps/dir_go_bypass/19"),
             Application::Go20DirBypass => String::from("tests/apps/dir_go_bypass/20"),
+            Application::NodeSpawn => String::from("node"),
         }
     }
 
@@ -426,6 +432,10 @@ impl Application {
             }
             Application::NodeFileOps => {
                 app_path.push("fileops.js");
+                vec![app_path.to_string_lossy().to_string()]
+            }
+            Application::NodeSpawn => {
+                app_path.push("node_spawn.js");
                 vec![app_path.to_string_lossy().to_string()]
             }
             Application::PythonSelfConnect => {
@@ -461,6 +471,7 @@ impl Application {
             | Application::RustFileOps
             | Application::EnvBashCat
             | Application::NodeFileOps
+            | Application::NodeSpawn
             | Application::Go20Issue834
             | Application::Go19Issue834
             | Application::Go18Issue834

--- a/mirrord/layer/tests/spawn.rs
+++ b/mirrord/layer/tests/spawn.rs
@@ -1,0 +1,39 @@
+use std::{path::PathBuf, time::Duration};
+
+use rstest::rstest;
+use tokio::net::TcpListener;
+
+mod common;
+
+pub use common::*;
+
+/// Some versions of node use `posix_spawn` and not `execve`, so make sure we load into processes
+/// that are created by node, with the node version installed where this test is executed.
+///
+/// Since the new process started by the app is bash, it is SIP on mac, so if we don't hook it's
+/// spawning we won't load to it. So if we get a second layer connection, it means we successfully
+/// hooked the spawning and patched bash (or we're not on macOS).
+/// The app starts the process `["/bin/sh", "-c", "echo \"Hello over shell\""]`.
+#[rstest]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[timeout(Duration::from_secs(20))]
+async fn test_node_spawn(dylib_path: &PathBuf) {
+    let application = Application::NodeSpawn;
+    let executable = application.get_executable().await;
+    println!("Using executable: {}", &executable);
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap().to_string();
+    println!("Listening for messages from the layer on {addr}");
+    let env = get_env_no_fs(dylib_path.to_str().unwrap(), &addr);
+    let mut test_process =
+        TestProcess::start_process(executable, application.get_args(), env).await;
+
+    // Accept the connection from the layer and verify initial messages.
+    let _node_layer_connection = LayerConnection::get_initialized_connection(&listener).await;
+    // Accept the connection from the layer and verify initial messages.
+    let _shell_layer_connection = LayerConnection::get_initialized_connection(&listener).await;
+
+    test_process.wait().await;
+    test_process.assert_no_error_in_stdout();
+    test_process.assert_no_error_in_stderr();
+}

--- a/mirrord/sip/src/lib.rs
+++ b/mirrord/sip/src/lib.rs
@@ -354,6 +354,7 @@ mod main {
             trace!("Using temp dir: {:?} for sip patches", &tmp_dir);
             Some(patch_some_sip(&path, shebang_target, tmp_dir)).transpose()
         } else {
+            trace!("No SIP detected on {:?}", binary_path);
             Ok(None)
         }
     }


### PR DESCRIPTION
Fixes https://github.com/metalbear-co/mirrord/issues/987.

The problem was that this newer node version does not use libc's `execve` to spawn a new process but libuv's `uv_spawn`, which calls `posix_spawn`. This means that our `execve` was not being called and so we could not patch SIP binaries, and we would therefore not load into the new process.
So now we also hook `posix_spawn`.

This PR also adds a regression test. The test was verified to be meaningful by checking that it indeed fails without the new hook: https://github.com/t4lz/mirrord/actions/runs/4028503663/jobs/6925471767#step:19:283.