### PR TITLE
Refactor how we convert raw str ptr -> CStr -> T into a trait.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,7 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "tokio",
- "tokio-util 0.7.4",
+ "tokio-util 0.7.7",
 ]
 
 [[package]]
@@ -94,7 +94,7 @@ dependencies = [
  "num-traits",
  "rusticata-macros",
  "thiserror",
- "time 0.3.17",
+ "time 0.3.20",
 ]
 
 [[package]]
@@ -122,19 +122,20 @@ dependencies = [
 
 [[package]]
 name = "async-stream"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad5c83079eae9969be7fadefe640a1c566901f05ff91ab221de4b6f68d9507e"
+checksum = "ad445822218ce64be7a341abfb0b1ea43b5c23aa83902542a4542e78309d8e5e"
 dependencies = [
  "async-stream-impl",
  "futures-core",
+ "pin-project-lite",
 ]
 
 [[package]]
 name = "async-stream-impl"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f203db73a71dfa2fb6dd22763990fa26f3d2625a6da2da900d23b87d26be27"
+checksum = "e4655ae1a7b0cdf149156f780c5bf3f1352bc53cbd9e0a361a7ef7b22947e965"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -143,9 +144,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.64"
+version = "0.1.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd7fce9ba8c3c042128ce72d8b2ddbf3a05747efb67ea0313c635e10bda47a2"
+checksum = "b84f9ebcc6c1f5b8cb160f6990096a5c127f423fcb6e1ccc46c370cbdfb75dfc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -171,20 +172,20 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axum"
-version = "0.6.4"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5694b64066a2459918d8074c2ce0d5a88f409431994c2356617c8ae0c4721fc"
+checksum = "2fb79c228270dcf2426e74864cabc94babb5dbab01a4314e702d2f16540e1591"
 dependencies = [
  "async-trait",
  "axum-core",
- "base64 0.20.0",
+ "base64 0.21.0",
  "bitflags",
  "bytes",
  "futures-util",
  "http",
  "http-body 0.4.5",
  "hyper 0.14.24",
- "itoa 1.0.5",
+ "itoa",
  "matchit",
  "memchr",
  "mime",
@@ -207,9 +208,9 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cae3e661676ffbacb30f1a824089a8c9150e71017f7e1e38f2aa32009188d34"
+checksum = "b2f958c80c248b34b9a877a643811be8dbca03ca5ba827f2b63baf3a81e5fc4e"
 dependencies = [
  "async-trait",
  "bytes",
@@ -253,12 +254,6 @@ name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea22880d78093b0cbe17c89f64a7d457941e65759157ec6cb31a31d652b05e5"
 
 [[package]]
 name = "base64"
@@ -366,7 +361,7 @@ dependencies = [
  "serde_urlencoded",
  "thiserror",
  "tokio",
- "tokio-util 0.7.4",
+ "tokio-util 0.7.7",
  "url",
  "winapi",
 ]
@@ -391,18 +386,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bstr"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
-dependencies = [
- "lazy_static",
- "memchr",
- "regex-automata",
- "serde",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -421,9 +404,9 @@ dependencies = [
 
 [[package]]
 name = "bytemuck"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c041d3eab048880cb0b86b256447da3f18859a163c3b8d8893f4e6368abe6393"
+checksum = "17febce684fd15d89027105661fec94afb475cb995fbc59d2865198446ba2eea"
 
 [[package]]
 name = "byteorder"
@@ -514,9 +497,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "1.4.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa2e27ae6ab525c3d369ded447057bca5438d86dc3a68f6faafb8269ba82ebf3"
+checksum = "77ed9a53e5d4d9c573ae844bfac6872b159cb1d1585a83b29e7a64b7eef7332a"
 dependencies = [
  "glob",
  "libc",
@@ -525,9 +508,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.1.4"
+version = "4.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f13b9c79b5d1dd500d20ef541215a6423c75829ef43117e1b4d17fd8af0b5d76"
+checksum = "c3d7ae14b20b94cb02149ed21a86c423859cbe18dc7ed69845cace50e52b40a5"
 dependencies = [
  "bitflags",
  "clap_derive",
@@ -540,9 +523,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.1.0"
+version = "4.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "684a277d672e91966334af371f1a7b5833f9aa00b07c84e92fbce95e00208ce8"
+checksum = "44bec8e5c9d09e439c4335b1af0abaab56dcf3b94999a936e1bb47b9134288f0"
 dependencies = [
  "heck 0.4.1",
  "proc-macro-error",
@@ -553,9 +536,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "783fe232adfca04f90f56201b26d79682d4cd2625e0bc7290b95123afe558ade"
+checksum = "350b9cf31731f9957399229e9b2adc51eeabdfbe9d71d9a0552275fd12710d09"
 dependencies = [
  "os_str_bytes",
 ]
@@ -651,9 +634,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
+checksum = "cf2b3e8478797446514c91ef04bafcb59faba183e621ad488df88983cc14128c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -661,9 +644,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.14"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
+checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
 dependencies = [
  "cfg-if",
 ]
@@ -686,13 +669,12 @@ dependencies = [
 
 [[package]]
 name = "csv"
-version = "1.1.6"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
+checksum = "af91f40b7355f82b0a891f50e70399475945bb0b0da4f1700ce60761c9d3e359"
 dependencies = [
- "bstr",
  "csv-core",
- "itoa 0.4.8",
+ "itoa",
  "ryu",
  "serde",
 ]
@@ -718,9 +700,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.89"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc831ee6a32dd495436e317595e639a587aa9907bef96fe6e6abc290ab6204e9"
+checksum = "9a140f260e6f3f79013b8bfc65e7ce630c9ab4388c6a89c71e07226f49487b72"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -730,9 +712,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.89"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94331d54f1b1a8895cd81049f7eaaaef9d05a7dcb4d1fd08bf3ff0806246789d"
+checksum = "da6383f459341ea689374bf0a42979739dc421874f112ff26f829b8040b8e613"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -745,15 +727,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.89"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48dcd35ba14ca9b40d6e4b4b39961f23d835dbb8eed74565ded361d93e1feb8a"
+checksum = "90201c1a650e95ccff1c8c0bb5a343213bdd317c6e600a93075bca2eff54ec97"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.89"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bbeb29798b407ccd82a3324ade1a7286e0d29851475990b612670f6f5124d2"
+checksum = "0b75aed41bb2e6367cae39e6326ef817a851db13c13e4f3263714ca3cfb8de56"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -961,9 +943,9 @@ checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9b0705efd4599c15a38151f4721f7bc388306f61084d3bfd50bd07fbca5cb60"
+checksum = "68b0cf012f1230e43cd00ebb729c6bb58707ecfa8ad08b52ef3a4ccd2697fc30"
 
 [[package]]
 name = "either"
@@ -1064,9 +1046,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
 dependencies = [
  "instant",
 ]
@@ -1306,9 +1288,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.27.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "221996f774192f0f718773def8201c4ae31f02616a54ccfc2d358bb0e5cefdec"
+checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
 
 [[package]]
 name = "glob"
@@ -1318,9 +1300,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "h2"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f9f29bc9dda355256b2916cf526ab02ce0aeaaaf2bad60d65ef3f12f11dd0f4"
+checksum = "5be7b54589b581f624f566bf5d8eb2bab1db736c51528720b6bd36b96b55924d"
 dependencies = [
  "bytes",
  "fnv",
@@ -1331,7 +1313,7 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio",
- "tokio-util 0.7.4",
+ "tokio-util 0.7.7",
  "tracing",
 ]
 
@@ -1402,13 +1384,13 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
+checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
 dependencies = [
  "bytes",
  "fnv",
- "itoa 1.0.5",
+ "itoa",
 ]
 
 [[package]]
@@ -1494,7 +1476,7 @@ dependencies = [
  "http-body 0.4.5",
  "httparse",
  "httpdate",
- "itoa 1.0.5",
+ "itoa",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1505,9 +1487,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "289cfdbf735dea222b0ec6a10224b4d9552c7662bb451d4589cbfda3d407d1a3"
+checksum = "7b75264b2003a3913f118d35c586e535293b3e22e41f074930762929d071e092"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1518,7 +1500,7 @@ dependencies = [
  "http-body 1.0.0-rc.2",
  "httparse",
  "httpdate",
- "itoa 1.0.5",
+ "itoa",
  "pin-project-lite",
  "tokio",
  "tracing",
@@ -1694,9 +1676,9 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e18b0a45d56fe973d6db23972bf5bc46f988a4a2385deac9cc29572f09daef"
+checksum = "21b6b32576413a8e69b90e952e4a026476040d81017b80445deda5f2d3921857"
 dependencies = [
  "hermit-abi 0.3.1",
  "io-lifetimes",
@@ -1721,15 +1703,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.8"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
-
-[[package]]
-name = "itoa"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
+checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "jni"
@@ -1845,7 +1821,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-tungstenite",
- "tokio-util 0.7.4",
+ "tokio-util 0.7.7",
  "tower",
  "tower-http",
  "tracing",
@@ -1902,7 +1878,7 @@ dependencies = [
  "smallvec",
  "thiserror",
  "tokio",
- "tokio-util 0.7.4",
+ "tokio-util 0.7.7",
  "tracing",
 ]
 
@@ -2091,14 +2067,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
+checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
 dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -2155,7 +2131,7 @@ dependencies = [
  "futures",
  "http-body-util",
  "httparse",
- "hyper 1.0.0-rc.2",
+ "hyper 1.0.0-rc.3",
  "iptables",
  "libc",
  "mirrord-protocol",
@@ -2176,7 +2152,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
- "tokio-util 0.7.4",
+ "tokio-util 0.7.7",
  "tracing",
  "tracing-subscriber",
  "trust-dns-resolver",
@@ -2206,7 +2182,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "serde_yaml 0.9.17",
+ "serde_yaml 0.9.19",
  "thiserror",
  "toml",
  "tracing",
@@ -2255,7 +2231,7 @@ dependencies = [
  "mirrord-progress",
  "mirrord-protocol",
  "rand 0.8.5",
- "rstest 0.15.0",
+ "rstest 0.16.0",
  "serde_json",
  "thiserror",
  "tokio",
@@ -2283,7 +2259,7 @@ dependencies = [
  "http-body 0.4.5",
  "http-body-util",
  "hyper 0.14.24",
- "hyper 1.0.0-rc.2",
+ "hyper 1.0.0-rc.3",
  "itertools",
  "k8s-openapi",
  "libc",
@@ -2298,7 +2274,7 @@ dependencies = [
  "os_info",
  "rand 0.8.5",
  "regex",
- "rstest 0.15.0",
+ "rstest 0.16.0",
  "serde_json",
  "socket2",
  "streammap-ext",
@@ -2306,7 +2282,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
- "tokio-util 0.7.4",
+ "tokio-util 0.7.7",
  "tower",
  "tracing",
  "tracing-appender",
@@ -2346,7 +2322,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "serde_yaml 0.9.17",
+ "serde_yaml 0.9.19",
  "thiserror",
  "tokio",
  "tokio-tungstenite",
@@ -2373,7 +2349,7 @@ dependencies = [
  "fancy-regex",
  "http-body-util",
  "http-serde",
- "hyper 1.0.0-rc.2",
+ "hyper 1.0.0-rc.3",
  "libc",
  "serde",
  "thiserror",
@@ -2538,15 +2514,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nom8"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae01545c9c7fc4486ab7debaf2aad7003ac19431791868fb2e8066df97fad2f8"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2683,18 +2650,18 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.5.9"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d829733185c1ca374f17e52b762f24f535ec625d2cc1f070e34c8a9068f341b"
+checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
 dependencies = [
  "num_enum_derive",
 ]
 
 [[package]]
 name = "num_enum_derive"
-version = "0.5.9"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2be1598bf1c313dcdd12092e3f1920f463462525a21b7b4e11b4168353d0123e"
+checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2745,9 +2712,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "openssl-probe"
@@ -2818,9 +2785,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d01a5bd0424d00070b0098dd17ebca6f961a959dead1dbcbbbc1d1cd8d3deeba"
+checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
 
 [[package]]
 name = "peeking_take_while"
@@ -3032,9 +2999,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66618389e4ec1c7afe67d51a9bf34ff9236480f8d51e7489b7d5ab0303c13f34"
+checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
 dependencies = [
  "once_cell",
  "toml_edit",
@@ -3239,7 +3206,7 @@ checksum = "ffbe84efe2f38dea12e9bfc1f65377fdf03e53a18cb3b995faedf7934c7e785b"
 dependencies = [
  "pem",
  "ring",
- "time 0.3.17",
+ "time 0.3.20",
  "x509-parser",
  "yasna",
 ]
@@ -3462,9 +3429,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.8"
+version = "0.36.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43abb88211988493c1abb44a70efa56ff0ce98f233b7b276146f1f3f7ba9644"
+checksum = "fd5c6ff11fecd55b40746d1995a02f2eb375bf8c00d192d521ee09f42bef37bc"
 dependencies = [
  "bitflags",
  "errno",
@@ -3508,15 +3475,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5583e89e108996506031660fe09baa5011b9dd0341b89029313006d1fb508d70"
+checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
 
 [[package]]
 name = "ryu"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
+checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "same-file"
@@ -3546,9 +3513,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a5fb6c61f29e723026dc8e923d94c694313212abbecbbe5f55a7748eec5b307"
+checksum = "02c613288622e5f0c3fdc5dbd4db1c5fbe752746b1d1a56a0630b78fd00de44f"
 dependencies = [
  "chrono",
  "dyn-clone",
@@ -3559,9 +3526,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f188d036977451159430f3b8dc82ec76364a42b7e289c2b18a9a18f4470058e9"
+checksum = "109da1e6b197438deb6db99952990c7f959572794b80ff93707d55a232545e7c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3577,9 +3544,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "scratch"
-version = "1.0.3"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddccb15bcce173023b3fedd9436f882a0739b8dfb45e4f6b6002bee5929f61b2"
+checksum = "1792db035ce95be60c3f8853017b3999209281c24e2ba5bc8e59bf97a0c590c1"
 
 [[package]]
 name = "sct"
@@ -3689,21 +3656,21 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
+checksum = "1c533a59c9d8a93a09c6ab31f0fd5e5f4dd1b8fc9434804029839884765d04ea"
 dependencies = [
  "indexmap",
- "itoa 1.0.5",
+ "itoa",
  "ryu",
  "serde",
 ]
 
 [[package]]
 name = "serde_path_to_error"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b04f22b563c91331a10074bda3dd5492e3cc39d56bd557e91c0af42b6c7341"
+checksum = "db0969fff533976baadd92e08b1d102c5a3d8a8049eadfd69d4d1e3c5b2ed189"
 dependencies = [
  "serde",
 ]
@@ -3715,7 +3682,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa 1.0.5",
+ "itoa",
  "ryu",
  "serde",
 ]
@@ -3756,12 +3723,12 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.17"
+version = "0.9.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fb06d4b6cdaef0e0c51fa881acb721bed3c924cfaa71d9c94a3b771dfdf6567"
+checksum = "f82e6c8c047aa50a7328632d067bcae6ef38772a79e28daf32f735e0e4f3dd10"
 dependencies = [
  "indexmap",
- "itoa 1.0.5",
+ "itoa",
  "ryu",
  "serde",
  "unsafe-libyaml",
@@ -3795,18 +3762,18 @@ checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "slab"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
+checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
 dependencies = [
  "autocfg",
 ]
@@ -3825,9 +3792,9 @@ checksum = "f67ad224767faa3c7d8b6d91985b78e70a1324408abcb1cfcc2be4c06bc06043"
 
 [[package]]
 name = "socket2"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
+checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
 dependencies = [
  "libc",
  "winapi",
@@ -3884,9 +3851,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.107"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3934,16 +3901,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+checksum = "af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95"
 dependencies = [
  "cfg-if",
  "fastrand",
- "libc",
  "redox_syscall",
- "remove_dir_all",
- "winapi",
+ "rustix",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -4029,7 +3995,7 @@ dependencies = [
  "tempdir",
  "tokio",
  "tokio-tungstenite",
- "tokio-util 0.7.4",
+ "tokio-util 0.7.7",
  "wsl",
 ]
 
@@ -4046,18 +4012,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.38"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
+checksum = "a5ab016db510546d856297882807df8da66a16fb8c4101cb8b30054b0d5b2d9c"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.38"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
+checksum = "5420d42e90af0c38c3290abcca25b9b3bdf379fc9f55c528f53a269d9c9a267e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4066,9 +4032,9 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.5"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d805f96b7e61fce8728f142e213a3eb2f6b10538efff2d637c923efa4bfca048"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4087,11 +4053,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.17"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
+checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
 dependencies = [
- "itoa 1.0.5",
+ "itoa",
  "serde",
  "time-core",
  "time-macros",
@@ -4105,9 +4071,9 @@ checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
 
 [[package]]
 name = "time-macros"
-version = "0.2.6"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d967f99f534ca7e495c575c62638eebc2898a8c84c119b89e250477bc4ba16b2"
+checksum = "fd80a657e71da814b8e5d60d3374fc6d35045062245d80224748ae522dd76f36"
 dependencies = [
  "time-core",
 ]
@@ -4138,9 +4104,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.25.0"
+version = "1.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e00990ebabbe4c14c08aca901caed183ecd5c09562a12c824bb53d3c3fd3af"
+checksum = "03201d01c3c27a29c8a5cee5b55a93ddae1ccf6f08f65365c2c918f8c1b76f64"
 dependencies = [
  "autocfg",
  "bytes",
@@ -4152,7 +4118,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -4189,9 +4155,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d660770404473ccd7bc9f8b28494a811bc18542b915c0855c51e8f419d5223ce"
+checksum = "8fb52b74f05dbf495a8fba459fdc331812b96aa086d9eb78101fa0d4569c3313"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -4226,9 +4192,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.4"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bb2e075f03b3d66d8d8785356224ba688d2906a371015e225beeb65ca92c740"
+checksum = "5427d89453009325de0d8f342c9490009f76e999cb7672d77e46267448f7e6b2"
 dependencies = [
  "bytes",
  "futures-core",
@@ -4250,19 +4216,19 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.5.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4553f467ac8e3d374bc9a177a26801e5d0f9b211aa1673fb137a403afd1c9cf5"
+checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
 
 [[package]]
 name = "toml_edit"
-version = "0.18.1"
+version = "0.19.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c59d8dd7d0dcbc6428bf7aa2f0e823e26e43b3c9aca15bbc9475d23e5fa12b"
+checksum = "9a1eb0622d28f4b9c90adc4ea4b2b46b47663fde9ac5fafcb14a1369d5508825"
 dependencies = [
  "indexmap",
- "nom8",
  "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -4322,7 +4288,7 @@ dependencies = [
  "rand 0.8.5",
  "slab",
  "tokio",
- "tokio-util 0.7.4",
+ "tokio-util 0.7.7",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -4380,7 +4346,7 @@ source = "git+https://github.com/metalbear-co/tracing?branch=worker_options_non_
 dependencies = [
  "crossbeam-channel",
  "thiserror",
- "time 0.3.17",
+ "time 0.3.20",
  "tracing-subscriber",
 ]
 
@@ -4547,9 +4513,9 @@ checksum = "d54675592c1dbefd78cbd98db9bacd89886e1ca50692a0692baefffdeb92dd58"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
 
 [[package]]
 name = "unicode-linebreak"
@@ -4599,9 +4565,9 @@ dependencies = [
 
 [[package]]
 name = "unsafe-libyaml"
-version = "0.2.5"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc7ed8ba44ca06be78ea1ad2c3682a43349126c8818054231ee6f4748012aed2"
+checksum = "ad2024452afd3874bf539695e04af6732ba06517424dbf958fdb16a01f3bef6c"
 
 [[package]]
 name = "untrusted"
@@ -4950,6 +4916,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
 
 [[package]]
+name = "winnow"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c95fb4ff192527911dd18eb138ac30908e7165b8944e528b6af93aa4c842d345"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "winreg"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4980,7 +4955,7 @@ dependencies = [
  "ring",
  "rusticata-macros",
  "thiserror",
- "time 0.3.17",
+ "time 0.3.20",
 ]
 
 [[package]]
@@ -5031,7 +5006,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aed2e7a52e3744ab4d0c05c20aa065258e84c49fd4226f5191b2ed29712710b4"
 dependencies = [
- "time 0.3.17",
+ "time 0.3.20",
 ]
 
 [[package]]

--- a/mirrord/layer/src/common.rs
+++ b/mirrord/layer/src/common.rs
@@ -100,7 +100,7 @@ pub(crate) trait FromPtr<P> {
     fn from_ptr(value: P) -> Self;
 }
 
-impl FromPtr<*const c_char> for Detour<String> {
+impl FromPtr<*const c_char> for Detour<&str> {
     fn from_ptr(value: *const c_char) -> Self {
         let converted = (!value.is_null())
             .then(|| unsafe { CStr::from_ptr(value) })
@@ -108,10 +108,15 @@ impl FromPtr<*const c_char> for Detour<String> {
             .map_err(|fail| {
                 warn!("Failed converting `value` from `CStr` with {:#?}", fail);
                 Bypass::CStrConversion
-            })
-            .map(String::from)?;
+            })?;
 
         Detour::Success(converted)
+    }
+}
+
+impl FromPtr<*const c_char> for Detour<String> {
+    fn from_ptr(value: *const c_char) -> Self {
+        Detour::<&str>::from_ptr(value).map(String::from)
     }
 }
 

--- a/mirrord/layer/src/common.rs
+++ b/mirrord/layer/src/common.rs
@@ -95,13 +95,13 @@ pub(crate) enum HookMessage {
 /// These conversions happen in the unsafe `hook` functions, and we pass the converted value inside
 /// a [`Detour`] to defer the handling of `null` pointers (and other _invalid-ish_ values) when the
 /// `ops` version of the function returns an `Error` or [`Bypass`].
-pub(crate) trait TryFromPtr<P> {
+pub(crate) trait TryFromPtr<P>: Sized {
     /// Converts pointer `P` to `Self`.
-    fn try_from_ptr(value: P) -> Self;
+    fn try_from_ptr(value: P) -> Detour<Self>;
 }
 
-impl TryFromPtr<*const c_char> for Detour<&str> {
-    fn try_from_ptr(value: *const c_char) -> Self {
+impl TryFromPtr<*const c_char> for &str {
+    fn try_from_ptr(value: *const c_char) -> Detour<Self> {
         let converted = (!value.is_null())
             .then(|| unsafe { CStr::from_ptr(value) })
             .map(CStr::to_str)?
@@ -114,20 +114,20 @@ impl TryFromPtr<*const c_char> for Detour<&str> {
     }
 }
 
-impl TryFromPtr<*const c_char> for Detour<String> {
-    fn try_from_ptr(value: *const c_char) -> Self {
-        Detour::<&str>::try_from_ptr(value).map(String::from)
+impl TryFromPtr<*const c_char> for String {
+    fn try_from_ptr(value: *const c_char) -> Detour<Self> {
+        <&str as TryFromPtr<*const c_char>>::try_from_ptr(value).map(From::from)
     }
 }
 
-impl TryFromPtr<*const c_char> for Detour<PathBuf> {
-    fn try_from_ptr(value: *const c_char) -> Self {
-        Detour::<String>::try_from_ptr(value).map(PathBuf::from)
+impl TryFromPtr<*const c_char> for PathBuf {
+    fn try_from_ptr(value: *const c_char) -> Detour<Self> {
+        String::try_from_ptr(value).map(From::from)
     }
 }
 
-impl TryFromPtr<*const c_char> for Detour<OpenOptionsInternal> {
-    fn try_from_ptr(value: *const c_char) -> Self {
-        Detour::<String>::try_from_ptr(value).map(OpenOptionsInternal::from_mode)
+impl TryFromPtr<*const c_char> for OpenOptionsInternal {
+    fn try_from_ptr(value: *const c_char) -> Detour<Self> {
+        String::try_from_ptr(value).map(OpenOptionsInternal::from_mode)
     }
 }

--- a/mirrord/layer/src/common.rs
+++ b/mirrord/layer/src/common.rs
@@ -95,13 +95,13 @@ pub(crate) enum HookMessage {
 /// These conversions happen in the unsafe `hook` functions, and we pass the converted value inside
 /// a [`Detour`] to defer the handling of `null` pointers (and other _invalid-ish_ values) when the
 /// `ops` version of the function returns an `Error` or [`Bypass`].
-pub(crate) trait FromPtr<P> {
+pub(crate) trait TryFromPtr<P> {
     /// Converts pointer `P` to `Self`.
-    fn from_ptr(value: P) -> Self;
+    fn try_from_ptr(value: P) -> Self;
 }
 
-impl FromPtr<*const c_char> for Detour<&str> {
-    fn from_ptr(value: *const c_char) -> Self {
+impl TryFromPtr<*const c_char> for Detour<&str> {
+    fn try_from_ptr(value: *const c_char) -> Self {
         let converted = (!value.is_null())
             .then(|| unsafe { CStr::from_ptr(value) })
             .map(CStr::to_str)?
@@ -114,20 +114,20 @@ impl FromPtr<*const c_char> for Detour<&str> {
     }
 }
 
-impl FromPtr<*const c_char> for Detour<String> {
-    fn from_ptr(value: *const c_char) -> Self {
-        Detour::<&str>::from_ptr(value).map(String::from)
+impl TryFromPtr<*const c_char> for Detour<String> {
+    fn try_from_ptr(value: *const c_char) -> Self {
+        Detour::<&str>::try_from_ptr(value).map(String::from)
     }
 }
 
-impl FromPtr<*const c_char> for Detour<PathBuf> {
-    fn from_ptr(value: *const c_char) -> Self {
-        Detour::<String>::from_ptr(value).map(PathBuf::from)
+impl TryFromPtr<*const c_char> for Detour<PathBuf> {
+    fn try_from_ptr(value: *const c_char) -> Self {
+        Detour::<String>::try_from_ptr(value).map(PathBuf::from)
     }
 }
 
-impl FromPtr<*const c_char> for Detour<OpenOptionsInternal> {
-    fn from_ptr(value: *const c_char) -> Self {
-        Detour::<String>::from_ptr(value).map(OpenOptionsInternal::from_mode)
+impl TryFromPtr<*const c_char> for Detour<OpenOptionsInternal> {
+    fn try_from_ptr(value: *const c_char) -> Self {
+        Detour::<String>::try_from_ptr(value).map(OpenOptionsInternal::from_mode)
     }
 }

--- a/mirrord/layer/src/common.rs
+++ b/mirrord/layer/src/common.rs
@@ -85,7 +85,18 @@ pub(crate) enum HookMessage {
     GetAddrinfo(GetAddrInfo),
 }
 
+/// Converts raw pointer values `P` to some other type.
+///
+/// ## Usage
+///
+/// Mainly used to convert from raw C strings (`*const c_char`) into a Rust type wrapped in
+/// [`Detour`].
+///
+/// These conversions happen in the unsafe `hook` functions, and we pass the converted value inside
+/// a [`Detour`] to defer the handling of `null` pointers (and other _invalid-ish_ values) when the
+/// `ops` version of the function returns an `Error` or [`Bypass`].
 pub(crate) trait FromPtr<P> {
+    /// Converts pointer `P` to `Self`.
     fn from_ptr(value: P) -> Self;
 }
 

--- a/mirrord/layer/src/detour.rs
+++ b/mirrord/layer/src/detour.rs
@@ -288,13 +288,20 @@ impl<S> Detour<S> {
         }
     }
 
+    pub(crate) fn unwrap_or_default(self) -> S
+    where
+        S: Default,
+    {
+        match self {
+            Detour::Success(s) => s,
+            _ => self.unwrap_or(Default::default()),
+        }
+    }
+
     /// Return the contained `Success` value or a provided default if `Bypass` or `Error`.
     ///
     /// To be used in hooks that are deemed non-essential, and the run should continue even if they
     /// fail.
-    /// Currently defined only on macos because it is only used in macos-only code.
-    /// Remove the cfg attribute to enable using in other code.
-    #[cfg(target_os = "macos")]
     pub(crate) fn unwrap_or(self, default: S) -> S {
         match self {
             Detour::Success(s) => s,

--- a/mirrord/layer/src/detour.rs
+++ b/mirrord/layer/src/detour.rs
@@ -288,6 +288,7 @@ impl<S> Detour<S> {
         }
     }
 
+    /// Return the contained `Success` value or `S::default()`.
     pub(crate) fn unwrap_or_default(self) -> S
     where
         S: Default,

--- a/mirrord/layer/src/exec.rs
+++ b/mirrord/layer/src/exec.rs
@@ -137,7 +137,7 @@ fn intercept_tmp_dir(argv_arr: &Nul<*const c_char>) -> Detour<Argv> {
             // that we don't just keep going indefinitely if a bad argv was passed.
             return Bypass(TooManyArgs);
         }
-        let arg_str = Detour::<&str>::from_ptr(arg)?;
+        let arg_str = Detour::<&str>::from_ptr(*arg)?;
         trace!("exec arg: {arg_str}");
 
         c_string_vec.0.push(

--- a/mirrord/layer/src/exec.rs
+++ b/mirrord/layer/src/exec.rs
@@ -15,13 +15,13 @@ use null_terminated::Nul;
 use tracing::{trace, warn};
 
 use crate::{
+    common::FromPtr,
     detour::{
         Bypass::{ExecOnNonExistingFile, NoSipDetected, TooManyArgs},
         Detour,
         Detour::{Bypass, Error, Success},
     },
     error::HookError,
-    file::ops::str_from_rawish,
     hooks::HookManager,
     replace,
 };
@@ -78,12 +78,6 @@ pub(super) fn patch_if_sip(path: &str) -> Detour<String> {
             Error(HookError::FailedSipPatch(sip_error))
         }
     }
-}
-
-/// Get a string slice from a reference to a C string (raw char pointer).
-fn raw_to_str(raw_str: &*const c_char) -> Detour<&str> {
-    let rawish_str = (!raw_str.is_null()).then(|| unsafe { CStr::from_ptr(raw_str.to_owned()) });
-    str_from_rawish(rawish_str)
 }
 
 /// Hold a vector of new CStrings to use instead of the original argv.
@@ -143,7 +137,7 @@ fn intercept_tmp_dir(argv_arr: &Nul<*const c_char>) -> Detour<Argv> {
             // that we don't just keep going indefinitely if a bad argv was passed.
             return Bypass(TooManyArgs);
         }
-        let arg_str = raw_to_str(arg)?;
+        let arg_str = FromPtr::from_ptr(arg)?;
         trace!("exec arg: {arg_str}");
 
         c_string_vec.0.push(
@@ -180,7 +174,7 @@ unsafe fn patch_sip_for_new_process(
         .unwrap_or_default();
     trace!("Executable {} called execve/posix_spawn", calling_exe);
 
-    let path_str = raw_to_str(&path)?;
+    let path_str = From::ptr(path)?;
 
     let path_c_string = patch_if_sip(path_str)
         .and_then(|new_path| Success(CString::new(new_path)?))

--- a/mirrord/layer/src/exec.rs
+++ b/mirrord/layer/src/exec.rs
@@ -15,7 +15,7 @@ use null_terminated::Nul;
 use tracing::{trace, warn};
 
 use crate::{
-    common::FromPtr,
+    common::TryFromPtr,
     detour::{
         Bypass::{ExecOnNonExistingFile, NoSipDetected, TooManyArgs},
         Detour,
@@ -137,7 +137,7 @@ fn intercept_tmp_dir(argv_arr: &Nul<*const c_char>) -> Detour<Argv> {
             // that we don't just keep going indefinitely if a bad argv was passed.
             return Bypass(TooManyArgs);
         }
-        let arg_str = Detour::<&str>::from_ptr(*arg)?;
+        let arg_str = Detour::<&str>::try_from_ptr(*arg)?;
         trace!("exec arg: {arg_str}");
 
         c_string_vec.0.push(
@@ -174,7 +174,7 @@ unsafe fn patch_sip_for_new_process(
         .unwrap_or_default();
     trace!("Executable {} called execve/posix_spawn", calling_exe);
 
-    let path_str = Detour::<&str>::from_ptr(path)?;
+    let path_str = Detour::<&str>::try_from_ptr(path)?;
 
     let path_c_string = patch_if_sip(path_str)
         .and_then(|new_path| Success(CString::new(new_path)?))

--- a/mirrord/layer/src/exec.rs
+++ b/mirrord/layer/src/exec.rs
@@ -137,7 +137,7 @@ fn intercept_tmp_dir(argv_arr: &Nul<*const c_char>) -> Detour<Argv> {
             // that we don't just keep going indefinitely if a bad argv was passed.
             return Bypass(TooManyArgs);
         }
-        let arg_str: &str = FromPtr::from_ptr(arg)?;
+        let arg_str = Detour::<&str>::from_ptr(arg)?;
         trace!("exec arg: {arg_str}");
 
         c_string_vec.0.push(
@@ -174,7 +174,7 @@ unsafe fn patch_sip_for_new_process(
         .unwrap_or_default();
     trace!("Executable {} called execve/posix_spawn", calling_exe);
 
-    let path_str = FromPtr::from_ptr(path)?;
+    let path_str = Detour::<&str>::from_ptr(path)?;
 
     let path_c_string = patch_if_sip(path_str)
         .and_then(|new_path| Success(CString::new(new_path)?))

--- a/mirrord/layer/src/exec.rs
+++ b/mirrord/layer/src/exec.rs
@@ -2,7 +2,7 @@
 
 use std::{
     env,
-    ffi::{c_void, CStr, CString},
+    ffi::{c_void, CString},
     marker::PhantomData,
     ptr,
     sync::OnceLock,
@@ -137,7 +137,7 @@ fn intercept_tmp_dir(argv_arr: &Nul<*const c_char>) -> Detour<Argv> {
             // that we don't just keep going indefinitely if a bad argv was passed.
             return Bypass(TooManyArgs);
         }
-        let arg_str = FromPtr::from_ptr(arg)?;
+        let arg_str: &str = FromPtr::from_ptr(arg)?;
         trace!("exec arg: {arg_str}");
 
         c_string_vec.0.push(
@@ -174,7 +174,7 @@ unsafe fn patch_sip_for_new_process(
         .unwrap_or_default();
     trace!("Executable {} called execve/posix_spawn", calling_exe);
 
-    let path_str = From::ptr(path)?;
+    let path_str = FromPtr::from_ptr(path)?;
 
     let path_c_string = patch_if_sip(path_str)
         .and_then(|new_path| Success(CString::new(new_path)?))

--- a/mirrord/layer/src/file.rs
+++ b/mirrord/layer/src/file.rs
@@ -46,11 +46,6 @@ type LocalFd = RawFd;
 type RemoteFd = u64;
 type DirStreamFd = usize;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct DirStream {
-    direntry: Box<DirEntryInternal>,
-}
-
 /// `OPEN_FILES` is used to track open files and their corrospending remote file descriptor.
 /// We use Arc so we can support dup more nicely, this means that if user
 /// Opens file `A`, receives fd 1, then dups, receives 2 - both stay open, until both are closed.

--- a/mirrord/layer/src/file/ops.rs
+++ b/mirrord/layer/src/file/ops.rs
@@ -113,29 +113,6 @@ fn blocking_send_file_message(message: FileOperation) -> Result<()> {
     blocking_send_hook_message(HookMessage::File(message))
 }
 
-/// Converts a [`CStr`] path into a [`&str`], or bypasses when this fails.
-pub(crate) fn str_from_rawish(rawish_path: Option<&CStr>) -> Detour<&str> {
-    let path = rawish_path
-        .map(CStr::to_str)
-        .transpose()
-        .map_err(|fail| {
-            warn!(
-                "Failed converting `rawish_path` from `CStr` with {:#?}",
-                fail
-            );
-
-            Bypass::CStrConversion
-        })?
-        .ok_or(HookError::NullPointer)?;
-
-    Detour::Success(path)
-}
-
-/// Converts a [`CStr`] path into a [`PathBuf`], or bypasses when this fails.
-fn path_from_rawish(rawish_path: Option<&CStr>) -> Detour<PathBuf> {
-    str_from_rawish(rawish_path).map(PathBuf::from)
-}
-
 /// Blocking wrapper around `libc::open` call.
 ///
 /// **Bypassed** when trying to load system files, and files from the current working directory
@@ -148,8 +125,8 @@ fn path_from_rawish(rawish_path: Option<&CStr>) -> Detour<PathBuf> {
 /// _local_ and _remote_ file association, plus **inserting** it into the storage for
 /// [`OPEN_FILES`].
 #[tracing::instrument(level = "trace")]
-pub(crate) fn open(rawish_path: Option<&CStr>, open_options: OpenOptionsInternal) -> Detour<RawFd> {
-    let path = path_from_rawish(rawish_path)?;
+pub(crate) fn open(path: Detour<PathBuf>, open_options: OpenOptionsInternal) -> Detour<RawFd> {
+    let path = path?;
 
     if path.is_relative() {
         // Calls with non absolute paths are sent to libc::open.
@@ -186,23 +163,10 @@ pub(crate) fn open(rawish_path: Option<&CStr>, open_options: OpenOptionsInternal
 
 /// Calls [`open`] and returns a [`FILE`] pointer based on the **local** `fd`.
 #[tracing::instrument(level = "trace")]
-pub(crate) fn fopen(rawish_path: Option<&CStr>, rawish_mode: Option<&CStr>) -> Detour<*mut FILE> {
-    let open_options: OpenOptionsInternal = rawish_mode
-        .map(CStr::to_str)
-        .transpose()
-        .map_err(|fail| {
-            warn!(
-                "Failed converting `rawish_mode` from `CStr` with {:#?}",
-                fail
-            );
+pub(crate) fn fopen(path: Detour<PathBuf>, mode: Detour<OpenOptionsInternal>) -> Detour<*mut FILE> {
+    let open_options = mode.unwrap_or_default();
 
-            Bypass::CStrConversion
-        })?
-        .map(String::from)
-        .map(OpenOptionsInternalExt::from_mode)
-        .unwrap_or_default();
-
-    let local_file_fd = open(rawish_path, open_options)?;
+    let local_file_fd = open(path, open_options)?;
     let result = OPEN_FILES
         .lock()?
         .get_key_value(&local_file_fd)
@@ -317,15 +281,15 @@ pub(crate) fn closedir(dir_stream: usize) -> Detour<c_int> {
 #[tracing::instrument(level = "trace")]
 pub(crate) fn openat(
     fd: RawFd,
-    rawish_path: Option<&CStr>,
+    path: Detour<PathBuf>,
     open_options: OpenOptionsInternal,
 ) -> Detour<RawFd> {
-    let path = path_from_rawish(rawish_path)?;
+    let path = path?;
 
     // `openat` behaves the same as `open` when the path is absolute. When called with AT_FDCWD, the
     // call is propagated to `open`.
     if path.is_absolute() || fd == AT_FDCWD {
-        open(rawish_path, open_options)
+        open(Detour::Success(path), open_options)
     } else {
         // Relative path requires special handling, we must identify the relative part (relative to
         // what).
@@ -487,8 +451,8 @@ pub(crate) fn write(local_fd: RawFd, write_bytes: Option<Vec<u8>>) -> Detour<isi
 }
 
 #[tracing::instrument(level = "trace")]
-pub(crate) fn access(rawish_path: Option<&CStr>, mode: u8) -> Detour<c_int> {
-    let path = path_from_rawish(rawish_path)?;
+pub(crate) fn access(path: Detour<PathBuf>, mode: u8) -> Detour<c_int> {
+    let path = path?;
 
     should_ignore!(path, false);
 
@@ -519,15 +483,15 @@ pub(crate) fn access(rawish_path: Option<&CStr>, mode: u8) -> Detour<c_int> {
 /// and non existing argument (For error handling)
 #[tracing::instrument(level = "trace")]
 pub(crate) fn xstat(
-    rawish_path: Option<Option<&CStr>>,
+    path: Option<Detour<PathBuf>>,
     fd: Option<RawFd>,
     follow_symlink: bool,
 ) -> Detour<XstatResponse> {
     // Can't use map because we need to propagate captured error
-    let (path, fd) = match (rawish_path, fd) {
+    let (path, fd) = match (path, fd) {
         // fstatat
         (Some(path), Some(fd)) => {
-            let path = path_from_rawish(path)?;
+            let path = path?;
             let fd = {
                 if fd == AT_FDCWD {
                     if path.is_relative() {
@@ -545,7 +509,7 @@ pub(crate) fn xstat(
         }
         // lstat/stat
         (Some(path), None) => {
-            let path = path_from_rawish(path)?;
+            let path = path?;
             if path.is_relative() {
                 // Calls with non absolute paths are sent to libc::open.
                 return Detour::Bypass(Bypass::RelativePath(path));

--- a/mirrord/layer/src/socket/ops.rs
+++ b/mirrord/layer/src/socket/ops.rs
@@ -4,6 +4,7 @@ use std::{
     io,
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
     os::unix::io::RawFd,
+    path::PathBuf,
     ptr,
     sync::{Arc, OnceLock},
 };
@@ -661,10 +662,10 @@ pub(super) fn getaddrinfo(
 
 /// Retrieves the `hostname` from the agent's `/etc/hostname` to be used by [`gethostname`]
 fn remote_hostname_string() -> Detour<CString> {
-    let hostname_path = CString::new("/etc/hostname")?;
+    let hostname_path = PathBuf::from(r"/etc/hostname");
 
     let hostname_fd = file::ops::open(
-        Some(&hostname_path),
+        Detour::Success(hostname_path),
         OpenOptionsInternal {
             read: true,
             ..Default::default()


### PR DESCRIPTION
- Issue: #947 

Found this a bit messy while looking into #947.

Refactor how we convert C string pointers into rust types. We were kinda converting these in each function, having to check for `null` and stuff.

This adds a trait and implements it for various `Detour<T>` that we're using.