### PR TITLE
Remove quotes in InvalidTarget' target error message

### DIFF
--- a/changelog.d/+invalid-target-msg.changed.md
+++ b/changelog.d/+invalid-target-msg.changed.md
@@ -1,0 +1,1 @@
+Remove quotes in InvalidTarget' target error message

--- a/mirrord/config/src/target.rs
+++ b/mirrord/config/src/target.rs
@@ -146,7 +146,7 @@ impl FromStr for Target {
             }
             Some("pod") => PodTarget::from_split(&mut split).map(Target::Pod),
             _ => Err(ConfigError::InvalidTarget(format!(
-                "Provided target: {target:?} is neither a pod or a deployment. Did you mean pod/{target:?} or deployment/{target:?}\n{FAIL_PARSE_DEPLOYMENT_OR_POD}",
+                "Provided target: {target} is neither a pod or a deployment. Did you mean pod/{target} or deployment/{target}\n{FAIL_PARSE_DEPLOYMENT_OR_POD}",
             ))),
         }
     }


### PR DESCRIPTION
Current message output was:
```
"Provided target: \"ip-visit-counter-6cf56d9ddf-bqjp8\" is neither a pod or a deployment. Did you mean pod/\"ip-visit-counter-6cf56d9ddf-bqjp8\" or deployment/\"ip-visit-counter-6cf56d9ddf-bqjp8\"\n\nmirrord-laye
```
might make users thing they need quotes after the type (pod/deployment)