### PR TITLE
Display mirrord loading progress in the status bar

### DIFF
--- a/changelog.d/1337.changed.md
+++ b/changelog.d/1337.changed.md
@@ -1,0 +1,1 @@
+mirrord loading progress is displayed in the staus indicator on IntelliJ, replacing the singleton notifier

--- a/intellij-ext/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordApi.kt
+++ b/intellij-ext/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordApi.kt
@@ -4,11 +4,7 @@ import com.google.gson.Gson
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.wsl.WSLCommandLineOptions
 import com.intellij.execution.wsl.WSLDistribution
-import com.intellij.openapi.progress.ProgressIndicator
-import com.intellij.openapi.progress.ProgressManager
-import com.intellij.openapi.progress.Task
 import com.intellij.openapi.project.Project
-import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
 
 
@@ -73,7 +69,7 @@ object MirrordApi {
         process.waitFor(60, TimeUnit.SECONDS)
 
         if (process.exitValue() != 0) {
-            MirrordNotifier.errorNotification("mirrord failed to list available targets", project);
+            MirrordNotifier.errorNotification("mirrord failed to list available targets", project)
             val data = process.errorStream.bufferedReader().readText()
             MirrordLogger.logger.debug("mirrord ls failed: %s".format(data))
             return null

--- a/intellij-ext/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordApi.kt
+++ b/intellij-ext/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordApi.kt
@@ -19,7 +19,7 @@ enum class MessageType {
 
 
 // I don't know how to do tags like Rust so this format is for parsing both kind of messages ;_;
-data class Message (
+data class Message(
     val type: MessageType,
     val name: String,
     val parent: String?,
@@ -87,7 +87,12 @@ object MirrordApi {
 
     }
 
-    fun exec(target: String?, configFile: String?, project: Project?, wslDistribution: WSLDistribution?): MutableMap<String, String> {
+    fun exec(
+        target: String?,
+        configFile: String?,
+        project: Project?,
+        wslDistribution: WSLDistribution?
+    ): MutableMap<String, String> {
         val commandLine = GeneralCommandLine(cliPath(wslDistribution), "ext")
 
         target?.let {
@@ -118,38 +123,29 @@ object MirrordApi {
         val bufferedReader = process.inputStream.reader().buffered()
         val gson = Gson()
 
-        var environment = CompletableFuture<MutableMap<String, String>>()
-
-        val progressIndicator = ProgressManager.getInstance().progressIndicator
-
-
-        ProgressManager.getInstance().runProcess({
-            for (line in bufferedReader.lines()) {
-                val message = gson.fromJson(line, Message::class.java)
-                // See if it's the final message
-                if (message.name == "mirrord preparing to launch"
-                    && message.type == MessageType.FinishedTask) {
-                    val success = message.success ?: throw Error("Invalid message")
-                    if (success) {
-                        val innerMessage = message.message ?: throw Error("Invalid inner message")
-                        val executionInfo = gson.fromJson(innerMessage, MirrordExecution::class.java)
-                        progressIndicator.text = "mirrord started!"
-                        environment.complete(executionInfo.environment)
-                    } else {
-                        MirrordNotifier.errorNotification("mirrord failed to launch", project)
-                    }
+        for (line in bufferedReader.lines()) {
+            val message = gson.fromJson(line, Message::class.java)
+            // See if it's the final message
+            if (message.name == "mirrord preparing to launch"
+                && message.type == MessageType.FinishedTask
+            ) {
+                val success = message.success ?: throw Error("Invalid message")
+                if (success) {
+                    val innerMessage = message.message ?: throw Error("Invalid inner message")
+                    val executionInfo = gson.fromJson(innerMessage, MirrordExecution::class.java)
+                    MirrordNotifier.progress("mirrord started!")
+                    return executionInfo.environment
+                } else {
+                    MirrordNotifier.errorNotification("mirrord failed to launch", project)
                 }
-                var displayMessage = message.name
-                message.message?.let {
-                    displayMessage += ": $it"
-                }
-                progressIndicator.text = displayMessage
             }
-        }, progressIndicator)
-
-        environment?.let {
-            return it.get()
+            var displayMessage = message.name
+            message.message?.let {
+                displayMessage += ": $it"
+            }
+            MirrordNotifier.progress(displayMessage)
         }
+
         logger.error("mirrord stderr: %s".format(process.errorStream.reader().readText()))
         MirrordNotifier.errorNotification("mirrord failed to launch", project)
         throw Error("failed launch")

--- a/intellij-ext/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordExecManager.kt
+++ b/intellij-ext/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordExecManager.kt
@@ -94,7 +94,7 @@ object MirrordExecManager {
             }
             if (target == null) {
                 MirrordLogger.logger.warn("mirrord loading canceled")
-                MirrordNotifier.progress("mirrord loading canceled.", project)
+                MirrordNotifier.notify("mirrord loading canceled.", NotificationType.WARNING, project)
                 return null
             }
         }

--- a/intellij-ext/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordNotifier.kt
+++ b/intellij-ext/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordNotifier.kt
@@ -25,7 +25,7 @@ object MirrordNotifier {
     }
 
     fun progress(message: String) {
-        ProgressManager.getInstance().progressIndicator.text = message
+        ProgressManager.getInstance().progressIndicator.text = "mirrord: $message"
     }
 
     fun notifier(message: String, type: NotificationType): Notification {

--- a/intellij-ext/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordNotifier.kt
+++ b/intellij-ext/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordNotifier.kt
@@ -6,10 +6,6 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.util.NlsContexts
-import com.intellij.openapi.wm.ToolWindowManager
-import java.util.concurrent.atomic.AtomicReference
-import java.util.function.Consumer
 
 /**
  * Mirrord notification handler

--- a/intellij-ext/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordNotifier.kt
+++ b/intellij-ext/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordNotifier.kt
@@ -4,6 +4,7 @@ import com.intellij.ide.BrowserUtil
 import com.intellij.notification.*
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.NlsContexts
 import com.intellij.openapi.wm.ToolWindowManager
@@ -18,7 +19,7 @@ object MirrordNotifier {
         .getInstance()
         .getNotificationGroup("mirrord Notification Handler")
 
-    private val progressNotificationManager = SingletonNotificationManager("mirrord Notification Handler", NotificationType.INFORMATION)
+    private val progressIndicator = ProgressManager.getInstance().progressIndicator
 
     fun notify(message: String, type: NotificationType, project: Project?) {
         ApplicationManager.getApplication().invokeLater {
@@ -28,10 +29,8 @@ object MirrordNotifier {
         }
     }
 
-    fun progress(message: String, project: Project?) {
-        ApplicationManager.getApplication().invokeLater {
-            progressNotificationManager.notify("mirrord", message, project) {}
-        }
+    fun progress(message: String) {
+        progressIndicator.text = message
     }
 
     fun notifier(message: String, type: NotificationType): Notification {


### PR DESCRIPTION
closes #1337

the above-mentioned issue mentions "mirrord started!" is never displayed, this happened because of the underlying implementation of the Signleton notifier being used as it did not display the notification if a bubble had not expired. To fix this we use the ProgressManager API, however we still don't usually see "mirrord started!" because it happens too fast.

some considerations while making this change:

- 
```
  /**
   * Runs the given process synchronously in calling thread, associating this thread with the specified progress indicator.
   * This means that it'll be returned by {@link ProgressManager#getProgressIndicator()} inside the {@code process},
   * and {@link ProgressManager#checkCanceled()} will throw a {@link ProcessCanceledException} if the progress indicator is canceled.
   *
   * @param progress an indicator to use, {@code null} means reuse current progress
   */
  public abstract void runProcess(@NotNull Runnable process, @Nullable ProgressIndicator progress) throws ProcessCanceledException;
```

this works the same as what has been implemented in the PR except we associate it to a particular progress indicator which is `ProgressManager.getInstance().progressIndicator` and we can use it directly

- 
```
  /**
   * Runs a specified {@code task} in either background/foreground thread and shows a progress dialog.
   *
   * @param task task to run (either {@link Task.Modal} or {@link Task.Backgroundable}).
   */
  public abstract void run(@NotNull Task task);
```

this and most other methods run on dialog boxes and not on status indicators, i haven't been able to find a way to run a `Task` with a custom indicator

- 
```
public abstract void runProcessWithProgressAsynchronously(@NotNull Task.Backgroundable task, @NotNull ProgressIndicator progressIndicator);
```
errors out and recommends to use: 
```
  /**
   * @param progress an indicator to use, {@code null} means reuse current progress
   */
  public abstract void executeProcessUnderProgress(@NotNull Runnable process, @Nullable ProgressIndicator progress) throws ProcessCanceledException;
```
, also not desirable IMO since its run in a background thread

-- 
Should the buffer loop be run as a background task or a foreground task using `Task`, `Runnable` constructs? or are we okay with running it in sync as implemented right now while directly accessing the ProgressManager