### PR TITLE
Fix possible race with `IndexAllocator`

### DIFF
--- a/changelog.d/+index-allocator-improvement.internal.md
+++ b/changelog.d/+index-allocator-improvement.internal.md
@@ -1,0 +1,1 @@
+Provide buffer for `IndexAllocator` to avoid re-use of indices too fast

--- a/mirrord/agent/src/file.rs
+++ b/mirrord/agent/src/file.rs
@@ -58,7 +58,7 @@ pub struct FileManager {
     pub open_files: HashMap<u64, RemoteFile>,
     pub dir_streams: HashMap<u64, Enumerate<ReadDir>>,
     pub getdents_streams: HashMap<u64, GetDEnts64Stream>,
-    index_allocator: IndexAllocator<u64>,
+    index_allocator: IndexAllocator<u64, 100>,
 }
 
 pub fn get_root_path_from_optional_pid(pid: Option<u64>) -> PathBuf {

--- a/mirrord/agent/src/main.rs
+++ b/mirrord/agent/src/main.rs
@@ -77,7 +77,7 @@ const CHANNEL_SIZE: usize = 1024;
 #[derive(Debug)]
 struct State {
     clients: HashSet<ClientId>,
-    index_allocator: IndexAllocator<ClientId>,
+    index_allocator: IndexAllocator<ClientId, 100>,
     /// Handle to the target container if there is one.
     /// This is optional because it is acceptable not to pass the container runtime and id if not
     /// pausing. When those args are not passed, container is [`None`].

--- a/mirrord/agent/src/outgoing.rs
+++ b/mirrord/agent/src/outgoing.rs
@@ -47,7 +47,7 @@ pub(crate) struct TcpOutgoingApi {
 #[tracing::instrument(level = "trace", skip(allocator, writers, readers, daemon_tx))]
 async fn layer_recv(
     layer_message: LayerTcpOutgoing,
-    allocator: &mut IndexAllocator<ConnectionId>,
+    allocator: &mut IndexAllocator<ConnectionId, 100>,
     writers: &mut HashMap<ConnectionId, WriteHalf<SocketStream>>,
     readers: &mut StreamMap<ConnectionId, ReaderStream<ReadHalf<SocketStream>>>,
     daemon_tx: Sender<DaemonTcpOutgoing>,
@@ -161,7 +161,7 @@ impl TcpOutgoingApi {
         daemon_tx: Sender<Daemon>,
         pid: Option<u64>,
     ) -> Result<()> {
-        let mut allocator: IndexAllocator<ConnectionId> = Default::default();
+        let mut allocator: IndexAllocator<ConnectionId, 100> = Default::default();
 
         // TODO: Right now we're manually keeping these 2 maps in sync (aviram suggested using
         // `Weak` for `writers`).

--- a/mirrord/agent/src/outgoing/udp.rs
+++ b/mirrord/agent/src/outgoing/udp.rs
@@ -130,7 +130,7 @@ impl UdpOutgoingApi {
         mut layer_rx: Receiver<Layer>,
         daemon_tx: Sender<Daemon>,
     ) -> Result<()> {
-        let mut allocator = IndexAllocator::<ConnectionId>::default();
+        let mut allocator = IndexAllocator::<ConnectionId, 100>::default();
 
         // TODO: Right now we're manually keeping these 2 maps in sync (aviram suggested using
         // `Weak` for `writers`).

--- a/mirrord/agent/src/sniffer.rs
+++ b/mirrord/agent/src/sniffer.rs
@@ -316,7 +316,7 @@ pub struct TcpConnectionSniffer {
     sessions: TCPSessionMap,
     //todo: impl drop for index allocator and connection id..
     connection_id_to_tcp_identifier: HashMap<ConnectionId, TcpSessionIdentifier>,
-    index_allocator: IndexAllocator<ConnectionId>,
+    index_allocator: IndexAllocator<ConnectionId, 100>,
 }
 
 impl TcpConnectionSniffer {

--- a/mirrord/agent/src/steal/connection.rs
+++ b/mirrord/agent/src/steal/connection.rs
@@ -61,7 +61,7 @@ pub(crate) struct TcpConnectionStealer {
     /// Connected clients (layer instances) and the channels which the stealer task uses to send
     /// back messages (stealer -> agent -> layer).
     clients: HashMap<ClientId, Sender<DaemonTcp>>,
-    index_allocator: IndexAllocator<ConnectionId>,
+    index_allocator: IndexAllocator<ConnectionId, 100>,
 
     /// Intercepts the connections, instead of letting them go through their normal pathways, this
     /// is used to steal the traffic.

--- a/mirrord/agent/src/util.rs
+++ b/mirrord/agent/src/util.rs
@@ -90,6 +90,8 @@ where
 /// It keeps tracked of the indices that were freed, and reuses them when possible.
 /// You can provide a buffer of indices using the second generic `N` to avoid re-using indices
 /// too fast.
+/// TODO: Consider just having a simple IndexAllocator that keeps track of last index and increases by 1 as
+/// it'd be hard to exhaust u64. (which is usually T)
 #[derive(Debug)]
 pub struct IndexAllocator<T, const N: usize>
 where

--- a/mirrord/agent/src/util.rs
+++ b/mirrord/agent/src/util.rs
@@ -1,6 +1,6 @@
 use std::{
     clone::Clone,
-    collections::{HashMap, HashSet},
+    collections::{HashMap, HashSet, VecDeque},
     future::Future,
     hash::Hash,
     path::PathBuf,
@@ -96,7 +96,7 @@ where
     T: Num,
 {
     index: T,
-    vacant_indices: Vec<T>,
+    vacant_indices: VecDeque<T>,
 }
 
 impl<T, const N: usize> IndexAllocator<T, N>
@@ -105,7 +105,7 @@ where
 {
     /// Returns the next available index, returns None if not available (reached max)
     pub fn next_index(&mut self) -> Option<T> {
-        if self.vacant_indices.len() > N && let Some(i) = self.vacant_indices.pop() {
+        if self.vacant_indices.len() > N && let Some(i) = self.vacant_indices.pop_front() {
             return Some(i);
         }
         match self.index.checked_add(&T::one()) {
@@ -119,7 +119,7 @@ where
     }
 
     pub fn free_index(&mut self, index: T) {
-        self.vacant_indices.push(index)
+        self.vacant_indices.push_back(index)
     }
 }
 

--- a/mirrord/agent/src/util.rs
+++ b/mirrord/agent/src/util.rs
@@ -90,8 +90,8 @@ where
 /// It keeps tracked of the indices that were freed, and reuses them when possible.
 /// You can provide a buffer of indices using the second generic `N` to avoid re-using indices
 /// too fast.
-/// TODO: Consider just having a simple IndexAllocator that keeps track of last index and increases by 1 as
-/// it'd be hard to exhaust u64. (which is usually T)
+/// TODO: Consider just having a simple IndexAllocator that keeps track of last index and increases
+/// by 1 as it'd be hard to exhaust u64. (which is usually T)
 #[derive(Debug)]
 pub struct IndexAllocator<T, const N: usize>
 where

--- a/mirrord/agent/src/util.rs
+++ b/mirrord/agent/src/util.rs
@@ -123,7 +123,7 @@ where
     }
 }
 
-impl<T, const N: usize> IndexAllocator<T, N>
+impl<T, const N: usize> Default for IndexAllocator<T, N>
 where
     T: Num,
 {

--- a/mirrord/agent/src/util.rs
+++ b/mirrord/agent/src/util.rs
@@ -123,7 +123,7 @@ where
     }
 }
 
-impl<T> Default for IndexAllocator<T>
+impl<T, const N: usize> IndexAllocator<T, N>
 where
     T: Num,
 {
@@ -253,6 +253,24 @@ mod indexallocator_tests {
         let index = index_allocator.next_index().unwrap();
         assert_eq!(1, index);
         index_allocator.free_index(0);
+        let index = index_allocator.next_index().unwrap();
+        assert_eq!(0, index);
+    }
+
+    #[test]
+    fn sanity_buffer() {
+        let mut index_allocator: IndexAllocator<u32, 2> = Default::default();
+        let index = index_allocator.next_index().unwrap();
+        assert_eq!(0, index);
+        let index = index_allocator.next_index().unwrap();
+        assert_eq!(1, index);
+        index_allocator.free_index(0);
+        let index = index_allocator.next_index().unwrap();
+        assert_eq!(2, index);
+        let index = index_allocator.next_index().unwrap();
+        assert_eq!(3, index);
+        index_allocator.free_index(1);
+        index_allocator.free_index(2);
         let index = index_allocator.next_index().unwrap();
         assert_eq!(0, index);
     }

--- a/mirrord/layer/tests/common/mod.rs
+++ b/mirrord/layer/tests/common/mod.rs
@@ -1059,7 +1059,7 @@ pub fn get_env<'a>(
     config: Option<&'a str>,
 ) -> HashMap<&'a str, &'a str> {
     let mut env = HashMap::new();
-    env.insert("RUST_LOG", "warn,mirrord=trace");
+    env.insert("RUST_LOG", "warn,mirrord=debug");
     env.insert("MIRRORD_IMPERSONATED_TARGET", "pod/mock-target"); // Just pass some value.
     env.insert("MIRRORD_CONNECT_TCP", addr);
     env.insert("MIRRORD_REMOTE_DNS", "false");
@@ -1076,7 +1076,7 @@ pub fn get_env<'a>(
 
 pub fn get_env_no_fs<'a>(dylib_path_str: &'a str, addr: &'a str) -> HashMap<&'a str, &'a str> {
     let mut env = HashMap::new();
-    env.insert("RUST_LOG", "warn,mirrord=trace");
+    env.insert("RUST_LOG", "warn,mirrord=debug");
     env.insert("MIRRORD_IMPERSONATED_TARGET", "pod/mock-target"); // Just pass some value.
     env.insert("MIRRORD_CONNECT_TCP", addr);
     env.insert("MIRRORD_REMOTE_DNS", "false");

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -395,9 +395,9 @@ mod utils {
         let mut base_env = HashMap::new();
         base_env.insert("MIRRORD_AGENT_IMAGE", "test");
         base_env.insert("MIRRORD_CHECK_VERSION", "false");
-        base_env.insert("MIRRORD_AGENT_RUST_LOG", "warn,mirrord=trace");
+        base_env.insert("MIRRORD_AGENT_RUST_LOG", "warn,mirrord=debug");
         base_env.insert("MIRRORD_AGENT_COMMUNICATION_TIMEOUT", "180");
-        base_env.insert("RUST_LOG", "warn,mirrord=trace");
+        base_env.insert("RUST_LOG", "warn,mirrord=debug");
 
         if let Some(env) = env {
             for (key, value) in env {

--- a/tests/src/traffic/steal.rs
+++ b/tests/src/traffic/steal.rs
@@ -305,7 +305,7 @@ mod steal {
             )
             .await;
 
-        mirrorded_process.wait_for_line(Duration::from_secs(15), "daemon subscribed");
+        mirrorded_process.wait_for_line(Duration::from_secs(40), "daemon subscribed");
 
         let addr = SocketAddr::new(host.trim().parse().unwrap(), port as u16);
         let mut stream = TcpStream::connect(addr).unwrap();
@@ -375,7 +375,7 @@ mod steal {
             )
             .await;
 
-        mirrorded_process.wait_for_line(Duration::from_secs(20), "daemon subscribed");
+        mirrorded_process.wait_for_line(Duration::from_secs(40), "daemon subscribed");
 
         // Create a websocket connection to test the HTTP upgrade bypass.
         let host = host.trim();

--- a/tests/src/traffic/steal.rs
+++ b/tests/src/traffic/steal.rs
@@ -98,7 +98,7 @@ mod steal {
     /// then run test with MIRRORD_TESTS_USE_BINARY=../target/universal-apple-darwin/debug/mirrord
     #[rstest]
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    #[timeout(Duration::from_secs(45))]
+    #[timeout(Duration::from_secs(120))]
     async fn filter_with_single_client_and_only_matching_requests(
         #[future] service: KubeService,
         #[future] kube_client: Client,
@@ -143,7 +143,7 @@ mod steal {
 
     #[rstest]
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    #[timeout(Duration::from_secs(45))]
+    #[timeout(Duration::from_secs(120))]
     async fn test_filter_with_single_client_and_only_matching_requests_http2(
         #[future] http2_service: KubeService,
         #[future] kube_client: Client,
@@ -210,7 +210,7 @@ mod steal {
     /// then run test with MIRRORD_TESTS_USE_BINARY=../target/universal-apple-darwin/debug/mirrord
     #[rstest]
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    #[timeout(Duration::from_secs(45))]
+    #[timeout(Duration::from_secs(120))]
     async fn filter_with_single_client_and_some_matching_requests(
         #[future] service: KubeService,
         #[future] kube_client: Client,


### PR DESCRIPTION
Provide buffer for `IndexAllocator` to avoid re-use of indices too fast