### PR TITLE
Change mirrord ls to show only pods that are in running state 

### DIFF
--- a/changelog.d/1436.changed.md
+++ b/changelog.d/1436.changed.md
@@ -1,0 +1,1 @@
+Change mirrord ls to show only pods that are in running state (not crashing,starting,etc)

--- a/mirrord/cli/src/main.rs
+++ b/mirrord/cli/src/main.rs
@@ -225,7 +225,11 @@ async fn get_kube_pods(
         .map_err(CliError::KubernetesApiFailed)?;
     let api: Api<Pod> = get_k8s_resource_api(&client, namespace.as_deref());
     let pods = api
-        .list(&ListParams::default().labels("app!=mirrord"))
+        .list(
+            &ListParams::default()
+                .labels("app!=mirrord")
+                .fields("status.phase=Running"),
+        )
         .await
         .map_err(KubeApiError::from)
         .map_err(CliError::KubernetesApiFailed)?;


### PR DESCRIPTION
Closes #1436 
(not crashing,starting,etc)