### PR TITLE
Have the same fs-mode everywhere.

### DIFF
--- a/changelog.d/+consistent-fs-mode.internal.md
+++ b/changelog.d/+consistent-fs-mode.internal.md
@@ -1,0 +1,1 @@
+We were overriding the fs mode only for the file filter, but not for the rest of the config.


### PR DESCRIPTION
We override the fs mode on targetless to be `localwithoverrides` regardless of user config.
However, it was only being done for the `FILE_FILTER` global. This PR changes it to be consistent everywhere (also in `FILE_MODE` and in the config object passed to the layer task). 