### PR TITLE
mirrord-operator: Default resources limits

### DIFF
--- a/changelog.d/+operator-limits.changed.md
+++ b/changelog.d/+operator-limits.changed.md
@@ -1,0 +1,1 @@
+Add default requests and limits values to mirrord-operator setup (100m/100Mi).

--- a/mirrord/operator/src/setup.rs
+++ b/mirrord/operator/src/setup.rs
@@ -38,7 +38,7 @@ static OPERATOR_SERVICE_NAME: &str = "mirrord-operator";
 
 static APP_LABELS: LazyLock<BTreeMap<String, String>> =
     LazyLock::new(|| BTreeMap::from([("app".to_owned(), OPERATOR_NAME.to_owned())]));
-static RESOURCE_LIMITS: LazyLock<BTreeMap<String, Quantity>> = LazyLock::new(|| {
+static RESOURCE_REQUESTS: LazyLock<BTreeMap<String, Quantity>> = LazyLock::new(|| {
     BTreeMap::from([
         ("cpu".to_owned(), Quantity("100m".to_owned())),
         ("memory".to_owned(), Quantity("100Mi".to_owned())),
@@ -230,8 +230,7 @@ impl OperatorDeployment {
                 ..Default::default()
             }),
             resources: Some(ResourceRequirements {
-                requests: Some(RESOURCE_LIMITS.clone()),
-                limits: Some(RESOURCE_LIMITS.clone()),
+                requests: Some(RESOURCE_REQUESTS.clone()),
                 ..Default::default()
             }),
             ..Default::default()


### PR DESCRIPTION
Add default requests and limits values to mirrord-operator setup.

Equivalent to
```yaml
    ...
    resources:
      requests:
        memory: "100Mi"
        cpu: "100m"
      limits:
        memory: "100Mi"
        cpu: "100m"
```