### PR TITLE
make python run on apple.

### DIFF
--- a/changelog.d/1570.changed.md
+++ b/changelog.d/1570.changed.md
@@ -1,0 +1,1 @@
+The path `/opt` itself is read locally by default (up until now paths inside that directory were read locally by default, but not the directory itself).

--- a/changelog.d/1570.fixed.md
+++ b/changelog.d/1570.fixed.md
@@ -1,0 +1,1 @@
+Running python with mirrord on apple CPUs.

--- a/mirrord/layer/src/file/filter.rs
+++ b/mirrord/layer/src/file/filter.rs
@@ -57,7 +57,7 @@ fn generate_local_set() -> RegexSet {
         r"^/bin/.*$",
         r"^/sbin/.*$",
         r"^/dev/.*$",
-        r"^/opt/.*$",
+        r"^/opt(/|$)",
         r"^/home/.*$",
         r"^/tmp(/|$)",
         r"^/snap/.*$",


### PR DESCRIPTION
Prevents #1570 from happening and enables using mirrord for running python on mac, but does not solve the underlying problem with Rust/Tokio/Frida/our SIP sidestepping.