### PR TITLE
Prevent a possible race condition on config dropdown

### DIFF
--- a/changelog.d/+towncrier.fixed.md
+++ b/changelog.d/+towncrier.fixed.md
@@ -1,0 +1,1 @@
+Prevent a possible race condition

--- a/changelog.d/+towncrier.fixed.md
+++ b/changelog.d/+towncrier.fixed.md
@@ -1,1 +1,0 @@
-Prevent a possible race condition with indexes on intelliJ extension

--- a/changelog.d/+towncrier.fixed.md
+++ b/changelog.d/+towncrier.fixed.md
@@ -1,1 +1,1 @@
-Prevent a possible race condition
+Prevent a possible race condition with indexes on intelliJ extension

--- a/changelog.d/1030.added.md
+++ b/changelog.d/1030.added.md
@@ -1,1 +1,1 @@
-mirrord config dropdown for intelliJ
+mirrord config dropdown for intelliJ.

--- a/intellij-ext/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordConfigDropDown.kt
+++ b/intellij-ext/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordConfigDropDown.kt
@@ -17,7 +17,6 @@ import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.util.indexing.*
 import com.intellij.util.io.EnumeratorStringDescriptor
 import com.intellij.util.io.KeyDescriptor
-import com.intellij.util.io.exists
 import java.nio.file.Path
 import java.util.*
 import java.util.concurrent.atomic.AtomicBoolean
@@ -119,6 +118,8 @@ class MirrordConfigDropDown : ComboBoxAction() {
             object : Task.Backgroundable(project, "mirrord") {
                 override fun run(indicator: ProgressIndicator) {
                     val dumbService = DumbService.getInstance(project)
+                    // refer to `DumbService`, there is no "guarantee" still, but we stay in a loop
+                    // todo: should probably look into using the message bus to listen for indexing to finish
                     while (true) {
                         dumbService.waitForSmartMode()
                         val success = ReadAction.compute<Boolean, RuntimeException> {
@@ -199,7 +200,7 @@ class MirrordConfigIndex : ScalarIndexExtension<String>() {
 
     override fun getInputFilter(): FileBasedIndex.InputFilter {
         return FileBasedIndex.InputFilter {
-            it.isInLocalFileSystem && !it.isDirectory && it.path.endsWith("mirrord.json") && Path.of(it.path).exists()
+            it.isInLocalFileSystem && !it.isDirectory && it.path.endsWith("mirrord.json")
         }
     }
 

--- a/intellij-ext/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordConfigDropDown.kt
+++ b/intellij-ext/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordConfigDropDown.kt
@@ -113,7 +113,7 @@ class MirrordConfigDropDown : ComboBoxAction() {
 
     // this function spawns a background task to query the index, not blocking the current thread
     // it maintains a single task to do so, using the `blockQueries` flag
-    private fun queryIndexInSmartMode(project: Project, query: (project: Project) -> Unit) {
+    private fun queryIndexInSmartMode(project: Project, query: (Project) -> Unit) {
         if (!blockQueries.getAndSet(true)) {
             object : Task.Backgroundable(project, "mirrord") {
                 override fun run(indicator: ProgressIndicator) {
@@ -146,7 +146,6 @@ class MirrordConfigDropDown : ComboBoxAction() {
             }.queue()
         }
     }
-
 
     companion object {
         var chosenFile: String? = null

--- a/intellij-ext/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordConfigDropDown.kt
+++ b/intellij-ext/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordConfigDropDown.kt
@@ -103,7 +103,7 @@ class MirrordConfigDropDown : ComboBoxAction() {
                 chosenFile = files.first()
             }
 
-            e.presentation.text = getReadablePath(chosenFile!!, e.project!!)
+            e.presentation.text = getReadablePath(chosenFile!!, project)
             e.presentation.isVisible = true
         }
     }

--- a/intellij-ext/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordConfigDropDown.kt
+++ b/intellij-ext/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordConfigDropDown.kt
@@ -32,6 +32,7 @@ import kotlin.collections.HashSet
 class MirrordConfigDropDown : ComboBoxAction() {
 
     private lateinit var configFiles: HashSet<String>
+    private var blockQueries = AtomicBoolean(false)
 
     override fun getActionUpdateThread() = ActionUpdateThread.BGT
 
@@ -56,7 +57,7 @@ class MirrordConfigDropDown : ComboBoxAction() {
         e.project?.let { project ->
             // this check ensures that we don't query the index when it is being built
             // querying the index during the startup can give us 0
-            if (!::configFiles.isInitialized) {
+            if (!::configFiles.isInitialized && !blockQueries.getAndSet(true)) {
                 // there is a possibility of a race condition in case index is accessed while being built
                 // so all index queries need to be done in smart mode
                 runInSmartModeOrDirectly({


### PR DESCRIPTION
Problem: query the index while it is being built is bad

Solution:
If there is an update available, spawn a task that queries the index while blocking new tasks from being started so there is only one task in case there is an update available

