### PR TITLE
[Merged by Bors] - Fix rare file close deadlock.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
   leading to use the local nameserver for resolving. Fixes [#989](https://github.com/metalbear-co/mirrord/issues/989)
 - mirrord-agent: Infinite reading a file when using `fgets`/`read_line` due to bug seeking to start of file.
 
+### Fixed
+
+- Rare deadlock on file close that caused the e2e file-ops test to sometimes fail
+  ([#994](https://github.com/metalbear-co/mirrord/issues/994)).
+
 ## 3.21.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,6 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
   since `/etc/resolv.conf` and `/etc/hosts` were in the local read override,
   leading to use the local nameserver for resolving. Fixes [#989](https://github.com/metalbear-co/mirrord/issues/989)
 - mirrord-agent: Infinite reading a file when using `fgets`/`read_line` due to bug seeking to start of file.
-
-### Fixed
-
 - Rare deadlock on file close that caused the e2e file-ops test to sometimes fail
   ([#994](https://github.com/metalbear-co/mirrord/issues/994)).
 

--- a/mirrord/layer/src/file/ops.rs
+++ b/mirrord/layer/src/file/ops.rs
@@ -30,7 +30,9 @@ impl RemoteFile {
 
 impl Drop for RemoteFile {
     fn drop(&mut self) {
-        trace!("dropping RemoteFile {self:?}");
+        // TODO: put a warning about logging from here.
+        // TODO: delete commented out log.
+        // trace!("dropping RemoteFile {self:?}");
         let closing_file = Close { fd: self.fd };
 
         if let Err(err) = blocking_send_file_message(FileOperation::Close(closing_file)) {

--- a/mirrord/layer/src/file/ops.rs
+++ b/mirrord/layer/src/file/ops.rs
@@ -38,11 +38,9 @@ impl Drop for RemoteFile {
         // `OPEN_FILES.lock()?.remove()` and then while still locked, `OPEN_FILES.lock()` again)
         let closing_file = Close { fd: self.fd };
 
-        if let Err(err) = blocking_send_file_message(FileOperation::Close(closing_file)) {
-            println!(
-                "mirrord failed to send close file message to main layer thread. Error: {err:?}"
-            );
-        };
+        blocking_send_file_message(FileOperation::Close(closing_file)).expect(
+            "mirrord failed to send close file message to main layer thread. Error: {err:?}",
+        );
     }
 }
 

--- a/mirrord/layer/src/lib.rs
+++ b/mirrord/layer/src/lib.rs
@@ -830,9 +830,10 @@ pub(crate) unsafe extern "C" fn close_nocancel_detour(fd: c_int) -> c_int {
 #[cfg(target_os = "linux")]
 #[hook_guard_fn]
 pub(crate) unsafe extern "C" fn uv_fs_close(a: usize, b: usize, fd: c_int, c: usize) -> c_int {
-    let res = FN_UV_FS_CLOSE(a, b, fd, c);
+    // In this case we call `close_layer_fd` before the original close function, because execution
+    // does not return to here after calling `FN_UV_FS_CLOSE`.
     close_layer_fd(fd);
-    res
+    FN_UV_FS_CLOSE(a, b, fd, c)
 }
 
 /// Message presented to the user as a sort of footer when mirrord crashes.

--- a/mirrord/layer/src/lib.rs
+++ b/mirrord/layer/src/lib.rs
@@ -830,8 +830,9 @@ pub(crate) unsafe extern "C" fn close_nocancel_detour(fd: c_int) -> c_int {
 #[cfg(target_os = "linux")]
 #[hook_guard_fn]
 pub(crate) unsafe extern "C" fn uv_fs_close(a: usize, b: usize, fd: c_int, c: usize) -> c_int {
+    let res = FN_UV_FS_CLOSE(a, b, fd, c);
     close_layer_fd(fd);
-    FN_UV_FS_CLOSE(a, b, fd, c)
+    res
 }
 
 /// Message presented to the user as a sort of footer when mirrord crashes.

--- a/tests/src/file_ops.rs
+++ b/tests/src/file_ops.rs
@@ -21,7 +21,7 @@ mod file_ops {
             FileOps::Python,
             FileOps::Go18,
             FileOps::Go19,
-            // FileOps::Go20,
+            FileOps::Go20,
             FileOps::Rust
         )]
         ops: FileOps,


### PR DESCRIPTION
The deadlock has only been observed in the E2E fileops test with Go-1.20 on GitHub Actions.

This PR hopefully eliminate this deadlock, but also contains some fixes of problematic lockings that did not cause this deadlock.

Part of #994.