### PR TITLE
Skip `gcc` - debugging Go with VSCode extension

### DIFF
--- a/changelog.d/+ignore-gcc-for-go-vsc.fixed.md
+++ b/changelog.d/+ignore-gcc-for-go-vsc.fixed.md
@@ -1,0 +1,1 @@
+Skipping `gcc` when debugging Go in VS Code extension.

--- a/vscode-ext/src/extension.ts
+++ b/vscode-ext/src/extension.ts
@@ -476,7 +476,7 @@ class ConfigurationProvider implements vscode.DebugConfigurationProvider {
 		}
 
 		if (config.type === "go") {
-			config.env["MIRRORD_SKIP_PROCESSES"] = "dlv;debugserver;compile;go;asm;cgo;link;git";
+			config.env["MIRRORD_SKIP_PROCESSES"] = "dlv;debugserver;compile;go;asm;cgo;link;git;gcc";
 			// use our custom delve to fix being loaded into debugserver
 
 			if (process.platform === "darwin") {


### PR DESCRIPTION
When investigating user's issues in Go + VSCode setup I noticed that layer gets loaded into a `gcc` process spawned with `gcc -### -x c -c -`. Probably not what we want