### PR TITLE
Improve target selection in IntelliJ extension

### DIFF
--- a/changelog.d/1267.added.md
+++ b/changelog.d/1267.added.md
@@ -1,0 +1,1 @@
+A descriptive message is now presented in the IntelliJ extension when no target is available. Listing targets failure is now handled and an error notification is presented.

--- a/intellij-ext/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordApi.kt
+++ b/intellij-ext/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordApi.kt
@@ -41,7 +41,7 @@ object MirrordApi {
         return path
     }
 
-    fun listPods(configFile: String?, project: Project?, wslDistribution: WSLDistribution?): List<String> {
+    fun listPods(configFile: String?, project: Project?, wslDistribution: WSLDistribution?): List<String>? {
         MirrordLogger.logger.debug("listing pods")
         val commandLine = GeneralCommandLine(cliPath(wslDistribution), "ls", "-o", "json")
         configFile?.let {
@@ -67,6 +67,13 @@ object MirrordApi {
 
         MirrordLogger.logger.debug("waiting for process to finish")
         process.waitFor(60, TimeUnit.SECONDS)
+
+        if (process.exitValue() != 0) {
+            MirrordNotifier.errorNotification("mirrord failed to list available targets", project);
+            val data = process.errorStream.bufferedReader().readText()
+            MirrordLogger.logger.debug("mirrord ls failed: %s".format(data))
+            return null
+        }
 
         MirrordLogger.logger.debug("process wait finished, reading output")
         val data = process.inputStream.bufferedReader().readText()

--- a/intellij-ext/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordExecManager.kt
+++ b/intellij-ext/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordExecManager.kt
@@ -1,6 +1,7 @@
 package com.metalbear.mirrord
 
 import com.intellij.execution.wsl.WSLDistribution
+import com.intellij.notification.NotificationType
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.SystemInfo
@@ -29,9 +30,15 @@ object MirrordExecManager {
                 project,
                 wslDistribution
             )
+        pods ?: return null
 
         if (pods.isEmpty()) {
-            MirrordNotifier.progress("no pods found, please check namespace/kubeconfig.", project)
+            MirrordNotifier.notify(
+                    "No mirrord target available in the configured namespace. " +
+                            "Set a different target namespace or kubeconfig in the mirrord configuration file.",
+                    NotificationType.ERROR,
+                    project,
+            )
             return null
         }
 


### PR DESCRIPTION
Fixes #1267

I changed the error notification for the case when no target is available. Now the message matches the one we show in the VS Code extension and suggests changing the namespace or kubeconfig.
By the way, I noticed that a failure of `mirrord ls` was not handled and resulted with a null pointer exception. Added an error prompt and a log of stderr.
[See in action here](https://user-images.githubusercontent.com/34063647/232569283-d7895a63-fa56-4491-b320-5843f5548f71.webm)
