### PR TITLE
Fixed `go run` failing because of reading remote files 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,24 +8,6 @@ This project uses [*towncrier*](https://towncrier.readthedocs.io/) and the chang
 
 <!-- towncrier release notes start -->
 
-## [3.42.0](https://github.com/metalbear-co/mirrord/tree/3.42.0) - 2023-05-10
-
-
-### Changed
-
-- Read paths under /private and /var/folders locally by default.
-
-
-### Fixed
-
-- Added better detection for protected binaries, fixes not loading into Go
-  binary [#1397#](https://github.com/metalbear-co/mirrord/issues/1397#)
-- Fixed `go run` failing because of reading remote files (tweaked local
-  overrides to have `/private` `/tmp` and removes `.*$` from the pattern to
-  include directory listing as well
-  [#1397](https://github.com/metalbear-co/mirrord/issues/1397)
-
-
 ## [3.41.1](https://github.com/metalbear-co/mirrord/tree/3.41.1) - 2023-05-07
 
 

--- a/mirrord/layer/src/file/filter.rs
+++ b/mirrord/layer/src/file/filter.rs
@@ -58,9 +58,10 @@ fn generate_local_set() -> RegexSet {
         r"^/dev/.*$",
         r"^/opt/.*$",
         r"^/home/.*$",
-        r"^/tmp/.*$",
-        r"^/private/.*$",
-        r"^/var/folders/.*$",
+        // don't use `/.*$` so lstat on the directory will also be local
+        r"^/private",
+        r"^/var/folders",
+        r"^/tmp",
         r"^/snap/.*$",
         // support for nixOS.
         r"^/nix/.*$",


### PR DESCRIPTION
tweaked locals overrides to have `/private` `/tmp` and removes `.*$` from the pattern to include directory listing as well

Partially solves #1397 