### PR TITLE
mirrod-layer: gethostname detour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+### Added
+
+- `gethostname` detour that returns contents of `/etc/hostname` from target pod. See relevant [#1041](https://github.com/metalbear-co/mirrord/issues/1041).
+
 ### Fixed
 
 - `getsockname` now returns the **remote** local address of the socket, instead of the

--- a/mirrord/layer/src/detour.rs
+++ b/mirrord/layer/src/detour.rs
@@ -366,11 +366,11 @@ impl<T> OnceLockExt<T> for OnceLock<T> {
         F: FnOnce() -> Detour<T>,
     {
         if let Some(value) = self.get() {
-            return Detour::Success(value);
+            Detour::Success(value)
+        } else {
+            let value = f()?;
+
+            Detour::Success(self.get_or_init(|| value))
         }
-
-        let value = f()?;
-
-        Detour::Success(self.get_or_init(|| value))
     }
 }

--- a/mirrord/layer/src/detour.rs
+++ b/mirrord/layer/src/detour.rs
@@ -298,6 +298,17 @@ impl<S> Detour<S> {
             _ => default,
         }
     }
+    /// Return the contained `Success` wrapped in `Some` and swallows `Bypass` or `Error` in
+    /// exchange for `None`
+    ///
+    /// To be used in hooks that are deemed non-essential, and the run should continue even if they
+    /// fail.
+    pub(crate) fn ok(self) -> Option<S> {
+        match self {
+            Detour::Success(s) => Some(s),
+            _ => None,
+        }
+    }
 }
 
 impl<S> Detour<S>

--- a/mirrord/layer/src/detour.rs
+++ b/mirrord/layer/src/detour.rs
@@ -354,7 +354,9 @@ impl<T> OptionExt for Option<T> {
     }
 }
 
+/// Extends [`OnceLock`] with a helper function to initialize it with a [`Detour`].
 pub(crate) trait OnceLockExt<T> {
+    /// Initializes a [`OnceLock`] with a [`Detour`] (similar to [`OnceLock::get_or_try_init`]).
     fn get_or_detour_init<F>(&self, f: F) -> Detour<&T>
     where
         F: FnOnce() -> Detour<T>;

--- a/mirrord/layer/src/file/filter.rs
+++ b/mirrord/layer/src/file/filter.rs
@@ -103,6 +103,7 @@ fn generate_remote_ro_set() -> RegexSet {
         // for dns resolving
         r"^/etc/resolv.conf$",
         r"^/etc/hosts$",
+        r"^/etc/hostname$",
     ];
     RegexSetBuilder::new(patterns)
         .case_insensitive(true)

--- a/mirrord/layer/src/socket/hooks.rs
+++ b/mirrord/layer/src/socket/hooks.rs
@@ -82,13 +82,14 @@ pub(crate) unsafe extern "C" fn gethostname_detour(
         .map(|host| {
             let host_len = host.as_bytes().len();
 
-            if host_len <= name_length {
-                raw_name.copy_from_nonoverlapping(host.as_ptr(), cmp::min(name_length, host_len));
-                0
-            } else {
+            raw_name.copy_from_nonoverlapping(host.as_ptr(), cmp::min(name_length, host_len));
+
+            if host_len > name_length {
                 set_errno(Errno(EINVAL));
 
                 -1
+            } else {
+                0
             }
         })
         .unwrap_or_bypass_with(|_| FN_GETHOSTNAME(raw_name, name_length))

--- a/mirrord/layer/src/socket/hooks.rs
+++ b/mirrord/layer/src/socket/hooks.rs
@@ -73,6 +73,10 @@ pub(crate) unsafe extern "C" fn getsockname_detour(
         .unwrap_or_bypass_with(|_| FN_GETSOCKNAME(sockfd, address, address_len))
 }
 
+/// Hook for `libc::gethostname`.
+///
+/// Reads remote hostname bytes into `raw_name`, will rais EINVAL errno and return -1 if hostname
+/// read more than `name_length`
 #[hook_guard_fn]
 pub(crate) unsafe extern "C" fn gethostname_detour(
     raw_name: *mut c_char,

--- a/mirrord/layer/src/socket/hooks.rs
+++ b/mirrord/layer/src/socket/hooks.rs
@@ -77,7 +77,7 @@ pub(crate) unsafe extern "C" fn gethostname_detour(
     raw_name: *mut c_char,
     name_length: usize,
 ) -> c_int {
-    gethostname(name_length)
+    gethostname()
         .map(|host| {
             raw_name.copy_from_nonoverlapping(
                 host.as_ptr(),

--- a/mirrord/layer/src/socket/ops.rs
+++ b/mirrord/layer/src/socket/ops.rs
@@ -635,7 +635,7 @@ pub(super) fn getaddrinfo(
     Detour::Success(result)
 }
 
-fn read_file_string(path: &str, read_length: usize) -> Detour<String> {
+fn remote_read_into_string(path: &str, read_length: usize) -> Detour<String> {
     let hostname_path = CString::new(path).unwrap();
 
     let hostname_fd = file::ops::open(
@@ -668,7 +668,7 @@ pub(super) fn gethostname(raw_name: *mut c_char, name_length: usize) -> Detour<i
     let host = match HOSTNAME.get() {
         Some(hostname) => CString::new(hostname.as_str()),
         None => {
-            let hostname = read_file_string("/etc/hostname", name_length)?
+            let hostname = remote_read_into_string("/etc/hostname", name_length)?
                 .trim()
                 .to_owned();
 

--- a/mirrord/layer/src/socket/ops.rs
+++ b/mirrord/layer/src/socket/ops.rs
@@ -647,7 +647,7 @@ fn remote_hostname_string() -> Option<CString> {
     )
     .ok()?;
 
-    let hostname_file = file::ops::fgets(hostname_fd, 256).ok()?;
+    let hostname_file = file::ops::read(hostname_fd, 256).ok()?;
 
     close_layer_fd(hostname_fd);
 

--- a/mirrord/layer/src/socket/ops.rs
+++ b/mirrord/layer/src/socket/ops.rs
@@ -636,7 +636,7 @@ pub(super) fn getaddrinfo(
 }
 
 fn remote_read_into_string(path: &str, read_length: usize) -> Detour<CString> {
-    let hostname_path = CString::new(path).unwrap();
+    let hostname_path = CString::new(path)?;
 
     let hostname_fd = file::ops::open(
         Some(&hostname_path),

--- a/mirrord/layer/src/socket/ops.rs
+++ b/mirrord/layer/src/socket/ops.rs
@@ -660,9 +660,9 @@ fn remote_read_into_string(path: &str, read_length: usize) -> Detour<CString> {
 }
 
 /// Resolve the fake local address to the real local address.
-#[tracing::instrument(level = "trace", skip(raw_name, name_length))]
-pub(super) fn gethostname(raw_name: *mut c_char, name_length: usize) -> Detour<i32> {
-    let host = match HOSTNAME.get() {
+#[tracing::instrument(level = "trace", skip(name_length))]
+pub(super) fn gethostname(name_length: usize) -> Detour<CString> {
+    let hostname = match HOSTNAME.get() {
         Some(hostname) => hostname,
         None => {
             let hostname = remote_read_into_string("/etc/hostname", name_length)?;
@@ -671,10 +671,5 @@ pub(super) fn gethostname(raw_name: *mut c_char, name_length: usize) -> Detour<i
         }
     };
 
-    unsafe {
-        raw_name
-            .copy_from_nonoverlapping(host.as_ptr(), cmp::min(name_length, host.as_bytes().len()));
-    }
-
-    Detour::Success(0)
+    Detour::Success(hostname.clone())
 }

--- a/mirrord/layer/src/socket/ops.rs
+++ b/mirrord/layer/src/socket/ops.rs
@@ -28,6 +28,7 @@ use crate::{
     ENABLED_TCP_OUTGOING, ENABLED_UDP_OUTGOING,
 };
 
+/// Hostname initialized from the agent with [`gethostname`].
 pub(crate) static HOSTNAME: OnceLock<CString> = OnceLock::new();
 
 /// Helper struct for connect results where we want to hold the original errno
@@ -635,6 +636,7 @@ pub(super) fn getaddrinfo(
     Detour::Success(result)
 }
 
+/// Retrieves the `hostname` from the agent's `/etc/hostname` to be used by [`gethostname`]
 fn remote_hostname_string() -> Detour<CString> {
     let hostname_path = CString::new("/etc/hostname")?;
 
@@ -660,7 +662,7 @@ fn remote_hostname_string() -> Detour<CString> {
     .map(Detour::Success)?
 }
 
-/// Resolve the fake local address to the real local address.
+/// Resolve hostname from remote host with caching for the result
 #[tracing::instrument(level = "trace")]
 pub(super) fn gethostname() -> Detour<&'static CString> {
     HOSTNAME.get_or_detour_init(remote_hostname_string)

--- a/mirrord/layer/tests/bash.rs
+++ b/mirrord/layer/tests/bash.rs
@@ -52,6 +52,7 @@ async fn test_bash_script(dylib_path: &Path) {
     bash_layer_connection.expect_file_read("foobar\n", fd).await;
 
     bash_layer_connection.expect_file_close(fd).await;
+    bash_layer_connection.expect_file_close(fd).await;
 
     let mut cat_layer_connection = LayerConnection::get_initialized_connection(&listener).await;
     // TODO: theoretically the connections arrival order could be different, should we handle it?

--- a/mirrord/layer/tests/bash.rs
+++ b/mirrord/layer/tests/bash.rs
@@ -49,32 +49,6 @@ async fn test_bash_script(dylib_path: &Path) {
         .expect_file_open_for_reading("/etc/hostname", fd)
         .await;
 
-    #[cfg(not(target_os = "macos"))]
-    {
-        assert_eq!(
-            bash_layer_connection.codec.next().await.unwrap().unwrap(),
-            ClientMessage::FileRequest(FileRequest::Xstat(XstatRequest {
-                path: None,
-                fd: Some(fd),
-                follow_symlink: true
-            }))
-        );
-
-        let metadata = MetadataInternal {
-            size: 100,
-            blocks: 2,
-            ..Default::default()
-        };
-
-        bash_layer_connection
-            .codec
-            .send(DaemonMessage::File(FileResponse::Xstat(Ok(
-                XstatResponse { metadata },
-            ))))
-            .await
-            .unwrap();
-    }
-
     bash_layer_connection.expect_file_read("foobar\n", fd).await;
 
     bash_layer_connection.expect_file_close(fd).await;

--- a/mirrord/layer/tests/bash.rs
+++ b/mirrord/layer/tests/bash.rs
@@ -45,15 +45,7 @@ async fn test_bash_script(dylib_path: &Path) {
 
     let fd: u64 = 1;
 
-    bash_layer_connection
-        .expect_file_open_for_reading("/etc/hostname", fd)
-        .await;
-
-    bash_layer_connection
-        .expect_single_file_read("foobar\n", fd)
-        .await;
-
-    bash_layer_connection.expect_file_close(fd).await;
+    bash_layer_connection.expect_gethostname(fd).await;
 
     let mut cat_layer_connection = LayerConnection::get_initialized_connection(&listener).await;
     // TODO: theoretically the connections arrival order could be different, should we handle it?

--- a/mirrord/layer/tests/bash.rs
+++ b/mirrord/layer/tests/bash.rs
@@ -49,9 +49,6 @@ async fn test_bash_script(dylib_path: &Path) {
         .expect_file_open_for_reading("/etc/hostname", fd)
         .await;
 
-    bash_layer_connection.expect_file_read("foobar\n", fd).await;
-
-    bash_layer_connection.expect_file_close(fd).await;
     bash_layer_connection.expect_file_close(fd).await;
 
     let mut cat_layer_connection = LayerConnection::get_initialized_connection(&listener).await;

--- a/mirrord/layer/tests/bash.rs
+++ b/mirrord/layer/tests/bash.rs
@@ -49,6 +49,10 @@ async fn test_bash_script(dylib_path: &Path) {
         .expect_file_open_for_reading("/etc/hostname", fd)
         .await;
 
+    bash_layer_connection
+        .expect_single_file_read("foobar\n", fd)
+        .await;
+
     bash_layer_connection.expect_file_close(fd).await;
 
     let mut cat_layer_connection = LayerConnection::get_initialized_connection(&listener).await;

--- a/mirrord/layer/tests/bash.rs
+++ b/mirrord/layer/tests/bash.rs
@@ -1,5 +1,5 @@
 #![feature(assert_matches)]
-use std::{path::PathBuf, time::Duration};
+use std::{path::Path, time::Duration};
 
 #[cfg(not(target_os = "macos"))]
 use futures::SinkExt;
@@ -25,7 +25,7 @@ use tokio_stream::StreamExt;
 #[rstest]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[timeout(Duration::from_secs(60))]
-async fn test_bash_script(dylib_path: &PathBuf) {
+async fn test_bash_script(dylib_path: &Path) {
     let application = Application::EnvBashCat;
     let executable = application.get_executable().await; // Own it.
     println!("Using executable: {}", &executable);
@@ -76,6 +76,12 @@ async fn test_bash_script(dylib_path: &PathBuf) {
             .await
             .unwrap();
     }
+
+    cat_layer_connection
+        .expect_file_open_for_reading("/etc/hostname", 2)
+        .await;
+
+    cat_layer_connection.expect_file_read("foobar\n", 2).await;
 
     cat_layer_connection
         .expect_file_read("Very interesting contents.", fd)

--- a/mirrord/layer/tests/common/mod.rs
+++ b/mirrord/layer/tests/common/mod.rs
@@ -382,7 +382,7 @@ impl LayerConnection {
             assert_eq!(expected_fd, requested_fd);
             return buffer_size;
         }
-        panic!("Expected Read FileRequest.");
+        panic!("Expected Read FileRequest. Got {message:?}");
     }
 
     /// Verify the layer hooks a read of `expected_fd`, return buffer size.

--- a/mirrord/layer/tests/common/mod.rs
+++ b/mirrord/layer/tests/common/mod.rs
@@ -554,6 +554,15 @@ impl LayerConnection {
         }
         message
     }
+
+    /// Expect all the requested requests for gethostname hook
+    pub async fn expect_gethostname(&mut self, fd: u64) {
+        self.expect_file_open_for_reading("/etc/hostname", fd).await;
+
+        self.expect_single_file_read("foobar\n", fd).await;
+
+        self.expect_file_close(fd).await;
+    }
 }
 
 #[derive(Debug)]

--- a/mirrord/layer/tests/sip.rs
+++ b/mirrord/layer/tests/sip.rs
@@ -1,6 +1,6 @@
 #![feature(assert_matches)]
 #![cfg(target_os = "macos")]
-use std::{path::PathBuf, time::Duration};
+use std::{path::Path, time::Duration};
 
 use rstest::rstest;
 use tokio::net::TcpListener;
@@ -17,7 +17,7 @@ use mirrord_sip::sip_patch;
 #[rstest]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[timeout(Duration::from_secs(20))]
-async fn test_tmp_dir_read_locally(dylib_path: &PathBuf) {
+async fn test_tmp_dir_read_locally(dylib_path: &Path) {
     let application = Application::BashShebang;
     let executable = application.get_executable().await;
     let executable = sip_patch(&executable).unwrap().unwrap();
@@ -32,6 +32,8 @@ async fn test_tmp_dir_read_locally(dylib_path: &PathBuf) {
     // Accept the connection from the layer and verify initial messages.
     let mut layer_connection = LayerConnection::get_initialized_connection(&listener).await;
     println!("Application subscribed to port, sending tcp messages.");
+
+    layer_connection.expect_gethostname(1).await;
 
     assert!(layer_connection.is_ended().await);
     test_process.wait().await;

--- a/tests/python-e2e/hostname.py
+++ b/tests/python-e2e/hostname.py
@@ -4,7 +4,7 @@ import unittest
 class Hostname(unittest.TestCase):
 
 	def test_is_equal(self):
-		self.assertEq(socket.gethostname(), 'hostname-echo')
+		self.assertIn('hostname-echo', socket.gethostname())
 
 if __name__ == "__main__":
 	unittest.main()

--- a/tests/python-e2e/hostname.py
+++ b/tests/python-e2e/hostname.py
@@ -1,0 +1,10 @@
+import socket
+import unittest
+
+class Hostname(unittest.TestCase):
+
+	def test_is_equal(self):
+		self.assertEq(socket.gethostname(), 'hostname-echo')
+
+if __name__ == "__main__":
+	unittest.main()

--- a/tests/python-e2e/hostname.py
+++ b/tests/python-e2e/hostname.py
@@ -10,5 +10,4 @@ class Hostname(unittest.TestCase):
 		self.assertEqual(hostname.rstrip(), hostname)
 
 if __name__ == "__main__":
-	print("{} socket".format(socket.gethostname()))
 	unittest.main()

--- a/tests/python-e2e/hostname.py
+++ b/tests/python-e2e/hostname.py
@@ -2,9 +2,13 @@ import socket
 import unittest
 
 class Hostname(unittest.TestCase):
-
-	def test_is_equal(self):
+	def test_contains_hostname_echo(self):
 		self.assertIn('hostname-echo', socket.gethostname())
 
+	def test_trimmed(self):
+		hostname = socket.gethostname()
+		self.assertEqual(hostname.rstrip(), hostname)
+
 if __name__ == "__main__":
+	print("{} socket".format(socket.gethostname()))
 	unittest.main()

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -702,7 +702,7 @@ mod utils {
             "NodePort",
             "ghcr.io/metalbear-co/mirrord-pytest:latest",
             "hostname-echo",
-            false,
+            true,
             true,
         )
         .await

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -692,6 +692,22 @@ mod utils {
         .await
     }
 
+    /// Service that listens on port 80 and returns "remote: <DATA>" when getting "<DATA>" directly
+    /// over TCP, not HTTP.
+    #[fixture]
+    pub async fn hostname_service(#[future] kube_client: Client) -> KubeService {
+        service(
+            kube_client,
+            "default",
+            "NodePort",
+            "ghcr.io/metalbear-co/mirrord-pytest:latest",
+            "hostname-echo",
+            false,
+            true,
+        )
+        .await
+    }
+
     pub fn resolve_node_host() -> String {
         if (cfg!(target_os = "linux") && !wsl::is_wsl()) || std::env::var("USE_MINIKUBE").is_ok() {
             let output = std::process::Command::new("minikube")


### PR DESCRIPTION
gethostname detour that uses the `/host/hostname` file on the remote to get the hostname

relevant for #1041 