### PR TITLE
mirrord-config: specify custom path for kubeconfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+### Added
+
+- Add a field to mirrord-config to specify custom path for kubeconfig , resolves [#1027](https://github.com/metalbear-co/mirrord/issues/1027).
+
 ## 3.23.0
 
 ### Fixed

--- a/mirrord-schema.json
+++ b/mirrord-schema.json
@@ -11,6 +11,13 @@
         "null"
       ]
     },
+    "kubeconfig": {
+      "description": "Path to a kubeconfig file, if not specified, will use KUBECONFIG or ~/.kube/config or the in-cluster config.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "agent": {
       "description": "Agent configuration, see [`agent::AgentFileConfig`].",
       "anyOf": [

--- a/mirrord-schema.json
+++ b/mirrord-schema.json
@@ -11,13 +11,6 @@
         "null"
       ]
     },
-    "kubeconfig": {
-      "description": "Path to a kubeconfig file, if not specified, will use KUBECONFIG or ~/.kube/config or the in-cluster config.",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
     "agent": {
       "description": "Agent configuration, see [`agent::AgentFileConfig`].",
       "anyOf": [
@@ -61,6 +54,13 @@
         {
           "type": "null"
         }
+      ]
+    },
+    "kubeconfig": {
+      "description": "Path to a kubeconfig file, if not specified, will use KUBECONFIG or ~/.kube/config or the in-cluster config.",
+      "type": [
+        "string",
+        "null"
       ]
     },
     "operator": {

--- a/mirrord/config/src/lib.rs
+++ b/mirrord/config/src/lib.rs
@@ -121,6 +121,10 @@ pub struct LayerConfig {
     /// Allow to lookup if operator is installed on cluster and use it
     #[config(env = "MIRRORD_OPERATOR_ENABLE", default = true)]
     pub operator: bool,
+
+    /// Custom path to the kubeconfig file
+    #[config(env = "MIRRORD_KUBECONFIG")]
+    pub kubeconfig: Option<String>,
 }
 
 impl LayerConfig {
@@ -318,6 +322,7 @@ mod tests {
 
         let expect = LayerFileConfig {
             accept_invalid_certificates: Some(false),
+            kubeconfig: None,
             connect_agent_name: None,
             connect_agent_port: None,
             target: Some(TargetFileConfig::Advanced {

--- a/mirrord/config/src/lib.rs
+++ b/mirrord/config/src/lib.rs
@@ -122,7 +122,8 @@ pub struct LayerConfig {
     #[config(env = "MIRRORD_OPERATOR_ENABLE", default = true)]
     pub operator: bool,
 
-    /// Custom path to the kubeconfig file
+    /// Path to a kubeconfig file, if not specified, will use KUBECONFIG or ~/.kube/config or the
+    /// in-cluster config.
     #[config(env = "MIRRORD_KUBECONFIG")]
     pub kubeconfig: Option<String>,
 }

--- a/mirrord/kube/src/api/kubernetes.rs
+++ b/mirrord/kube/src/api/kubernetes.rs
@@ -160,8 +160,8 @@ pub async fn create_kube_api(config: Option<LayerConfig>) -> Result<Client> {
 
         #[cfg_attr(not(feature = "env_guard"), allow(unused_mut))]
         if config.accept_invalid_certificates {
-            // Only warn the first time connecting to the agent, not on child processes.
             kube_config.accept_invalid_certs = true;
+            // Only warn the first time connecting to the agent, not on child processes.
             if config.connect_agent_name.is_none() {
                 warn!("Accepting invalid certificates");
             }

--- a/mirrord/kube/src/error.rs
+++ b/mirrord/kube/src/error.rs
@@ -13,6 +13,9 @@ pub enum KubeApiError {
     #[error("mirrord-layer: Failed to get `KubeConfig`!")]
     KubeConfigError(#[from] kube::config::InferConfigError),
 
+    #[error("mirrord-layer: Failed to get the custom path for `KubeConfig`!")]
+    KubeConfigPathError(#[from] kube::config::KubeconfigError),
+
     #[error("mirrord-layer: JSON convert error")]
     JSONConvertError(#[from] serde_json::Error),
 


### PR DESCRIPTION
closes #1027 