### PR TITLE
[Merged by Bors] - Update CI to build and deploy rust docs to gh-pages.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,9 +78,9 @@ jobs:
       - run: cargo fmt --all -- --check
       - run: cargo clippy -- -D warnings
 
-  generate-rust-docs:
+  check-rust-docs:
     runs-on: ubuntu-latest
-    # needs: changed_files
+    needs: changed_files
     if: ${{needs.changed_files.outputs.rs_changed == 'true'}}
     env:
       # enables the creation of a workspace index.html page.
@@ -93,11 +93,6 @@ jobs:
           toolchain: nightly
       - uses: Swatinem/rust-cache@v2
       - run: cargo doc --document-private-items
-      - name: Deploy rust docs 🚀🦀
-        if: ${{ github.ref == 'refs/heads/main' }}
-        uses: JamesIves/github-pages-deploy-action@v4
-        with:
-          folder: target/doc # The folder the action should deploy
 
   lint_macos:
     runs-on: macos-latest

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -1,0 +1,41 @@
+# Simple workflow for deploying static content to GitHub Pages
+name: Deploy mirrord rust-docs to gh-pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: [main]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  # Generates rust docs with `RUSTDOCFLAGS` flags, and push it to `gh-pages` branch.
+  deploy-rust-docs:
+    runs-on: ubuntu-latest
+    env:
+      # enables the creation of a workspace index.html page.
+      RUSTDOCFLAGS: "--enable-index-page -Zunstable-options"
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo doc --document-private-items
+      - name: Deploy rust docs 🚀🦀
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: target/doc # The folder the action should deploy


### PR DESCRIPTION
- Issue: #917 

Adds a workflow to push rust docs to the `gh-pages` branch.

The docs are built and checked without deploying during the normal workflow, and are built and deployed when pushed to the `main` branch.