### PR TITLE
Fixed dynamic pause with operator not working

### DIFF
--- a/changelog.d/+dynamic-pause-operator.fixed.md
+++ b/changelog.d/+dynamic-pause-operator.fixed.md
@@ -1,0 +1,1 @@
+Fixed dynamic pause with operator not working - moved pause request to be from internal proxy

--- a/changelog.d/+fix-timeout-on-proxy.fixed.md
+++ b/changelog.d/+fix-timeout-on-proxy.fixed.md
@@ -1,0 +1,1 @@
+Fixed case where proxy can timeout since it holds a stale connection. Added heartbeat to the connection handling

--- a/mirrord/cli/src/error.rs
+++ b/mirrord/cli/src/error.rs
@@ -40,6 +40,8 @@ pub(crate) enum InternalProxyError {
     SetSidError(nix::Error),
     #[error("No connection method, please report a bug")]
     NoConnectionMethod,
+    #[error("Failed pausing target container {0:#?}")]
+    PauseError(String),
 }
 
 #[derive(Debug, Error, Diagnostic)]

--- a/mirrord/cli/src/execution.rs
+++ b/mirrord/cli/src/execution.rs
@@ -99,14 +99,6 @@ impl MirrordExecution {
             }
         }
 
-        if config.pause {
-            tokio::time::timeout(communication_timeout, Self::request_pause(&mut connection))
-                .await
-                .map_err(|_| {
-                    CliError::InitialCommFailed("Timeout requesting for target container pause.")
-                })??;
-        }
-
         let lib_path: String = lib_path.to_string_lossy().into();
         // Set LD_PRELOAD/DYLD_INSERT_LIBRARIES
         // If already exists, we append.
@@ -216,33 +208,6 @@ impl MirrordExecution {
             Some(DaemonMessage::GetEnvVarsResponse(Ok(remote_env))) => {
                 trace!("DaemonMessage::GetEnvVarsResponse {:#?}!", remote_env.len());
                 Ok(remote_env)
-            }
-            msg => Err(CliError::InvalidMessage(format!("{msg:#?}"))),
-        }
-    }
-
-    /// Request target container pause from the connected agent.
-    async fn request_pause(connection: &mut AgentConnection) -> Result<()> {
-        info!("Requesting target container pause from the agent");
-        connection
-            .sender
-            .send(ClientMessage::PauseTargetRequest(true))
-            .await
-            .map_err(|_| {
-                CliError::InitialCommFailed("Failed to request target container pause.")
-            })?;
-
-        match connection.receiver.recv().await {
-            Some(DaemonMessage::PauseTarget(DaemonPauseTarget::PauseResponse {
-                changed,
-                container_paused: true,
-            })) => {
-                if changed {
-                    info!("Target container is now paused.");
-                } else {
-                    info!("Target container was already paused.");
-                }
-                Ok(())
             }
             msg => Err(CliError::InvalidMessage(format!("{msg:#?}"))),
         }

--- a/mirrord/cli/src/execution.rs
+++ b/mirrord/cli/src/execution.rs
@@ -6,9 +6,7 @@ use std::{
 use mirrord_config::LayerConfig;
 use mirrord_operator::client::OperatorSessionInformation;
 use mirrord_progress::Progress;
-use mirrord_protocol::{
-    pause::DaemonPauseTarget, ClientMessage, DaemonMessage, EnvVars, GetEnvVarsRequest,
-};
+use mirrord_protocol::{ClientMessage, DaemonMessage, EnvVars, GetEnvVarsRequest};
 #[cfg(target_os = "macos")]
 use mirrord_sip::sip_patch;
 use serde::Serialize;
@@ -16,7 +14,7 @@ use tokio::{
     io::{AsyncBufReadExt, BufReader},
     process::{Child, Command},
 };
-use tracing::{info, trace};
+use tracing::trace;
 
 use crate::{
     connection::{create_and_connect, AgentConnectInfo, AgentConnection},

--- a/mirrord/cli/src/internal_proxy.rs
+++ b/mirrord/cli/src/internal_proxy.rs
@@ -145,7 +145,7 @@ pub(crate) async fn proxy(args: InternalProxyArgs) -> Result<()> {
     // Create a main connection, that will be held until proxy is closed.
     // This will guarantee agent staying alive and will enable us to
     // make the agent close on last connection close immediately (will help in tests)
-    let (main_connection, operator) = connect_and_ping(&config).await?;
+    let (mut main_connection, operator) = connect_and_ping(&config).await?;
     if config.pause {
         tokio::time::timeout(
             Duration::from_secs(config.agent.communication_timeout.unwrap_or(30).into()),

--- a/mirrord/kube/src/api.rs
+++ b/mirrord/kube/src/api.rs
@@ -63,6 +63,9 @@ pub fn wrap_raw_connection(
     let (out_tx, out_rx) = mpsc::channel(CONNECTION_CHANNEL_SIZE);
 
     tokio::spawn(async move {
+        let mut timeout_check = tokio::time::interval(std::time::Duration::from_secs(30));
+        timeout_check.tick().await;
+        let mut ticked = false;
         loop {
             tokio::select! {
                 msg = in_rx.recv() => {
@@ -81,6 +84,8 @@ pub fn wrap_raw_connection(
                     }
                 }
                 daemon_message = codec.next() => {
+                    timeout_check.reset();
+                    ticked = false;
                     match daemon_message {
                         Some(Ok(DaemonMessage::LogMessage(log_message))) => {
                             match log_message.level {
@@ -108,6 +113,18 @@ pub fn wrap_raw_connection(
 
                             break;
                         }
+                    }
+                },
+                _ = timeout_check.tick() => {
+                    if ticked {
+                        info!("Timeout waiting for agent message");
+                        break
+                    } else {
+                        if let Err(fail) = codec.send(ClientMessage::Ping).await {
+                            error!("Error sending client message: {:#?}", fail);
+                            break;
+                        }
+                        ticked = true;
                     }
                 }
             }

--- a/mirrord/layer/src/error.rs
+++ b/mirrord/layer/src/error.rs
@@ -159,9 +159,6 @@ pub(crate) enum LayerError {
     )]
     NewConnectionAfterSocketClose(ConnectionId),
 
-    #[error("mirrord-layer: Unmatched pong!")]
-    UnmatchedPong,
-
     #[error("mirrord-layer: JSON convert error")]
     JSONConvertError(#[from] serde_json::Error),
 

--- a/mirrord/layer/src/lib.rs
+++ b/mirrord/layer/src/lib.rs
@@ -113,7 +113,6 @@ use tokio::{
     runtime::Runtime,
     select,
     sync::mpsc::{channel, Receiver, Sender},
-    time::{sleep, Duration},
 };
 use tracing::{debug, error, info, trace, warn};
 use tracing_subscriber::{fmt::format::FmtSpan, prelude::*};
@@ -595,13 +594,6 @@ struct Layer {
     /// loop, where we receive the remote [`DaemonMessage`]s, and send them through it.
     rx: Receiver<DaemonMessage>,
 
-    /// Part of the heartbeat mechanism of mirrord.
-    ///
-    /// When it's been too long since we've last received a message (60 seconds), and this is
-    /// `false`, we send a [`ClientMessage::Ping`], set this to `true`, and expect to receive a
-    /// [`DaemonMessage::Pong`], setting it to `false` and completing the hearbeat detection.
-    ping: bool,
-
     /// Handler to the TCP mirror operations, see [`TcpMirrorHandler`].
     tcp_mirror_handler: TcpMirrorHandler,
 
@@ -663,7 +655,6 @@ impl Layer {
         Self {
             tx,
             rx,
-            ping: false,
             tcp_mirror_handler: TcpMirrorHandler::new(port_mapping.clone()),
             tcp_outgoing_handler: TcpOutgoingHandler::default(),
             udp_outgoing_handler: Default::default(),
@@ -740,10 +731,6 @@ impl Layer {
     ///
     /// ## Special case
     ///
-    /// ### [`DaemonMessage::Pong`]
-    ///
-    /// This message has no dedicated handler, and is thus handled directly here, changing the
-    /// [`Self::ping`] state.
     ///
     /// ### [`DaemonMessage::GetEnvVarsResponse`] and [`DaemonMessage::PauseTarget`]
     ///
@@ -779,13 +766,7 @@ impl Layer {
                     .await
             }
             DaemonMessage::Pong => {
-                if self.ping {
-                    self.ping = false;
-                    trace!("Daemon sent pong!");
-                } else {
-                    Err(LayerError::UnmatchedPong)?;
-                }
-
+                trace!("pong!");
                 Ok(())
             }
             DaemonMessage::GetEnvVarsResponse(_) => {
@@ -827,9 +808,6 @@ impl Layer {
 ///
 /// - Read from the [`Layer`] feature handlers [`Receiver`]s, to turn outgoing messages into
 ///   [`ClientMessage`]s, sending them with `Layer::send`;
-///
-/// - Handle the heartbeat mechanism (Ping/Pong feature), sending a [`ClientMessage::Ping`] if all
-///   the other channels received nothing for a while (60 seconds);
 async fn thread_loop(
     mut receiver: Receiver<HookMessage>,
     tx: Sender<ClientMessage>,
@@ -893,15 +871,6 @@ async fn thread_loop(
             }
             Some(response) = layer.http_response_receiver.recv() => {
                 layer.send(ClientMessage::TcpSteal(LayerTcpSteal::HttpResponse(response))).await.unwrap();
-            }
-            _ = sleep(Duration::from_secs(30)) => {
-                if !layer.ping {
-                    layer.send(ClientMessage::Ping).await.unwrap();
-                    trace!("sent ping to daemon");
-                    layer.ping = true;
-                } else {
-                    panic!("Client: unmatched ping");
-                }
             }
         }
     }


### PR DESCRIPTION
- moved pause request to be from internal proxy
- Fixed case where proxy can timeout since it holds a stale connection. Added heartbeat to the connection handling
