### PR TITLE
Run agent as a non-privileged container

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,9 +127,9 @@ You can read more about it [here](https://mirrord.dev/docs/overview/introduction
 ### Additional capabilities
 
 Container run inside the pod launched by mirrord requires additional [Linux capabilities](https://man7.org/linux/man-pages/man7/capabilities.7.html):
-* `CAP_NET_ADMIN` - for modifying routing tables
-* `CAP_SYS_PTRACE` - for reading target pod environment
-* `CAP_SYS_ADMIN` - for joining target pod network namespace
+- `CAP_NET_ADMIN` - for modifying routing tables
+- `CAP_SYS_PTRACE` - for reading target pod environment
+- `CAP_SYS_ADMIN` - for joining target pod network namespace
 
 <p align="center">
   <img src="./images/how_it_works.svg" alt="How It Works"/>

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ You can read more about it [here](https://mirrord.dev/docs/overview/introduction
 ### Additional capabilities
 
 Container run inside the pod launched by mirrord requires additional [Linux capabilities](https://man7.org/linux/man-pages/man7/capabilities.7.html):
+
 - `CAP_NET_ADMIN` - for modifying routing tables
 - `CAP_SYS_PTRACE` - for reading target pod environment
 - `CAP_SYS_ADMIN` - for joining target pod network namespace

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ It comes as a Visual Studio Code extension, an IntelliJ plugin and a CLI tool. Y
     - [Installation](#installation-2)
     - [How To Use](#how-to-use-2)
   - [How It Works](#how-it-works)
+    - [Additional capabilities](#additional-capabilities)
   - [FAQ](#faq)
   - [Contributing](#contributing)
   - [Help and Community](#help-and-community)
@@ -118,10 +119,17 @@ mirrord exec node app.js --target pod/my-pod
 
 ## How It Works
 
-When you select a pod to impersonate, mirrord launches a privileged pod on the same node as the pod you selected.
+When you select a pod to impersonate, mirrord launches a pod on the same node as the pod you selected.
 The new pod is then used to connect your local process and the impersonated pod: it mirrors incoming traffic from the pod to your process,
 routes outgoing traffic from your process through the pod, and does the same for file reads, file writes, and environment variables.
 You can read more about it [here](https://mirrord.dev/docs/overview/introduction/).
+
+### Additional capabilities
+
+Container run inside the pod launched by mirrord requires additional [Linux capabilities](https://man7.org/linux/man-pages/man7/capabilities.7.html):
+* `CAP_NET_ADMIN` - for modifying routing tables
+* `CAP_SYS_PTRACE` - for reading target pod environment
+* `CAP_SYS_ADMIN` - for joining target pod network namespace
 
 <p align="center">
   <img src="./images/how_it_works.svg" alt="How It Works"/>

--- a/changelog.d/1615.changed.md
+++ b/changelog.d/1615.changed.md
@@ -1,0 +1,1 @@
+Agent container is no longer privileged. Instead, it is given a specific set of Linux capabilities: `CAP_NET_ADMIN`, `CAP_SYS_PTRACE`, `CAP_SYS_ADMIN`.

--- a/mirrord/kube/src/api/container.rs
+++ b/mirrord/kube/src/api/container.rs
@@ -217,7 +217,13 @@ impl ContainerApi for JobContainer {
                                 "securityContext": targeted.then(||
                                     json!({
                                         "runAsGroup": agent_gid,
-                                        "privileged": true,
+                                        "capabilities": {
+                                            "add": [
+                                                "NET_ADMIN",
+                                                "SYS_PTRACE",
+                                                "SYS_ADMIN"
+                                            ]
+                                        }
                                     })
                                 ),
                                 "volumeMounts": targeted.then(||
@@ -342,9 +348,12 @@ impl ContainerApi for EphemeralContainer {
             "securityContext": {
                 "runAsGroup": agent_gid,
                 "capabilities": {
-                    "add": ["NET_RAW", "NET_ADMIN"],
+                    "add": [
+                        "NET_ADMIN",
+                        "SYS_PTRACE",
+                        "SYS_ADMIN"
+                    ]
                 },
-                "privileged": true,
             },
             "imagePullPolicy": agent.image_pull_policy,
             "targetContainerName": runtime_data.container_name,


### PR DESCRIPTION
Solves #1615 

I found that `CAP_NET_ADMIN`, `CAP_SYS_PTRACE` and `CAP_SYS_ADMIN` is a minimal set allowing the agent to function. E2E tests pass and removing any of these capabilities causes them to fail.

* `CAP_NET_ADMIN` - modifying ip tables
* `CAP_SYS_PTRACE` - reading `/proc/<target>/environ`
* `CAP_SYS_ADMIN` - entering target's network namespace

Sadly, `CAP_SYS_ADMIN` is a very broad capability. AFAIK it is used by kernel developers too often. Quote from "Note to developers": "It can plausibly be called the new root"