### PR TITLE
Make progress text consistently lowercase.

### DIFF
--- a/changelog.d/+lowercase-progress.changed.md
+++ b/changelog.d/+lowercase-progress.changed.md
@@ -1,0 +1,1 @@
+Make progress text consitently lowercase.

--- a/mirrord/cli/src/connection.rs
+++ b/mirrord/cli/src/connection.rs
@@ -30,7 +30,7 @@ pub(crate) async fn connect_operator<P>(
 where
     P: Progress + Send + Sync,
 {
-    let sub_progress = progress.subtask("Checking Operator");
+    let sub_progress = progress.subtask("checking operator");
 
     match OperatorApi::discover(config, progress)
         .await
@@ -38,17 +38,17 @@ where
         .into_diagnostic()
     {
         Ok(Some(connection)) => {
-            sub_progress.done_with("Connected to Operator");
+            sub_progress.done_with("connected to operator");
 
             Some(connection)
         }
         Ok(None) => {
-            sub_progress.done_with("No Operator Detected");
+            sub_progress.done_with("no operator detected");
 
             None
         }
         Err(err) => {
-            sub_progress.done_with("Unable to check if operator exists, probably due to RBAC");
+            sub_progress.done_with("unable to check if operator exists, probably due to RBAC");
 
             trace!("{err}");
 

--- a/mirrord/cli/src/operator.rs
+++ b/mirrord/cli/src/operator.rs
@@ -79,7 +79,7 @@ async fn operator_status(config: Option<String>) -> Result<()> {
 
     let status_api: Api<MirrordOperatorCrd> = Api::all(kube_api);
 
-    let status_progress = progress.subtask("Fetching Status");
+    let status_progress = progress.subtask("fetching status");
 
     let mirrord_status = match status_api
         .get(OPERATOR_STATUS_NAME)
@@ -90,13 +90,13 @@ async fn operator_status(config: Option<String>) -> Result<()> {
     {
         Ok(status) => status,
         Err(err) => {
-            status_progress.fail_with("Unable to get Status");
+            status_progress.fail_with("unable to get status");
 
             return Err(err);
         }
     };
 
-    status_progress.done_with("Fetched Status");
+    status_progress.done_with("fetched status");
 
     progress.done();
 

--- a/mirrord/operator/src/client.rs
+++ b/mirrord/operator/src/client.rs
@@ -65,16 +65,16 @@ impl OperatorApi {
             // propagating an env var, don't think it's worth the extra complexity though
             let mirrord_version = Version::parse(env!("CARGO_PKG_VERSION")).unwrap();
             if operator_version != mirrord_version {
-                progress.subtask("Comparing versions").print_message(MessageKind::Warning, Some(&format!("Your mirrord version {} does not match the operator version {}. This can lead to unforeseen issues.", mirrord_version, operator_version)));
+                progress.subtask("comparing versions").print_message(MessageKind::Warning, Some(&format!("Your mirrord version {} does not match the operator version {}. This can lead to unforeseen issues.", mirrord_version, operator_version)));
                 if operator_version > mirrord_version {
-                    progress.subtask("Comparing versions").print_message(
+                    progress.subtask("comparing versions").print_message(
                         MessageKind::Warning,
                         Some(
                             "Consider updating your mirrord version to match the operator version.",
                         ),
                     );
                 } else {
-                    progress.subtask("Comparing versions").print_message(MessageKind::Warning, Some("Consider either updating your operator version to match your mirrord version, or downgrading your mirrord version."));
+                    progress.subtask("comparing versions").print_message(MessageKind::Warning, Some("Consider either updating your operator version to match your mirrord version, or downgrading your mirrord version."));
                 }
             }
             operator_api.connect_target(target).await.map(Some)


### PR DESCRIPTION
Most of the progress statuses and task names are lowercase so it doesn't look very good when just one line is capitalized, so this PR makes all of the task names and statuses lowercase, so that instead of:
```
⠸ mirrord cli starting
  ✓ ready to launch process
  ✓ layer extracted
  ✓ No Operator Detected       # <---- only this is capitalized.
  ✓ agent pod created
  ✓ pod is ready
```
we get
```
⠼ mirrord cli starting
  ✓ ready to launch process
  ✓ layer extracted
  ✓ no operator detected
  ✓ agent pod created
  ✓ pod is ready
```

Sending this PR now because I want to include a screenshot in a blogpost and I want it to look nice :)