### PR TITLE
Fixed delve patch not working on GoLand macOS when running go tests

### DIFF
--- a/changelog.d/1364.fixed.md
+++ b/changelog.d/1364.fixed.md
@@ -1,0 +1,1 @@
+Fixed delve patch not working on GoLand macOS when running go tests


### PR DESCRIPTION
Fixes #1364 