### PR TITLE
Vscode sip fix

### DIFF
--- a/changelog.d/1271.fixed.md
+++ b/changelog.d/1271.fixed.md
@@ -1,0 +1,1 @@
+Executable field was set to null if present, but no SIP patching was done.

--- a/vscode-ext/src/extension.ts
+++ b/vscode-ext/src/extension.ts
@@ -342,14 +342,19 @@ export async function activate(context: vscode.ExtensionContext) {
 }
 
 // Get the name of the field that holds the exectuable in a debug configuration of the given type.
-function getExecutableFieldName(debuggerType: string): keyof vscode.DebugConfiguration{
-	switch (debuggerType) {
+function getExecutableFieldName(config: vscode.DebugConfiguration): keyof vscode.DebugConfiguration{
+	switch (config.type) {
 		case "pwa-node":
 		case "node": {
 			return "runtimeExecutable";
 		}
 		case "python": {
-			return "python";
+			if ("python" in config) {
+				return "python";
+			}
+			// Official documentation states the relevant field name is "python" (https://code.visualstudio.com/docs/python/debugging#_python), 
+			// but when debugging we see the field is called "pythonPath".
+			return "pythonPath";
 		}
 		default: {
 			return "program";
@@ -417,7 +422,7 @@ class ConfigurationProvider implements vscode.DebugConfigurationProvider {
 		// todo: find better way to resolve the exact ports.
 		config.env["DEBUGGER_IGNORE_PORTS_PATCH"] = "45000-65535";
 
-		let executableFieldName = getExecutableFieldName(config.type);
+		let executableFieldName = getExecutableFieldName(config);
 
 		let executionInfo;
 		if (executableFieldName in config) {
@@ -429,7 +434,7 @@ class ConfigurationProvider implements vscode.DebugConfigurationProvider {
 
 		// For sidestepping SIP on macOS. If we didn't patch, we don't change that config value.
 		let patched_path = executionInfo?.patched_path;
-		if (executableFieldName in config) {
+		if (patched_path) {
 			config[executableFieldName] = patched_path;
 		}
 


### PR DESCRIPTION
  Fixes for the vscode extention's SIP sidestepping
  
  1. Fix executable field name: documentation says "python", but when
     running I see "pythonPath".
  2. If the field was present but there was no patch, the field was
     set to null. Now only setting the field if patched path is not
     null.
