### PR TITLE
Fix intelliJ compatibility error

### DIFF
--- a/changelog.d/+towncrier.fixed.md
+++ b/changelog.d/+towncrier.fixed.md
@@ -1,0 +1,1 @@
+Fix intelliJ compatability issue by implementing missing createPopupActionGroup

--- a/intellij-ext/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordConfigDropDown.kt
+++ b/intellij-ext/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordConfigDropDown.kt
@@ -54,7 +54,6 @@ class MirrordConfigDropDown : ComboBoxAction() {
         }
     }
 
-
     @Deprecated(
         "Deprecated in Java", ReplaceWith(
             "createPopupActionGroup(button, DataManager.getInstance().getDataContext(button))",

--- a/intellij-ext/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordConfigDropDown.kt
+++ b/intellij-ext/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordConfigDropDown.kt
@@ -2,6 +2,7 @@
 
 package com.metalbear.mirrord
 
+import com.intellij.ide.DataManager
 import com.intellij.openapi.actionSystem.*
 import com.intellij.openapi.actionSystem.ex.ComboBoxAction
 import com.intellij.openapi.application.ReadAction
@@ -51,6 +52,17 @@ class MirrordConfigDropDown : ComboBoxAction() {
         return DefaultActionGroup().apply {
             addAll(actions)
         }
+    }
+
+
+    @Deprecated(
+        "Deprecated in Java", ReplaceWith(
+            "createPopupActionGroup(button, DataManager.getInstance().getDataContext(button))",
+            "com.intellij.ide.DataManager"
+        )
+    )
+    override fun createPopupActionGroup(button: JComponent): DefaultActionGroup {
+        return createPopupActionGroup(button, DataManager.getInstance().getDataContext(button))
     }
 
     private fun getReadablePath(path: String, project: Project): String {


### PR DESCRIPTION
Fix:

```
mirrord 3.42.0 is binary incompatible with IntelliJ IDEA Ultimate IU-222.4554.10 due to the following problem
Abstract method is not implemented (1 problem)
Abstract method ComboBoxAction.createPopupActionGroup(JComponent) is not implemented (1 problem)
```