### PR TITLE
Return valid error on failed DNS lookup.

### DIFF
--- a/changelog.d/+return-dns-error.fixed.md
+++ b/changelog.d/+return-dns-error.fixed.md
@@ -1,0 +1,1 @@
+Return valid error code when dns lookup fails, instead of -1.

--- a/mirrord/layer/src/error.rs
+++ b/mirrord/layer/src/error.rs
@@ -263,10 +263,13 @@ impl From<HookError> for i64 {
                     mirrord_protocol::RemoteError::ConnectTimedOut(_) => libc::ENETUNREACH,
                     _ => libc::EINVAL,
                 },
-                ResponseError::DnsLookup(dns_fail) => match dns_fail.kind {
-                    mirrord_protocol::ResolveErrorKindInternal::Timeout => libc::EAI_AGAIN,
-                    _ => libc::EAI_FAIL,
-                },
+                ResponseError::DnsLookup(dns_fail) => {
+                    return match dns_fail.kind {
+                        mirrord_protocol::ResolveErrorKindInternal::Timeout => libc::EAI_AGAIN,
+                        _ => libc::EAI_FAIL,
+                        // TODO: Add more error kinds, next time we break protocol compatibility.
+                    } as _;
+                }
                 // for listen, EINVAL means "socket is already connected."
                 // Will not happen, because this ResponseError is not return from any hook, so it
                 // never appears as HookError::ResponseError(PortAlreadyStolen(_)).

--- a/mirrord/layer/tests/outgoing.rs
+++ b/mirrord/layer/tests/outgoing.rs
@@ -19,6 +19,9 @@ mod common;
 pub use common::*;
 use futures::{SinkExt, TryStreamExt};
 
+// TODO: add a test for when DNS lookup is unsuccessful, to make sure the layer returns a valid
+//      error to the user application.
+
 /// Test outgoing UDP.
 /// Application, for each remote peer in [`RUST_OUTGOING_PEERS`]:
 /// 1. Opens a UDP port at [`RUST_OUTGOING_LOCAL`]


### PR DESCRIPTION
Return an error code on failed DNS lookup, instead of returning -1 and setting errno.