### PR TITLE
Detect Python debugger PyCharm

### DIFF
--- a/changelog.d/1020.fixed.md
+++ b/changelog.d/1020.fixed.md
@@ -1,0 +1,1 @@
+PyCharm plugin now detects `pydevd` debugger and properly excludes its port.

--- a/intellij-ext/build.gradle.kts
+++ b/intellij-ext/build.gradle.kts
@@ -42,7 +42,15 @@ intellij {
     }
 
     // Plugin Dependencies. Uses `platformPlugins` property from the gradle.properties file.
-    plugins.set(properties("platformPlugins").split(',').map(String::trim).filter(String::isNotEmpty))
+    if (platformType != "PY" && platformType != "PC") {
+        plugins.set(
+                properties("platformPlugins")
+                        .split(',')
+                        .map(String::trim)
+                        .filter(String::isNotEmpty)
+        )
+    }
+
     updateSinceUntilBuild.set(false)
 }
 

--- a/intellij-ext/modules/products/pycharm/src/main/kotlin/com/metalbear/mirrord/products/pycharm/PythonCommandLineProvider.kt
+++ b/intellij-ext/modules/products/pycharm/src/main/kotlin/com/metalbear/mirrord/products/pycharm/PythonCommandLineProvider.kt
@@ -36,6 +36,8 @@ class PythonCommandLineProvider : PythonCommandLineTargetEnvironmentProvider {
                         pythonExecution.addEnvironmentVariable(entry.key, entry.value)
                     }
                 }
+
+                pythonExecution.addEnvironmentVariable("MIRRORD_DETECT_DEBUGGER_PORT", "pydevd")
             } catch (e: ExecutionException) {
                 throw RuntimeException(e)
             }

--- a/intellij-ext/modules/products/pycharm/src/main/kotlin/com/metalbear/mirrord/products/pycharm/PythonRunConfigurationExtension.kt
+++ b/intellij-ext/modules/products/pycharm/src/main/kotlin/com/metalbear/mirrord/products/pycharm/PythonRunConfigurationExtension.kt
@@ -44,6 +44,8 @@ class PythonRunConfigurationExtension: PythonRunConfigurationExtension() {
                 currentEnv[entry.key] =  entry.value
             }
         }
+
+        currentEnv["MIRRORD_DETECT_DEBUGGER_PORT"] = "pydevd"
     }
 
 }


### PR DESCRIPTION
Fixes #1020 

Added new `DebuggerType` variant for PyDevD used by PyCharm.

Also fixed `:runIde` command for PyCharm Community and Ultimate