### PR TITLE
Implemented `Default` for `Subscriptions` struct

### DIFF
--- a/changelog.d/+default_subscriptions.internal.md
+++ b/changelog.d/+default_subscriptions.internal.md
@@ -1,0 +1,1 @@
+Implemented `Default` for `Subscriptions`. Replaced usages of `Subscriptions::new` with `Default::default`.

--- a/mirrord/agent/src/sniffer.rs
+++ b/mirrord/agent/src/sniffer.rs
@@ -335,7 +335,7 @@ impl TcpConnectionSniffer {
         Ok(Self {
             receiver,
             raw_capture,
-            port_subscriptions: Subscriptions::new(),
+            port_subscriptions: Default::default(),
             client_senders: HashMap::new(),
             sessions: TCPSessionMap::new(),
             //todo: impl drop for index allocator and connection id..

--- a/mirrord/agent/src/util.rs
+++ b/mirrord/agent/src/util.rs
@@ -15,7 +15,7 @@ use crate::{error::AgentError, runtime::set_namespace};
 /// Struct that helps you manage topic -> subscribers
 ///
 /// When a topic has no subscribers, it is removed.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct Subscriptions<T, C> {
     _inner: HashMap<T, HashSet<C>>,
 }
@@ -27,13 +27,6 @@ where
     T: Eq + Hash + Clone + Copy,
     C: Eq + Hash + Clone + Copy,
 {
-    // TODO(alex): Same as `IndexAllocator`, make a good `Default` impl, then delete this.
-    pub fn new() -> Subscriptions<T, C> {
-        Subscriptions {
-            _inner: HashMap::new(),
-        }
-    }
-
     /// Add a new subscription to a topic for a given client.
     pub fn subscribe(&mut self, client: C, topic: T) {
         self._inner
@@ -212,7 +205,7 @@ mod subscription_tests {
 
     #[test]
     fn sanity() {
-        let mut subscriptions = Subscriptions::<Port, _>::new();
+        let mut subscriptions: Subscriptions<Port, _> = Default::default();
         subscriptions.subscribe(3, 2);
         subscriptions.subscribe(3, 3);
         subscriptions.subscribe(3, 1);


### PR DESCRIPTION
According to `todo` left by @meowjesty 

Removed `Subscriptions::new` method and implemented `Default` trait.