### PR TITLE
Fix pause test

### DIFF
--- a/changelog.d/1261.internal.md
+++ b/changelog.d/1261.internal.md
@@ -1,0 +1,1 @@
+Fix pause E2E test.

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -18,9 +18,7 @@ mod utils {
         time::Duration,
     };
 
-    use bytes::Bytes;
     use chrono::Utc;
-    use futures::Stream;
     use futures_util::stream::{StreamExt, TryStreamExt};
     use k8s_openapi::api::{
         apps::v1::Deployment,
@@ -908,11 +906,5 @@ mod utils {
             headers.clone(),
         )
         .await;
-    }
-
-    pub async fn get_next_log<T: Stream<Item = Result<Bytes, kube::Error>> + Unpin>(
-        stream: &mut T,
-    ) -> String {
-        String::from_utf8_lossy(&stream.try_next().await.unwrap().unwrap()).to_string()
     }
 }

--- a/tests/src/pause.rs
+++ b/tests/src/pause.rs
@@ -42,7 +42,6 @@ mod pause {
     /// To run on mac, first build universal binary: (from repo root) `scripts/build_fat_mac.sh`
     /// then run test with MIRRORD_TESTS_USE_BINARY=../target/universal-apple-darwin/debug/mirrord
     /// Because the test runs a bash script with mirrord and that requires the universal binary.
-    #[ignore]
     #[rstest]
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     #[timeout(Duration::from_secs(240))]


### PR DESCRIPTION
The log_stream provided by kube-rs just returns a stream of chunks of bytes, and up until last week those chunks were one line per chunk, and then this changed and it's not clear why. In this PR we convert this stream into `AsyncRead` and use the `.lines()` method to buffer the bytes and read the logs line-by-line.

This new version was tested to work multiple time on the CI https://github.com/t4lz/mirrord/actions/runs/4677010752.