### PR TITLE
Using json progress tracker as default in extension

### DIFF
--- a/changelog.d/+default-json-progress-ext.fixed.md
+++ b/changelog.d/+default-json-progress-ext.fixed.md
@@ -1,0 +1,1 @@
+CLI now uses the json progress tracker as default.

--- a/mirrord/cli/src/extension.rs
+++ b/mirrord/cli/src/extension.rs
@@ -1,13 +1,14 @@
 use std::collections::HashMap;
 
 use mirrord_config::LayerConfig;
-use mirrord_progress::{Progress, ProgressTracker};
+use mirrord_progress::{JsonProgress, Progress, ProgressTracker};
 
 use crate::{config::ExtensionExecArgs, error::CliError, execution::MirrordExecution, Result};
 
 /// Facilitate the execution of a process using mirrord by an IDE extension
 pub(crate) async fn extension_exec(args: ExtensionExecArgs) -> Result<()> {
-    let mut progress = ProgressTracker::from_env("mirrord preparing to launch");
+    let mut progress = ProgressTracker::try_from_env("mirrord preparing to launch")
+        .unwrap_or_else(|| JsonProgress::new("mirrord preparing to launch").into());
     let mut env: HashMap<String, String> = HashMap::new();
 
     if let Some(config_file) = args.config_file {


### PR DESCRIPTION
This is a regression in `mirrord cli`. IntelliJ extension does not set `MIRRORD_PROGRESS_MODE`.