### PR TITLE
limit test threads to 2 for integration tests.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -358,7 +358,8 @@ jobs:
         with:
           name: mirrord-artifacts
           path: target/debug/
-      - run: cargo test -p mirrord-layer
+      # running serially because some tests get flakey when run in parallel.
+      - run: cargo test -p mirrord-layer -- --test-threads=2
 
   integration_tests_macos:
     runs-on: macos-12
@@ -427,7 +428,8 @@ jobs:
       - uses: actions/setup-node@v3 # version 19 spawns processes with `posix_spawn`, so test that also.
         with:
           node-version: 19
-      - run: cargo test -p mirrord-layer
+      # running serially because some tests get flakey when run in parallel.
+      - run: cargo test -p mirrord-layer -- --test-threads=2
 
   e2e:
     runs-on: ubuntu-latest

--- a/changelog.d/+serial-integration-tests.internal.md
+++ b/changelog.d/+serial-integration-tests.internal.md
@@ -1,0 +1,1 @@
+Run integration tests with only 2 threads so that they don't run in parallel and get flakey.


### PR DESCRIPTION
In order to reduce CI flake.