### PR TITLE
Handle user app closing a socket

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3402,7 +3402,7 @@ dependencies = [
 
 [[package]]
 name = "mirrord-protocol"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "actix-codec",
  "bincode",

--- a/changelog.d/1530.fixed.md
+++ b/changelog.d/1530.fixed.md
@@ -1,0 +1,1 @@
+If the local user application closes a socket but continues running, we now also stop mirroring/stealing from the target.

--- a/mirrord/agent/src/steal/connection.rs
+++ b/mirrord/agent/src/steal/connection.rs
@@ -518,6 +518,9 @@ impl TcpConnectionStealer {
         };
         if port_unsubscribed {
             // No remaining subscribers on this port.
+
+            // If there are ongoing connections, this will interrupt them. This is a known issue
+            // https://github.com/metalbear-co/mirrord/issues/1575
             self.iptables()?
                 .remove_redirect(port, self.stealer.local_addr()?.port())
                 .await?;

--- a/mirrord/layer/src/error.rs
+++ b/mirrord/layer/src/error.rs
@@ -154,8 +154,10 @@ pub(crate) enum LayerError {
     #[error("mirrord-layer: No connection found for id `{0}`!")]
     NoConnectionId(ConnectionId),
 
-    #[error("mirrord-layer: Failed to find port `{0}`!")]
-    PortNotFound(u16),
+    #[error(
+        "mirrord-layer: Got new connection from daemon after layer already closed that socket."
+    )]
+    NewConnectionAfterSocketClose(ConnectionId),
 
     #[error("mirrord-layer: Unmatched pong!")]
     UnmatchedPong,

--- a/mirrord/layer/src/lib.rs
+++ b/mirrord/layer/src/lib.rs
@@ -947,7 +947,10 @@ pub(crate) fn close_layer_fd(fd: c_int) {
                         // agent about the closed connection from there.
                         SocketState::Connected(_) => {}
                         _ => {
-                            // TODO: can we do anything with this result?
+                            // Ignoring errors here. We continue running, potentially without
+                            // informing the layer's and agent's TCP handlers about the socket
+                            // close. The agent might try to continue sending incoming
+                            // connections/data.
                             let _ = blocking_send_hook_message(HookMessage::Tcp(
                                 tcp::TcpIncoming::Close(port),
                             ));

--- a/mirrord/layer/src/socket.rs
+++ b/mirrord/layer/src/socket.rs
@@ -213,6 +213,22 @@ impl UserSocket {
             kind,
         }
     }
+
+    /// Return the local (requested) port the user socket is conceptually bound to.
+    /// So if the app tried to bind port 80, return `Some(80)` (even if we actually mapped it to
+    /// some other port).
+    /// `None` if socket is not bound yet.
+    pub(crate) fn get_port(&self) -> Option<u16> {
+        match &self.state {
+            SocketState::Initialized => None,
+            SocketState::Bound(Bound { address, .. })
+            | SocketState::Listening(Bound { address, .. }) => Some(address.port()),
+            SocketState::Connected(Connected {
+                local_address: address,
+                ..
+            }) => address.get_port(),
+        }
+    }
 }
 
 #[inline]

--- a/mirrord/layer/src/socket.rs
+++ b/mirrord/layer/src/socket.rs
@@ -221,8 +221,12 @@ impl UserSocket {
     pub(crate) fn get_port(&self) -> Option<u16> {
         match &self.state {
             SocketState::Initialized => None,
-            SocketState::Bound(Bound { address, .. })
-            | SocketState::Listening(Bound { address, .. }) => Some(address.port()),
+            SocketState::Bound(Bound {
+                requested_address, ..
+            })
+            | SocketState::Listening(Bound {
+                requested_address, ..
+            }) => Some(requested_address.port()),
             SocketState::Connected(Connected {
                 local_address: address,
                 ..

--- a/mirrord/layer/src/socket.rs
+++ b/mirrord/layer/src/socket.rs
@@ -16,6 +16,7 @@ use trust_dns_resolver::config::Protocol;
 
 use self::id::SocketId;
 use crate::{
+    common::{blocking_send_hook_message, HookMessage},
     detour::{Bypass, Detour, OptionExt},
     error::{HookError, HookResult},
     INCOMING_IGNORE_PORTS,
@@ -214,23 +215,41 @@ impl UserSocket {
         }
     }
 
-    /// Return the local (requested) port the user socket is conceptually bound to.
+    /// Return the local (requested) port a bound/listening (NOT CONNECTED) user socket is
+    /// conceptually bound to.
+    ///
     /// So if the app tried to bind port 80, return `Some(80)` (even if we actually mapped it to
     /// some other port).
-    /// `None` if socket is not bound yet.
-    pub(crate) fn get_port(&self) -> Option<u16> {
+    ///
+    /// `None` if socket is not bound yet, or if this socket is a connection socket.
+    fn get_bound_port(&self) -> Option<u16> {
         match &self.state {
-            SocketState::Initialized => None,
             SocketState::Bound(Bound {
                 requested_address, ..
             })
             | SocketState::Listening(Bound {
                 requested_address, ..
             }) => Some(requested_address.port()),
-            SocketState::Connected(Connected {
-                local_address: address,
-                ..
-            }) => address.get_port(),
+            _ => None,
+        }
+    }
+
+    /// Inform TCP handler about closing a bound/listening port.
+    pub(crate) fn close(&self) {
+        if let Some(port) = self.get_bound_port() {
+            match self.kind {
+                SocketKind::Tcp(_) => {
+                    // Ignoring errors here. We continue running, potentially without
+                    // informing the layer's and agent's TCP handlers about the socket
+                    // close. The agent might try to continue sending incoming
+                    // connections/data.
+                    let _ = blocking_send_hook_message(HookMessage::Tcp(
+                        super::tcp::TcpIncoming::Close(port),
+                    ));
+                }
+                // We don't do incoming UDP, so no need to notify anyone about this.
+                SocketKind::Udp(_) => {}
+            }
         }
     }
 }

--- a/mirrord/layer/src/tcp.rs
+++ b/mirrord/layer/src/tcp.rs
@@ -70,8 +70,7 @@ impl From<&Listen> for SocketAddr {
     }
 }
 
-pub(crate) trait TcpHandler {
-    const IS_STEAL: bool;
+pub(crate) trait TcpHandler<const IS_STEAL: bool> {
     fn ports(&self) -> &HashSet<Listen>;
     fn ports_mut(&mut self) -> &mut HashSet<Listen>;
     fn port_mapping_ref(&self) -> &BiMap<u16, u16>;
@@ -94,7 +93,7 @@ pub(crate) trait TcpHandler {
             // 3. Agent sniffs new incoming connection and sends it to the layer.
             // 4. Agent receives `PortUnsubscribe`.
             // Step 2 could even happen after 4.
-            if Self::IS_STEAL {
+            if IS_STEAL {
                 warn!(
                     "Got incoming tcp connection (mirrord connection id: {connection_id}) after \
                     the application already closed the socket. The connection will not be handled."

--- a/mirrord/layer/src/tcp.rs
+++ b/mirrord/layer/src/tcp.rs
@@ -88,7 +88,7 @@ pub(crate) trait TcpHandler {
     /// Handle a potential [`LayerError::NewConnectionAfterSocketClose`] error.
     fn check_connection_handling_result(res: Result<(), LayerError>) -> Result<(), LayerError> {
         if let Err(LayerError::NewConnectionAfterSocketClose(connection_id)) = res {
-            // This can happen and is valid:
+            // This can happen:
             // 1. User app closes socket.
             // 2. mirrord sends `PortUnsubscribe` to agent.
             // 3. Agent sniffs new incoming connection and sends it to the layer.
@@ -97,9 +97,7 @@ pub(crate) trait TcpHandler {
             if Self::IS_STEAL {
                 warn!(
                     "Got incoming tcp connection (mirrord connection id: {connection_id}) after \
-                    the application already closed the socket. The connection will not be handled \
-                    and will be reset once the agent is informed about the application closing the \
-                    socket."
+                    the application already closed the socket. The connection will not be handled."
                 )
             } else {
                 info!(

--- a/mirrord/layer/src/tcp_mirror.rs
+++ b/mirrord/layer/src/tcp_mirror.rs
@@ -128,9 +128,7 @@ impl TcpMirrorHandler {
     }
 }
 
-impl TcpHandler for TcpMirrorHandler {
-    const IS_STEAL: bool = false;
-
+impl TcpHandler<false> for TcpMirrorHandler {
     /// Handle NewConnection messages
     #[tracing::instrument(level = "trace", skip(self))]
     async fn handle_new_connection(&mut self, tcp_connection: NewTcpConnection) -> Result<()> {

--- a/mirrord/layer/src/tcp_mirror.rs
+++ b/mirrord/layer/src/tcp_mirror.rs
@@ -234,9 +234,13 @@ impl TcpHandler for TcpMirrorHandler {
         port: Port,
         tx: &Sender<ClientMessage>,
     ) -> std::result::Result<(), LayerError> {
-        self.ports_mut().remove(&port);
-        tx.send(ClientMessage::Tcp(LayerTcp::PortUnsubscribe(port)))
-            .await
-            .map_err(From::from)
+        if self.ports_mut().remove(&port) {
+            tx.send(ClientMessage::Tcp(LayerTcp::PortUnsubscribe(port)))
+                .await
+                .map_err(From::from)
+        } else {
+            // was not listening on closed socket, could be an outgoing socket.
+            Ok(())
+        }
     }
 }

--- a/mirrord/layer/src/tcp_mirror.rs
+++ b/mirrord/layer/src/tcp_mirror.rs
@@ -129,6 +129,8 @@ impl TcpMirrorHandler {
 }
 
 impl TcpHandler for TcpMirrorHandler {
+    const IS_STEAL: bool = false;
+
     /// Handle NewConnection messages
     #[tracing::instrument(level = "trace", skip(self))]
     async fn handle_new_connection(&mut self, tcp_connection: NewTcpConnection) -> Result<()> {

--- a/mirrord/layer/src/tcp_mirror.rs
+++ b/mirrord/layer/src/tcp_mirror.rs
@@ -204,9 +204,12 @@ impl TcpHandler for TcpMirrorHandler {
         let request_port = listen.requested_port;
 
         if self.ports_mut().replace(listen).is_some() {
-            // This can also be because we currently don't inform the tcp handler when an app closes
-            // a socket (stops listening).
-            info!("Received listen hook message for port {request_port} while already listening. Might be on different address",);
+            // Since this struct identifies listening sockets by their port (#1558), we can only
+            // forward the incoming traffic to one socket with that port.
+            info!(
+                "Received listen hook message for port {request_port} while already listening. \
+                Might be on different address. Sending all incoming traffic to newest socket."
+            );
             return Ok(());
         }
 

--- a/mirrord/layer/src/tcp_steal.rs
+++ b/mirrord/layer/src/tcp_steal.rs
@@ -111,6 +111,8 @@ pub struct TcpStealHandler {
 }
 
 impl TcpHandler for TcpStealHandler {
+    const IS_STEAL: bool = true;
+
     #[tracing::instrument(level = "trace", skip(self))]
     async fn handle_new_connection(
         &mut self,

--- a/mirrord/layer/src/tcp_steal.rs
+++ b/mirrord/layer/src/tcp_steal.rs
@@ -261,12 +261,16 @@ impl TcpHandler for TcpStealHandler {
         port: Port,
         tx: &Sender<ClientMessage>,
     ) -> Result<(), LayerError> {
-        self.ports_mut().remove(&port);
-        tx.send(ClientMessage::TcpSteal(LayerTcpSteal::PortUnsubscribe(
-            port,
-        )))
-        .await
-        .map_err(From::from)
+        if self.ports_mut().remove(&port) {
+            tx.send(ClientMessage::TcpSteal(LayerTcpSteal::PortUnsubscribe(
+                port,
+            )))
+            .await
+            .map_err(From::from)
+        } else {
+            // was not listening on closed socket, could be an outgoing socket.
+            Ok(())
+        }
     }
 }
 

--- a/mirrord/layer/src/tcp_steal.rs
+++ b/mirrord/layer/src/tcp_steal.rs
@@ -264,6 +264,9 @@ impl TcpHandler for TcpStealHandler {
         tx: &Sender<ClientMessage>,
     ) -> Result<(), LayerError> {
         if self.ports_mut().remove(&port) {
+            // There is a known issue - https://github.com/metalbear-co/mirrord/issues/1575 - where
+            // the agent is currently not able to keep ongoing connections, so once we send this
+            // message, any ongoing connections are going to be interrupted.
             tx.send(ClientMessage::TcpSteal(LayerTcpSteal::PortUnsubscribe(
                 port,
             )))

--- a/mirrord/layer/src/tcp_steal.rs
+++ b/mirrord/layer/src/tcp_steal.rs
@@ -110,9 +110,7 @@ pub struct TcpStealHandler {
     port_mapping: BiMap<u16, u16>,
 }
 
-impl TcpHandler for TcpStealHandler {
-    const IS_STEAL: bool = true;
-
+impl TcpHandler<true> for TcpStealHandler {
     #[tracing::instrument(level = "trace", skip(self))]
     async fn handle_new_connection(
         &mut self,

--- a/mirrord/layer/src/tcp_steal.rs
+++ b/mirrord/layer/src/tcp_steal.rs
@@ -222,9 +222,12 @@ impl TcpHandler for TcpStealHandler {
         let request_port = listen.requested_port;
 
         if self.ports_mut().replace(listen).is_some() {
-            // This can also be because we currently don't inform the tcp handler when an app closes
-            // a socket (stops listening).
-            info!("Received listen hook message for port {request_port} while already listening. Might be on different address",);
+            // Since this struct identifies listening sockets by their port (#1558), we can only
+            // forward the incoming traffic to one socket with that port.
+            info!(
+                "Received listen hook message for port {request_port} while already listening. \
+                Might be on different address. Sending all incoming traffic to newest socket."
+            );
             return Ok(());
         }
 

--- a/mirrord/layer/src/tcp_steal.rs
+++ b/mirrord/layer/src/tcp_steal.rs
@@ -252,6 +252,19 @@ impl TcpHandler for TcpStealHandler {
         .await
         .map_err(From::from)
     }
+
+    async fn handle_server_side_socket_close(
+        &mut self,
+        port: Port,
+        tx: &Sender<ClientMessage>,
+    ) -> Result<(), LayerError> {
+        self.ports_mut().remove(&port);
+        tx.send(ClientMessage::TcpSteal(LayerTcpSteal::PortUnsubscribe(
+            port,
+        )))
+        .await
+        .map_err(From::from)
+    }
 }
 
 impl TcpStealHandler {

--- a/mirrord/layer/src/tcp_steal.rs
+++ b/mirrord/layer/src/tcp_steal.rs
@@ -334,10 +334,9 @@ impl TcpStealHandler {
         &mut self,
         http_request: HttpRequest,
     ) -> Result<(), LayerError> {
-        let listen = self
-            .ports()
-            .get(&http_request.port)
-            .ok_or(LayerError::PortNotFound(http_request.port))?;
+        let listen = self.ports().get(&http_request.port).ok_or(
+            LayerError::NewConnectionAfterSocketClose(http_request.connection_id),
+        )?;
         let addr: SocketAddr = listen.into();
         let connection_id = http_request.connection_id;
         let port = http_request.port;

--- a/mirrord/layer/tests/self_connect.rs
+++ b/mirrord/layer/tests/self_connect.rs
@@ -4,10 +4,12 @@
 use std::{path::PathBuf, time::Duration};
 
 use rstest::rstest;
+use tokio_stream::StreamExt;
 
 mod common;
 
 pub use common::*;
+use mirrord_protocol::tcp::LayerTcp;
 
 /// Verify that if mirrord application connects to it own listening port it
 /// doesn't go through the layer unnecessarily.
@@ -19,6 +21,18 @@ async fn self_connect(dylib_path: &PathBuf) {
     let (mut test_process, mut layer_connection) = application
         .start_process_with_layer_and_port(dylib_path, vec![("MIRRORD_FILE_MODE", "local")], None)
         .await;
+    match layer_connection.codec.next().await {
+        // Accepting both a PortUnsubscribe and a hangup without it, so that this test does not
+        // depend on unrelated implementation details.
+        Some(Ok(mirrord_protocol::ClientMessage::Tcp(LayerTcp::PortUnsubscribe(_)))) | None => {}
+
+        // We want to make sure the layer does not try to connect to itself via the agent by sending
+        // messages, but a message was sent by the layer to the agent. If that message is not about
+        // the connection, and is valid, you can add it to this match.
+        // We're not just accepting any message except for the connection one, so that the test
+        // won't just pass by accident if we change the outgoing connection's implementation.
+        _ => panic!("Expected the application to exit without sending further messages"),
+    }
     assert!(layer_connection.is_ended().await);
     test_process.wait_assert_success().await;
     test_process.assert_no_error_in_stderr();

--- a/mirrord/protocol/Cargo.toml
+++ b/mirrord/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mirrord-protocol"
-version = "1.2.0"
+version = "1.2.1"
 authors.workspace = true
 description.workspace = true
 documentation.workspace = true

--- a/mirrord/protocol/src/outgoing.rs
+++ b/mirrord/protocol/src/outgoing.rs
@@ -25,6 +25,15 @@ pub enum SocketAddress {
     Unix(UnixAddr),
 }
 
+impl SocketAddress {
+    pub fn get_port(&self) -> Option<u16> {
+        match self {
+            SocketAddress::Ip(address) => Some(address.port()),
+            SocketAddress::Unix(_) => None,
+        }
+    }
+}
+
 /// A unix socket address type with rust member types (not libc stuff).
 #[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
 pub enum UnixAddr {

--- a/tests/python-e2e/close_socket.py
+++ b/tests/python-e2e/close_socket.py
@@ -7,7 +7,6 @@ import fileinput
 
 from sys import stderr
 
-TEST_DATA = b"test"
 LISTEN_ADDR = ("127.0.0.1", 80)
 
 

--- a/tests/python-e2e/close_socket.py
+++ b/tests/python-e2e/close_socket.py
@@ -1,0 +1,30 @@
+"""
+This is an application that listens to a socket and accepts 1 connection, and closes the socket once that connection is
+closed.
+"""
+import socket
+import fileinput
+
+from sys import stderr
+
+TEST_DATA = b"test"
+LISTEN_ADDR = ("127.0.0.1", 80)
+
+
+def main():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listen:
+        listen.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        listen.bind(LISTEN_ADDR)
+        listen.listen(1)
+
+    # Here we are outside of the context above, so the socket is closed.
+    # We continue running after closing the socket.
+
+    print("Closed socket.", file=stderr)
+
+    # The (Rust) test code informs this application via stdin when it can exit
+    fileinput.input().readline()
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/python-e2e/close_socket_keep_connection.py
+++ b/tests/python-e2e/close_socket_keep_connection.py
@@ -1,0 +1,39 @@
+"""
+This is an application that listens to a socket and accepts 1 connection, and closes the socket once that connection is
+closed.
+"""
+import socket
+import fileinput
+
+from sys import stderr
+
+TEST_DATA = b"test"
+LISTEN_ADDR = ("127.0.0.1", 80)
+
+
+def main():
+
+    initial_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    initial_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    initial_socket.bind(LISTEN_ADDR)
+    initial_socket.listen(1)
+
+    print("app listening.")
+
+    connected_socket, _ = initial_socket.accept()
+    print("app accepted connection.")
+
+    initial_socket.close()
+    print("Closed socket.", file=stderr)
+
+    data = connected_socket.recv(16, socket.MSG_WAITALL)
+    connected_socket.sendall(data.upper())
+
+    connected_socket.close()
+
+    # The (Rust) test code informs this application via stdin when it can exit
+    fileinput.input().readline()
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -105,6 +105,7 @@ mod utils {
         Go20HTTP,
         CurlToKubeApi,
         PythonCloseSocket,
+        PythonCloseSocketKeepConnection,
     }
 
     #[derive(Debug)]
@@ -255,6 +256,13 @@ mod utils {
                 }
                 Application::PythonCloseSocket => {
                     vec!["python3", "-u", "python-e2e/close_socket.py"]
+                }
+                Application::PythonCloseSocketKeepConnection => {
+                    vec![
+                        "python3",
+                        "-u",
+                        "python-e2e/close_socket_keep_connection.py",
+                    ]
                 }
                 Application::NodeHTTP => vec!["node", "node-e2e/app.js"],
                 Application::NodeHTTP2 => {

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -40,7 +40,7 @@ mod utils {
     use serde_json::json;
     use tempfile::{tempdir, TempDir};
     use tokio::{
-        io::{AsyncReadExt, BufReader},
+        io::{AsyncReadExt, AsyncWriteExt, BufReader},
         process::{Child, Command},
         sync::oneshot::{self, Sender},
     };
@@ -104,6 +104,7 @@ mod utils {
         Go19HTTP,
         Go20HTTP,
         CurlToKubeApi,
+        PythonCloseSocket,
     }
 
     #[derive(Debug)]
@@ -164,6 +165,11 @@ mod utils {
             assert!(!self.stderr.lock().unwrap().contains("FAILED"));
         }
 
+        pub async fn wait_assert_success(self) {
+            let output = self.child.wait_with_output().await.unwrap();
+            assert!(output.status.success());
+        }
+
         pub fn wait_for_line(&self, timeout: Duration, line: &str) {
             let now = std::time::Instant::now();
             while now.elapsed() < timeout {
@@ -173,6 +179,14 @@ mod utils {
                 }
             }
             panic!("Timeout waiting for line: {line}");
+        }
+
+        pub async fn write_to_stdin(&mut self, data: &[u8]) {
+            if let Some(ref mut stdin) = self.child.stdin {
+                stdin.write(data).await.unwrap();
+            } else {
+                panic!("Can't write to test app's stdin!");
+            }
         }
 
         pub fn from_child(mut child: Child, tempdir: TempDir) -> TestProcess {
@@ -238,6 +252,9 @@ mod utils {
                         "--app-dir=./python-e2e/",
                         "app_fastapi:app",
                     ]
+                }
+                Application::PythonCloseSocket => {
+                    vec!["python3", "-u", "python-e2e/close_socket.py"]
                 }
                 Application::NodeHTTP => vec!["node", "node-e2e/app.js"],
                 Application::NodeHTTP2 => {
@@ -415,6 +432,7 @@ mod utils {
         let server = Command::new(path)
             .args(args.clone())
             .envs(base_env)
+            .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .spawn()

--- a/tests/src/traffic/steal.rs
+++ b/tests/src/traffic/steal.rs
@@ -169,6 +169,10 @@ mod steal {
     /// 7. The test app closes also the connection's socket.
     /// 8. This test tells the test app to exit.
     /// 9. This test sends a request to the service and verifies it's not stolen.
+    ///
+    /// This test is ignored: it's a known issue: when the user application closes a socket, we stop
+    /// stealing existing connections.
+    #[ignore]
     #[rstest]
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     #[timeout(Duration::from_secs(240))]

--- a/tests/src/traffic/steal.rs
+++ b/tests/src/traffic/steal.rs
@@ -170,8 +170,9 @@ mod steal {
     /// 8. This test tells the test app to exit.
     /// 9. This test sends a request to the service and verifies it's not stolen.
     ///
-    /// This test is ignored: it's a known issue: when the user application closes a socket, we stop
-    /// stealing existing connections.
+    /// This test is ignored: it's a
+    /// [known issue](https://github.com/metalbear-co/mirrord/issues/1575): when the user
+    /// application closes a socket, we stop stealing existing connections.
     #[ignore]
     #[rstest]
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]


### PR DESCRIPTION
closes #1530.

When `close()` is called, if it's a socket managed by mirrord - notify the TcpHandler (mirror/steal) via `HookMessage`, which removes the port from the listen set, and sends a `PortUnsubscribe` to the agent.

The agent side's handling was already implemented.