### PR TITLE
Add missing hook for `read$NOCANCEL`

### DIFF
--- a/changelog.d/1747.fixed.md
+++ b/changelog.d/1747.fixed.md
@@ -1,0 +1,1 @@
+Add missing hook for `read$NOCANCEL`, fixes reading remote files in some scenarios.


### PR DESCRIPTION
Add missing hook for `read$NOCANCEL`, fixes reading remote files in some scenarios.