### PR TITLE
More consistent behavior between Mesh and Non Mesh stealing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+### Changed
+
+- mirrord-agent: localhost traffic (like healthprobes) won't be stolen by mirrord on meshed targets to allign behavior with non meshed targets. See [#1070](https://github.com/metalbear-co/mirrord/pull/1070)
+
 ### Fixed
 
 - Fix cache does not work on test-agent workflow. See [#251](https://github.com/metalbear-co/mirrord/issues/251).

--- a/mirrord/agent/src/main.rs
+++ b/mirrord/agent/src/main.rs
@@ -555,14 +555,14 @@ async fn start_iptable_guard() -> Result<()> {
 
     let result = spawn_child_agent();
 
-    run_thread_in_namespace(
+    let _ = run_thread_in_namespace(
         clear_iptable_chain(chain_name),
         "clear iptables".to_owned(),
         pid,
         "net",
     )
     .join()
-    .map_err(|_| AgentError::JoinTask)??;
+    .map_err(|_| AgentError::JoinTask)?;
 
     result
 }

--- a/mirrord/agent/src/steal/ip_tables.rs
+++ b/mirrord/agent/src/steal/ip_tables.rs
@@ -360,6 +360,14 @@ mod tests {
             .with(eq("OUTPUT"))
             .returning(|_| Ok(vec!["-j PROXY_INIT_OUTPUT".to_owned()]));
 
+        mock.expect_list_rules()
+            .with(eq("PROXY_INIT_OUTPUT"))
+            .returning(|_| Ok(vec![
+                "-N PROXY_INIT_OUTPUT".to_owned(),
+                "-A PROXY_INIT_OUTPUT -m owner --uid-owner 2102 -m comment --comment \"proxy-init/ignore-proxy-user-id/1676542558\" -j RETURN".to_owned(),
+                "-A PROXY_INIT_OUTPUT -o lo -m comment --comment \"proxy-init/ignore-loopback/1676542558\" -j RETURN".to_owned(),
+            ]));
+
         mock.expect_create_chain()
             .with(str::starts_with("MIRRORD_REDIRECT_"))
             .times(1)
@@ -378,7 +386,7 @@ mod tests {
         mock.expect_insert_rule()
             .with(
                 str::starts_with("MIRRORD_REDIRECT_"),
-                eq("-o lo -m tcp -p tcp --dport 69 -j REDIRECT --to-ports 420"),
+                eq("-m owner --uid-owner 2102 -m tcp -p tcp --dport 69 -j REDIRECT --to-ports 420"),
                 eq(1),
             )
             .times(1)
@@ -392,7 +400,7 @@ mod tests {
         mock.expect_remove_rule()
             .with(
                 str::starts_with("MIRRORD_REDIRECT_"),
-                eq("-o lo -m tcp -p tcp --dport 69 -j REDIRECT --to-ports 420"),
+                eq("-m owner --uid-owner 2102 -m tcp -p tcp --dport 69 -j REDIRECT --to-ports 420"),
             )
             .times(1)
             .returning(|_, _| Ok(()));

--- a/mirrord/agent/src/steal/ip_tables.rs
+++ b/mirrord/agent/src/steal/ip_tables.rs
@@ -257,7 +257,7 @@ impl IPTableFormatter {
         match self {
             IPTableFormatter::Normal => redirect_rule,
             IPTableFormatter::Mesh => {
-                format!("-o lo {redirect_rule}")
+                format!("-m owner --uid-owner 2102 {redirect_rule}")
             }
         }
     }

--- a/mirrord/agent/src/steal/ip_tables.rs
+++ b/mirrord/agent/src/steal/ip_tables.rs
@@ -250,9 +250,9 @@ impl IPTableFormatter {
                         .then_some(IPTableFormatter::MESH_NAMES[index])
                 })
         }) {
-            /// We extract --uid-owner value from the mesh's rules to get messages only from them
-            /// and not other processes sendning messages from localhost like healthprobe for grpc.
-            /// This to more closely match behavior with non meshed services
+            // We extract --uid-owner value from the mesh's rules to get messages only from them
+            // and not other processes sendning messages from localhost like healthprobe for grpc.
+            // This to more closely match behavior with non meshed services
             let filter = ipt
                 .list_rules(mesh_ipt_chain)?
                 .iter()

--- a/mirrord/agent/src/steal/ip_tables.rs
+++ b/mirrord/agent/src/steal/ip_tables.rs
@@ -221,6 +221,7 @@ where
     }
 }
 
+#[derive(Debug)]
 pub(crate) enum IPTableFormatter {
     Normal,
     Mesh(String),
@@ -229,7 +230,7 @@ pub(crate) enum IPTableFormatter {
 impl IPTableFormatter {
     const MESH_OUTPUTS: [&'static str; 2] = ["-j PROXY_INIT_OUTPUT", "-j ISTIO_OUTPUT"];
     const MESH_FILTERS: [(&'static str, &'static str); 2] = [
-        ("PROXY_INIT_OUTPUT", r"-m owner --uid-owner /d+"),
+        ("PROXY_INIT_OUTPUT", r"-m owner --uid-owner \d+"),
         ("ISTIO_OUTPUT", r"-o lo"),
     ];
 
@@ -268,6 +269,7 @@ impl IPTableFormatter {
         }
     }
 
+    #[tracing::instrument(level = "trace", ret)]
     fn redirect_rule(&self, redirected_port: Port, target_port: Port) -> String {
         let redirect_rule =
             format!("-m tcp -p tcp --dport {redirected_port} -j REDIRECT --to-ports {target_port}");

--- a/mirrord/agent/src/steal/ip_tables.rs
+++ b/mirrord/agent/src/steal/ip_tables.rs
@@ -249,8 +249,6 @@ impl IPTableFormatter {
                         .then_some(IPTableFormatter::MESH_NAMES[index])
                 })
         }) {
-            let filter_reg = Regex::new(filter_reg).unwrap();
-
             let filter = ipt
                 .list_rules(mesh_ipt_chain)?
                 .iter()

--- a/mirrord/agent/src/steal/ip_tables.rs
+++ b/mirrord/agent/src/steal/ip_tables.rs
@@ -11,6 +11,7 @@ use crate::error::{AgentError, Result};
 
 pub(crate) static MIRRORD_IPTABLE_CHAIN_ENV: &str = "MIRRORD_IPTABLE_CHAIN_NAME";
 
+/// [`Regex`] used to select the `owner` rule from the list of `iptables` rules.
 static UID_LOOKUP_REGEX: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"-m owner --uid-owner \d+").unwrap());
 
@@ -249,6 +250,9 @@ impl IPTableFormatter {
                         .then_some(IPTableFormatter::MESH_NAMES[index])
                 })
         }) {
+            /// We extract --uid-owner value from the mesh's rules to get messages only from them
+            /// and not other processes sendning messages from localhost like healthprobe for grpc.
+            /// This to more closely match behavior with non meshed services
             let filter = ipt
                 .list_rules(mesh_ipt_chain)?
                 .iter()


### PR DESCRIPTION
This changes when tcp stealing on a meshed service, requests from localhost to localhost like healthprobes will skip mirrord 
and will be routed to the underlying service like when stealing from a non meshed service

Relevant for #1044