### PR TITLE
Targetless intellij

### DIFF
--- a/changelog.d/1375.added.md
+++ b/changelog.d/1375.added.md
@@ -1,0 +1,1 @@
+Support for agentless mode in IntelliJ based IDEs.

--- a/intellij-ext/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordApi.kt
+++ b/intellij-ext/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordApi.kt
@@ -40,6 +40,7 @@ data class MirrordExecution(
  */
 object MirrordApi {
     private const val cliBinary = "mirrord"
+    const val targetlessTargetName = "No Target (\"targetless\")"
     private val logger = MirrordLogger.logger
     private fun cliPath(wslDistribution: WSLDistribution?): String {
         val path = MirrordPathManager.getBinary(cliBinary, true)!!
@@ -49,7 +50,8 @@ object MirrordApi {
         return path
     }
 
-    fun listPods(configFile: String?, project: Project?, wslDistribution: WSLDistribution?): List<String>? {
+    /** run mirrord ls, return list of pods + targetless target. */
+    fun listPods(configFile: String?, project: Project?, wslDistribution: WSLDistribution?): List<String> {
         MirrordLogger.logger.debug("listing pods")
         val commandLine = GeneralCommandLine(cliPath(wslDistribution), "ls", "-o", "json")
         configFile?.let {
@@ -76,19 +78,30 @@ object MirrordApi {
         MirrordLogger.logger.debug("waiting for process to finish")
         process.waitFor(60, TimeUnit.SECONDS)
 
-        if (process.exitValue() != 0) {
+        val pods: MutableList<String> = if (process.exitValue() != 0) {
             MirrordNotifier.errorNotification("mirrord failed to list available targets", project)
             val data = process.errorStream.bufferedReader().readText()
             MirrordLogger.logger.debug("mirrord ls failed: %s".format(data))
-            return null
+            mutableListOf()
+        } else {
+            MirrordLogger.logger.debug("process wait finished, reading output")
+            val data = process.inputStream.bufferedReader().readText()
+            val gson = Gson()
+            MirrordLogger.logger.debug("parsing %s".format(data))
+            gson.fromJson(data, Array<String>::class.java).toMutableList()
         }
 
-        MirrordLogger.logger.debug("process wait finished, reading output")
-        val data = process.inputStream.bufferedReader().readText()
-        val gson = Gson()
-        MirrordLogger.logger.debug("parsing %s".format(data))
-        return gson.fromJson(data, Array<String>::class.java).asList()
+        if (pods.isEmpty()) {
+            MirrordNotifier.notify(
+                "No mirrord target available in the configured namespace. " +
+                        "You can run targetless, or set a different target namespace or kubeconfig in the mirrord configuration file.",
+                NotificationType.INFORMATION,
+                project,
+            )
+        }
 
+        pods.add(targetlessTargetName)
+        return pods
     }
 
     fun exec(

--- a/intellij-ext/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordExecDialog.kt
+++ b/intellij-ext/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordExecDialog.kt
@@ -17,6 +17,7 @@ object MirrordExecDialog {
     private const val dialogHeading: String = "mirrord"
     private const val targetLabel = "Select Target"
 
+    /** returns null if dialog cancelled or closed */
     fun selectTargetDialog(targets: List<String>): String? {
         var targets = targets.sorted().toMutableList()
         MirrordSettingsState.instance.mirrordState.lastChosenTarget?.let {
@@ -68,11 +69,16 @@ object MirrordExecDialog {
             })
             setTitle(dialogHeading)
         }.show()
-        if (result == DialogWrapper.OK_EXIT_CODE && !jbTargets.isSelectionEmpty) {
+        if (result == DialogWrapper.OK_EXIT_CODE) {
+            if (jbTargets.isSelectionEmpty) {
+                // The user did not select any target, and clicked ok.
+                return MirrordApi.targetlessTargetName
+            }
             val selectedValue = jbTargets.selectedValue
             MirrordSettingsState.instance.mirrordState.lastChosenTarget = selectedValue
             return selectedValue
         }
+        // The user clicked cancel, or closed the dialog.
         return null
     }
 

--- a/intellij-ext/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordExecManager.kt
+++ b/intellij-ext/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordExecManager.kt
@@ -16,6 +16,9 @@ import kotlinx.collections.immutable.toImmutableMap
 object MirrordExecManager {
     var enabled: Boolean = false
 
+    /** returns null if the user closed or cancelled target selection, otherwise the chosen target, which is either a
+     * pod or the targetless target
+     */
     private fun chooseTarget(wslDistribution: WSLDistribution?, project: Project): String? {
         MirrordLogger.logger.debug("choose target called")
         val path = MirrordConfigAPI.getConfigPath(project)
@@ -24,23 +27,13 @@ object MirrordExecManager {
             false -> null
         }
 
+        // includes targetless target.
         val pods =
             MirrordApi.listPods(
                 configPath,
                 project,
                 wslDistribution
             )
-        pods ?: return null
-
-        if (pods.isEmpty()) {
-            MirrordNotifier.notify(
-                    "No mirrord target available in the configured namespace. " +
-                            "Set a different target namespace or kubeconfig in the mirrord configuration file.",
-                    NotificationType.ERROR,
-                    project,
-            )
-            return null
-        }
 
         MirrordLogger.logger.debug("returning pods")
         return MirrordExecDialog.selectTargetDialog(pods)
@@ -93,8 +86,14 @@ object MirrordExecManager {
                 }.get()
             }
             if (target == null) {
+                MirrordLogger.logger.warn("mirrord loading canceled")
+                MirrordNotifier.notify("mirrord loading canceled.", NotificationType.WARNING, project)
+                return null
+            }
+            if (target == MirrordApi.targetlessTargetName) {
                 MirrordLogger.logger.warn("No target specified - running targetless")
                 MirrordNotifier.notify("No target specified, mirrord running targetless.", NotificationType.INFORMATION, project)
+                target = null
             }
         }
 

--- a/intellij-ext/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordExecManager.kt
+++ b/intellij-ext/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordExecManager.kt
@@ -93,9 +93,8 @@ object MirrordExecManager {
                 }.get()
             }
             if (target == null) {
-                MirrordLogger.logger.warn("mirrord loading canceled")
-                MirrordNotifier.notify("mirrord loading canceled.", NotificationType.WARNING, project)
-                return null
+                MirrordLogger.logger.warn("No target specified - running targetless")
+                MirrordNotifier.notify("No target specified, mirrord running targetless.", NotificationType.INFORMATION, project)
             }
         }
 


### PR DESCRIPTION
#1375 

Allow null targets in the intelliJ plugin, notify about targetless runs.
To run targetless the user can choose the targetless target (or no target).
If the user presses `cancel` or closes the dialog, we cancel the loading of mirrord.