### PR TITLE
Fix vscode e2e job not running

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -228,7 +228,7 @@ jobs:
   test_agent_image:
     runs-on: ubuntu-latest
     needs: changed_files
-    if: ${{needs.changed_files.outputs.rs_changed == 'true' || needs.changed_files.outputs.ci_changed == 'true'}}
+    if: ${{needs.changed_files.outputs.rs_changed == 'true' || needs.changed_files.outputs.ci_changed == 'true' || needs.changed_files.outputs.vscode_changed == 'true'}}
     steps:
       - uses: actions/checkout@v3
       - uses: docker/setup-buildx-action@v2
@@ -283,7 +283,7 @@ jobs:
     runs-on: ubuntu-latest
     name: build mirrord
     needs: changed_files
-    if: ${{needs.changed_files.outputs.rs_changed == 'true' || needs.changed_files.outputs.ci_changed == 'true'}}
+    if: ${{needs.changed_files.outputs.rs_changed == 'true' || needs.changed_files.outputs.ci_changed == 'true' || needs.changed_files.outputs.vscode_changed == 'true'}}
     steps:
       - uses: actions/checkout@v3
       - uses: arduino/setup-protoc@v1

--- a/changelog.d/+vscode-ci-fix.internal.md
+++ b/changelog.d/+vscode-ci-fix.internal.md
@@ -1,0 +1,1 @@
+Fix vscode e2e job not running


### PR DESCRIPTION
looks like the vscode e2e job doesnt run, since build_mirrord and test_agent_image dont see the fs change and it makes the e2e skip