### PR TITLE
e2e tests - fixed resource deletion blocking 2 runtime threads

### DIFF
--- a/changelog.d/+e2e-tests-improved.internal.md
+++ b/changelog.d/+e2e-tests-improved.internal.md
@@ -1,0 +1,1 @@
+Cleaning kube resources after e2e tests no longer needs two runtime threads.


### PR DESCRIPTION
Resource deletion now blocks 1 runtime thread - when dropped, `ResourceGuard` spawns another OS thread and runs the deletion logic in a separate single-threaded runtime.

Optimization - `KubeService` holds 3 resource guards, so it runs their deletions in one runtime when dropped.