### PR TITLE
Dynamic target pause

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,19 +4,19 @@ version = 3
 
 [[package]]
 name = "actix-codec"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a7559404a7f3573127aab53c08ce37a6c6a315c374a31070f3c91cd1b4a7fe"
+checksum = "617a8268e3537fe1d8c9ead925fca49ef6400927ee7bc26750e90ecee14ce4b8"
 dependencies = [
  "bitflags",
  "bytes",
  "futures-core",
  "futures-sink",
- "log",
  "memchr",
  "pin-project-lite",
  "tokio",
  "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -59,9 +59,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.20"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
 dependencies = [
  "memchr",
 ]
@@ -77,9 +77,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e579a7752471abc2a8268df8b20005e3eadd975f585398f17efcfd8d4927371"
+checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -116,9 +116,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcd8291a340dd8ac70e18878bc4501dd7b4ff970cfa21c207d36ece51ea88fd"
+checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
 dependencies = [
  "anstyle",
  "windows-sys 0.48.0",
@@ -126,9 +126,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.70"
+version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
+checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 
 [[package]]
 name = "asn1-rs"
@@ -143,7 +143,7 @@ dependencies = [
  "num-traits",
  "rusticata-macros",
  "thiserror",
- "time 0.3.20",
+ "time 0.3.21",
 ]
 
 [[package]]
@@ -188,7 +188,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -199,7 +199,7 @@ checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -221,9 +221,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axum"
-version = "0.6.15"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b32c5ea3aabaf4deb5f5ced2d688ec0844c881c9e6c696a8b769a05fc691e62"
+checksum = "f8175979259124331c1d7bf6586ee7e0da434155e4b2d48ec2c8386281d8df39"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -292,7 +292,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.6.2",
  "object 0.30.3",
  "rustc-demangle",
 ]
@@ -437,7 +437,7 @@ dependencies = [
 [[package]]
 name = "bs-filter"
 version = "0.1.0"
-source = "git+https://github.com/metalbear-co/rawsocket.git#24602214b41f4806a6a166d15b7a1378a9086f8f"
+source = "git+https://github.com/metalbear-co/rawsocket.git#4d5a48f4e18e3b6c51ec50dae0ed19c79819e668"
 dependencies = [
  "libc",
  "thiserror",
@@ -445,9 +445,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.12.0"
+version = "3.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
+checksum = "3c6ed94e98ecff0c12dd1b04c15ec0d7d9458ca8fe806cea6f12954efe74c63b"
 
 [[package]]
 name = "byte-strings-proc_macros"
@@ -566,9 +566,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.2.2"
+version = "4.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b802d85aaf3a1cdb02b224ba472ebdea62014fccfcb269b95a4d76443b5ee5a"
+checksum = "34d21f9bf1b425d2968943631ec91202fe5e837264063503708b83013f8fc938"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -577,9 +577,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.2.2"
+version = "4.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14a1a858f532119338887a4b8e1af9c60de8249cd7bafd68036a489e261e37b6"
+checksum = "914c8c79fb560f238ef6429439a30023c862f7a28e688c58f7203f12b29970bd"
 dependencies = [
  "anstream",
  "anstyle",
@@ -597,7 +597,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -605,16 +605,6 @@ name = "clap_lex"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
-
-[[package]]
-name = "codespan-reporting"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
-dependencies = [
- "termcolor",
- "unicode-width",
-]
 
 [[package]]
 name = "colorchoice"
@@ -686,9 +676,9 @@ checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "280a9f2d8b3a38871a3c8a46fb80db65e5e5ed97da80c4d08bf27fb63e35e181"
+checksum = "3e4c1eaa2012c47becbbad2ab175484c2a84d1185b566fb2cc5b8707343dfe58"
 dependencies = [
  "libc",
 ]
@@ -765,51 +755,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd4056f63fce3b82d852c3da92b08ea59959890813a7f4ce9c0ff85b10cf301b"
 dependencies = [
  "quote",
- "syn 2.0.15",
-]
-
-[[package]]
-name = "cxx"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f61f1b6389c3fe1c316bf8a4dccc90a38208354b330925bce1f74a6c4756eb93"
-dependencies = [
- "cc",
- "cxxbridge-flags",
- "cxxbridge-macro",
- "link-cplusplus",
-]
-
-[[package]]
-name = "cxx-build"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12cee708e8962df2aeb38f594aae5d827c022b6460ac71a7a3e2c3c2aae5a07b"
-dependencies = [
- "cc",
- "codespan-reporting",
- "once_cell",
- "proc-macro2",
- "quote",
- "scratch",
- "syn 2.0.15",
-]
-
-[[package]]
-name = "cxxbridge-flags"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7944172ae7e4068c533afbb984114a56c46e9ccddda550499caa222902c7f7bb"
-
-[[package]]
-name = "cxxbridge-macro"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -981,13 +927,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bf95dc3f046b9da4f2d51833c0d3547d8564ef6910f5c1ed130306a75b92886"
+checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -1155,12 +1101,12 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
+checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
 dependencies = [
  "crc32fast",
- "miniz_oxide",
+ "miniz_oxide 0.7.1",
 ]
 
 [[package]]
@@ -1283,7 +1229,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -1369,9 +1315,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "h2"
-version = "0.3.17"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66b91535aa35fea1523ad1b86cb6b53c28e0ae566ba4a460f4457e936cad7c6f"
+checksum = "d357c7ae988e7d2182f7d7871d0b963962420b0678b0997ce7de72001aeab782"
 dependencies = [
  "bytes",
  "fnv",
@@ -1573,10 +1519,23 @@ dependencies = [
  "http",
  "hyper 0.14.26",
  "log",
- "rustls",
+ "rustls 0.20.6",
  "rustls-native-certs",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.23.4",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0646026eb1b3eea4cd9ba47912ea5ce9cc07713d105b1a14698f4e6433d348b7"
+dependencies = [
+ "http",
+ "hyper 0.14.26",
+ "rustls 0.21.1",
+ "tokio",
+ "tokio-rustls 0.24.0",
 ]
 
 [[package]]
@@ -1620,12 +1579,11 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone-haiku"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
- "cxx",
- "cxx-build",
+ "cc",
 ]
 
 [[package]]
@@ -1781,9 +1739,9 @@ checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "js-sys"
-version = "0.3.61"
+version = "0.3.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
+checksum = "2f37a4a5928311ac501dee68b3c7613a1037d0edb30c8e5427bd832d55d1b790"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1868,7 +1826,7 @@ dependencies = [
  "http",
  "http-body 0.4.5",
  "hyper 0.14.26",
- "hyper-rustls",
+ "hyper-rustls 0.23.2",
  "hyper-timeout",
  "jsonpath_lib",
  "k8s-openapi",
@@ -1876,7 +1834,7 @@ dependencies = [
  "pem",
  "pin-project",
  "rand",
- "rustls",
+ "rustls 0.20.6",
  "rustls-pemfile",
  "secrecy",
  "serde",
@@ -1960,9 +1918,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.141"
+version = "0.2.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
+checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
 
 [[package]]
 name = "libloading"
@@ -1975,15 +1933,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "link-cplusplus"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1991,9 +1940,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.1"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59d8c75012853d2e872fb56bc8a2e53718e2cafe1a4c823143141c6d90c322f"
+checksum = "ece97ea872ece730aed82664c424eb4c8291e1ff2480247ccf7409044bc6479f"
 
 [[package]]
 name = "lock_api"
@@ -2087,10 +2036,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "miette"
-version = "5.7.0"
+name = "memoffset"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7abdc09c381c9336b9f2e9bd6067a9a5290d20e2d2e2296f275456121c33ae89"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "miette"
+version = "5.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92a992891d5579caa9efd8e601f82e30a1caa79a27a5db075dde30ecb9eab357"
 dependencies = [
  "backtrace",
  "backtrace-ext",
@@ -2109,13 +2067,13 @@ dependencies = [
 
 [[package]]
 name = "miette-derive"
-version = "5.7.0"
+version = "5.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8842972f23939443013dfd3720f46772b743e86f1a81d120d4b6fb090f87de1c"
+checksum = "4c65c625186a9bcce6699394bee511e1b1aec689aa7e3be1bf4e996e75834153"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -2135,6 +2093,15 @@ name = "miniz_oxide"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+dependencies = [
+ "adler",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
 dependencies = [
  "adler",
 ]
@@ -2500,7 +2467,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "libc",
- "memoffset",
+ "memoffset 0.6.5",
 ]
 
 [[package]]
@@ -2512,21 +2479,21 @@ dependencies = [
  "bitflags",
  "cfg-if",
  "libc",
- "memoffset",
+ "memoffset 0.6.5",
 ]
 
 [[package]]
 name = "nix"
-version = "0.25.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f346ff70e7dbfd675fe90590b92d59ef2de15a8779ae305ebcbfd3f0caf59be4"
+checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
 dependencies = [
- "autocfg",
  "bitflags",
  "cfg-if",
  "libc",
- "memoffset",
+ "memoffset 0.7.1",
  "pin-utils",
+ "static_assertions",
 ]
 
 [[package]]
@@ -2840,22 +2807,22 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.12"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
+checksum = "c95a7476719eab1e366eaf73d0260af3021184f18177925b07f54b30089ceead"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.12"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
+checksum = "39407670928234ebc5e6e580247dd567ad73a3578460c5990f9503df207e8f07"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -2872,9 +2839,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
+checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "pnet"
@@ -3059,9 +3026,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "c4ec6d5fe0b140acb27c9a0444118cf55bfbb4e0b259739429abb4521dd67c16"
 dependencies = [
  "unicode-ident",
 ]
@@ -3074,7 +3041,7 @@ checksum = "606c4ba35817e2922a308af55ad51bab3645b59eae5c570d4a6cf07e36bd493b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
  "version_check",
  "yansi",
 ]
@@ -3141,9 +3108,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
+checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
 dependencies = [
  "proc-macro2",
 ]
@@ -3187,13 +3154,13 @@ checksum = "f2ff9a1f06a88b01621b7ae906ef0211290d1c8a168a15542486a8f61c0833b9"
 [[package]]
 name = "rawsocket"
 version = "0.1.0"
-source = "git+https://github.com/metalbear-co/rawsocket.git#24602214b41f4806a6a166d15b7a1378a9086f8f"
+source = "git+https://github.com/metalbear-co/rawsocket.git#4d5a48f4e18e3b6c51ec50dae0ed19c79819e668"
 dependencies = [
  "bs-filter",
  "ipnetwork",
  "libc",
- "nix 0.25.1",
- "socket2 0.4.9",
+ "nix 0.26.2",
+ "socket2 0.5.3",
  "tokio",
 ]
 
@@ -3205,7 +3172,7 @@ checksum = "ffbe84efe2f38dea12e9bfc1f65377fdf03e53a18cb3b995faedf7934c7e785b"
 dependencies = [
  "pem",
  "ring",
- "time 0.3.20",
+ "time 0.3.21",
  "x509-parser",
  "yasna",
 ]
@@ -3241,13 +3208,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.3"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
+checksum = "af83e617f331cc6ae2da5443c602dfa5af81e517212d9d611a5b3ba1777b5370"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.7.1",
 ]
 
 [[package]]
@@ -3256,7 +3223,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 dependencies = [
- "regex-syntax",
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -3266,10 +3233,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
-name = "reqwest"
-version = "0.11.16"
+name = "regex-syntax"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b71749df584b7f4cac2c426c127a7c785a5106cc98f7a8feb044115f0fa254"
+checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
+
+[[package]]
+name = "reqwest"
+version = "0.11.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
 dependencies = [
  "base64 0.21.0",
  "bytes",
@@ -3280,7 +3253,7 @@ dependencies = [
  "http",
  "http-body 0.4.5",
  "hyper 0.14.26",
- "hyper-rustls",
+ "hyper-rustls 0.24.0",
  "ipnet",
  "js-sys",
  "log",
@@ -3288,13 +3261,13 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls",
+ "rustls 0.21.1",
  "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.0",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -3408,9 +3381,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.11"
+version = "0.37.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85597d61f83914ddeba6a47b3b8ffe7365107221c2e557ed94426489fefb5f77"
+checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
 dependencies = [
  "bitflags",
  "errno 0.3.1",
@@ -3432,6 +3405,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c911ba11bc8433e811ce56fde130ccf32f5127cab0e0194e9c68c5a5b671791e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki",
+ "sct",
+]
+
+[[package]]
 name = "rustls-native-certs"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3450,6 +3435,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
  "base64 0.21.0",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.100.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6207cd5ed3d8dca7816f8f3725513a34609c0c765bf652b8c3cb4cfd87db46b"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -3522,12 +3517,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
-name = "scratch"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1792db035ce95be60c3f8853017b3999209281c24e2ba5bc8e59bf97a0c590c1"
-
-[[package]]
 name = "sct"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3549,9 +3538,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.8.2"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a332be01508d814fed64bf28f798a146d73792121129962fdf335bb3c49a4254"
+checksum = "ca2855b3715770894e67cbfa3df957790aa0c9edc3bf06efa1a84d77fa0839d1"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -3562,9 +3551,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31c9bb296072e961fcbd8853511dd39c2d8be2deb1e17c6860b1d30732b323b4"
+checksum = "f51d0c0d83bec45f16480d0ce0058397a69e48fcdc52d1dc8855fb68acbd31a7"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3594,9 +3583,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.160"
+version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
+checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
 dependencies = [
  "serde_derive",
 ]
@@ -3613,13 +3602,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.160"
+version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
+checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -3662,7 +3651,7 @@ checksum = "bcec881020c684085e55a25f7fd888954d56609ef363479dc5a1305eb0d40cab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -3688,9 +3677,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "2.3.2"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331bb8c3bf9b92457ab7abecf07078c13f7d270ba490103e84e8b014490cd0b0"
+checksum = "07ff71d2c147a7b57362cead5e22f772cd52f6ab31cfcd9edcd7f6aeb2a0afbe"
 dependencies = [
  "base64 0.13.1",
  "chrono",
@@ -3698,7 +3687,7 @@ dependencies = [
  "indexmap",
  "serde",
  "serde_json",
- "time 0.3.20",
+ "time 0.3.21",
 ]
 
 [[package]]
@@ -3802,10 +3791,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2538b18701741680e0322a2302176d3253a35388e2e62f172f64f4f16605f877"
+dependencies = [
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "streammap-ext"
@@ -3834,9 +3839,9 @@ dependencies = [
 
 [[package]]
 name = "supports-hyperlinks"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b4806e0b03b9906e76b018a5d821ebf198c8e9dc0829ed3328eeeb5094aed60"
+checksum = "f84231692eb0d4d41e4cdd0cabfdd2e6cd9e255e65f80c9aa7c98dd502b4233d"
 dependencies = [
  "is-terminal",
 ]
@@ -3863,9 +3868,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.15"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
+checksum = "a6f671d4b5ffdb8eadec19c0ae67fe2639df8684bd7bc4b83d986b8db549cf01"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3923,15 +3928,6 @@ dependencies = [
  "dirs-next",
  "rustversion",
  "winapi",
-]
-
-[[package]]
-name = "termcolor"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
-dependencies = [
- "winapi-util",
 ]
 
 [[package]]
@@ -4029,7 +4025,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -4055,9 +4051,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.20"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
+checksum = "8f3403384eaacbca9923fa06940178ac13e4edb725486d70e8e15881d0c836cc"
 dependencies = [
  "itoa",
  "serde",
@@ -4067,15 +4063,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
 
 [[package]]
 name = "time-macros"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd80a657e71da814b8e5d60d3374fc6d35045062245d80224748ae522dd76f36"
+checksum = "372950940a5f07bf38dbe211d7283c9e6d7327df53794992d293e534c733d09b"
 dependencies = [
  "time-core",
 ]
@@ -4106,9 +4102,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.27.0"
+version = "1.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0de47a4eecbe11f498978a9b29d792f0d2692d1dd003650c24c76510e3bc001"
+checksum = "0aa32867d44e6f2ce3385e89dceb990188b8bb0fb25b0cf576647a6f98ac5105"
 dependencies = [
  "autocfg",
  "bytes",
@@ -4119,7 +4115,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2 0.4.9",
  "tokio-macros",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4134,13 +4130,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61a573bdc87985e9d6ddeed1b3d864e8a302c847e40d647746df2f1de209d1ce"
+checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -4149,16 +4145,26 @@ version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
 dependencies = [
- "rustls",
+ "rustls 0.20.6",
  "tokio",
  "webpki 0.22.0",
 ]
 
 [[package]]
-name = "tokio-stream"
-version = "0.1.12"
+name = "tokio-rustls"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fb52b74f05dbf495a8fba459fdc331812b96aa086d9eb78101fa0d4569c3313"
+checksum = "e0d409377ff5b1e3ca6437aa86c1eb7d40c134bfec254e44c830defa92669db5"
+dependencies = [
+ "rustls 0.21.1",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -4179,9 +4185,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5427d89453009325de0d8f342c9490009f76e999cb7672d77e46267448f7e6b2"
+checksum = "806fe8c2c87eccc8b3267cbae29ed3ab2d0bd37fca70ab622e46aaa9375ddb7d"
 dependencies = [
  "bytes",
  "futures-core",
@@ -4259,7 +4265,7 @@ dependencies = [
  "prost-derive",
  "rustls-pemfile",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.23.4",
  "tokio-stream",
  "tokio-util",
  "tower",
@@ -4353,7 +4359,7 @@ source = "git+https://github.com/metalbear-co/tracing?branch=worker_options_non_
 dependencies = [
  "crossbeam-channel",
  "thiserror",
- "time 0.3.20",
+ "time 0.3.21",
  "tracing-subscriber",
 ]
 
@@ -4670,9 +4676,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
+checksum = "5bba0e8cb82ba49ff4e229459ff22a191bbe9a1cb3a341610c9c33efc27ddf73"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -4680,24 +4686,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
+checksum = "19b04bc93f9d6bdee709f6bd2118f57dd6679cf1176a1af464fca3ab0d66d8fb"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.16",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.34"
+version = "0.4.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f219e0d211ba40266969f6dbdd90636da12f75bee4fc9d6c23d1260dadb51454"
+checksum = "2d1985d03709c53167ce907ff394f5316aa22cb4e12761295c5dc57dacb6297e"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -4707,9 +4713,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
+checksum = "14d6b024f1a526bb0234f52840389927257beb670610081360e5a03c5df9c258"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4717,28 +4723,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
+checksum = "e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.16",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
+checksum = "ed9d5b4305409d1fc9482fee2d7f9bcbf24b3972bf59817ef757e23982242a93"
 
 [[package]]
 name = "web-sys"
-version = "0.3.61"
+version = "0.3.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
+checksum = "3bdd9ef4e984da1187bf8110c5cf5b845fbc87a23602cdf912386a76fcd3a7c2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5001,9 +5007,9 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winnow"
-version = "0.4.1"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae8970b36c66498d8ff1d66685dc86b91b29db0c7739899012f63a63814b4b28"
+checksum = "61de7bac303dc551fe038e2b3cef0f571087a47571ea6e79a87692ac99b99699"
 dependencies = [
  "memchr",
 ]
@@ -5039,7 +5045,7 @@ dependencies = [
  "ring",
  "rusticata-macros",
  "thiserror",
- "time 0.3.20",
+ "time 0.3.21",
 ]
 
 [[package]]
@@ -5090,7 +5096,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
 dependencies = [
- "time 0.3.20",
+ "time 0.3.21",
 ]
 
 [[package]]

--- a/changelog.d/1408.added.md
+++ b/changelog.d/1408.added.md
@@ -1,1 +1,1 @@
-Changed agent's pause feature. Now the pause is requested dynamically during layer setup and the agent keeps the target container paused when at least one connected client demands it.
+Changed agent's pause feature. Now the pause is requested dynamically by CLI during setup and the agent keeps the target container paused until exit or the unpause request was received.

--- a/changelog.d/1408.added.md
+++ b/changelog.d/1408.added.md
@@ -1,0 +1,1 @@
+Changed agent's pause feature. Now the pause is requested dynamically during layer setup and the agent keeps the target container paused when at least one connected client demands it.

--- a/mirrord-schema.json
+++ b/mirrord-schema.json
@@ -70,6 +70,13 @@
         "null"
       ]
     },
+    "pause": {
+      "description": "Controls target pause feature. Unstable.\n\nWith this feature enabled, the remote container is paused while this layer is connected to the agent.",
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
     "sip_binaries": {
       "description": "Binaries to patch (macOS SIP). Use this when mirrord isn't loaded to protected binaries that weren't automatically patched. Runs `endswith` on the binary path (so `bash` would apply to any binary ending with `bash` while `/usr/bin/bash` would apply only for that binary).",
       "anyOf": [
@@ -229,13 +236,6 @@
           "description": "Which network interface to use for mirroring.\n\nThe default behavior is try to access the internet and use that interface and if that fails it uses eth0.",
           "type": [
             "string",
-            "null"
-          ]
-        },
-        "pause": {
-          "description": "Controls target pause feature. Unstable.\n\nWith this feature enabled, the remote container is paused while clients are connected to the agent.",
-          "type": [
-            "boolean",
             "null"
           ]
         },

--- a/mirrord/agent/src/container_handle.rs
+++ b/mirrord/agent/src/container_handle.rs
@@ -79,7 +79,7 @@ impl ContainerHandle {
     }
 
     /// Add the pause request to the set of active requests.
-    /// If the set became non-empty, pause the container.
+    /// If the set became non-empty, pause the container and return true. Otherwise, return false.
     pub(crate) async fn request_pause(&self, client_id: ClientId) -> Result<bool> {
         let mut guard = self.0.pause_requests.write().await;
         let do_pause = guard.is_empty();
@@ -94,7 +94,7 @@ impl ContainerHandle {
     }
 
     /// Remove pause request of the given client from the set of active requests.
-    /// If the set became empty, unpause the container.
+    /// If the set became empty, unpause the container and return true. Otherwise, return false.
     pub(crate) async fn client_disconnected(&self, client_id: ClientId) -> Result<bool> {
         let mut guard = self.0.pause_requests.write().await;
         let do_unpause = guard.contains(&client_id) && guard.len() == 1;

--- a/mirrord/agent/src/container_handle.rs
+++ b/mirrord/agent/src/container_handle.rs
@@ -1,47 +1,93 @@
-use std::collections::HashMap;
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
+
+use futures::executor;
+use tokio::sync::RwLock;
+use tracing::{error, info};
 
 use crate::{
     error::Result,
     runtime::{Container, ContainerInfo, ContainerRuntime},
+    util::ClientId,
 };
 
 #[derive(Debug)]
-pub(crate) struct ContainerHandle {
+struct Inner {
     container: Container,
-    should_pause: bool,
     pid: u64,
     raw_env: HashMap<String, String>,
+    pause_requests: RwLock<HashSet<ClientId>>,
 }
 
+/// This is to make sure we don't leave the target container paused if the agent hits an error and
+/// exits early without removing all of its clients.
+impl Drop for Inner {
+    fn drop(&mut self) {
+        let result = executor::block_on(async {
+            if self.pause_requests.read().await.is_empty() {
+                Ok(())
+            } else {
+                info!("Agent exiting without having removed all of the clients. Unpausing target container.");
+                self.container.unpause().await
+            }
+        });
+
+        if let Err(err) = result {
+            error!("Could not unpause target container while exiting early, got error: {err:?}");
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ContainerHandle(Arc<Inner>);
+
 impl ContainerHandle {
-    pub(crate) async fn new(container: Container, should_pause: bool) -> Result<Self> {
+    pub(crate) async fn new(container: Container) -> Result<Self> {
         let ContainerInfo { pid, env: raw_env } = container.get_info().await?;
 
-        Ok(Self {
+        let inner = Inner {
             container,
-            should_pause,
             pid,
             raw_env,
-        })
+            pause_requests: Default::default(),
+        };
+
+        Ok(Self(inner.into()))
     }
 
     pub(crate) fn pid(&self) -> u64 {
-        self.pid
+        self.0.pid
     }
 
     pub(crate) fn raw_env(&self) -> &HashMap<String, String> {
-        &self.raw_env
+        &self.0.raw_env
     }
 
-    pub(crate) fn should_pause(&self) -> bool {
-        self.should_pause
+    pub(crate) async fn request_pause(&self, client_id: ClientId) -> Result<bool> {
+        let mut guard = self.0.pause_requests.write().await;
+        let do_pause = guard.is_empty();
+
+        if do_pause {
+            self.0.container.pause().await?;
+        }
+
+        guard.insert(client_id);
+
+        Ok(do_pause)
     }
 
-    pub(crate) async fn pause(&self) -> Result<()> {
-        self.container.pause().await
-    }
+    pub(crate) async fn client_disconnected(&self, client_id: ClientId) -> Result<bool> {
+        let mut guard = self.0.pause_requests.write().await;
+        let do_unpause = guard.contains(&client_id) && guard.len() == 1;
 
-    pub(crate) async fn unpause(&self) -> Result<()> {
-        self.container.unpause().await
+        if do_unpause {
+            self.0.container.unpause().await?;
+        }
+
+        guard.remove(&client_id);
+
+        Ok(do_unpause)
     }
 }

--- a/mirrord/agent/src/container_handle.rs
+++ b/mirrord/agent/src/container_handle.rs
@@ -55,6 +55,7 @@ pub(crate) struct ContainerHandle(Arc<Inner>);
 
 impl ContainerHandle {
     /// Retrieve info about the container and initialize this struct.
+    #[tracing::instrument(level = "trace")]
     pub(crate) async fn new(container: Container) -> Result<Self> {
         let ContainerInfo { pid, env: raw_env } = container.get_info().await?;
 
@@ -80,6 +81,7 @@ impl ContainerHandle {
 
     /// Add the pause request to the set of active requests.
     /// If the set became non-empty, pause the container and return true. Otherwise, return false.
+    #[tracing::instrument(level = "trace", skip(self))]
     pub(crate) async fn request_pause(&self, client_id: ClientId) -> Result<bool> {
         let mut guard = self.0.pause_requests.write().await;
         let do_pause = guard.is_empty();
@@ -95,6 +97,7 @@ impl ContainerHandle {
 
     /// Remove pause request of the given client from the set of active requests.
     /// If the set became empty, unpause the container and return true. Otherwise, return false.
+    #[tracing::instrument(level = "trace", skip(self))]
     pub(crate) async fn client_disconnected(&self, client_id: ClientId) -> Result<bool> {
         let mut guard = self.0.pause_requests.write().await;
         let do_unpause = guard.contains(&client_id) && guard.len() == 1;

--- a/mirrord/agent/src/container_handle.rs
+++ b/mirrord/agent/src/container_handle.rs
@@ -26,10 +26,10 @@ impl Drop for Inner {
     fn drop(&mut self) {
         let result = executor::block_on(async {
             if *self.paused.read().await {
-                Ok(())
-            } else {
                 info!("Agent exiting with target container paused. Unpausing target container.");
                 self.container.unpause().await
+            } else {
+                Ok(())
             }
         });
 

--- a/mirrord/agent/src/container_handle.rs
+++ b/mirrord/agent/src/container_handle.rs
@@ -1,0 +1,47 @@
+use std::collections::HashMap;
+
+use crate::{
+    error::Result,
+    runtime::{Container, ContainerInfo, ContainerRuntime},
+};
+
+#[derive(Debug)]
+pub(crate) struct ContainerHandle {
+    container: Container,
+    should_pause: bool,
+    pid: u64,
+    raw_env: HashMap<String, String>,
+}
+
+impl ContainerHandle {
+    pub(crate) async fn new(container: Container, should_pause: bool) -> Result<Self> {
+        let ContainerInfo { pid, env: raw_env } = container.get_info().await?;
+
+        Ok(Self {
+            container,
+            should_pause,
+            pid,
+            raw_env,
+        })
+    }
+
+    pub(crate) fn pid(&self) -> u64 {
+        self.pid
+    }
+
+    pub(crate) fn raw_env(&self) -> &HashMap<String, String> {
+        &self.raw_env
+    }
+
+    pub(crate) fn should_pause(&self) -> bool {
+        self.should_pause
+    }
+
+    pub(crate) async fn pause(&self) -> Result<()> {
+        self.container.pause().await
+    }
+
+    pub(crate) async fn unpause(&self) -> Result<()> {
+        self.container.unpause().await
+    }
+}

--- a/mirrord/agent/src/error.rs
+++ b/mirrord/agent/src/error.rs
@@ -144,6 +144,9 @@ pub enum AgentError {
 
     #[error("Requested pause, but there is no target container.")]
     PauseAbsentTarget,
+
+    #[error("Pause feature is not supported with ephemeral agent.")]
+    PauseEphemeralAgent,
 }
 
 pub(crate) type Result<T, E = AgentError> = std::result::Result<T, E>;

--- a/mirrord/agent/src/error.rs
+++ b/mirrord/agent/src/error.rs
@@ -141,6 +141,9 @@ pub enum AgentError {
 
     #[error("Container Runtime Error while trying to pause: {0}")]
     PauseRuntimeError(String),
+
+    #[error("Requested pause, but there is no target container.")]
+    PauseAbsentTarget,
 }
 
 pub(crate) type Result<T, E = AgentError> = std::result::Result<T, E>;

--- a/mirrord/agent/src/main.rs
+++ b/mirrord/agent/src/main.rs
@@ -440,17 +440,16 @@ impl ClientConnectionHandler {
                 return Ok(false);
             }
             ClientMessage::PauseTarget => {
-                if let Some(handle) = self.container_handle.as_ref() {
-                    let response = if handle.request_pause(self.id).await? {
-                        PauseTargetResponse::Paused
-                    } else {
-                        PauseTargetResponse::AlreadyPaused
-                    };
-                    self.respond(DaemonMessage::PauseTarget(response)).await?;
+                let handle = self
+                    .container_handle
+                    .as_ref()
+                    .ok_or(AgentError::PauseAbsentTarget)?;
+                let response = if handle.request_pause(self.id).await? {
+                    PauseTargetResponse::Paused
                 } else {
-                    self.respond(DaemonMessage::PauseTarget(PauseTargetResponse::NoTarget))
-                        .await?;
-                }
+                    PauseTargetResponse::AlreadyPaused
+                };
+                self.respond(DaemonMessage::PauseTarget(response)).await?;
             }
         }
 

--- a/mirrord/agent/src/main.rs
+++ b/mirrord/agent/src/main.rs
@@ -444,6 +444,7 @@ impl ClientConnectionHandler {
                     .container_handle
                     .as_ref()
                     .ok_or(AgentError::PauseAbsentTarget)?;
+                // TODO handle ephemeral agent
                 let response = if handle.request_pause(self.id).await? {
                     PauseTargetResponse::Paused
                 } else {

--- a/mirrord/cli/src/error.rs
+++ b/mirrord/cli/src/error.rs
@@ -102,11 +102,11 @@ pub(crate) enum CliError {
         "This is a bug. Please report it in our Discord or GitHub repository. {GENERAL_HELP}"
     ))]
     InvalidMessage(String),
-    #[error("Timeout waiting for remote environment variables.")]
+    #[error("Initial communication with the agent failed. {0:#?}")]
     #[diagnostic(help(
         "Please make sure the agent is running and the logs are not showing any errors.{GENERAL_HELP}"
     ))]
-    GetEnvironmentTimeout,
+    InitialCommFailed(&'static str),
     #[error("Failed to execute binary `{0:#?}` with args `{1:#?}`")]
     #[diagnostic(help(
         r#"

--- a/mirrord/cli/src/execution.rs
+++ b/mirrord/cli/src/execution.rs
@@ -97,7 +97,7 @@ impl MirrordExecution {
             }
         }
 
-        if config.agent.pause {
+        if config.pause {
             tokio::time::timeout(
                 communication_timeout,
                 Self::setup_target_pause(&mut connection),

--- a/mirrord/cli/src/execution.rs
+++ b/mirrord/cli/src/execution.rs
@@ -5,7 +5,9 @@ use std::{
 
 use mirrord_config::LayerConfig;
 use mirrord_progress::Progress;
-use mirrord_protocol::{ClientMessage, DaemonMessage, EnvVars, GetEnvVarsRequest};
+use mirrord_protocol::{
+    pause::DaemonPauseTarget, ClientMessage, DaemonMessage, EnvVars, GetEnvVarsRequest,
+};
 #[cfg(target_os = "macos")]
 use mirrord_sip::sip_patch;
 use serde::Serialize;
@@ -13,7 +15,7 @@ use tokio::{
     io::{AsyncBufReadExt, BufReader},
     process::{Child, Command},
 };
-use tracing::trace;
+use tracing::{info, trace};
 
 use crate::{
     connection::{create_and_connect, AgentConnectInfo, AgentConnection},
@@ -93,6 +95,14 @@ impl MirrordExecution {
             if let Some(overrides) = &config.feature.env.overrides {
                 env_vars.extend(overrides.iter().map(|(k, v)| (k.clone(), v.clone())));
             }
+        }
+
+        if config.pause {
+            tokio::time::timeout(communication_timeout, Self::request_pause(&mut connection))
+                .await
+                .map_err(|_| {
+                    CliError::InitialCommFailed("Timeout requesting for target container pause.")
+                })??;
         }
 
         let lib_path: String = lib_path.to_string_lossy().into();
@@ -199,6 +209,33 @@ impl MirrordExecution {
             Some(DaemonMessage::GetEnvVarsResponse(Ok(remote_env))) => {
                 trace!("DaemonMessage::GetEnvVarsResponse {:#?}!", remote_env.len());
                 Ok(remote_env)
+            }
+            msg => Err(CliError::InvalidMessage(format!("{msg:#?}"))),
+        }
+    }
+
+    /// Request target container pause from the connected agent.
+    async fn request_pause(connection: &mut AgentConnection) -> Result<()> {
+        info!("Requesting target container pause from the agent");
+        connection
+            .sender
+            .send(ClientMessage::PauseTargetRequest(true))
+            .await
+            .map_err(|_| {
+                CliError::InitialCommFailed("Failed to request target container pause.")
+            })?;
+
+        match connection.receiver.recv().await {
+            Some(DaemonMessage::PauseTarget(DaemonPauseTarget::PauseResponse {
+                changed,
+                container_paused: true,
+            })) => {
+                if changed {
+                    info!("Target container is now paused.");
+                } else {
+                    info!("Target container was already paused.");
+                }
+                Ok(())
             }
             msg => Err(CliError::InvalidMessage(format!("{msg:#?}"))),
         }

--- a/mirrord/cli/src/execution.rs
+++ b/mirrord/cli/src/execution.rs
@@ -178,6 +178,7 @@ impl MirrordExecution {
         })
     }
 
+    /// Retrieve remote environment from the connected agent.
     async fn get_remote_env(
         connection: &mut AgentConnection,
         env_vars_filter: HashSet<String>,

--- a/mirrord/cli/src/main.rs
+++ b/mirrord/cli/src/main.rs
@@ -160,7 +160,7 @@ async fn exec(args: &ExecArgs, progress: &TaskProgress) -> Result<()> {
 
     let config = LayerConfig::from_env()?;
 
-    if config.agent.pause {
+    if config.pause {
         if config.agent.ephemeral {
             error!("Pausing is not yet supported together with an ephemeral agent container.");
             panic!("Mutually exclusive arguments `--pause` and `--ephemeral-container` passed together.");

--- a/mirrord/config/src/agent.rs
+++ b/mirrord/config/src/agent.rs
@@ -74,13 +74,6 @@ pub struct AgentConfig {
     #[config(env = "MIRRORD_AGENT_NETWORK_INTERFACE")]
     pub network_interface: Option<String>,
 
-    /// Controls target pause feature. Unstable.
-    ///
-    /// With this feature enabled, the remote container is paused while clients are connected to
-    /// the agent.
-    #[config(env = "MIRRORD_PAUSE", default = false, unstable)]
-    pub pause: bool,
-
     /// Flushes existing connections when starting to steal, might fix issues where connections
     /// aren't stolen (due to being already established)
     ///

--- a/mirrord/config/src/lib.rs
+++ b/mirrord/config/src/lib.rs
@@ -216,6 +216,7 @@ mod tests {
                     r#"
                     {
                         "accept_invalid_certificates": false,
+                        "pause": false,
                         "target": {
                             "path": "pod/test-service-abcdefg-abcd",
                             "namespace": "default"
@@ -228,7 +229,6 @@ mod tests {
                             "image_pull_secrets": [{"name": "testsecret"}],
                             "ttl": 60,
                             "ephemeral": false,
-                            "pause": false,
                             "flush_connections": false
                         },
                         "feature": {
@@ -251,6 +251,7 @@ mod tests {
                 ConfigType::Toml => {
                     r#"
                     accept_invalid_certificates = false
+                    pause = false
 
                     [target]
                     path = "pod/test-service-abcdefg-abcd"
@@ -264,7 +265,6 @@ mod tests {
                     image_pull_secrets = [{name = "testsecret"}]
                     ttl = 60
                     ephemeral = false
-                    pause = false
                     flush_connections = false
 
                     [feature]
@@ -285,6 +285,7 @@ mod tests {
                 ConfigType::Yaml => {
                     r#"
                     accept_invalid_certificates: false
+                    pause: false
                     target:
                         path: "pod/test-service-abcdefg-abcd"
                         namespace: "default"
@@ -298,7 +299,6 @@ mod tests {
                             - name: "testsecret"
                         ttl: 60
                         ephemeral: false
-                        pause: false
                         flush_connections: false
 
                     feature:
@@ -350,6 +350,7 @@ mod tests {
 
         let expect = LayerFileConfig {
             accept_invalid_certificates: Some(false),
+            pause: Some(false),
             kubeconfig: None,
             connect_agent_name: None,
             connect_agent_port: None,
@@ -375,7 +376,6 @@ mod tests {
                 communication_timeout: None,
                 startup_timeout: None,
                 network_interface: None,
-                pause: Some(false),
                 flush_connections: Some(false),
             }),
             feature: Some(FeatureFileConfig {

--- a/mirrord/config/src/lib.rs
+++ b/mirrord/config/src/lib.rs
@@ -99,6 +99,13 @@ pub struct LayerConfig {
     #[config(nested)]
     pub target: TargetConfig,
 
+    /// Controls target pause feature. Unstable.
+    ///
+    /// With this feature enabled, the remote container is paused while this layer is connected to
+    /// the agent.
+    #[config(env = "MIRRORD_PAUSE", default = false, unstable)]
+    pub pause: bool,
+
     /// IP:PORT to connect to instead of using k8s api, for testing purposes.
     #[config(env = "MIRRORD_CONNECT_TCP")]
     pub connect_tcp: Option<String>,

--- a/mirrord/kube/src/api/container.rs
+++ b/mirrord/kube/src/api/container.rs
@@ -150,9 +150,6 @@ impl ContainerApi for JobContainer {
             agent_command_line.push("-t".to_owned());
             agent_command_line.push(timeout.to_string());
         }
-        if agent.pause {
-            agent_command_line.push("--pause".to_owned());
-        }
 
         #[cfg(debug_assertions)]
         if agent.test_error {

--- a/mirrord/layer/src/lib.rs
+++ b/mirrord/layer/src/lib.rs
@@ -456,6 +456,7 @@ fn layer_start(config: LayerConfig) {
     RUNTIME.block_on(start_layer_thread(tx, rx, receiver, config));
 }
 
+/// Request target container pause from the connected agent.
 async fn request_pause(tx: &Sender<ClientMessage>, rx: &mut Receiver<DaemonMessage>) {
     trace!("Requesting target container pause from the agent");
     tx.send(ClientMessage::PauseTarget)

--- a/mirrord/layer/src/lib.rs
+++ b/mirrord/layer/src/lib.rs
@@ -457,6 +457,7 @@ fn layer_start(config: LayerConfig) {
 }
 
 /// Request target container pause from the connected agent.
+#[tracing::instrument(level = "trace", skip(tx, rx))]
 async fn request_pause(tx: &Sender<ClientMessage>, rx: &mut Receiver<DaemonMessage>) {
     trace!("Requesting target container pause from the agent");
     tx.send(ClientMessage::PauseTarget)

--- a/mirrord/layer/src/lib.rs
+++ b/mirrord/layer/src/lib.rs
@@ -625,7 +625,7 @@ impl Layer {
     /// This message has no dedicated handler, and is thus handled directly here, changing the
     /// [`Self::ping`] state.
     ///
-    /// ### [`DaemonMessage::GetEnvVarsResponse`]
+    /// ### [`DaemonMessage::GetEnvVarsResponse`] and [`DaemonMessage::PauseTarget`]
     ///
     /// Handled during mirrord-layer initialization, this message should never make it this far.
     ///
@@ -637,7 +637,7 @@ impl Layer {
     ///
     /// ### [`DaemonMessage::LogMessage`]
     ///
-    /// This message has no dedicated handler, the internal message is simply logged here.
+    /// This message is handled in protocol level `wrap_raw_connection`.
     #[tracing::instrument(level = "trace", skip(self))]
     async fn handle_daemon_message(&mut self, daemon_message: DaemonMessage) -> Result<()> {
         match daemon_message {
@@ -678,9 +678,9 @@ impl Layer {
                 .send(get_addr_info.0)
                 .map_err(|_| LayerError::SendErrorGetAddrInfoResponse),
             DaemonMessage::Close(error_message) => Err(LayerError::AgentErrorClosed(error_message)),
-            DaemonMessage::LogMessage(_) => {
-                // handled in protocol level `wrap_raw_connection`
-                Ok(())
+            DaemonMessage::LogMessage(_) => Ok(()),
+            DaemonMessage::PauseTarget(_) => {
+                unreachable!("We set pausing target only on initialization, shouldn't happen")
             }
         }
     }

--- a/mirrord/layer/src/lib.rs
+++ b/mirrord/layer/src/lib.rs
@@ -98,7 +98,6 @@ use mirrord_config::{
 use mirrord_layer_macro::{hook_fn, hook_guard_fn};
 use mirrord_protocol::{
     dns::{DnsLookup, GetAddrInfoRequest},
-    pause::PauseTargetResponse,
     tcp::{HttpResponse, LayerTcpSteal},
     ClientMessage, DaemonMessage,
 };
@@ -390,13 +389,7 @@ fn layer_start(config: LayerConfig) {
         .parse()
         .expect("couldn't parse proxy address");
 
-    let (tx, rx) = RUNTIME.block_on(async {
-        let (tx, mut rx) = connection::connect_to_proxy(address).await;
-        if config.pause {
-            request_pause(&tx, &mut rx).await;
-        }
-        (tx, rx)
-    });
+    let (tx, rx) = RUNTIME.block_on(connection::connect_to_proxy(address));
 
     let (sender, receiver) = channel::<HookMessage>(1000);
     HOOK_SENDER
@@ -454,27 +447,6 @@ fn layer_start(config: LayerConfig) {
     );
 
     RUNTIME.block_on(start_layer_thread(tx, rx, receiver, config));
-}
-
-/// Request target container pause from the connected agent.
-#[tracing::instrument(level = "trace", skip(tx, rx))]
-async fn request_pause(tx: &Sender<ClientMessage>, rx: &mut Receiver<DaemonMessage>) {
-    trace!("Requesting target container pause from the agent");
-    tx.send(ClientMessage::PauseTarget)
-        .await
-        .expect("Failed to request target container pause.");
-
-    let res = match rx.recv().await {
-        Some(DaemonMessage::PauseTarget(res)) => res,
-        other => panic!("Failed to pause the target container. Invalid agent response: {other:#?}"),
-    };
-
-    match res {
-        PauseTargetResponse::Paused => trace!("Target container paused."),
-        PauseTargetResponse::AlreadyPaused => {
-            trace!("Target container already paused by another user.")
-        }
-    }
 }
 
 /// We need to hook execve syscall to allow mirrord-layer to be loaded with sip patch when loading

--- a/mirrord/protocol/src/codec.rs
+++ b/mirrord/protocol/src/codec.rs
@@ -22,6 +22,7 @@ use crate::{
         tcp::{DaemonTcpOutgoing, LayerTcpOutgoing},
         udp::{DaemonUdpOutgoing, LayerUdpOutgoing},
     },
+    pause::PauseTargetResponse,
     tcp::{DaemonTcp, LayerTcp, LayerTcpSteal},
     ResponseError,
 };
@@ -92,6 +93,7 @@ pub enum ClientMessage {
     GetEnvVarsRequest(GetEnvVarsRequest),
     Ping,
     GetAddrInfoRequest(GetAddrInfoRequest),
+    PauseTarget,
 }
 
 /// Type alias for `Result`s that should be returned from mirrord-agent to mirrord-layer.
@@ -127,6 +129,7 @@ pub enum DaemonMessage {
     /// NOTE: can remove `RemoteResult` when we break protocol compatibility.
     GetEnvVarsResponse(RemoteResult<HashMap<String, String>>),
     GetAddrInfoResponse(GetAddrInfoResponse),
+    PauseTarget(PauseTargetResponse),
 }
 
 pub struct ClientCodec {

--- a/mirrord/protocol/src/codec.rs
+++ b/mirrord/protocol/src/codec.rs
@@ -22,7 +22,7 @@ use crate::{
         tcp::{DaemonTcpOutgoing, LayerTcpOutgoing},
         udp::{DaemonUdpOutgoing, LayerUdpOutgoing},
     },
-    pause::PauseTargetResponse,
+    pause::DaemonPauseTarget,
     tcp::{DaemonTcp, LayerTcp, LayerTcpSteal},
     ResponseError,
 };
@@ -93,7 +93,8 @@ pub enum ClientMessage {
     GetEnvVarsRequest(GetEnvVarsRequest),
     Ping,
     GetAddrInfoRequest(GetAddrInfoRequest),
-    PauseTarget,
+    /// Whether to pause or unpause the target container.
+    PauseTargetRequest(bool),
 }
 
 /// Type alias for `Result`s that should be returned from mirrord-agent to mirrord-layer.
@@ -129,7 +130,7 @@ pub enum DaemonMessage {
     /// NOTE: can remove `RemoteResult` when we break protocol compatibility.
     GetEnvVarsResponse(RemoteResult<HashMap<String, String>>),
     GetAddrInfoResponse(GetAddrInfoResponse),
-    PauseTarget(PauseTargetResponse),
+    PauseTarget(DaemonPauseTarget),
 }
 
 pub struct ClientCodec {

--- a/mirrord/protocol/src/lib.rs
+++ b/mirrord/protocol/src/lib.rs
@@ -8,6 +8,7 @@ pub mod dns;
 pub mod error;
 pub mod file;
 pub mod outgoing;
+pub mod pause;
 pub mod tcp;
 
 use std::{collections::HashSet, ops::Deref};

--- a/mirrord/protocol/src/pause.rs
+++ b/mirrord/protocol/src/pause.rs
@@ -1,0 +1,8 @@
+use bincode::{Decode, Encode};
+
+#[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
+pub enum PauseTargetResponse {
+    Paused,
+    AlreadyPaused,
+    NoTarget,
+}

--- a/mirrord/protocol/src/pause.rs
+++ b/mirrord/protocol/src/pause.rs
@@ -1,10 +1,14 @@
 use bincode::{Decode, Encode};
 
-/// Agent responses for target container pause request.
+/// `-agent` --> `-layer` messages regarding the pause feature.
+/// TODO add asynchronous notifications when the target container has changed its state
 #[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
-pub enum PauseTargetResponse {
-    /// The target container was paused according to the request.
-    Paused,
-    /// The target container was already paused when the agent received the request.
-    AlreadyPaused,
+pub enum DaemonPauseTarget {
+    /// Response for the client's request to pause or unpause the container.
+    PauseResponse {
+        /// The container changed its state.
+        changed: bool,
+        /// Current state of the container.
+        container_paused: bool,
+    },
 }

--- a/mirrord/protocol/src/pause.rs
+++ b/mirrord/protocol/src/pause.rs
@@ -1,7 +1,10 @@
 use bincode::{Decode, Encode};
 
+/// Agent responses for target container pause request.
 #[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
 pub enum PauseTargetResponse {
+    /// The target container was paused according to the request.
     Paused,
+    /// The target container was already paused when the agent received the request.
     AlreadyPaused,
 }

--- a/mirrord/protocol/src/pause.rs
+++ b/mirrord/protocol/src/pause.rs
@@ -4,5 +4,4 @@ use bincode::{Decode, Encode};
 pub enum PauseTargetResponse {
     Paused,
     AlreadyPaused,
-    NoTarget,
 }


### PR DESCRIPTION
Resolves #1408 

Clients can now dynamically request the agent to pause the remote container. This is done with a new message, which is sent only once (by the CLI, right after fetching the remote env). The remote container remains paused by the agent until exit or an unpause request has been received (this case will be handled in the operator).

The flag controlling the pause feature is moved from `AgentConfig` to `LayerConfig` and is still accessible through `MIRRORD_PAUSE` env variable.