### PR TITLE
Change tolerations default value documentation to json

### DIFF
--- a/changelog.d/+toleration-docs-json.fixed.md
+++ b/changelog.d/+toleration-docs-json.fixed.md
@@ -1,0 +1,1 @@
+Specify default value for `agent.tolerations` in docs as json instead of yaml.

--- a/mirrord-schema.json
+++ b/mirrord-schema.json
@@ -289,7 +289,7 @@
         },
         "tolerations": {
           "title": "agent.tolerations {#agent-tolerations}",
-          "description": "Set pod tolerations. (not with ephemeral agents) Default is ```yaml tolerations: - operator: Exists ```\n\nSet to an empty array to have no tolerations at all",
+          "description": "Set pod tolerations. (not with ephemeral agents) Default is ```json [ { \"operator\": \"Exists\" } ] ```\n\nSet to an empty array to have no tolerations at all",
           "type": [
             "array",
             "null"

--- a/mirrord/config/src/agent.rs
+++ b/mirrord/config/src/agent.rs
@@ -203,9 +203,12 @@ pub struct AgentConfig {
     ///
     /// Set pod tolerations. (not with ephemeral agents)
     /// Default is
-    /// ```yaml
-    /// tolerations:
-    /// - operator: Exists
+    /// ```json
+    /// [
+    ///   {
+    ///     "operator": "Exists"
+    ///   }
+    /// ]
     /// ```
     ///
     /// Set to an empty array to have no tolerations at all


### PR DESCRIPTION
All other configuratiuon values are documented as json, and the extensions only support json, I think.
See https://github.com/metalbear-co/mirrord.dev/pull/118#discussion_r1271320138