### PR TITLE
Fix listening on a port after it was closed not working

### DIFF
--- a/changelog.d/1526.fixed.md
+++ b/changelog.d/1526.fixed.md
@@ -1,0 +1,1 @@
+Mirroring/stealing a port for a second time after the user application closed it once.

--- a/mirrord/layer/src/tcp_mirror.rs
+++ b/mirrord/layer/src/tcp_mirror.rs
@@ -203,8 +203,10 @@ impl TcpHandler for TcpMirrorHandler {
         self.apply_port_mapping(&mut listen);
         let request_port = listen.requested_port;
 
-        if !self.ports_mut().insert(listen) {
-            info!("Port {request_port} already listening, might be on different address",);
+        if self.ports_mut().replace(listen).is_some() {
+            // This can also be because we currently don't inform the tcp handler when an app closes
+            // a socket (stops listening).
+            info!("Received listen hook message for port {request_port} while already listening. Might be on different address",);
             return Ok(());
         }
 

--- a/mirrord/layer/src/tcp_steal.rs
+++ b/mirrord/layer/src/tcp_steal.rs
@@ -223,8 +223,10 @@ impl TcpHandler for TcpStealHandler {
         self.apply_port_mapping(&mut listen);
         let request_port = listen.requested_port;
 
-        if !self.ports_mut().insert(listen) {
-            info!("Port {request_port} already listening, might be on different address");
+        if self.ports_mut().replace(listen).is_some() {
+            // This can also be because we currently don't inform the tcp handler when an app closes
+            // a socket (stops listening).
+            info!("Received listen hook message for port {request_port} while already listening. Might be on different address",);
             return Ok(());
         }
 

--- a/mirrord/layer/tests/common/mod.rs
+++ b/mirrord/layer/tests/common/mod.rs
@@ -313,7 +313,7 @@ impl LayerConnection {
             .expect("Close request success!")
             .expect("Close request exists!");
 
-        println!("Should be a close file request: {read_request:#?}");
+        println!("Should be a close file request: {close_request:#?}");
         assert_eq!(
             close_request,
             ClientMessage::FileRequest(FileRequest::Close(
@@ -326,8 +326,8 @@ impl LayerConnection {
             .codec
             .next()
             .await
-            .expect("PortSubscribe request success!")
-            .expect("PortSubscribe request exists!");
+            .expect("PortSubscribe request expected, but there are no more messages.")
+            .expect("Reading client message failed.");
         assert_eq!(
             port_subscribe,
             ClientMessage::Tcp(LayerTcp::PortSubscribe(port))
@@ -712,6 +712,12 @@ impl LayerConnection {
         self.expect_single_file_read("foobar\n", fd).await;
 
         self.expect_file_close(fd).await;
+    }
+
+    pub async fn print_all_subsequent_messages(&mut self, prefix: &str) {
+        while let Some(message) = self.codec.next().await {
+            eprintln!("{prefix}{:?}", message.unwrap());
+        }
     }
 }
 


### PR DESCRIPTION
closes #1526 

The bug is that when the app closes a socket it listens to, we don't remove it from our set of `Listen` objects, and if it then listens again on the same port, we don't update the `Listen` object, which results in the local port (the port mirrord connects to) not to be updated, so mirrord tries to connect to the local port from the first time the app listened on the same requested port.

The quick fix is to replace the `Listen` object if the app listens again. But maybe we want to [handle socket closes](https://github.com/metalbear-co/mirrord/issues/1530) (remove requested port from ports set, notify agent so that the agent stops listening...).