### PR TITLE
Change operator / cli version mismatch warning

### DIFF
--- a/changelog.d/+no-message-on-old-operator.changed.md
+++ b/changelog.d/+no-message-on-old-operator.changed.md
@@ -1,0 +1,1 @@
+Change operator / cli version mismatch to show only when mirrord is older than operator

--- a/mirrord/operator/src/client.rs
+++ b/mirrord/operator/src/client.rs
@@ -126,18 +126,14 @@ impl OperatorApi {
             // This is printed multiple times when the local process forks. Can be solved by e.g.
             // propagating an env var, don't think it's worth the extra complexity though
             let mirrord_version = Version::parse(env!("CARGO_PKG_VERSION")).unwrap();
-            if operator_version != mirrord_version {
+            if operator_version > mirrord_version {
                 progress.subtask("comparing versions").print_message(MessageKind::Warning, Some(&format!("Your mirrord plugin/CLI version {} does not match the operator version {}. This can lead to unforeseen issues.", mirrord_version, operator_version)));
-                if operator_version > mirrord_version {
-                    progress.subtask("comparing versions").print_message(
-                        MessageKind::Warning,
-                        Some(
-                            "Consider updating your mirrord plugin/CLI to match the operator version.",
-                        ),
-                    );
-                } else {
-                    progress.subtask("comparing versions").print_message(MessageKind::Warning, Some("Consider either updating your operator version to match your mirrord plugin/CLI version, or downgrading your mirrord plugin/CLI."));
-                }
+                progress.subtask("comparing versions").print_message(
+                    MessageKind::Warning,
+                    Some(
+                        "Consider updating your mirrord plugin/CLI to match the operator version.",
+                    ),
+                );
             }
             let operator_session_information = OperatorSessionInformation::new(
                 target,


### PR DESCRIPTION
Change operator / cli version mismatch to show only when mirrord is older than operator
