### PR TITLE
Introduce DashMap for OPEN_FILES.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2283,6 +2283,7 @@ dependencies = [
  "bytes",
  "chrono",
  "ctor",
+ "dashmap",
  "errno",
  "fancy-regex",
  "frida-gum",

--- a/changelog.d/1206.changed.md
+++ b/changelog.d/1206.changed.md
@@ -1,0 +1,1 @@
+Change OPEN_FILES from Mutex HashMap to just using DashMap.

--- a/mirrord/layer/Cargo.toml
+++ b/mirrord/layer/Cargo.toml
@@ -55,6 +55,7 @@ bytemuck = "1"
 hyper = { workspace = true, features = ["client"] }
 http-body-util  = { workspace = true }
 bimap.workspace = true
+dashmap = "5.4"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 mirrord-sip = { path = "../sip" }

--- a/mirrord/layer/src/file.rs
+++ b/mirrord/layer/src/file.rs
@@ -16,6 +16,7 @@ use std::{
     sync::{Arc, LazyLock, Mutex},
 };
 
+use dashmap::DashMap;
 use libc::{c_int, O_ACCMODE, O_APPEND, O_CREAT, O_RDONLY, O_RDWR, O_TRUNC, O_WRONLY};
 #[cfg(target_os = "linux")]
 use mirrord_protocol::file::{GetDEnts64Request, GetDEnts64Response};
@@ -54,8 +55,8 @@ pub(crate) struct DirStream {
 /// We use Arc so we can support dup more nicely, this means that if user
 /// Opens file `A`, receives fd 1, then dups, receives 2 - both stay open, until both are closed.
 /// Previously in such scenario we would close the remote, causing issues.
-pub(crate) static OPEN_FILES: LazyLock<Mutex<HashMap<LocalFd, Arc<ops::RemoteFile>>>> =
-    LazyLock::new(|| Mutex::new(HashMap::with_capacity(4)));
+pub(crate) static OPEN_FILES: LazyLock<DashMap<LocalFd, Arc<ops::RemoteFile>>> =
+    LazyLock::new(|| DashMap::with_capacity(4));
 
 pub(crate) static OPEN_DIRS: LazyLock<Mutex<HashMap<DirStreamFd, RemoteFd>>> =
     LazyLock::new(|| Mutex::new(HashMap::with_capacity(4)));

--- a/mirrord/layer/src/lib.rs
+++ b/mirrord/layer/src/lib.rs
@@ -888,7 +888,7 @@ pub(crate) fn close_layer_fd(fd: c_int) {
     if let Some(socket) = SOCKETS.lock().unwrap().remove(&fd) {
         CONNECTION_QUEUE.lock().unwrap().remove(socket.id);
     } else if file_mode_active {
-        OPEN_FILES.lock().unwrap().remove(&fd);
+        OPEN_FILES.remove(&fd);
     }
 }
 

--- a/mirrord/layer/src/socket/ops.rs
+++ b/mirrord/layer/src/socket/ops.rs
@@ -571,8 +571,8 @@ pub(super) fn dup(fd: c_int, dup_fd: i32) -> Result<(), HookError> {
         }
     } // Drop sockets, free Mutex.
 
-    if let Some(file) = OPEN_FILES.get(&fd).cloned() {
-        files.insert(dup_fd as RawFd, file);
+    if let Some(file) = OPEN_FILES.view(&fd, |_, file| file.clone()) {
+        OPEN_FILES.insert(dup_fd as RawFd, file);
     }
     Ok(())
 }

--- a/mirrord/layer/src/socket/ops.rs
+++ b/mirrord/layer/src/socket/ops.rs
@@ -571,8 +571,7 @@ pub(super) fn dup(fd: c_int, dup_fd: i32) -> Result<(), HookError> {
         }
     } // Drop sockets, free Mutex.
 
-    let mut files = OPEN_FILES.lock()?;
-    if let Some(file) = files.get(&fd).cloned() {
+    if let Some(file) = OPEN_FILES.get(&fd).cloned() {
         files.insert(dup_fd as RawFd, file);
     }
     Ok(())


### PR DESCRIPTION
- Issue: #1206 

Change `Mutex<HashMap>` to use `DashMap` for `OPEN_FILES`. Hoping this helps us with deadlocking woes.