### PR TITLE
[Merged by Bors] - small changes and fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 - mirrord-config: Fix disabled feature for env in config file, `env = false` should work. See [#1015](https://github.com/metalbear-co/mirrord/issues/1015).
 - VS Code extension: release universal extension as a fallback for Windows and other platforms to be used with WSL/Remote development. Fixes [#1017](https://github.com/metalbear-co/mirrord/issues/1017)
+- Fix `MIRRORD_AGENT_RUST_LOG` can't be more than info due to dependency on info log.
+
+### Changed
+
+- `DNSLookup` failures changed to be info log from error since it is a common case.
+- mirrord-agent: now prints "agent ready" instead of logging it so it can't be fudged with `RUST_LOG` control.
+- mirrord-agent: `agent::layer_recv` changed instrumentation to be trace instead of info.
 
 ## 3.22.0
 

--- a/mirrord/agent/src/main.rs
+++ b/mirrord/agent/src/main.rs
@@ -386,9 +386,8 @@ async fn start_agent() -> Result<()> {
     );
 
     // WARNING: This exact string is expected to be read in `pod_api.rs`, more specifically in
-    // `wait_for_agent_startup`. If you change this, or if this is not logged (i.e. user disables
-    // `MIRRORD_AGENT_RUST_LOG`), then mirrord fails to initialize.
-    info!("agent ready");
+    // `wait_for_agent_startup`. If you change this then mirrord fails to initialize.
+    println!("agent ready");
 
     let mut clients = FuturesUnordered::new();
     loop {

--- a/mirrord/agent/src/outgoing.rs
+++ b/mirrord/agent/src/outgoing.rs
@@ -42,7 +42,7 @@ pub(crate) struct TcpOutgoingApi {
     daemon_rx: Receiver<Daemon>,
 }
 
-#[tracing::instrument(skip(allocator, writers, readers, daemon_tx))]
+#[tracing::instrument(level = "trace", skip(allocator, writers, readers, daemon_tx))]
 async fn layer_recv(
     layer_message: LayerTcpOutgoing,
     allocator: &mut IndexAllocator<ConnectionId>,

--- a/mirrord/layer/src/error.rs
+++ b/mirrord/layer/src/error.rs
@@ -190,7 +190,8 @@ impl From<HookError> for i64 {
             | HookError::ResponseError(ResponseError::NotFile(_))
             | HookError::ResponseError(ResponseError::NotDirectory(_))
             | HookError::ResponseError(ResponseError::Remote(_))
-            | HookError::ResponseError(ResponseError::RemoteIO(_)) => {
+            | HookError::ResponseError(ResponseError::RemoteIO(_))
+            | HookError::ResponseError(ResponseError::DnsLookup(_)) => {
                 info!("libc error (doesn't indicate a problem) >> {:#?}", fail)
             }
             HookError::IO(ref e) if (is_ignored_code(e.raw_os_error())) => {


### PR DESCRIPTION
- Fix `MIRRORD_AGENT_RUST_LOG` can't be more than info due to dependency on info log.
- `DNSLookup` failures changed to be info log from error since it is a common case.
- mirrord-agent: now prints "agent ready" instead of logging it so it can't be fudged with `RUST_LOG` control.
- mirrord-agent: `agent::layer_recv` changed instrumentation to be trace instead of info.
