### PR TITLE
Unpause on Agent Error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+### Fixed
+
+- Unpause the target container before exiting if the agent exits early on an error and the container is paused -
+   [#1111](https://github.com/metalbear-co/mirrord/issues/1111).
+
 ## 3.28.4
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+### Added
+
+- mirrord debug feature (for mirrord developers to debug mirrord): Cause the agent to exit early with an error.
+
 ### Fixed
 
 - Unpause the target container before exiting if the agent exits early on an error and the container is paused -

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ### Added
 
 - mirrord debug feature (for mirrord developers to debug mirrord): Cause the agent to exit early with an error.
+- mirrord E2E tests: support for custom namespaces.
 
 ### Fixed
 

--- a/mirrord/agent/src/cli.rs
+++ b/mirrord/agent/src/cli.rs
@@ -38,6 +38,10 @@ pub struct Args {
 
     /// Return an error after accepting the first client connection, in order to test agent error
     /// cleanup.
+    ///
+    /// ## Internal
+    ///
+    /// This feature is used internally for debugging purposes only!
     #[arg(long, default_value_t = false, hide = true)]
     pub test_error: bool,
 }

--- a/mirrord/agent/src/cli.rs
+++ b/mirrord/agent/src/cli.rs
@@ -35,6 +35,11 @@ pub struct Args {
     /// Pause the target container while clients are connected.
     #[arg(short = 'p', long, default_value_t = false)]
     pub pause: bool,
+
+    /// Return an error after accepting the first client connection, in order to test agent error
+    /// cleanup.
+    #[arg(long, default_value_t = false, hide = true)]
+    pub test_error: bool,
 }
 
 const DEFAULT_RUNTIME: &str = "containerd";

--- a/mirrord/agent/src/error.rs
+++ b/mirrord/agent/src/error.rs
@@ -128,6 +128,9 @@ pub enum AgentError {
         Check agent logs for errors and please report a bug if kernel version >=4.20"#
     )]
     SnifferApiError,
+
+    #[error("Returning an error to test the agent's error cleanup. Should only ever be used when testing mirrord.")]
+    TestError,
 }
 
 pub(crate) type Result<T, E = AgentError> = std::result::Result<T, E>;

--- a/mirrord/agent/src/main.rs
+++ b/mirrord/agent/src/main.rs
@@ -522,6 +522,10 @@ async fn start_agent() -> Result<()> {
         }
     }
 
+    if args.test_error {
+        return Err(AgentError::TestError);
+    }
+
     loop {
         select! {
             Ok((stream, addr)) = listener.accept() => {

--- a/mirrord/config/src/agent.rs
+++ b/mirrord/config/src/agent.rs
@@ -84,6 +84,12 @@ pub struct AgentConfig {
         unstable
     )]
     pub flush_connections: bool,
+
+    /// Create an agent that returns an error after accepting the first client. For testing
+    /// purposes. Only supported with job agents (not with ephemeral agents).
+    #[cfg(all(debug_assertions, not(test)))] // not(test) so that it's not included in the schema json.
+    #[config(env = "MIRRORD_AGENT_TEST_ERROR", default = false, unstable)]
+    pub test_error: bool,
 }
 
 #[cfg(test)]

--- a/mirrord/kube/src/api/container.rs
+++ b/mirrord/kube/src/api/container.rs
@@ -158,6 +158,11 @@ impl ContainerApi for JobContainer {
             agent_command_line.push("--pause".to_owned());
         }
 
+        #[cfg(debug_assertions)]
+        if agent.test_error {
+            agent_command_line.push("--test-error".to_owned());
+        }
+
         let flush_connections = agent.flush_connections.to_string();
 
         let agent_pod: Job = serde_json::from_value(

--- a/tests/src/pause.rs
+++ b/tests/src/pause.rs
@@ -123,7 +123,9 @@ mod pause {
 
     /// Verify that when running mirrord with the pause feature, and the agent exits early due to an
     /// error, that it unpauses the container before exiting.
+    ///
     /// Test Plan:
+    ///
     /// 1. Run mirrord with pause and agent error.
     /// 2. Wait for the local child process to exit.
     /// 3. Wait for the all agent jobs to complete.

--- a/tests/src/pause.rs
+++ b/tests/src/pause.rs
@@ -128,7 +128,7 @@ mod pause {
     ///
     /// 1. Run mirrord with pause and agent error.
     /// 2. Wait for the local child process to exit.
-    /// 3. Wait for the all agent jobs to complete.
+    /// 3. Wait for the agent jobs to complete.
     /// 4. Verify the target pod is unpaused.
     #[rstest]
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]


### PR DESCRIPTION
#1111.

When agent is exiting, unpause the target container if paused.

This PR also adds a test. The test runs mirrord such that the agent accepts 1 connection, pauses the target container, and then exits with an error. The test then waits for the agent job to complete and then verifies that the container is unpaused (answers an http request).

To support this test this PR adds 
1. Support for custom namespaces in E2E tests.
2. A test-error feature that enables (in debug builds) to make the agent exit early with an error.

The fix, the test, and the two test utilities are each contained in their own commit, so if you want to break down the review into smaller parts, I recommend reviewing one commit at a time. 
