### PR TITLE
Bumped dependencies in the VS Code extension

### DIFF
--- a/changelog.d/+bump-vscode-ext-deps.internal.md
+++ b/changelog.d/+bump-vscode-ext-deps.internal.md
@@ -1,0 +1,1 @@
+Bumped versions of some VS Code extension dependencies.

--- a/vscode-ext/package-lock.json
+++ b/vscode-ext/package-lock.json
@@ -5749,9 +5749,9 @@
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
 		},
 		"node_modules/yaml": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.1.tgz",
-			"integrity": "sha512-e0WHiYql7+9wr4cWMx3TVQrNwejKaEe7/rHNmQmqRjazfOP5W8PB6Jpebb5o6fIapbz9o9+2ipcaTM2ZwDI6lw==",
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.1.tgz",
+			"integrity": "sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==",
 			"engines": {
 				"node": ">= 14"
 			}
@@ -9971,9 +9971,9 @@
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
 		},
 		"yaml": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.1.tgz",
-			"integrity": "sha512-e0WHiYql7+9wr4cWMx3TVQrNwejKaEe7/rHNmQmqRjazfOP5W8PB6Jpebb5o6fIapbz9o9+2ipcaTM2ZwDI6lw=="
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.1.tgz",
+			"integrity": "sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ=="
 		},
 		"yargs": {
 			"version": "16.2.0",


### PR DESCRIPTION
`npm install` no longer warns about critical vulnerabilities :)