### PR TITLE
[Merged by Bors] - Fix config file disabled env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+### Fixed
+
+- mirrord-config: Fix disabled feature for env in config file, `env = false` should work. See [#1015](https://github.com/metalbear-co/mirrord/issues/1015).
+
 ## 3.22.0
 
 ### Changed

--- a/mirrord/config/src/env.rs
+++ b/mirrord/config/src/env.rs
@@ -136,7 +136,7 @@ mod tests {
             Option<&str>,
             Option<&str>,
         ),
-        #[values((None, None), (Some("EVAR1"), Some("EVAR1")))] exclude: (
+        #[values((None, Some("*")), (Some("EVAR1"), Some("EVAR1")))] exclude: (
             Option<&str>,
             Option<&str>,
         ),

--- a/mirrord/config/src/env.rs
+++ b/mirrord/config/src/env.rs
@@ -90,7 +90,8 @@ impl MirrordToggleableConfig for EnvFileConfig {
                 .transpose()?,
             exclude: FromEnv::new("MIRRORD_OVERRIDE_ENV_VARS_EXCLUDE")
                 .source_value()
-                .transpose()?,
+                .transpose()?
+                .or_else(|| Some(VecOrSingle::Single("*".to_owned()))),
             overrides: None,
         })
     }


### PR DESCRIPTION
Fix incorrect behavior with env is disabled
```toml
[feature]
env = false
```
now should pass "*" to exclude

closes #1015