### PR TITLE
Improve e2e cleanup

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -83,6 +83,14 @@ And then in order to use that binary in the tests, run the tests like this:
 MIRRORD_TESTS_USE_BINARY=../target/universal-apple-darwin/debug/mirrord cargo test -p tests
 ```
 
+### Cleanup
+
+The Kubernetes resources created by an E2E test are automatically deleted when the test exists successfully. However, failed tests by default don't delete their resources to allow debugging. You can force resource deletion by setting a `MIRRORD_E2E_FORCE_CLEANUP` variable to any value.
+
+```bash
+MIRRORD_E2E_FORCE_CLEANUP=y cargo test --package tests
+```
+
 ## Integration Tests
 
 The layer's integration tests test the hooks and their logic without actually using a Kubernetes cluster and spawning

--- a/TESTING.md
+++ b/TESTING.md
@@ -91,6 +91,13 @@ The Kubernetes resources created by an E2E test are automatically deleted when t
 MIRRORD_E2E_FORCE_CLEANUP=y cargo test --package tests
 ```
 
+All test resources share a common label `MIRRORD_E2E_TEST_RESOURCE=true`. To delete them, simply run:
+
+```bash
+kubectl delete namespaces,deployments,services -l MIRRORD_E2E_TEST_RESOURCE=true
+```
+
+
 ## Integration Tests
 
 The layer's integration tests test the hooks and their logic without actually using a Kubernetes cluster and spawning

--- a/changelog.d/1256.added.md
+++ b/changelog.d/1256.added.md
@@ -1,0 +1,1 @@
+Use `MIRRORD_E2E_FORCE_CLEANUP` environment variable to force Kubernetes resources cleanup after failed E2E tests. All resources created for E2E tests now share a constant label `MIRRORD_E2E_TEST_RESOURCE=true`.

--- a/tests/README.md
+++ b/tests/README.md
@@ -3,9 +3,23 @@
 To run the tests locally with the latest mirrord-agent image, run the following in the mirrord directory:
 - `docker build -t test . --file mirrord/agent/Dockerfile`
 - `minikube image load test` (you might have to specify `-p <PROFILE-NAME>` as well)
-- `cargo test --package tests --lib -- tests --nocapture`
+- `cargo test --package tests`
 
-The name "test" is hardcoded for the CI, and the tests will fail with an `Elapsed` error if the image named "test" is not found. 
+The name `test` is hardcoded for the CI, and the tests will fail with an `Elapsed` error if the image named `test` is not found. 
 To use a different image change the environment variable `MIRRORD_AGENT_IMAGE` at `test_server_init` in `tests/src/utils.rs`.
 
 To use the latest release of mirrord-agent, comment out the line adding the `MIRRORD_AGENT_IMAGE` environment. 
+
+# Cleanup
+
+The Kubernetes resources created by an E2E test are automatically deleted when the test exists successfully. However, failed tests by default don't delete their resources to allow debugging. You can force resource deletion by setting a `MIRRORD_E2E_FORCE_CLEANUP` variable to any value.
+
+```bash
+MIRRORD_E2E_FORCE_CLEANUP=y cargo test --package tests
+```
+
+All test resources share a common label `MIRRORD_E2E_TEST_RESOURCE=true`. To delete them, simply run:
+
+```bash
+kubectl delete namespaces,deployments,services -l MIRRORD_E2E_TEST_RESOURCE=true
+```

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -50,6 +50,9 @@ mod utils {
     /// However, if this variable is set, resources will always be deleted.
     pub const FORCE_CLEANUP_ENV_NAME: &'static str = "MIRRORD_E2E_FORCE_CLEANUP";
 
+    /// All Kubernetes resources created for testing purposes share this label.
+    pub const TEST_RESOURCE_LABEL: (&'static str, &'static str) = ("MIRRORD_E2E_TEST_RESOURCE", "true");
+
     pub async fn watch_resource_exists<K: Debug + Clone + DeserializeOwned>(
         api: &Api<K>,
         name: &str,
@@ -534,6 +537,9 @@ mod utils {
             "kind": "Namespace",
             "metadata": {
                 "name": namespace,
+                "labels": {
+                    TEST_RESOURCE_LABEL.0: TEST_RESOURCE_LABEL.1,
+                }
             },
         }))
         .unwrap();
@@ -556,7 +562,8 @@ mod utils {
             "metadata": {
                 "name": &name,
                 "labels": {
-                    "app": &name
+                    "app": &name,
+                    TEST_RESOURCE_LABEL.0: TEST_RESOURCE_LABEL.1,
                 }
             },
             "spec": {
@@ -619,7 +626,8 @@ mod utils {
             "metadata": {
                 "name": &name,
                 "labels": {
-                    "app": &name
+                    "app": &name,
+                    TEST_RESOURCE_LABEL.0: TEST_RESOURCE_LABEL.1,
                 }
             },
             "spec": {


### PR DESCRIPTION
Fixes #1256

* Added a new environment variable `MIRRORD_E2E_FORCE_CLEANUP` - when set, E2E tests will delete their resources even after failure
* Added a new constant label `MIRRORD_E2E_TEST_RESOURCE=true` to all E2E test resources for easy cleanup
* Updated testing guides
* Made some style improvements and added docs around resource creation and deletion