### PR TITLE
Added protoc dependency to the build instructions

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -207,6 +207,8 @@ py-serv-deployment-ff89b5974-x9tjx   1/1     Running   0          3h8m
 
 ### Build and run mirrord
 
+To build this project, you will first need a [Protocol Buffer Compiler](https://grpc.io/docs/protoc-installation/) installed.
+
 #### macOS
 ```bash
 scripts/build_fat_mac.sh

--- a/changelog.d/+fix-build-instructions.internal.md
+++ b/changelog.d/+fix-build-instructions.internal.md
@@ -1,0 +1,1 @@
+Project build instructions in the testing guide now include the protoc dependency.


### PR DESCRIPTION
Building the project now requires a protoc installed (due to `k8s-cri` dependency in the agent)