### PR TITLE
Added env var exclusion for `_JAVA_OPTIONS` 

### DIFF
--- a/changelog.d/1695.changed.md
+++ b/changelog.d/1695.changed.md
@@ -1,0 +1,1 @@
+Added env var exclusion for `_JAVA_OPTIONS` to avoid loading remote jars or settings that wouldn't work locally.

--- a/mirrord/agent/src/env.rs
+++ b/mirrord/agent/src/env.rs
@@ -35,6 +35,7 @@ impl EnvFilter {
                 WildMatch::new("JAVA_HOME"),
                 WildMatch::new("PYTHONPATH"),
                 WildMatch::new("RUST_LOG"),
+                WildMatch::new("_JAVA_OPTIONS"),
             ];
 
             for selector in &filter_env_vars {


### PR DESCRIPTION
Added env var exclusion for `_JAVA_OPTIONS` to avoid loading remote jars or settings that wouldn't work locally.

Closes #1695 