### PR TITLE
Unflaking e2e tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -444,7 +444,7 @@ jobs:
       - name: Run targetless E2E test.
         run: cargo test -p tests targetless
       - name: Run all E2E test
-        run: cargo test -p tests
+        run: cargo test -p tests -- --test-threads=5
       - name: Collect logs
         if: ${{ failure() }}
         run: |

--- a/changelog.d/1453.internal.md
+++ b/changelog.d/1453.internal.md
@@ -1,0 +1,1 @@
+Fixed e2e tests' flakiness in the CI.


### PR DESCRIPTION
Solves #1453

I looked into the tests and the code around, couldn't find any exact reason for the tests to behave badly. Also, tests are failing only if too many of them are being run at the same time. I assume it is simply too much load for minikube. Even when the runtime is given 32 cores, running all 71 tests at once causes some to fail.

With concurrency now limited to 5 tests at the same time, the suite passes without problems.