### PR TITLE
Error message displayed in VS Code when there is no selectable target

### DIFF
--- a/changelog.d/1266.added.md
+++ b/changelog.d/1266.added.md
@@ -1,0 +1,1 @@
+Added an error prompt to the VS Code extension when there is no available target in the configured namespace.

--- a/vscode-ext/src/extension.ts
+++ b/vscode-ext/src/extension.ts
@@ -388,6 +388,15 @@ class ConfigurationProvider implements vscode.DebugConfigurationProvider {
 		// If target wasn't specified in the config file, let user choose pod from dropdown
 		if (!await isTargetInFile()) {
 			let targets = await mirrordApi.listTargets(configPath);
+			if (targets.length === 0) {
+				await vscode.window.showErrorMessage(
+					"No mirrord target available in the configured namespace. " +
+					"Set a different target namespace or kubeconfig in the mirrord configuration file.",
+				);
+
+				return undefined;
+			}
+
 			let targetName = await vscode.window.showQuickPick(targets, { placeHolder: 'Select a target path to mirror' });
 
 			if (targetName) {


### PR DESCRIPTION
Solves #1266 
When there is no target specified in the mirrord configuration file and there is no available target in the current namespace, an error prompt is shown to the user and debugging session is cancelled.
See in action [here](https://user-images.githubusercontent.com/34063647/230900208-bf32030b-94f0-4f6a-a559-de6e5627c73a.webm)
