### PR TITLE
Revert "use replace fast with frida (#1536)"

### DIFF
--- a/changelog.d/+frida-fast-replace.internal.md
+++ b/changelog.d/+frida-fast-replace.internal.md
@@ -1,1 +1,0 @@
-Frida use fast replace

--- a/mirrord/layer/src/hooks.rs
+++ b/mirrord/layer/src/hooks.rs
@@ -1,4 +1,4 @@
-use std::sync::LazyLock;
+use std::{ptr::null_mut, sync::LazyLock};
 
 use frida_gum::{interceptor::Interceptor, Gum, Module, NativePointer};
 use tracing::trace;
@@ -42,10 +42,11 @@ impl<'a> HookManager<'a> {
             }
             if let Ok(function) = get_export_by_name(Some(module), symbol) {
                 trace!("found {symbol:?} in {module:?}, hooking");
-                match self
-                    .interceptor
-                    .replace_fast(function, NativePointer(detour))
-                {
+                match self.interceptor.replace(
+                    function,
+                    NativePointer(detour),
+                    NativePointer(null_mut()),
+                ) {
                     Ok(original) => return Ok(original),
                     Err(err) => {
                         trace!("hook {symbol:?} in {module:?} failed with err {err:?}")
@@ -69,7 +70,7 @@ impl<'a> HookManager<'a> {
         let function = get_export_by_name(None, symbol)?;
 
         self.interceptor
-            .replace_fast(function, NativePointer(detour))
+            .replace(function, NativePointer(detour), NativePointer(null_mut()))
             .or_else(|_| self.hook_any_lib_export(symbol, detour))
     }
 
@@ -86,7 +87,7 @@ impl<'a> HookManager<'a> {
             .ok_or_else(|| LayerError::NoSymbolName(symbol.to_string()))?;
 
         self.interceptor
-            .replace_fast(function, NativePointer(detour))
+            .replace(function, NativePointer(detour), NativePointer(null_mut()))
             .map_err(Into::into)
     }
 


### PR DESCRIPTION
This reverts commit 2f656622b06fcdc0fa6f73ad6f1b279cc5552ed5.

this messes up c# debugger.