### PR TITLE
Integration tests for outgoing UDP/TCP

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -348,6 +348,9 @@ jobs:
       - run: |
           cd mirrord/layer/tests/apps/fileops
           cargo build
+      - run: |
+          cd mirrord/layer/tests/apps/outgoing
+          cargo build
       - name: download layer # Download layer lib built in the `build_mirrord` job.
         uses: actions/download-artifact@v3
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2833,6 +2833,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "outgoing"
+version = "3.36.0"
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2834,7 +2834,7 @@ dependencies = [
 
 [[package]]
 name = "outgoing"
-version = "3.36.0"
+version = "3.37.0"
 
 [[package]]
 name = "overload"
@@ -3440,9 +3440,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a36c42d1873f9a77c53bde094f9664d9891bc604a45b4798fd2c389ed12e5b"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustc-hash"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@
 members = [
     "mirrord/*",
     "mirrord/layer/tests/apps/fileops",
+    "mirrord/layer/tests/apps/outgoing",
     "sample/rust",
     "tests",
     "tests/rust-e2e-fileops",

--- a/changelog.d/1051.internal.md
+++ b/changelog.d/1051.internal.md
@@ -1,0 +1,1 @@
+Added integration tests for outgoing UDP and TCP.

--- a/mirrord/layer/tests/apps/outgoing/Cargo.toml
+++ b/mirrord/layer/tests/apps/outgoing/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "outgoing"
+version.workspace = true
+authors.workspace = true
+description.workspace = true
+documentation.workspace = true
+readme.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+publish.workspace = true
+edition.workspace = true

--- a/mirrord/layer/tests/apps/outgoing/src/main.rs
+++ b/mirrord/layer/tests/apps/outgoing/src/main.rs
@@ -1,0 +1,96 @@
+use std::{
+    env,
+    io::{Read, Write},
+    net::{SocketAddr, TcpStream, UdpSocket},
+};
+
+const MESSAGE: &[u8] = "FOO BAR HAM".as_bytes();
+
+fn parse_args() -> Option<(bool, SocketAddr, Vec<SocketAddr>)> {
+    let args = env::args().collect::<Vec<_>>();
+
+    if args.len() != 4 {
+        None?
+    }
+
+    let tcp = match args[1].as_str() {
+        "--tcp" => true,
+        "--udp" => false,
+        _ => None?,
+    };
+    let socket = args[2].parse::<SocketAddr>().ok()?;
+    let peers = args[3]
+        .split(',')
+        .map(|s| s.parse::<SocketAddr>())
+        .collect::<Result<Vec<_>, _>>()
+        .ok()?;
+
+    Some((tcp, socket, peers))
+}
+
+fn test_tcp(socket: SocketAddr, peer: SocketAddr) {
+    let mut conn = TcpStream::connect(peer).unwrap();
+
+    let local = conn.local_addr().unwrap();
+    if local != socket {
+        panic!("Invalid local address from local_addr: {local}.")
+    }
+
+    let remote = conn.peer_addr().unwrap();
+    if remote != peer {
+        panic!("Invalid peer address from peer_addr: {peer}.");
+    }
+
+    conn.write_all(MESSAGE).unwrap();
+    conn.flush().unwrap();
+
+    let mut response = vec![];
+    conn.read_to_end(&mut response).unwrap();
+
+    if response != MESSAGE {
+        panic!("Invalid response received: {response:?}");
+    }
+}
+
+fn test_udp(socket: SocketAddr, peer: SocketAddr) {
+    let udp_socket = UdpSocket::bind(socket).unwrap();
+    udp_socket.connect(peer).unwrap();
+
+    let local = udp_socket.local_addr().unwrap();
+    if local != socket {
+        panic!("Invalid local address from local_addr: {local}.")
+    }
+
+    let remote = udp_socket.peer_addr().unwrap();
+    if remote != peer {
+        panic!("Invalid peer address from peer_addr: {peer}.");
+    }
+
+    let sent = udp_socket.send(MESSAGE).unwrap();
+    if sent != MESSAGE.len() {
+        panic!("Partial send: {sent} bytes.");
+    }
+
+    let mut response = [0; MESSAGE.len()];
+    let (res_len, remote) = udp_socket.recv_from(&mut response).unwrap();
+    if res_len != MESSAGE.len() || response != MESSAGE {
+        panic!("Invalid response received: {:?}.", &response[..res_len]);
+    }
+    if remote != peer {
+        panic!("Invalid peer address from recv: {remote}.");
+    }
+}
+
+fn main() {
+    let Some((use_tcp, socket, peers)) = parse_args() else {
+        panic!("USAGE: {} --tcp/--udp <local socket> <peer sockets>", env::args().next().unwrap());
+    };
+
+    peers.into_iter().for_each(|peer| {
+        if use_tcp {
+            test_tcp(socket, peer);
+        } else {
+            test_udp(socket, peer);
+        }
+    });
+}

--- a/mirrord/layer/tests/common/mod.rs
+++ b/mirrord/layer/tests/common/mod.rs
@@ -28,6 +28,7 @@ use tokio::{
 };
 
 pub const RUST_OUTGOING_PEERS: &str = "1.1.1.1:1111,2.2.2.2:2222,3.3.3.3:3333";
+pub const RUST_OUTGOING_LOCAL: &str = "4.4.4.4:4444";
 
 pub struct TestProcess {
     pub child: Option<Child>,
@@ -748,11 +749,11 @@ impl Application {
             | Application::Go19SelfOpen
             | Application::Go19DirBypass
             | Application::Go20DirBypass => vec![],
-            Application::RustOutgoingUdp => ["--udp", "0.0.0.0:4444", RUST_OUTGOING_PEERS]
+            Application::RustOutgoingUdp => ["--udp", RUST_OUTGOING_LOCAL, RUST_OUTGOING_PEERS]
                 .into_iter()
                 .map(Into::into)
                 .collect(),
-            Application::RustOutgoingTcp => ["--tcp", "0.0.0.0:4444", RUST_OUTGOING_PEERS]
+            Application::RustOutgoingTcp => ["--tcp", RUST_OUTGOING_LOCAL, RUST_OUTGOING_PEERS]
                 .into_iter()
                 .map(Into::into)
                 .collect(),

--- a/mirrord/layer/tests/common/mod.rs
+++ b/mirrord/layer/tests/common/mod.rs
@@ -568,6 +568,7 @@ impl LayerConnection {
     }
 }
 
+/// Various applications used by integration tests.
 #[derive(Debug)]
 pub enum Application {
     Go19HTTP,

--- a/mirrord/layer/tests/common/mod.rs
+++ b/mirrord/layer/tests/common/mod.rs
@@ -27,6 +27,8 @@ use tokio::{
     process::{Child, Command},
 };
 
+pub const RUST_OUTGOING_PEERS: &str = "1.1.1.1:1111,2.2.2.2:2222,3.3.3.3:3333";
+
 pub struct TestProcess {
     pub child: Option<Child>,
     stderr: Arc<Mutex<String>>,
@@ -602,6 +604,8 @@ pub enum Application {
     Go19FAccessAt,
     Go20FAccessAt,
     Go19SelfOpen,
+    RustOutgoingUdp,
+    RustOutgoingTcp,
 }
 
 impl Application {
@@ -668,6 +672,11 @@ impl Application {
             Application::Go19FAccessAt => String::from("tests/apps/faccessat_go/19"),
             Application::Go20FAccessAt => String::from("tests/apps/faccessat_go/20"),
             Application::Go19SelfOpen => String::from("tests/apps/self_open/19"),
+            Application::RustOutgoingUdp | Application::RustOutgoingTcp => format!(
+                "{}/{}",
+                env!("CARGO_MANIFEST_DIR"),
+                "../../target/debug/outgoing",
+            ),
         }
     }
 
@@ -739,6 +748,14 @@ impl Application {
             | Application::Go19SelfOpen
             | Application::Go19DirBypass
             | Application::Go20DirBypass => vec![],
+            Application::RustOutgoingUdp => ["--udp", "0.0.0.0:4444", RUST_OUTGOING_PEERS]
+                .into_iter()
+                .map(Into::into)
+                .collect(),
+            Application::RustOutgoingTcp => ["--tcp", "0.0.0.0:4444", RUST_OUTGOING_PEERS]
+                .into_iter()
+                .map(Into::into)
+                .collect(),
         }
     }
 
@@ -777,9 +794,9 @@ impl Application {
             | Application::Go20DirBypass
             | Application::Go19SelfOpen
             | Application::Go19Dir
-            | Application::Go20Dir => {
-                unimplemented!("shouldn't get here")
-            }
+            | Application::Go20Dir
+            | Application::RustOutgoingUdp
+            | Application::RustOutgoingTcp => unimplemented!("shouldn't get here"),
             Application::PythonSelfConnect => 1337,
         }
     }

--- a/mirrord/layer/tests/common/mod.rs
+++ b/mirrord/layer/tests/common/mod.rs
@@ -27,7 +27,9 @@ use tokio::{
     process::{Child, Command},
 };
 
+/// Configuration for [`Application::RustOutgoingTcp`] and [`Application::RustOutgoingUdp`].
 pub const RUST_OUTGOING_PEERS: &str = "1.1.1.1:1111,2.2.2.2:2222,3.3.3.3:3333";
+/// Configuration for [`Application::RustOutgoingTcp`] and [`Application::RustOutgoingUdp`].
 pub const RUST_OUTGOING_LOCAL: &str = "4.4.4.4:4444";
 
 pub struct TestProcess {

--- a/mirrord/layer/tests/outgoing.rs
+++ b/mirrord/layer/tests/outgoing.rs
@@ -1,4 +1,5 @@
 #![feature(assert_matches)]
+#![cfg(target_os = "linux")]
 
 use std::{net::SocketAddr, path::PathBuf, time::Duration};
 

--- a/mirrord/layer/tests/outgoing.rs
+++ b/mirrord/layer/tests/outgoing.rs
@@ -1,5 +1,4 @@
 #![feature(assert_matches)]
-#![cfg(target_os = "linux")]
 
 use std::{net::SocketAddr, path::PathBuf, time::Duration};
 
@@ -15,7 +14,7 @@ use rstest::rstest;
 
 mod common;
 
-use common::*;
+pub use common::*;
 use futures::{SinkExt, TryStreamExt};
 
 /// Test outgoing UDP.

--- a/mirrord/layer/tests/outgoing.rs
+++ b/mirrord/layer/tests/outgoing.rs
@@ -29,7 +29,7 @@ use futures::{SinkExt, TryStreamExt};
 #[ignore]
 #[rstest]
 #[tokio::test]
-#[timeout(Duration::from_secs(5))]
+#[timeout(Duration::from_secs(10))]
 async fn outgoing_udp(dylib_path: &PathBuf) {
     let (mut test_process, layer_connection) = Application::RustOutgoingUdp
         .start_process_with_layer(dylib_path, vec![], None)
@@ -85,7 +85,7 @@ async fn outgoing_udp(dylib_path: &PathBuf) {
 /// 4. Expects the peer to send the same data back
 #[rstest]
 #[tokio::test]
-#[timeout(Duration::from_secs(5))]
+#[timeout(Duration::from_secs(10))]
 async fn outgoing_tcp(dylib_path: &PathBuf) {
     let (mut test_process, layer_connection) = Application::RustOutgoingTcp
         .start_process_with_layer(dylib_path, vec![], None)

--- a/mirrord/layer/tests/outgoing.rs
+++ b/mirrord/layer/tests/outgoing.rs
@@ -16,12 +16,13 @@ mod common;
 use common::*;
 use futures::{SinkExt, TryStreamExt};
 
+#[ignore]
 #[rstest]
 #[tokio::test]
 #[timeout(Duration::from_secs(5))]
 async fn outgoing_udp(dylib_path: &PathBuf) {
     let (mut test_process, layer_connection) = Application::RustOutgoingUdp
-        .start_process_with_layer(dylib_path, Default::default())
+        .start_process_with_layer(dylib_path, vec![], None)
         .await;
     let mut conn = layer_connection.codec;
 
@@ -40,7 +41,7 @@ async fn outgoing_udp(dylib_path: &PathBuf) {
             DaemonConnect {
                 connection_id: 0,
                 remote_address: addr.into(),
-                local_address: "0.0.0.0:4444".parse::<SocketAddr>().unwrap().into(),
+                local_address: RUST_OUTGOING_LOCAL.parse::<SocketAddr>().unwrap().into(),
             },
         ))))
         .await
@@ -71,7 +72,7 @@ async fn outgoing_udp(dylib_path: &PathBuf) {
 #[timeout(Duration::from_secs(5))]
 async fn outgoing_tcp(dylib_path: &PathBuf) {
     let (mut test_process, layer_connection) = Application::RustOutgoingTcp
-        .start_process_with_layer(dylib_path, Default::default())
+        .start_process_with_layer(dylib_path, vec![], None)
         .await;
     let mut conn = layer_connection.codec;
 
@@ -90,7 +91,7 @@ async fn outgoing_tcp(dylib_path: &PathBuf) {
             DaemonConnect {
                 connection_id: 0,
                 remote_address: addr.into(),
-                local_address: "0.0.0.0:4444".parse::<SocketAddr>().unwrap().into(),
+                local_address: RUST_OUTGOING_LOCAL.parse::<SocketAddr>().unwrap().into(),
             },
         ))))
         .await

--- a/mirrord/layer/tests/outgoing.rs
+++ b/mirrord/layer/tests/outgoing.rs
@@ -1,4 +1,6 @@
 #![feature(assert_matches)]
+#![cfg(target_os = "linux")]
+
 use std::{net::SocketAddr, path::PathBuf, time::Duration};
 
 use mirrord_protocol::{

--- a/mirrord/layer/tests/outgoing.rs
+++ b/mirrord/layer/tests/outgoing.rs
@@ -1,0 +1,117 @@
+#![feature(assert_matches)]
+use std::{net::SocketAddr, path::PathBuf, time::Duration};
+
+use mirrord_protocol::{
+    outgoing::{
+        tcp::{DaemonTcpOutgoing, LayerTcpOutgoing},
+        udp::{DaemonUdpOutgoing, LayerUdpOutgoing},
+        DaemonConnect, DaemonRead, LayerConnect, LayerWrite, SocketAddress,
+    },
+    ClientMessage, DaemonMessage,
+};
+use rstest::rstest;
+
+mod common;
+
+use common::*;
+use futures::{SinkExt, TryStreamExt};
+
+#[rstest]
+#[tokio::test]
+#[timeout(Duration::from_secs(5))]
+async fn outgoing_udp(dylib_path: &PathBuf) {
+    let (mut test_process, layer_connection) = Application::RustOutgoingUdp
+        .start_process_with_layer(dylib_path, Default::default())
+        .await;
+    let mut conn = layer_connection.codec;
+
+    let peers = RUST_OUTGOING_PEERS
+        .split(',')
+        .map(|s| s.parse::<SocketAddr>().unwrap())
+        .collect::<Vec<_>>();
+
+    for peer in peers {
+        let msg = conn.try_next().await.unwrap().unwrap();
+        let ClientMessage::UdpOutgoing(LayerUdpOutgoing::Connect(LayerConnect { remote_address: SocketAddress::Ip(addr) })) = msg else {
+            panic!("Invalid message received from layer: {msg:?}");
+        };
+        assert_eq!(addr, peer);
+        conn.send(DaemonMessage::UdpOutgoing(DaemonUdpOutgoing::Connect(Ok(
+            DaemonConnect {
+                connection_id: 0,
+                remote_address: addr.into(),
+                local_address: "0.0.0.0:4444".parse::<SocketAddr>().unwrap().into(),
+            },
+        ))))
+        .await
+        .unwrap();
+
+        let msg = conn.try_next().await.unwrap().unwrap();
+        let ClientMessage::UdpOutgoing(LayerUdpOutgoing::Write(LayerWrite { connection_id: 0, bytes })) = msg else {
+            panic!("Invalid message received from layer: {msg:?}");
+        };
+        conn.send(DaemonMessage::UdpOutgoing(DaemonUdpOutgoing::Read(Ok(
+            DaemonRead {
+                connection_id: 0,
+                bytes,
+            },
+        ))))
+        .await
+        .unwrap();
+        conn.send(DaemonMessage::UdpOutgoing(DaemonUdpOutgoing::Close(0)))
+            .await
+            .unwrap();
+    }
+
+    test_process.wait_assert_success().await;
+}
+
+#[rstest]
+#[tokio::test]
+#[timeout(Duration::from_secs(5))]
+async fn outgoing_tcp(dylib_path: &PathBuf) {
+    let (mut test_process, layer_connection) = Application::RustOutgoingTcp
+        .start_process_with_layer(dylib_path, Default::default())
+        .await;
+    let mut conn = layer_connection.codec;
+
+    let peers = RUST_OUTGOING_PEERS
+        .split(',')
+        .map(|s| s.parse::<SocketAddr>().unwrap())
+        .collect::<Vec<_>>();
+
+    for peer in peers {
+        let msg = conn.try_next().await.unwrap().unwrap();
+        let ClientMessage::TcpOutgoing(LayerTcpOutgoing::Connect(LayerConnect { remote_address: SocketAddress::Ip(addr) })) = msg else {
+            panic!("Invalid message received from layer: {msg:?}");
+        };
+        assert_eq!(addr, peer);
+        conn.send(DaemonMessage::TcpOutgoing(DaemonTcpOutgoing::Connect(Ok(
+            DaemonConnect {
+                connection_id: 0,
+                remote_address: addr.into(),
+                local_address: "0.0.0.0:4444".parse::<SocketAddr>().unwrap().into(),
+            },
+        ))))
+        .await
+        .unwrap();
+
+        let msg = conn.try_next().await.unwrap().unwrap();
+        let ClientMessage::TcpOutgoing(LayerTcpOutgoing::Write(LayerWrite { connection_id: 0, bytes })) = msg else {
+            panic!("Invalid message received from layer: {msg:?}");
+        };
+        conn.send(DaemonMessage::TcpOutgoing(DaemonTcpOutgoing::Read(Ok(
+            DaemonRead {
+                connection_id: 0,
+                bytes,
+            },
+        ))))
+        .await
+        .unwrap();
+        conn.send(DaemonMessage::TcpOutgoing(DaemonTcpOutgoing::Close(0)))
+            .await
+            .unwrap();
+    }
+
+    test_process.wait_assert_success().await;
+}

--- a/mirrord/layer/tests/outgoing.rs
+++ b/mirrord/layer/tests/outgoing.rs
@@ -16,6 +16,15 @@ mod common;
 use common::*;
 use futures::{SinkExt, TryStreamExt};
 
+/// Test outgoing UDP.
+/// Application, for each remote peer in [`RUST_OUTGOING_PEERS`]:
+/// 1. Opens a UDP port at [`RUST_OUTGOING_LOCAL`]
+/// 2. Connects to the remote peer
+/// 3. Sends some data
+/// 4. Expects the peer to send the same data back
+///
+/// # Ignored
+/// This test is ignored due to a bug - `recv_from` call returns an invalid remote peer address.
 #[ignore]
 #[rstest]
 #[tokio::test]
@@ -67,6 +76,12 @@ async fn outgoing_udp(dylib_path: &PathBuf) {
     test_process.wait_assert_success().await;
 }
 
+/// Test outgoing TCP.
+/// Application, for each remote peer in [`RUST_OUTGOING_PEERS`]:
+/// 1. Opens a TCP port at [`RUST_OUTGOING_LOCAL`]
+/// 2. Connects to the remote peer
+/// 3. Sends some data
+/// 4. Expects the peer to send the same data back
 #[rstest]
 #[tokio::test]
 #[timeout(Duration::from_secs(5))]


### PR DESCRIPTION
Fixes #1051 

Udp test fails for now, remote address returned from `recv_from` is some localhost port.