### PR TITLE
Update dev docs.

### DIFF
--- a/DEBUGGING.md
+++ b/DEBUGGING.md
@@ -63,8 +63,7 @@ If you want to see the layer's logs, [use the console](#mirrord-console) by sett
             }
 
 ```
- in the
-launch configuration of the second window.
+in the launch configuration of the second window.
 
 ## Debugging the JetBrains plugin
 

--- a/DEBUGGING.md
+++ b/DEBUGGING.md
@@ -1,5 +1,7 @@
 # Debugging mirrord
 
+## mirrord console
+
 Debugging mirrord can get hard since we're running from another app flow, so the fact we're debugging might affect the program and make it unusable/buggy (due to sharing stdout with scripts/other applications).
 
 The recommended way to do it is to use `mirrord-console`. It is a small application that receives log information from different mirrord instances and prints it, controlled via `RUST_LOG` environment variable.
@@ -39,3 +41,23 @@ kubectl logs <YOUR_POD_NAME> | less -R
 ```
 
 where you would replace `<YOUR_POD_NAME>` with the name of the pod.
+
+## Debugging the vscode extension
+In order to debug the vscode extension, first [build the mirrord binary](TESTING.md#build-and-run-mirrord). Then run:
+```bash
+cd vscode-ext
+```
+```bash
+npm install
+npm run compile
+```
+Now you can just open the extension's code in vscode and run. Another vscode window will start. You can set breakpoints
+in the extension's code in the first window, and use the extension in the second window to reach the breakpoints.
+When in debug mode, the extension will automatically use the debug mirrord binary.
+
+If you want to see the layer's logs, [use the console](#mirrord-console) by setting the environment variable in the
+launch configuration of the second window.
+
+## Debugging the JetBrains plugin
+
+TODO

--- a/DEBUGGING.md
+++ b/DEBUGGING.md
@@ -51,7 +51,7 @@ cd vscode-ext
 npm install
 npm run compile
 ```
-Now you can just open the extension's code in vscode and run. Another vscode window will start. You can set breakpoints
+Now you can just open the extension's code in vscode and run, using the "Launch Extension" run configuration. Another vscode window will start. You can set breakpoints
 in the extension's code in the first window, and use the extension in the second window to reach the breakpoints.
 When in debug mode, the extension will automatically use the debug mirrord binary.
 

--- a/DEBUGGING.md
+++ b/DEBUGGING.md
@@ -55,7 +55,15 @@ Now you can just open the extension's code in vscode and run, using the "Launch 
 in the extension's code in the first window, and use the extension in the second window to reach the breakpoints.
 When in debug mode, the extension will automatically use the debug mirrord binary.
 
-If you want to see the layer's logs, [use the console](#mirrord-console) by setting the environment variable in the
+If you want to see the layer's logs, [use the console](#mirrord-console) by setting
+```json
+            "env": {
+                "RUST_LOG": "warn,mirrord=trace",
+                "MIRRORD_CONSOLE_ADDR": "127.0.0.1:11233"
+            }
+
+```
+ in the
 launch configuration of the second window.
 
 ## Debugging the JetBrains plugin

--- a/TESTING.md
+++ b/TESTING.md
@@ -199,7 +199,7 @@ cargo +nightly build
 
 #### Run mirrord with a local process
 
-Sample web server - `app.js` (present in that path in the repo)
+Sample web server - `app.js` (present at `sample/node/app.mjs` in the repo)
 
 <details>
   <summary>sample/node/app.mjs</summary>

--- a/changelog.d/+dev-docs.internal.md
+++ b/changelog.d/+dev-docs.internal.md
@@ -1,0 +1,1 @@
+Update testing and building docs, and add instructions for the IDE extensions.


### PR DESCRIPTION
Update some outdated stuff like the commands for building the agent, or the layer on macOS.

Add instructions for the IDE extensions.