### PR TITLE
Propagate steal issues

### DIFF
--- a/changelog.d/1163.added.md
+++ b/changelog.d/1163.added.md
@@ -1,0 +1,1 @@
+Notify clients about errors happening in agent's background tasks.

--- a/mirrord/agent/src/dns.rs
+++ b/mirrord/agent/src/dns.rs
@@ -110,9 +110,13 @@ impl DnsApi {
         rx.await.map_err(Into::into)
     }
 
-    pub async fn make_request(&self, request: GetAddrInfoRequest) -> Result<GetAddrInfoResponse> {
-        self.try_make_request(request)
-            .await
-            .map_err(|e| self.task_status.check().unwrap_or(e))
+    pub async fn make_request(
+        &mut self,
+        request: GetAddrInfoRequest,
+    ) -> Result<GetAddrInfoResponse> {
+        match self.try_make_request(request).await {
+            Ok(res) => Ok(res),
+            Err(_) => Err(self.task_status.unwrap_err().await),
+        }
     }
 }

--- a/mirrord/agent/src/error.rs
+++ b/mirrord/agent/src/error.rs
@@ -100,7 +100,7 @@ pub enum AgentError {
     #[error("Pause was set, but container id or runtime is missing.")]
     MissingContainerInfo,
 
-    #[error("start_client -> Ran out of connections, dropping new connection")]
+    #[error("Ran out of connections, dropping new connection")]
     ConnectionLimitReached,
 
     #[error("An internal invariant of the agent was violated, this should not happen.")]

--- a/mirrord/agent/src/error.rs
+++ b/mirrord/agent/src/error.rs
@@ -136,6 +136,9 @@ pub enum AgentError {
     )]
     ContainerdSocketNotFound,
 
+    #[error("Background task `{task}` failed with `{cause}`")]
+    BackgroundTaskFailed { task: &'static str, cause: String },
+
     #[error("Returning an error to test the agent's error cleanup. Should only ever be used when testing mirrord.")]
     TestError,
 }

--- a/mirrord/agent/src/error.rs
+++ b/mirrord/agent/src/error.rs
@@ -43,9 +43,6 @@ pub enum AgentError {
     #[error("UdpOutgoingTrafficRequest sender failed with `{0}`")]
     SendUdpOutgoingTrafficRequest(#[from] tokio::sync::mpsc::error::SendError<LayerUdpOutgoing>),
 
-    #[error("Receiver channel is closed!")]
-    ReceiverClosed,
-
     #[error("Request channel closed unexpectedly.")]
     HttpRequestReceiverClosed,
 

--- a/mirrord/agent/src/main.rs
+++ b/mirrord/agent/src/main.rs
@@ -168,7 +168,7 @@ impl State {
                         "maximum concurrent connections reached".into(),
                     ))
                     .await
-                    .ok();
+                    .ok(); // Ignore message send error.
 
                 return Ok(None);
             }
@@ -178,7 +178,7 @@ impl State {
                 stream
                     .send(DaemonMessage::Close(err.to_string()))
                     .await
-                    .ok();
+                    .ok(); // Ignore message send error.
 
                 return Err(err);
             }
@@ -300,7 +300,7 @@ impl ClientConnectionHandler {
                 stream
                     .send(DaemonMessage::LogMessage(LogMessage::warn(message)))
                     .await
-                    .ok();
+                    .ok(); // Ignore message send error.
 
                 None
             }
@@ -321,7 +321,7 @@ impl ClientConnectionHandler {
                         "Failed to create TcpStealerApi: {e}."
                     )))
                     .await
-                    .ok();
+                    .ok(); // Ignore message send error.
 
                 return Err(e);
             }

--- a/mirrord/agent/src/main.rs
+++ b/mirrord/agent/src/main.rs
@@ -564,7 +564,7 @@ async fn start_agent() -> Result<()> {
         (task, status)
     };
 
-    let bg_tasks = BackgroundTasks {
+    let mut bg_tasks = BackgroundTasks {
         sniffer_status,
         sniffer_sender: sniffer_command_tx,
         stealer_status,
@@ -648,12 +648,12 @@ async fn start_agent() -> Result<()> {
     drop(cancel_guard);
 
     sniffer_task.join().map_err(|_| AgentError::JoinTask)?;
-    if let Some(err) = &*bg_tasks.sniffer_status.err() {
+    if let Some(err) = bg_tasks.sniffer_status.err().await {
         error!("start_agent -> sniffer task failed with error: {}", err);
     }
 
     stealer_task.join().map_err(|_| AgentError::JoinTask)?;
-    if let Some(err) = &*bg_tasks.stealer_status.err() {
+    if let Some(err) = bg_tasks.stealer_status.err().await {
         error!("start_agent -> stealer task failed with error: {}", err);
     }
 

--- a/mirrord/agent/src/outgoing.rs
+++ b/mirrord/agent/src/outgoing.rs
@@ -19,6 +19,7 @@ use tracing::{trace, warn};
 use crate::{
     error::{AgentError, Result},
     util::{run_thread_in_namespace, IndexAllocator},
+    watched_task::{TaskStatus, WatchedTask},
 };
 
 pub(crate) mod socket_stream;
@@ -31,7 +32,10 @@ type Daemon = DaemonTcpOutgoing;
 /// passing of these messages to the `interceptor_task` thread.
 pub(crate) struct TcpOutgoingApi {
     /// Holds the `interceptor_task`.
-    _task: thread::JoinHandle<Result<()>>,
+    _task: thread::JoinHandle<()>,
+
+    /// Status of the `interceptor_task`.
+    task_status: TaskStatus,
 
     /// Sends the `Layer` message to the `interceptor_task`.
     layer_tx: Sender<Layer>,
@@ -124,19 +128,27 @@ async fn layer_recv(
 }
 
 impl TcpOutgoingApi {
+    const TASK_NAME: &'static str = "TcpOutgoing";
+
     pub(crate) fn new(pid: Option<u64>) -> Self {
         let (layer_tx, layer_rx) = mpsc::channel(1000);
         let (daemon_tx, daemon_rx) = mpsc::channel(1000);
 
-        let task = run_thread_in_namespace(
+        let watched_task = WatchedTask::new(
+            Self::TASK_NAME,
             Self::interceptor_task(layer_rx, daemon_tx, pid),
-            "TcpOutgoing".to_string(),
+        );
+        let task_status = watched_task.status();
+        let task = run_thread_in_namespace(
+            watched_task.start(),
+            Self::TASK_NAME.to_string(),
             pid,
             "net",
         );
 
         Self {
             _task: task,
+            task_status,
             layer_tx,
             daemon_rx,
         }
@@ -204,14 +216,19 @@ impl TcpOutgoingApi {
     /// Sends a `TcpOutgoingRequest` to the `interceptor_task`.
     #[tracing::instrument(level = "trace", skip(self))]
     pub(crate) async fn layer_message(&mut self, message: LayerTcpOutgoing) -> Result<()> {
-        Ok(self.layer_tx.send(message).await?)
+        self.layer_tx
+            .send(message)
+            .await
+            .map_err(AgentError::from)
+            .map_err(|e| self.task_status.check().unwrap_or(e))
     }
 
     /// Receives a `TcpOutgoingResponse` from the `interceptor_task`.
     pub(crate) async fn daemon_message(&mut self) -> Result<DaemonTcpOutgoing> {
-        self.daemon_rx
-            .recv()
-            .await
-            .ok_or(AgentError::ReceiverClosed)
+        self.daemon_rx.recv().await.ok_or_else(|| {
+            self.task_status
+                .check()
+                .unwrap_or(AgentError::ReceiverClosed)
+        })
     }
 }

--- a/mirrord/agent/src/outgoing.rs
+++ b/mirrord/agent/src/outgoing.rs
@@ -154,7 +154,7 @@ impl TcpOutgoingApi {
         }
     }
 
-    /// Does the actual work for `Request`s and prepares the `Responses:
+    /// Does the actual work for `Request`s and prepares the `Response`s:
     #[tracing::instrument(level = "trace", skip(layer_rx, daemon_tx))]
     async fn interceptor_task(
         mut layer_rx: Receiver<Layer>,

--- a/mirrord/agent/src/outgoing/udp.rs
+++ b/mirrord/agent/src/outgoing/udp.rs
@@ -29,6 +29,7 @@ use tracing::{debug, trace, warn};
 use crate::{
     error::{AgentError, Result},
     util::{run_thread_in_namespace, IndexAllocator},
+    watched_task::{TaskStatus, WatchedTask},
 };
 
 type Layer = LayerUdpOutgoing;
@@ -41,7 +42,10 @@ const DNS_PORT: u16 = 53;
 /// passing of these messages to the `interceptor_task` thread.
 pub(crate) struct UdpOutgoingApi {
     /// Holds the `interceptor_task`.
-    _task: thread::JoinHandle<Result<()>>,
+    _task: thread::JoinHandle<()>,
+
+    /// Status of the `interceptor_task`.
+    task_status: TaskStatus,
 
     /// Sends the `Layer` message to the `interceptor_task`.
     layer_tx: Sender<Layer>,
@@ -96,19 +100,25 @@ async fn connect(remote_address: SocketAddr) -> Result<UdpSocket, ResponseError>
 }
 
 impl UdpOutgoingApi {
+    const TASK_NAME: &'static str = "UdpOutgoing";
+
     pub(crate) fn new(pid: Option<u64>) -> Self {
         let (layer_tx, layer_rx) = mpsc::channel(1000);
         let (daemon_tx, daemon_rx) = mpsc::channel(1000);
 
+        let watched_task =
+            WatchedTask::new(Self::TASK_NAME, Self::interceptor_task(layer_rx, daemon_tx));
+        let task_status = watched_task.status();
         let task = run_thread_in_namespace(
-            Self::interceptor_task(layer_rx, daemon_tx),
-            "UdpOutgoing".to_string(),
+            watched_task.start(),
+            Self::TASK_NAME.to_string(),
             pid,
             "net",
         );
 
         Self {
             _task: task,
+            task_status,
             layer_tx,
             daemon_rx,
         }
@@ -256,14 +266,20 @@ impl UdpOutgoingApi {
             "UdpOutgoingApi::layer_message -> layer_message {:#?}",
             message
         );
-        Ok(self.layer_tx.send(message).await?)
+
+        self.layer_tx
+            .send(message)
+            .await
+            .map_err(AgentError::from)
+            .map_err(|e| self.task_status.check().unwrap_or(e))
     }
 
     /// Receives a `UdpOutgoingResponse` from the `interceptor_task`.
     pub(crate) async fn daemon_message(&mut self) -> Result<DaemonUdpOutgoing> {
-        self.daemon_rx
-            .recv()
-            .await
-            .ok_or(AgentError::ReceiverClosed)
+        self.daemon_rx.recv().await.ok_or_else(|| {
+            self.task_status
+                .check()
+                .unwrap_or(AgentError::ReceiverClosed)
+        })
     }
 }

--- a/mirrord/agent/src/sniffer.rs
+++ b/mirrord/agent/src/sniffer.rs
@@ -225,7 +225,8 @@ impl TcpSnifferApi {
     /// * `client_id` - id of the client using this struct
     /// * `sniffer_sender` - channel used to send commands to the [`TcpConnectionSniffer`]
     /// * `task_status` - handle to the [`TcpConnectionSniffer`] exit status
-    /// * `channel_size` - capacity of the channel connecting [`TcpConnectionSniffer`] back to this struct
+    /// * `channel_size` - capacity of the channel connecting [`TcpConnectionSniffer`] back to this
+    ///   struct
     pub async fn new(
         client_id: ClientId,
         sniffer_sender: Sender<SnifferCommand>,
@@ -271,7 +272,8 @@ impl TcpSnifferApi {
         }
     }
 
-    /// Tansform the given message into a [`SnifferCommands`] and pass it to the connected [`TcpConnectionSniffer`].
+    /// Tansform the given message into a [`SnifferCommands`] and pass it to the connected
+    /// [`TcpConnectionSniffer`].
     pub async fn handle_client_message(&mut self, message: LayerTcp) -> Result<(), AgentError> {
         self.send_command(message.into()).await
     }

--- a/mirrord/agent/src/steal/connection.rs
+++ b/mirrord/agent/src/steal/connection.rs
@@ -114,6 +114,8 @@ pub(crate) struct TcpConnectionStealer {
 }
 
 impl TcpConnectionStealer {
+    pub const TASK_NAME: &'static str = "Stealer";
+
     /// Initializes a new [`TcpConnectionStealer`] fields, but doesn't start the actual working
     /// task (call [`TcpConnectionStealer::start`] to do so).
     #[tracing::instrument(level = "trace")]

--- a/mirrord/agent/src/util.rs
+++ b/mirrord/agent/src/util.rs
@@ -20,6 +20,7 @@ pub struct Subscriptions<T, C> {
     _inner: HashMap<T, HashSet<C>>,
 }
 
+/// Id of an agent's client. Each new client connection is assigned with a unique id.
 pub type ClientId = u32;
 
 impl<T, C> Subscriptions<T, C>

--- a/mirrord/agent/src/watched_task.rs
+++ b/mirrord/agent/src/watched_task.rs
@@ -31,11 +31,11 @@ impl TaskStatus {
     /// Return a view over the error that occurred during the execution of the task.
     /// This guard should not be held for a long time, especially across .await points.
     pub fn err(&self) -> RwLockReadGuard<'_, Option<AgentError>> {
-        self.error.read().expect("task statuc lock poisoned")
+        self.error.read().expect("task status lock poisoned")
     }
 }
 
-/// A wrapper aroung asynchronous task.
+/// A wrapper around asynchronous task.
 /// Captures the task's status and exposes it through [`TaskStatus`].
 pub(crate) struct WatchedTask<F> {
     /// Shared view on the task status.
@@ -83,7 +83,7 @@ mod test {
     use super::*;
 
     #[tokio::test]
-    async fn simple_successfull() {
+    async fn simple_successful() {
         let task = WatchedTask::new("task", async move { Ok(()) });
         let status = task.status();
         task.start().await;

--- a/mirrord/agent/src/watched_task.rs
+++ b/mirrord/agent/src/watched_task.rs
@@ -54,17 +54,17 @@ impl<F> WatchedTask<F> {
             task,
         }
     }
+
+    /// Return a shared view over the inner [`TaskStatus`].
+    pub(crate) fn status(&self) -> TaskStatus {
+        self.status.clone()
+    }
 }
 
 impl<T> WatchedTask<T>
 where
     T: Future<Output = Result<(), AgentError>>,
 {
-    /// Return a shared view over the inner [`TaskStatus`].
-    pub(crate) fn status(&self) -> TaskStatus {
-        self.status.clone()
-    }
-
     /// Execute the wrapped task.
     /// If an error occurred during the execution, store it in the inner [`TaskStatus`].
     pub(crate) async fn start(self) {

--- a/mirrord/agent/src/watched_task.rs
+++ b/mirrord/agent/src/watched_task.rs
@@ -61,6 +61,7 @@ pub(crate) struct WatchedTask<F> {
 }
 
 impl<F> WatchedTask<F> {
+    /// Wrap the given task in a new instance of this struct.
     pub(crate) fn new(task_name: &'static str, task: F) -> Self {
         let (result_tx, result_rx) = watch::channel(None);
 

--- a/mirrord/agent/src/watched_task.rs
+++ b/mirrord/agent/src/watched_task.rs
@@ -77,3 +77,26 @@ where
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[tokio::test]
+    async fn simple_successfull() {
+        let task = WatchedTask::new("task", async move { Ok(()) });
+        let status = task.status();
+        task.start().await;
+        assert!(status.check().is_none());
+        assert!(status.err().is_none());
+    }
+
+    #[tokio::test]
+    async fn simple_failing() {
+        let task = WatchedTask::new("task", async move { Err(AgentError::ReceiverClosed) });
+        let status = task.status();
+        task.start().await;
+        assert!(status.check().is_some());
+        assert!(status.err().is_some());
+    }
+}

--- a/mirrord/agent/src/watched_task.rs
+++ b/mirrord/agent/src/watched_task.rs
@@ -1,7 +1,6 @@
-use std::{
-    future::Future,
-    sync::{Arc, RwLock, RwLockReadGuard},
-};
+use std::future::Future;
+
+use tokio::sync::watch::{self, Receiver, Sender};
 
 use crate::error::AgentError;
 
@@ -10,28 +9,43 @@ use crate::error::AgentError;
 pub struct TaskStatus {
     /// Name of the task.
     task_name: &'static str,
-    /// An error that occurred during the execution of the task.
-    error: Arc<RwLock<Option<AgentError>>>,
+    /// Channel to receive the result of the task.
+    /// Initially, this channel contains [`None`].
+    /// Only one value should ever be sent through this channel and it should be [`Some`].
+    result_rx: Receiver<Option<Result<(), AgentError>>>,
 }
 
 impl TaskStatus {
-    /// Check if an error occurred during the execution of the task.
-    /// If yes, return [`AgentError::BackgroundTaskFailed`].
-    pub fn check(&self) -> Option<AgentError> {
-        self.error
-            .read()
-            .expect("task status lock poisoned")
+    /// Wait for the task to complete and return the error.
+    /// Can be called multiple times and safely cancelled.
+    ///
+    /// # Panics
+    /// Panic if the task has not failed.
+    pub async fn unwrap_err(&mut self) -> AgentError {
+        self.err().await.expect("task did not fail")
+    }
+
+    /// Wait for the task to complete.
+    /// If the task has failed, return the error.
+    /// Can be called multiple times and safely cancelled.
+    pub async fn err(&mut self) -> Option<AgentError> {
+        if self.result_rx.borrow().is_none() && self.result_rx.changed().await.is_err() {
+            return Some(AgentError::BackgroundTaskFailed {
+                task: self.task_name,
+                cause: "task panicked".into(),
+            });
+        }
+
+        self.result_rx
+            .borrow()
             .as_ref()
+            .expect("WatchedTask set an empty status on exit")
+            .as_ref()
+            .err()
             .map(|e| AgentError::BackgroundTaskFailed {
                 task: self.task_name,
                 cause: e.to_string(),
             })
-    }
-
-    /// Return a view over the error that occurred during the execution of the task.
-    /// This guard should not be held for a long time, especially across .await points.
-    pub fn err(&self) -> RwLockReadGuard<'_, Option<AgentError>> {
-        self.error.read().expect("task status lock poisoned")
     }
 }
 
@@ -42,16 +56,21 @@ pub(crate) struct WatchedTask<F> {
     status: TaskStatus,
     /// The task to be executed.
     task: F,
+    /// Channel to send the task result.
+    result_tx: Sender<Option<Result<(), AgentError>>>,
 }
 
 impl<F> WatchedTask<F> {
     pub(crate) fn new(task_name: &'static str, task: F) -> Self {
+        let (result_tx, result_rx) = watch::channel(None);
+
         Self {
             status: TaskStatus {
                 task_name,
-                error: Default::default(),
+                result_rx,
             },
             task,
+            result_tx,
         }
     }
 
@@ -66,15 +85,10 @@ where
     T: Future<Output = Result<(), AgentError>>,
 {
     /// Execute the wrapped task.
-    /// If an error occurred during the execution, store it in the inner [`TaskStatus`].
+    /// Store its result in the inner [`TaskStatus`].
     pub(crate) async fn start(self) {
-        if let Err(e) = self.task.await {
-            self.status
-                .error
-                .write()
-                .expect("task status lock poisoned")
-                .replace(e);
-        }
+        let result = self.task.await;
+        self.result_tx.send(Some(result)).ok(); // All receivers may be dropped.
     }
 }
 
@@ -85,18 +99,17 @@ mod test {
     #[tokio::test]
     async fn simple_successful() {
         let task = WatchedTask::new("task", async move { Ok(()) });
-        let status = task.status();
+        let mut status = task.status();
         task.start().await;
-        assert!(status.check().is_none());
-        assert!(status.err().is_none());
+        assert!(status.err().await.is_none());
     }
 
     #[tokio::test]
     async fn simple_failing() {
-        let task = WatchedTask::new("task", async move { Err(AgentError::ReceiverClosed) });
-        let status = task.status();
+        let task = WatchedTask::new("task", async move { Err(AgentError::TestError) });
+        let mut status = task.status();
         task.start().await;
-        assert!(status.check().is_some());
-        assert!(status.err().is_some());
+        assert!(status.err().await.is_some());
+        status.unwrap_err().await;
     }
 }

--- a/mirrord/agent/src/watched_task.rs
+++ b/mirrord/agent/src/watched_task.rs
@@ -1,0 +1,79 @@
+use std::{
+    future::Future,
+    sync::{Arc, RwLock, RwLockReadGuard},
+};
+
+use crate::error::AgentError;
+
+/// A shared clonable view on a background task's status.
+#[derive(Debug, Clone)]
+pub struct TaskStatus {
+    /// Name of the task.
+    task_name: &'static str,
+    /// An error that occurred during the execution of the task.
+    error: Arc<RwLock<Option<AgentError>>>,
+}
+
+impl TaskStatus {
+    /// Check if an error occurred during the execution of the task.
+    /// If yes, return [`AgentError::BackgroundTaskFailed`].
+    pub fn check(&self) -> Option<AgentError> {
+        self.error
+            .read()
+            .expect("task status lock poisoned")
+            .as_ref()
+            .map(|e| AgentError::BackgroundTaskFailed {
+                task: self.task_name,
+                cause: e.to_string(),
+            })
+    }
+
+    /// Return a view over the error that occurred during the execution of the task.
+    /// This guard should not be held for a long time, especially across .await points.
+    pub fn err(&self) -> RwLockReadGuard<'_, Option<AgentError>> {
+        self.error.read().expect("task statuc lock poisoned")
+    }
+}
+
+/// A wrapper aroung asynchronous task.
+/// Captures the task's status and exposes it through [`TaskStatus`].
+pub(crate) struct WatchedTask<F> {
+    /// Shared view on the task status.
+    status: TaskStatus,
+    /// The task to be executed.
+    task: F,
+}
+
+impl<F> WatchedTask<F> {
+    pub(crate) fn new(task_name: &'static str, task: F) -> Self {
+        Self {
+            status: TaskStatus {
+                task_name,
+                error: Default::default(),
+            },
+            task,
+        }
+    }
+}
+
+impl<T> WatchedTask<T>
+where
+    T: Future<Output = Result<(), AgentError>>,
+{
+    /// Return a shared view over the inner [`TaskStatus`].
+    pub(crate) fn status(&self) -> TaskStatus {
+        self.status.clone()
+    }
+
+    /// Execute the wrapped task.
+    /// If an error occurred during the execution, store it in the inner [`TaskStatus`].
+    pub(crate) async fn start(self) {
+        if let Err(e) = self.task.await {
+            self.status
+                .error
+                .write()
+                .expect("task status lock poisoned")
+                .replace(e);
+        }
+    }
+}

--- a/mirrord/layer/src/lib.rs
+++ b/mirrord/layer/src/lib.rs
@@ -96,6 +96,7 @@ use mirrord_config::{
 };
 use mirrord_layer_macro::{hook_fn, hook_guard_fn};
 use mirrord_protocol::{
+    codec::LogLevel,
     dns::{DnsLookup, GetAddrInfoRequest},
     tcp::{HttpResponse, LayerTcpSteal},
     ClientMessage, DaemonMessage,
@@ -112,7 +113,7 @@ use tokio::{
     sync::mpsc::{channel, Receiver, Sender},
     time::{sleep, Duration},
 };
-use tracing::{debug, error, info, trace, warn, Level};
+use tracing::{error, info, trace, warn};
 use tracing_subscriber::{fmt::format::FmtSpan, prelude::*};
 
 use crate::{
@@ -681,15 +682,10 @@ impl Layer {
             DaemonMessage::Close(error_message) => Err(LayerError::AgentErrorClosed(error_message)),
             DaemonMessage::LogMessage(log_message) => {
                 match log_message.level {
-                    Level::DEBUG => {
-                        debug!(message = log_message.message, "Daemon sent log message")
+                    LogLevel::Warn => {
+                        warn!(message = log_message.message, "Daemon sent log message")
                     }
-                    Level::TRACE => {
-                        trace!(message = log_message.message, "Daemon sent log message")
-                    }
-                    Level::INFO => info!(message = log_message.message, "Daemon sent log message"),
-                    Level::WARN => warn!(message = log_message.message, "Daemon sent log message"),
-                    Level::ERROR => {
+                    LogLevel::Error => {
                         error!(message = log_message.message, "Daemon sent log message")
                     }
                 }

--- a/mirrord/protocol/src/codec.rs
+++ b/mirrord/protocol/src/codec.rs
@@ -4,13 +4,8 @@ use std::{
 };
 
 use actix_codec::{Decoder, Encoder};
-use bincode::{
-    de, enc,
-    error::{DecodeError, EncodeError},
-    BorrowDecode, Decode, Encode,
-};
+use bincode::{error::DecodeError, Decode, Encode};
 use bytes::{Buf, BufMut, BytesMut};
-use tracing::Level;
 
 #[cfg(target_os = "linux")]
 use crate::file::{GetDEnts64Request, GetDEnts64Response};
@@ -31,41 +26,16 @@ use crate::{
     ResponseError,
 };
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Encode, Decode, Debug, PartialEq, Eq, Clone, Copy)]
+pub enum LogLevel {
+    Warn,
+    Error,
+}
+
+#[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
 pub struct LogMessage {
     pub message: String,
-    pub level: Level,
-}
-
-impl Encode for LogMessage {
-    fn encode<E: enc::Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
-        self.message.encode(encoder)?;
-        self.level.as_str().encode(encoder)?;
-
-        Ok(())
-    }
-}
-
-impl Decode for LogMessage {
-    fn decode<D: de::Decoder>(decoder: &mut D) -> Result<Self, DecodeError> {
-        let message = Decode::decode(decoder)?;
-        let level = <String as Decode>::decode(decoder)?
-            .parse::<Level>()
-            .map_err(|e| DecodeError::OtherString(e.to_string()))?;
-
-        Ok(Self { message, level })
-    }
-}
-
-impl<'de> BorrowDecode<'de> for LogMessage {
-    fn borrow_decode<D: de::BorrowDecoder<'de>>(decoder: &mut D) -> Result<Self, DecodeError> {
-        let message = BorrowDecode::borrow_decode(decoder)?;
-        let level = <&'de str as BorrowDecode>::borrow_decode(decoder)?
-            .parse::<Level>()
-            .map_err(|e| DecodeError::OtherString(e.to_string()))?;
-
-        Ok(Self { message, level })
-    }
+    pub level: LogLevel,
 }
 
 #[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]

--- a/mirrord/protocol/src/codec.rs
+++ b/mirrord/protocol/src/codec.rs
@@ -38,6 +38,22 @@ pub struct LogMessage {
     pub level: LogLevel,
 }
 
+impl LogMessage {
+    pub fn warn(message: String) -> Self {
+        Self {
+            message,
+            level: LogLevel::Warn,
+        }
+    }
+
+    pub fn error(message: String) -> Self {
+        Self {
+            message,
+            level: LogLevel::Error,
+        }
+    }
+}
+
 #[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
 pub struct GetEnvVarsRequest {
     pub env_vars_filter: HashSet<String>,


### PR DESCRIPTION
Solves #1163.

## Changes
1. Changed `protocol::codec::LogMessage` to allow sending logs on `warn`/`error` level from agent to layer.
2. Added `WatchedTask` and `TaskStatus` helper structs to capture errors from agent's background tasks and access them from different contexts.
3. Wrapped all agent's background tasks with those structs. Implemented returning errors to clients using tasks' APIs (`DnsApi`, `TcpStealerApi`, ...).

## Suggestions needed
1. `DaemonMessage::LogMessage` is propably not very useful. In all cases we stop serving the client after the first error, so using the existing `DaemonMessage::Close` was sufficient. I use `DaemonMessage::LogMessage` in just one case - when we can't create the API for the sniffer. Should I leave it as is or remove that variant completely?
2. I removed casting all errors to `AgentError::SnifferApiError` in `TcpSnifferApi`. Instead I return the error from the sniffer task. I believe the API struct should never exist in the first place if sniffing was not available (which `AgentError::SnifferApiError` suggests). To create it we actually have to exchange messages with the sniffer task, so it had to work at least for some time. Please correct me if I'm wrong.
3. Do we still support environments which don't allow sniffing? Currently the agent only logs errors and sends `DaemonMessage::Close` to any client which tries it.