### PR TITLE
Fix running java 17.0.6-tem with mirrord on macOS

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -308,6 +308,13 @@ jobs:
       - run: |
           cd mirrord/layer/tests/apps/issue1458portnot53
           rustc issue1458portnot53.rs --out-dir target
+      # For the `java_temurin_sip` test.
+      - uses: sdkman/sdkman-action@b1f9b696c79148b66d3d3a06f7ea801820318d0f
+        id: sdkman
+        with:
+          candidate: java
+          version: 17.0.6-tem
+      - run: java -version
       - uses: actions/setup-node@v3 # For http mirroring test.
         with:
           node-version: 14
@@ -415,6 +422,13 @@ jobs:
           cd mirrord/layer/tests/apps/dns_resolve
           cargo build
       - run: ./scripts/build_c_apps.sh
+      # For the `java_temurin_sip` test.
+      - uses: sdkman/sdkman-action@b1f9b696c79148b66d3d3a06f7ea801820318d0f
+        id: sdkman
+        with:
+          candidate: java
+          version: 17.0.6-tem
+      - run: java -version
       - uses: actions/setup-node@v3
         with:
           node-version: 14

--- a/changelog.d/1459.fixed.md
+++ b/changelog.d/1459.fixed.md
@@ -1,0 +1,1 @@
+Running java 17.0.6-tem with mirrord.

--- a/mirrord/layer/src/file/hooks.rs
+++ b/mirrord/layer/src/file/hooks.rs
@@ -91,7 +91,7 @@ pub(super) unsafe extern "C" fn open_detour(
 
 /// Hook for `libc::open$NOCANCEL`.
 #[hook_fn]
-pub(super) unsafe extern "C" fn _open_nocancel_detour(
+pub(super) unsafe extern "C" fn open_nocancel_detour(
     raw_path: *const c_char,
     open_flags: c_int,
     mut args: ...
@@ -99,12 +99,12 @@ pub(super) unsafe extern "C" fn _open_nocancel_detour(
     let mode: c_int = args.arg();
     let guard = DetourGuard::new();
     if guard.is_none() {
-        FN__OPEN_NOCANCEL(raw_path, open_flags, mode)
+        FN_OPEN_NOCANCEL(raw_path, open_flags, mode)
     } else {
         open_logic(raw_path, open_flags, mode).unwrap_or_bypass_with(|_bypass| {
             #[cfg(target_os = "macos")]
             let raw_path = update_ptr_from_bypass(raw_path, _bypass);
-            FN__OPEN_NOCANCEL(raw_path, open_flags, mode)
+            FN_OPEN_NOCANCEL(raw_path, open_flags, mode)
         })
     }
 }
@@ -747,10 +747,10 @@ pub(crate) unsafe fn enable_file_hooks(hook_manager: &mut HookManager) {
     replace!(hook_manager, "open", open_detour, FnOpen, FN_OPEN);
     replace!(
         hook_manager,
-        "_openat$NOCANCEL",
-        _open_nocancel_detour,
-        Fn_open_nocancel,
-        FN__OPEN_NOCANCEL
+        "open$NOCANCEL",
+        open_nocancel_detour,
+        FnOpen_nocancel,
+        FN_OPEN_NOCANCEL
     );
 
     replace!(hook_manager, "openat", openat_detour, FnOpenat, FN_OPENAT);

--- a/mirrord/layer/tests/apps/java_temurin_sip/.gitignore
+++ b/mirrord/layer/tests/apps/java_temurin_sip/.gitignore
@@ -1,0 +1,33 @@
+### IntelliJ IDEA ###
+out/
+!**/src/main/**/out/
+!**/src/test/**/out/
+
+
+*.iml
+*.class
+
+### Eclipse ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+bin/
+!**/src/main/**/bin/
+!**/src/test/**/bin/
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+
+### VS Code ###
+.vscode/
+
+### Mac OS ###
+.DS_Store

--- a/mirrord/layer/tests/apps/java_temurin_sip/src/Main.java
+++ b/mirrord/layer/tests/apps/java_temurin_sip/src/Main.java
@@ -1,0 +1,5 @@
+public class Main {
+    public static void main(String[] args) {
+        System.out.println("Hello world!");
+    }
+}

--- a/mirrord/layer/tests/java_sip.rs
+++ b/mirrord/layer/tests/java_sip.rs
@@ -1,0 +1,35 @@
+#![feature(assert_matches)]
+#![warn(clippy::indexing_slicing)]
+
+use std::{path::PathBuf, time::Duration};
+
+use rstest::rstest;
+use tokio::net::TcpListener;
+
+mod common;
+pub use common::*;
+
+/// Regression test for https://github.com/metalbear-co/mirrord/issues/1459
+/// Test that Java Termulin installed via SDKMan can run with mirrord.
+///
+/// This test requires there to be a java binary at ~/.sdkman/candidates/java/17.0.6-tem/bin/java to
+/// pass.
+#[rstest]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[timeout(Duration::from_secs(60))]
+async fn java_temurin_sip(dylib_path: &PathBuf) {
+    let application = Application::JavaTemurinSip;
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap().to_string();
+    println!("Listening for messages from the layer on {addr}");
+
+    let env = get_env_no_fs(dylib_path.to_str().unwrap(), &addr);
+
+    let mut test_process = application.get_test_process(env).await;
+    let _layer_connection = LayerConnection::get_initialized_connection(&listener).await;
+
+    test_process.wait_assert_success().await;
+    test_process.assert_no_error_in_stderr().await;
+    test_process.assert_no_error_in_stdout().await;
+}

--- a/mirrord/sip/src/error.rs
+++ b/mirrord/sip/src/error.rs
@@ -10,6 +10,9 @@ pub enum SipError {
     #[error("Signing failed statuscode: `{0}`, output: `{1}`")]
     Sign(i32, String),
 
+    #[error("Adding Rpaths failed with statuscode: `{0}`, output: `{1}`")]
+    AddingRpathsFailed(i32, String),
+
     #[error("Can't patch file format `{0}`")]
     UnsupportedFileFormat(String),
 
@@ -32,4 +35,7 @@ pub enum SipError {
 
     #[error("Can't perform SIP check - there is a cycle in the shebang graph, found at `{0}`")]
     CyclicShebangs(String),
+
+    #[error("Got invalid string.")]
+    NonUtf8Str(#[from] std::str::Utf8Error),
 }

--- a/mirrord/sip/src/rpath.rs
+++ b/mirrord/sip/src/rpath.rs
@@ -1,0 +1,35 @@
+use std::{iter, os::unix::process::ExitStatusExt, path::Path, process::Command};
+
+use crate::error::{Result, SipError};
+
+/// Run `install_name_tool` in a child process to add a loader command for each given rpath entry
+/// to the binary in `path`.
+pub(crate) fn add_rpaths<P: AsRef<Path>>(path: P, rpath_entries: Vec<String>) -> Result<()> {
+    if rpath_entries.is_empty() {
+        return Ok(());
+    }
+    let path_str = path.as_ref().to_string_lossy().to_string();
+
+    // args are `-add_rpath RPATH` for each rpath entry, and the binary's path at the end.
+    let args = iter::once(String::from("-add_rpath"))
+        .chain(
+            rpath_entries
+                .into_iter()
+                .intersperse(String::from("-add_rpath")),
+        )
+        .chain(iter::once(path_str));
+
+    let output = Command::new("install_name_tool") // most forgettable tool name ever.
+        .args(args)
+        .output()?;
+
+    if output.status.success() {
+        Ok(())
+    } else {
+        let code = output.status.into_raw();
+        Err(SipError::AddingRpathsFailed(
+            code,
+            String::from_utf8_lossy(&output.stderr).to_string(),
+        ))
+    }
+}

--- a/scripts/install_test_app_frameworks.sh
+++ b/scripts/install_test_app_frameworks.sh
@@ -1,0 +1,8 @@
+
+# ------------------ Integration Tests ------------------
+
+# for `java_temurin_sip`
+curl -s "https://get.sdkman.io" | bash
+sdk install java 17.0.6-tem
+
+# ---------------------- E2E Tests ----------------------


### PR DESCRIPTION
closes #1459.

1. Adding a test that verify that java from that specific distribution can start with mirrord (the process couldn't even start before).
2. The problem was the binary had `rpath` loader commands with `@loader_path`, and dependencies that are in `rpath`, so the loader was looking for paths that are relative to the patched binary, and did not find them. So we now add an `rpath` entry to `@loader_path` or `@executalbe_path` with the path of the original binary instead.
3. Also, the binary was calling `dlopen` on a path that's inside our patch dir, so we're adding a hook for `dlopen` with the standard path stripping.
4. The `open$NOCANCEL` hook was replacing the wrong symbol.

I recommend reviewing this PR one commit at a time.