### PR TITLE
Fix broken target config.

### DIFF
--- a/changelog.d/574.added.md
+++ b/changelog.d/574.added.md
@@ -1,1 +1,1 @@
-Support for targetless execution: when not specifying any target for the agent, mirrord now spins up an independent agent. This can be useful e.g. if you are just interested in getting the cluster's dns resolution and outgoing connectivity but don't want any pod's incoming traffic or FS. 
+Support for targetless execution: when not specifying any target for the agent, mirrord now spins up an independent agent. This can be useful e.g. if you are just interested in getting the cluster's DNS resolution and outgoing connectivity but don't want any pod's incoming traffic or FS.

--- a/mirrord/config/src/target.rs
+++ b/mirrord/config/src/target.rs
@@ -28,6 +28,7 @@ use crate::{
 #[derive(Deserialize, PartialEq, Eq, Clone, Debug, JsonSchema)]
 #[serde(untagged, rename_all = "lowercase")]
 pub enum TargetFileConfig {
+    /// Generated when the value of the `target` field is a string, or when there is no target.
     // we need default else target value will be required in some scenarios.
     Simple(#[serde(default, deserialize_with = "string_or_struct_option")] Option<Target>),
     Advanced {
@@ -58,11 +59,56 @@ impl FromMirrordConfig for TargetConfig {
 }
 
 impl TargetFileConfig {
+    /// Get the final path.
+    /// Will return the environment variable's value if set, if not the value from the
+    /// configuration (passed argument), and if that is not set as well, `None`.
+    ///
+    /// # Arguments
+    ///
+    /// * `path_from_config_file` - The optional value read from the config file.
     fn get_optional_path(path_from_config_file: Option<Target>) -> Result<Option<Target>> {
         FromEnvWithError::new("MIRRORD_IMPERSONATED_TARGET")
             .or(path_from_config_file)
             .source_value()
             .transpose()
+    }
+
+    /// Get the final namespace.
+    /// Will return the environment variable's value if set, if not the value from the
+    /// configuration (passed argument), and if that is not set as well, `None`.
+    ///
+    /// # Arguments
+    ///
+    /// * `namespace_from_config_file` - The optional value read from the config file.
+    fn get_optional_namespace(
+        namespace_from_config_file: Option<String>,
+    ) -> Result<Option<String>> {
+        FromEnv::new("MIRRORD_TARGET_NAMESPACE")
+            .or(namespace_from_config_file)
+            .source_value()
+            .transpose()
+    }
+
+    /// Take the final values (after taking into account the values from the file and from env), and
+    /// return the optional `TargetConfig` (`None` if targetless).
+    ///
+    /// # Errors
+    /// * `ConfigError::TargetNamespaceWithoutTarget` - if namespace is some but path is `None`,
+    ///   because the target namespace does not mean anything without a target path. The user might
+    ///   have meant the agent namespace.
+    fn from_final_path_and_namespace(
+        path: Option<Target>,
+        namespace: Option<String>,
+    ) -> Result<Option<TargetConfig>> {
+        if let Some(path) = path {
+            Ok(Some(TargetConfig { path, namespace }))
+        } else {
+            if namespace.is_some() {
+                Err(ConfigError::TargetNamespaceWithoutTarget)
+            } else {
+                Ok(None)
+            }
+        }
     }
 }
 
@@ -76,50 +122,21 @@ impl MirrordConfig for TargetFileConfig {
     /// Specifying target namespace without target is not allowed and results in an error that
     /// explains to the user what to do instead.
     fn generate_config(self) -> Result<Self::Generated> {
-        let config = match self {
+        match self {
             TargetFileConfig::Simple(path) => {
                 // Namespace was not specified via file, get it from env var if set.
                 let namespace: Option<String> = FromEnv::new("MIRRORD_TARGET_NAMESPACE")
                     .source_value()
                     .transpose()?;
-
-                let path = if let Some(path) = Self::get_optional_path(path)? {
-                    path
-                } else {
-                    // No path specified, neither via file, nor via env. So no `TargetConfig`,
-                    // running targetless.
-
-                    if let Some(namespace_from_env) = namespace {
-                        // env var (or CLI flag) was set.
-
-                        if !namespace_from_env.is_empty() {
-                            // And the value is not the empty string.
-
-                            return Err(ConfigError::TargetNamespaceWithoutTarget);
-                        }
-                    }
-                    return Ok(None); // Run targetless.
-                };
-                TargetConfig { path, namespace }
+                let path = Self::get_optional_path(path)?;
+                Self::from_final_path_and_namespace(path, namespace)
             }
             TargetFileConfig::Advanced { path, namespace } => {
-                debug_assert!(namespace.is_some()); // Should only be advanced if namespace there.
-                let path = if let Some(path) = Self::get_optional_path(path)? {
-                    path
-                } else {
-                    return Err(ConfigError::TargetNamespaceWithoutTarget);
-                };
-                TargetConfig {
-                    path,
-                    namespace: FromEnv::new("MIRRORD_TARGET_NAMESPACE")
-                        .or(namespace)
-                        .source_value()
-                        .transpose()?,
-                }
+                let path = Self::get_optional_path(path)?;
+                let namespace = Self::get_optional_namespace(namespace)?;
+                Self::from_final_path_and_namespace(path, namespace)
             }
-        };
-
-        Ok(Some(config))
+        }
     }
 }
 

--- a/mirrord/config/src/target.rs
+++ b/mirrord/config/src/target.rs
@@ -28,7 +28,7 @@ use crate::{
 #[derive(Deserialize, PartialEq, Eq, Clone, Debug, JsonSchema)]
 #[serde(untagged, rename_all = "lowercase")]
 pub enum TargetFileConfig {
-    /// Generated when the value of the `target` field is a string, or when there is no target.
+    // Generated when the value of the `target` field is a string, or when there is no target.
     // we need default else target value will be required in some scenarios.
     Simple(#[serde(default, deserialize_with = "string_or_struct_option")] Option<Target>),
     Advanced {

--- a/mirrord/config/src/target.rs
+++ b/mirrord/config/src/target.rs
@@ -102,12 +102,10 @@ impl TargetFileConfig {
     ) -> Result<Option<TargetConfig>> {
         if let Some(path) = path {
             Ok(Some(TargetConfig { path, namespace }))
+        } else if namespace.is_some() {
+            Err(ConfigError::TargetNamespaceWithoutTarget)
         } else {
-            if namespace.is_some() {
-                Err(ConfigError::TargetNamespaceWithoutTarget)
-            } else {
-                Ok(None)
-            }
+            Ok(None)
         }
     }
 }

--- a/mirrord/kube/src/api/container.rs
+++ b/mirrord/kube/src/api/container.rs
@@ -122,34 +122,6 @@ async fn wait_for_agent_startup(
 #[derive(Debug)]
 pub struct JobContainer;
 
-// impl JobContainer {
-//     /// Some fields of are only added if `runtime_data` is not `None` (the agent is not
-// targetless).     ///
-//     /// Add those fields according to `runtime_data`
-//     fn add_conditional_fields(
-//         job_spec: Option<&mut JobSpec>,
-//         runtime_data: Option<&RuntimeData>,
-//         agent_gid: u16,
-//     ) {
-//         // We will always go into the first two `if let`s, as we just create the specs in the
-//         // calling function.
-//         if let Some(job_spec) = job_spec {
-//             if let Some(pod_spec) = job_spec.template.spec.as_mut() {
-//                 if let Some(runtime_data) = runtime_data {
-//                     // targetless
-//                     pod_spec.node_name = Some(runtime_data.node_name.clone());
-//                     pod_spec.host_pid = Some(true);
-//                     pod_spec.security_context = Some(SecurityContext {
-//                         run_as_group: Some(agent_gid as _),
-//                         privileged: Some(true),
-//                         ..Default::default()
-//                     })
-//                 }
-//             }
-//         }
-//     }
-// }
-
 impl ContainerApi for JobContainer {
     /// runtime_data is `None` when targetless.
     async fn create_agent<P>(
@@ -283,8 +255,6 @@ impl ContainerApi for JobContainer {
         });
 
         let agent_pod: Job = serde_json::from_value(json_value)?;
-
-        // Self::add_conditional_fields(agent_pod.spec.as_mut(), runtime_data.as_ref(), agent_gid);
 
         let job_api = get_k8s_resource_api(client, agent.namespace.as_deref());
 


### PR DESCRIPTION
In the unreleased targetless PR I broke the target config because I misunderstood when the `Simple` and `Advanced` variants are generated. This PR fixes that.