### PR TITLE
Update socket2 dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3181,7 +3181,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "socket2 0.5.1",
+ "socket2 0.5.3",
  "streammap-ext",
  "test_bin",
  "thiserror",
@@ -3311,7 +3311,7 @@ dependencies = [
  "regex",
  "rstest",
  "serde_json",
- "socket2 0.5.1",
+ "socket2 0.5.3",
  "streammap-ext",
  "test-cdylib",
  "thiserror",
@@ -3390,7 +3390,7 @@ dependencies = [
  "libc",
  "nix 0.24.3",
  "serde",
- "socket2 0.5.1",
+ "socket2 0.5.3",
  "thiserror",
  "tracing",
  "trust-dns-resolver",
@@ -5102,15 +5102,6 @@ checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
 dependencies = [
  "libc",
  "winapi",
-]
-
-[[package]]
-name = "socket2"
-version = "0.5.1"
-source = "git+https://github.com/t4lz/socket2?branch=unix-sockets#040f8c0c8861b2aaff53d9d1af63ca35b1b69fab"
-dependencies = [
- "libc",
- "windows-sys 0.45.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ http-body = { git = "https://github.com/meowjesty/http-body", branch = "issue/92
 http-body-util = { git = "https://github.com/meowjesty/http-body", branch = "issue/922/http2" }
 libc = "0.2"
 bimap = "0.6.2"
-socket2 = { git = "https://github.com/t4lz/socket2", branch = "unix-sockets", features = ["all"]}
+socket2 = { version = "0.5.3", features = ["all"]}
 which = "4"
 semver = "1"
 

--- a/changelog.d/+socket2.internal.md
+++ b/changelog.d/+socket2.internal.md
@@ -1,0 +1,1 @@
+Update our socket2 dependency, since the code we pushed there was released.


### PR DESCRIPTION
In https://github.com/rust-lang/socket2/pull/403, we added some code to `socket2`, for https://github.com/metalbear-co/mirrord/issues/1105. Up until now the dependency was on my `socket2` fork, but a version that includes those changes was released already, so we can depend on the new version of the official crate again.