### PR TITLE
No error logs on failed SIP.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+### Fixed
+
+- Unnecessary error logs when running a script that uses `env` in its shebang.
+
 ## 3.30.0
 
 ### Added

--- a/mirrord/sip/src/lib.rs
+++ b/mirrord/sip/src/lib.rs
@@ -17,7 +17,7 @@ mod main {
         read::macho::{FatArch, MachHeader},
         Architecture, Endianness, FileKind,
     };
-    use tracing::{error, trace};
+    use tracing::trace;
     use which::which;
 
     use super::*;
@@ -330,16 +330,13 @@ mod main {
                 Ok(None)
             }
             Err(err) => {
-                error!(
+                trace!(
                     "Checking the SIP status of {binary_path} (or of the binary in its shebang, if \
-                    applicable) failed with error {err:?}. Continuing without SIP-sidestepping."
+                    applicable) failed with {err:?}. Continuing without SIP-sidestepping.\
+                    This is not necessarily an error."
                 );
-                // We don't exit here so that execution fails in the same way it normally does when
-                // some file that should exist does not exist (or whatever the problem is), so that
-                // the user gets that feedback and can change whatever is wrong.
-                // Exiting on SIP-check confused users.
-                // (Or if the check failed because of a bug in mirrord, the user can still keep
-                // using it in case the file is not SIP.)
+                // E.g. `env` tries to execute a bunch of non-existing files and fails, and that's
+                // just its valid flow.
                 Ok(None)
             }
         }


### PR DESCRIPTION
This was an error log so that if SIP detection fails the user is informed, so that they don't think everything is going fine but actually mirrord might not be loaded into their new process.

However this produced false-positives, because e.g. `env` works by trying to execute the given name from all paths in `PATH` one by one and just failing until one of them works. So SIP detection failed on the non existing paths, and did not exit mirrord, but did emit an error log.

This PR just makes those logs `trace`. Alternatively we could match the error type and emit an error log only if it's not `FileNotFound`.  