### PR TITLE
Fix detecting skipped processes

### DIFF
--- a/changelog.d/1752.fixed.md
+++ b/changelog.d/1752.fixed.md
@@ -1,0 +1,1 @@
+Fixed detecting skipped processes during layer injection.

--- a/mirrord/config/src/util.rs
+++ b/mirrord/config/src/util.rs
@@ -59,6 +59,13 @@ pub enum VecOrSingle<T> {
 }
 
 impl<T> VecOrSingle<T> {
+    pub fn as_slice(&self) -> &[T] {
+        match self {
+            Self::Single(v) => std::slice::from_ref(v),
+            Self::Multiple(v) => v.as_slice(),
+        }
+    }
+
     pub fn join<Separator>(self, sep: Separator) -> <[T] as Join<Separator>>::Output
     where
         [T]: Join<Separator>,

--- a/mirrord/layer/src/debugger_ports.rs
+++ b/mirrord/layer/src/debugger_ports.rs
@@ -48,7 +48,7 @@ pub enum DebuggerType {
     /// --client 127.0.0.1 --port 32845 --file /path/to/script.py`
     ///
     /// Port would not be extracted from a command like `/path/to/python /path/to/script.py ...`
-    /// (debugger name missing) or `/path/to/pycharm/plugins/pydevd.py ...` (python invokation
+    /// (debugger name missing) or `/path/to/pycharm/plugins/pydevd.py ...` (python invocation
     /// missing) or `/path/to/python /path/to/pycharm/plugins/pydevd.py --client 127.0.0.1 ...`
     /// (port missing).
     PyDevD,

--- a/mirrord/layer/src/lib.rs
+++ b/mirrord/layer/src/lib.rs
@@ -90,6 +90,7 @@ use error::{LayerError, Result};
 use file::{filter::FileFilter, OPEN_FILES};
 use hooks::HookManager;
 use libc::{c_int, pid_t};
+use load::ExecutableName;
 use mirrord_config::{
     feature::{
         fs::{FsConfig, FsModeConfig},
@@ -280,7 +281,7 @@ pub(crate) static LISTEN_PORTS: OnceLock<BiMap<u16, u16>> = OnceLock::new();
 // that aren't safe to use after fork.
 
 /// Executable we're loaded to
-pub(crate) static EXECUTABLE_NAME: OnceLock<String> = OnceLock::new();
+pub(crate) static EXECUTABLE_NAME: OnceLock<ExecutableName> = OnceLock::new();
 
 /// Executable path we're loaded to
 pub(crate) static EXECUTABLE_PATH: OnceLock<String> = OnceLock::new();
@@ -298,16 +299,7 @@ pub(crate) fn is_debugger_port(addr: &SocketAddr) -> bool {
 
 /// Loads mirrord configuration and does some patching (SIP, dotnet, etc)
 fn layer_pre_initialization() -> Result<(), LayerError> {
-    let given_process = EXECUTABLE_NAME.get_or_try_init(|| {
-        std::env::current_exe()
-            .ok()
-            .and_then(|arg| {
-                arg.file_name()
-                    .and_then(|os_str| os_str.to_str())
-                    .map(String::from)
-            })
-            .ok_or(LayerError::NoProcessFound)
-    })?;
+    let given_process = EXECUTABLE_NAME.get_or_try_init(ExecutableName::from_env)?;
 
     EXECUTABLE_PATH.get_or_try_init(|| {
         std::env::current_exe().map(|arg| arg.to_string_lossy().into_owned())
@@ -341,7 +333,7 @@ fn layer_pre_initialization() -> Result<(), LayerError> {
         }
     }
 
-    match load::load_type(given_process, config) {
+    match given_process.load_type(config) {
         LoadType::Full(config) => layer_start(*config),
         #[cfg(target_os = "macos")]
         LoadType::SIPOnly => sip_only_layer_start(patch_binaries),

--- a/mirrord/layer/src/load.rs
+++ b/mirrord/layer/src/load.rs
@@ -87,7 +87,7 @@ impl ExecutableName {
 
         !skip_processes
             .iter()
-            .any(|name| name.as_ref() == &self.exec_name || name.as_ref() == &self.invoked_as)
+            .any(|name| name.as_ref() == self.exec_name || name.as_ref() == self.invoked_as)
     }
 
     /// Determine the [`LoadType`] for this process.

--- a/mirrord/layer/src/load.rs
+++ b/mirrord/layer/src/load.rs
@@ -70,6 +70,11 @@ impl ExecutableName {
         })
     }
 
+    #[cfg(target_os = "macos")]
+    pub fn ends_with(&self, suffix: &str) -> bool {
+        self.exec_name.ends_with(suffix) || self.invoked_as.ends_with(suffix)
+    }
+
     fn is_build_tool(&self) -> bool {
         BUILD_TOOL_PROCESSES.contains(self.exec_name.as_str())
             || BUILD_TOOL_PROCESSES.contains(self.invoked_as.as_str())

--- a/mirrord/layer/src/load.rs
+++ b/mirrord/layer/src/load.rs
@@ -39,7 +39,8 @@ static BUILD_TOOL_PROCESSES: LazyLock<HashSet<&str>> = LazyLock::new(|| {
 pub struct ExecutableName {
     /// Executable file name, for example `x86_64-linux-gnu-ld.bfd`.
     exec_name: String,
-    /// Last part of the process name as seen in the arguments, for example `ld` extracted from `/usr/bin/ld`.
+    /// Last part of the process name as seen in the arguments, for example `ld` extracted from
+    /// `/usr/bin/ld`.
     invoked_as: String,
 }
 
@@ -92,7 +93,11 @@ impl ExecutableName {
 
     /// Determine the [`LoadType`] for this process.
     pub fn load_type(&self, config: LayerConfig) -> LoadType {
-        let skip_processes = config.skip_processes.as_ref().map(VecOrSingle::as_slice).unwrap_or(&[]);
+        let skip_processes = config
+            .skip_processes
+            .as_ref()
+            .map(VecOrSingle::as_slice)
+            .unwrap_or(&[]);
 
         if self.should_load(skip_processes, config.skip_build_tools) {
             trace!("Loading into process: {self}.");
@@ -166,7 +171,7 @@ mod tests {
     ) {
         let executable_name = ExecutableName {
             exec_name: exec_name.to_string(),
-            invoked_as: invoked_as.to_string()
+            invoked_as: invoked_as.to_string(),
         };
 
         assert!(executable_name.should_load(skip_processes, skip_build_tools));

--- a/mirrord/layer/tests/apps/open_file/open_file.c
+++ b/mirrord/layer/tests/apps/open_file/open_file.c
@@ -1,0 +1,6 @@
+#include <fcntl.h>
+
+int main() {
+    int fd = open("/etc/hostname", O_RDONLY);
+    return fd >= 0 ? 0 : 1;
+}

--- a/mirrord/layer/tests/apps/open_file/open_file.c
+++ b/mirrord/layer/tests/apps/open_file/open_file.c
@@ -1,6 +1,6 @@
 #include <fcntl.h>
 
 int main() {
-    int fd = open("/etc/hostname", O_RDONLY);
+    int fd = open("/etc/resolv.conf", O_RDONLY);
     return fd >= 0 ? 0 : 1;
 }

--- a/mirrord/layer/tests/common/mod.rs
+++ b/mirrord/layer/tests/common/mod.rs
@@ -627,10 +627,8 @@ pub enum Application {
     RustRecvFrom,
     RustListenPorts,
     Fork,
+    OpenFile,
     // For running applications with the executable and arguments determined at runtime.
-    // Compiled only on macos just because it's currently only used there, but could be used also
-    // on Linux.
-    #[cfg(target_os = "macos")]
     DynamicApp(String, Vec<String>),
 }
 
@@ -732,8 +730,12 @@ impl Application {
                     "../../target/debug/listen_ports"
                 )
             }
-            #[cfg(target_os = "macos")]
-            Application::DynamicApp(exe, _args) => exe.clone(),
+            Application::OpenFile => format!(
+                "{}/{}",
+                env!("CARGO_MANIFEST_DIR"),
+                "tests/apps/open_file/out.c_test_app",
+            ), // String::from("tests/apps/open_file/out.c_test_app"),
+            Application::DynamicApp(exe, _) => exe.clone(),
         }
     }
 
@@ -816,7 +818,8 @@ impl Application {
             | Application::BashShebang
             | Application::Go19SelfOpen
             | Application::Go19DirBypass
-            | Application::Go20DirBypass => vec![],
+            | Application::Go20DirBypass
+            | Application::OpenFile => vec![],
             Application::RustOutgoingUdp => ["--udp", RUST_OUTGOING_LOCAL, RUST_OUTGOING_PEERS]
                 .into_iter()
                 .map(Into::into)
@@ -825,8 +828,7 @@ impl Application {
                 .into_iter()
                 .map(Into::into)
                 .collect(),
-            #[cfg(target_os = "macos")]
-            Application::DynamicApp(_exe, args) => args.to_owned(),
+            Application::DynamicApp(_, args) => args.to_owned(),
         }
     }
 
@@ -876,9 +878,9 @@ impl Application {
             | Application::RustIssue1458
             | Application::RustIssue1458PortNot53
             | Application::RustListenPorts
-            | Application::RustRecvFrom => unimplemented!("shouldn't get here"),
-            #[cfg(target_os = "macos")]
-            Application::DynamicApp(_, _) => unimplemented!("shouldn't get here"),
+            | Application::RustRecvFrom
+            | Application::OpenFile
+            | Application::DynamicApp(..) => unimplemented!("shouldn't get here"),
             Application::PythonSelfConnect => 1337,
         }
     }

--- a/mirrord/layer/tests/skipping_process.rs
+++ b/mirrord/layer/tests/skipping_process.rs
@@ -80,7 +80,7 @@ async fn dont_skip(dylib_path: &PathBuf) {
         .await;
 
     let mut conn = LayerConnection::get_initialized_connection(&listener).await;
-    conn.expect_file_open_for_reading("/etc/hostname", 5).await;
+    conn.expect_file_open_for_reading("/etc/resolv.conf", 5).await;
 
     test_process.wait_assert_success().await;
 }

--- a/mirrord/layer/tests/skipping_process.rs
+++ b/mirrord/layer/tests/skipping_process.rs
@@ -1,0 +1,86 @@
+#![feature(assert_matches)]
+#![warn(clippy::indexing_slicing)]
+
+use std::{env::temp_dir, os::unix::fs, path::PathBuf, time::Duration};
+
+use rand::prelude::*;
+use rstest::rstest;
+
+mod common;
+pub use common::*;
+
+/// Creates a new [`Application`], which is a symlink to the existing executable.
+/// The link is created in the temporary directory and its name is randomized.
+async fn symlink_app(app: &Application) -> Application {
+    let path = temp_dir().join(format!(
+        "test-dynamic-app-{}",
+        rand::thread_rng().gen::<u128>()
+    ));
+    println!("{}", app.get_executable().await);
+
+    fs::symlink(app.get_executable().await, &path).expect("failed to create executable symlink");
+
+    Application::DynamicApp(path.to_str().unwrap().to_string(), vec![])
+}
+
+#[rstest]
+#[tokio::test]
+#[timeout(Duration::from_secs(20))]
+async fn skip_based_on_exec_name(dylib_path: &PathBuf) {
+    let app = Application::OpenFile;
+    let symlinked_app = symlink_app(&app).await;
+
+    let ignore = app
+        .get_executable()
+        .await
+        .rsplit('/')
+        .next()
+        .unwrap()
+        .to_string();
+
+    let (mut test_process, _listener) = symlinked_app
+        .get_test_process_and_listener(dylib_path, vec![("MIRRORD_SKIP_PROCESSES", &ignore)], None)
+        .await;
+
+    test_process.wait_assert_success().await;
+}
+
+#[rstest]
+#[tokio::test]
+#[timeout(Duration::from_secs(20))]
+async fn skip_based_on_invokation_name(dylib_path: &PathBuf) {
+    let app = Application::OpenFile;
+    let symlinked_app = symlink_app(&app).await;
+
+    let ignore = symlinked_app
+        .get_executable()
+        .await
+        .rsplit('/')
+        .next()
+        .unwrap()
+        .to_string();
+
+    let (mut test_process, _listener) = symlinked_app
+        .get_test_process_and_listener(dylib_path, vec![("MIRRORD_SKIP_PROCESSES", &ignore)], None)
+        .await;
+
+    test_process.wait_assert_success().await;
+}
+
+/// This is just a sanity test. Tests whether the application actually uses the layer.
+#[rstest]
+#[tokio::test]
+#[timeout(Duration::from_secs(20))]
+async fn dont_skip(dylib_path: &PathBuf) {
+    let app = Application::OpenFile;
+    let symlinked_app = symlink_app(&app).await;
+
+    let (mut test_process, listener) = symlinked_app
+        .get_test_process_and_listener(dylib_path, vec![], None)
+        .await;
+
+    let mut conn = LayerConnection::get_initialized_connection(&listener).await;
+    conn.expect_file_open_for_reading("/etc/hostname", 5).await;
+
+    test_process.wait_assert_success().await;
+}

--- a/mirrord/layer/tests/skipping_process.rs
+++ b/mirrord/layer/tests/skipping_process.rs
@@ -23,6 +23,8 @@ async fn symlink_app(app: &Application) -> Application {
     Application::DynamicApp(path.to_str().unwrap().to_string(), vec![])
 }
 
+// This doesn't work on macOS, probably different way it determines executable.
+#[cfg(not(target_os = "macos"))]
 #[rstest]
 #[tokio::test]
 #[timeout(Duration::from_secs(20))]
@@ -48,7 +50,7 @@ async fn skip_based_on_exec_name(dylib_path: &PathBuf) {
 #[rstest]
 #[tokio::test]
 #[timeout(Duration::from_secs(20))]
-async fn skip_based_on_invokation_name(dylib_path: &PathBuf) {
+async fn skip_based_on_invocation_name(dylib_path: &PathBuf) {
     let app = Application::OpenFile;
     let symlinked_app = symlink_app(&app).await;
 
@@ -80,7 +82,8 @@ async fn dont_skip(dylib_path: &PathBuf) {
         .await;
 
     let mut conn = LayerConnection::get_initialized_connection(&listener).await;
-    conn.expect_file_open_for_reading("/etc/resolv.conf", 5).await;
+    conn.expect_file_open_for_reading("/etc/resolv.conf", 5)
+        .await;
 
     test_process.wait_assert_success().await;
 }

--- a/scripts/build_c_apps.sh
+++ b/scripts/build_c_apps.sh
@@ -13,7 +13,7 @@ else
   name=$1
 fi
 
-for source_file in $(find . -name "*.c" -not -path "./target/*" -not -path "*/venv/*")
+for source_file in $(find . -name "*.c" -not -path "./target/*" -not -path "*/venv/*" -not -path "*/node_modules/*")
 do
     directory=$(dirname "$source_file")
     out_file="$directory/$name"


### PR DESCRIPTION
Closes #1725 

Using mirrord with a go project was failing even without the devcontainer, because the layer was injecting into common build tools like `gcc` or `ld`. This is a regression introduced recently.

Layer now inspects both path to the executable name and the process arguments when determining load type.