### PR TITLE
Add SIP sidestepping to the vs-code extension, with support from the cli extension command.

### DIFF
--- a/changelog.d/1061.added.md
+++ b/changelog.d/1061.added.md
@@ -1,0 +1,1 @@
+Support for running SIP binaries via the vscode extension, for common configuration types.

--- a/mirrord/cli/src/config.rs
+++ b/mirrord/cli/src/config.rs
@@ -264,6 +264,9 @@ pub(super) struct ExtensionExecArgs {
     /// Specify target
     #[arg(short = 't')]
     pub target: Option<String>,
+    /// User executable - the executable the layer is going to be injected to.
+    #[arg(short = 'e')]
+    pub executable: Option<String>,
 }
 
 #[derive(Args, Debug)]

--- a/mirrord/cli/src/execution.rs
+++ b/mirrord/cli/src/execution.rs
@@ -37,7 +37,7 @@ pub(crate) struct MirrordExecution {
     #[serde(skip)]
     child: Child,
 
-    /// The path to the patched binary, if patched.
+    /// The path to the patched binary, if patched for SIP sidestepping.
     pub patched_path: Option<String>,
 }
 

--- a/mirrord/cli/src/extension.rs
+++ b/mirrord/cli/src/extension.rs
@@ -32,7 +32,12 @@ pub(crate) async fn extension_exec(args: ExtensionExecArgs) -> Result<()> {
 
     // extension needs more timeout since it might need to build
     // or run tasks before actually launching.
+    #[cfg(target_os = "macos")]
+    let mut execution_info =
+        MirrordExecution::start(&config, args.executable.as_deref(), &progress, Some(60)).await?;
+    #[cfg(not(target_os = "macos"))]
     let mut execution_info = MirrordExecution::start(&config, &progress, Some(60)).await?;
+
     // We don't execute so set envs aren't passed, so we need to add config file and target to env.
     execution_info.environment.extend(env);
 

--- a/mirrord/cli/src/main.rs
+++ b/mirrord/cli/src/main.rs
@@ -17,8 +17,6 @@ use mirrord_kube::{
     error::KubeApiError,
 };
 use mirrord_progress::{Progress, TaskProgress};
-#[cfg(target_os = "macos")]
-use mirrord_sip::sip_patch;
 use operator::operator_command;
 use semver::Version;
 use serde_json::json;
@@ -160,22 +158,6 @@ async fn exec(args: &ExecArgs, progress: &TaskProgress) -> Result<()> {
 
     let config = LayerConfig::from_env()?;
 
-    #[cfg(target_os = "macos")]
-    let (_did_sip_patch, binary) = match sip_patch(
-        &args.binary,
-        &config
-            .sip_binaries
-            .clone()
-            .map(|x| x.to_vec())
-            .unwrap_or_default(),
-    )? {
-        None => (false, args.binary.clone()),
-        Some(sip_result) => (true, sip_result),
-    };
-
-    #[cfg(not(target_os = "macos"))]
-    let binary = args.binary.clone();
-
     if config.agent.pause {
         if config.agent.ephemeral {
             error!("Pausing is not yet supported together with an ephemeral agent container.");
@@ -186,7 +168,17 @@ async fn exec(args: &ExecArgs, progress: &TaskProgress) -> Result<()> {
         }
     }
 
-    let execution_info = MirrordExecution::start(&config, progress, None).await?;
+    let execution_info =
+        MirrordExecution::start(&config, Some(&args.binary), progress, None).await?;
+
+    #[cfg(target_os = "macos")]
+    let (_did_sip_patch, binary) = match execution_info.patched_path {
+        None => (false, args.binary.clone()),
+        Some(sip_result) => (true, sip_result),
+    };
+
+    #[cfg(not(target_os = "macos"))]
+    let binary = args.binary.clone();
 
     // Stop confusion with layer
     std::env::set_var(mirrord_progress::MIRRORD_PROGRESS_ENV, "off");
@@ -197,6 +189,7 @@ async fn exec(args: &ExecArgs, progress: &TaskProgress) -> Result<()> {
     }
 
     let mut binary_args = args.binary_args.clone();
+    // Put original executable in argv[0] even if actually running patched version.
     binary_args.insert(0, args.binary.clone());
 
     sub_progress.done_with("ready to launch process");

--- a/mirrord/cli/src/main.rs
+++ b/mirrord/cli/src/main.rs
@@ -168,8 +168,11 @@ async fn exec(args: &ExecArgs, progress: &TaskProgress) -> Result<()> {
         }
     }
 
+    #[cfg(target_os = "macos")]
     let execution_info =
         MirrordExecution::start(&config, Some(&args.binary), progress, None).await?;
+    #[cfg(not(target_os = "macos"))]
+    let execution_info = MirrordExecution::start(&config, progress, None).await?;
 
     #[cfg(target_os = "macos")]
     let (_did_sip_patch, binary) = match execution_info.patched_path {

--- a/mirrord/layer/src/load.rs
+++ b/mirrord/layer/src/load.rs
@@ -1,4 +1,5 @@
 use mirrord_config::{util::VecOrSingle, LayerConfig};
+use tracing::trace;
 
 /// For processes that spawn other processes and also specified in `MIRRORD_SKIP_PROCESSES` list we
 /// should patch sip for the spawned instances, curretly limiting to list from
@@ -31,13 +32,16 @@ pub fn load_type(given_process: &str, config: LayerConfig) -> LoadType {
     let skip_processes = config.skip_processes.clone().map(VecOrSingle::to_vec);
 
     if should_load(given_process, skip_processes) {
+        trace!("Loading into process: {given_process}.");
         LoadType::Full(Box::new(config))
     } else {
         #[cfg(target_os = "macos")]
         if sip::is_sip_only(given_process) {
+            trace!("Loading into process: {given_process}, but only hooking exec/spawn.");
             return LoadType::SIPOnly;
         }
 
+        trace!("Not loading into process: {given_process}.");
         LoadType::Skip
     }
 }


### PR DESCRIPTION
Part of #747, solves #1061.

Since we do this by changing the executable field in the launch configuration and that field is different in each configuration type we need to add specify the configuration type -> configuration field name for each configuration type we want to support, currently supporting node and python.