### PR TITLE
fix strip test

### DIFF
--- a/changelog.d/+fix-strip-test.internal.md
+++ b/changelog.d/+fix-strip-test.internal.md
@@ -1,0 +1,1 @@
+Fix the test of reading from the SIP patch dir, that was not testing anything.

--- a/mirrord/layer/tests/fileops.rs
+++ b/mirrord/layer/tests/fileops.rs
@@ -66,7 +66,10 @@ async fn read_from_mirrord_bin(dylib_path: &PathBuf) {
     let mirrord_bin = temp_dir.join(MIRRORD_PATCH_DIR);
 
     // <TMPDIR>/mirrord-bin/<TMPDIR>/mirrord-test-read-from-mirrord-bin.
-    let path_in_mirrord_bin = mirrord_bin.join(&file_path);
+    let path_in_mirrord_bin = mirrord_bin.join(&file_path.strip_prefix("/").unwrap());
+
+    // Make sure we write and read from different paths (this is "meta check").
+    assert_ne!(file_path, path_in_mirrord_bin);
 
     let executable = sip_patch("cat", &Vec::new()).unwrap().unwrap();
 


### PR DESCRIPTION
This test tests our logic that makes file operations in our SIP-patch dir happen locally, and outside of that dir.

So if there is a read from /tmp/mirrord-bin/usr/lib/whatever, it should happen locally, but to /usr/lib/whatever.

The way the test verifies this is by writing some content to /tmp/whatever, then running `mirrord exec cat /tmp/mirrord-bin/tmp/whatever` and verifying it reads what it wrote.

However due to a bug in the test it was not reading directly from where it wrote.
This PR fixes this test bug and also adds an check that the read path is not the same as the write one.