### PR TITLE
Detect debugger port in VS Code extension

### DIFF
--- a/changelog.d/1145.fixed.md
+++ b/changelog.d/1145.fixed.md
@@ -1,0 +1,1 @@
+VS Code extension now detects `debugpy` debugger and properly handles excludes its port.

--- a/intellij-ext/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordExecManager.kt
+++ b/intellij-ext/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordExecManager.kt
@@ -101,7 +101,7 @@ object MirrordExecManager {
 
         val env = MirrordApi.exec(target, getConfigPath(project), project, wslDistribution)
 
-        env["DEBUGGER_IGNORE_PORTS_PATCH"] = "45000-65535"
+        env["MIRRORD_IGNORE_DEBUGGER_PORTS"] = "45000-65535"
         return env.toImmutableMap()
     }
 }

--- a/mirrord/layer/src/debugger_ports.rs
+++ b/mirrord/layer/src/debugger_ports.rs
@@ -126,3 +126,19 @@ impl DebuggerPorts {
                 .unwrap_or(false))
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn detect_debugpy_port() {
+        let debugger = DebuggerType::DebugPy;
+        let command = "/home/user/path/to/venv/bin/python /home/user/.vscode/extensions/ms-python.python-2023.6.1/pythonFiles/lib/python/debugpy/adapter/../../debugpy/launcher/../../debugpy --connect 127.0.0.1:57141 --configure-qt none --adapter-access-token c2d745556a5a571d09dbf9c14af2898b3d6c174597d6b7198d9d30c105d5ab24 /home/user/path/to/script.py";
+
+        assert_eq!(
+            debugger.get_port(&command.split_ascii_whitespace().map(ToString::to_string).collect::<Vec<_>>()),
+            Some(57141),
+        )
+    }
+}

--- a/mirrord/layer/src/debugger_ports.rs
+++ b/mirrord/layer/src/debugger_ports.rs
@@ -1,0 +1,128 @@
+use std::{
+    env,
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
+    ops::RangeInclusive,
+    str::FromStr,
+};
+
+use tracing::{error, warn};
+
+/// Environment variable used to tell the layer that it should dynamically detect the local port
+/// port used by the given debugger. Value passed through this variable should parse into
+/// [`DebuggerType`]. Used when injecting the layer through IDE, because the debugger port is chosen
+/// dynamically.
+pub const MIRRORD_DETECT_DEBUGGER_PORT_ENV: &str = "MIRRORD_DETECT_DEBUGGER_PORT";
+
+/// Environment variable used to tell the layer that it should ignore certain local ports used by
+/// the debugger. Used when injecting the layer through IDE.
+///
+/// Value passed through this variable can represent a single port like '12233' or a range of ports
+/// like `12233-13000`.
+pub const MIRRORD_IGNORE_DEBUGGER_PORTS_ENV: &str = "MIRRORD_IGNORE_DEBUGGER_PORTS";
+
+/// Type of debugger which is used to run the user's processes.
+#[derive(Debug, Clone, Copy)]
+pub enum DebuggerType {
+    DebugPy,
+}
+
+impl FromStr for DebuggerType {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "debugpy" => Ok(Self::DebugPy),
+            _ => Err(format!("invalid debugger type: {s}")),
+        }
+    }
+}
+
+impl DebuggerType {
+    fn get_port(self, args: &[String]) -> Option<u16> {
+        match self {
+            Self::DebugPy => {
+                let is_python = args.first()?.rsplit('/').next().unwrap().contains("python");
+                let runs_debugpy = args.get(1)?.ends_with("debugpy");
+                if is_python && runs_debugpy {
+                    args.windows(2).find_map(|window| match window {
+                        [opt, val] if opt == "--connect" => val.parse::<SocketAddr>().ok(),
+                        _ => None,
+                    })
+                } else {
+                    None
+                }
+            }
+        }
+        .and_then(|addr| match addr.ip() {
+            IpAddr::V4(Ipv4Addr::LOCALHOST) | IpAddr::V6(Ipv6Addr::LOCALHOST) => Some(addr.port()),
+            other => {
+                warn!(
+                    "Debugger uses a remote socket address {:?}! This case is not yet handled properly.",
+                    other,
+                );
+                None
+            }
+        })
+    }
+}
+
+/// Local ports used by the debugger running the process.
+/// These should be ignored by the layer.
+#[derive(Debug)]
+pub struct DebuggerPorts {
+    detected: Option<u16>,
+    fixed: Option<RangeInclusive<u16>>,
+}
+
+impl DebuggerPorts {
+    /// Create a new instance of this struct based on the environment variables
+    /// ([`MIRRORD_DETECT_DEBUGGER_PORT_ENV`] and [`MIRRORD_IGNORE_DEBUGGER_PORTS_ENV`]) and command
+    /// line arguments.
+    ///
+    /// Log errors (like malformed env variables) but do not panic.
+    pub fn from_env() -> Self {
+        let detected = env::var(MIRRORD_DETECT_DEBUGGER_PORT_ENV)
+            .ok()
+            .and_then(|s| {
+                DebuggerType::from_str(&s)
+                    .inspect_err(|e| {
+                        error!(
+                            "Failed to decode debugger type from {} env variable: {}",
+                            MIRRORD_DETECT_DEBUGGER_PORT_ENV, e
+                        )
+                    })
+                    .ok()
+            })
+            .and_then(|d| d.get_port(&std::env::args().collect::<Vec<_>>()));
+
+        let fixed = env::var(MIRRORD_IGNORE_DEBUGGER_PORTS_ENV).ok().and_then(|s| {
+            let chunks = s.split('-').map(u16::from_str).collect::<Result<Vec<_>, _>>().inspect_err(|e| error!("Failed to decode debugger ports from {} env variable: {}", MIRRORD_IGNORE_DEBUGGER_PORTS_ENV, e)).ok()?;
+            match *chunks.as_slice() {
+                [p] => Some(p..=p),
+                [p1, p2] if p1 <= p2 => Some(p1..=p2),
+                _ => {
+                    error!(
+                        "Failed to decode debugger ports from {} env variable: expected a port or a range of ports",
+                        MIRRORD_IGNORE_DEBUGGER_PORTS_ENV,
+                    );
+                    None
+                },
+            }
+        });
+
+        Self { detected, fixed }
+    }
+
+    /// Return whether the given [SocketAddr] is used by the debugger.
+    pub fn contains(&self, addr: &SocketAddr) -> bool {
+        matches!(
+            addr.ip(),
+            IpAddr::V4(Ipv4Addr::LOCALHOST) | IpAddr::V6(Ipv6Addr::LOCALHOST)
+        ) && (self.detected == Some(addr.port())
+            || self
+                .fixed
+                .as_ref()
+                .map(|r| r.contains(&addr.port()))
+                .unwrap_or(false))
+    }
+}

--- a/vscode-ext/src/extension.ts
+++ b/vscode-ext/src/extension.ts
@@ -440,11 +440,13 @@ class ConfigurationProvider implements vscode.DebugConfigurationProvider {
 			if (process.platform === "darwin") {
 				config.dlvToolPath = path.join(globalContext.extensionPath, "bin", "darwin", "dlv-" + process.arch);
 			}
+		} else if (config.type === "python") {
+			config.env["MIRRORD_DETECT_DEBUGGER_PORT"] = "debugpy";
 		}
-		
-		// add range of ports that vs code uses for debugging (mostly Python)
-		// todo: find better way to resolve the exact ports.
-		config.env["DEBUGGER_IGNORE_PORTS_PATCH"] = "45000-65535";
+
+		// Add a fixed range of ports that VS Code uses for debugging.
+		// TODO: find a way to use MIRRORD_DETECT_DEBUGGER_PORT for other debuggers.
+		config.env["MIRRORD_IGNORE_DEBUGGER_PORTS"] = "45000-65535";
 
 		let executableFieldName = getExecutableFieldName(config);
 


### PR DESCRIPTION
Resolves #1145 

This workaround is quite ugly, but I don't think there's any nicer way to handle debugger ports in VS Code. The port is not exposed in the API and it can't be set by the extension.

I don't expect this change to fix the problem for everyone, as the exact command used to invoke the debugger is specific to my setup and not universal. However, I wrote the code in a way that allows handling more debuggers and patterns.