### PR TITLE
Fixed random crash in `close_layer_fd`

### DIFF
--- a/changelog.d/+random_crash_fix.fixed.md
+++ b/changelog.d/+random_crash_fix.fixed.md
@@ -1,0 +1,1 @@
+Fixed random crash in `close_layer_fd` caused by supposed closing of stdout/stderr then calling to log that writes to it

--- a/mirrord/layer/src/lib.rs
+++ b/mirrord/layer/src/lib.rs
@@ -877,8 +877,8 @@ fn enable_hooks(enabled_file_ops: bool, enabled_remote_dns: bool, patch_binaries
 /// ## Details
 ///
 /// Removes the `fd` key from either [`SOCKETS`] or [`OPEN_FILES`].
+/// **DON'T ADD LOGS HERE SINCE CALLER MIGHT CLOSE STDOUT/STDERR CAUSING THIS TO CRASH**
 pub(crate) fn close_layer_fd(fd: c_int) {
-    trace!("Closing fd {}", fd);
     let file_mode_active = FILE_MODE
         .get()
         .expect("Should be set during initialization!")


### PR DESCRIPTION
caused by supposed closing of stdout/stderr then calling to log that writes to it
