### PR TITLE
`ResponseError::DnsLookup` for errors during DNS lookup

### DIFF
--- a/changelog.d/1809.fixed.md
+++ b/changelog.d/1809.fixed.md
@@ -1,0 +1,1 @@
+Send only ResponseError::DnsLookup for all errors during DNS lookups

--- a/mirrord/agent/src/dns.rs
+++ b/mirrord/agent/src/dns.rs
@@ -78,9 +78,9 @@ pub async fn dns_worker(mut rx: Receiver<DnsRequest>, pid: Option<u64>) -> Resul
                     kind: ResolveErrorKindInternal::Unknown,
                 }),
             });
-            if let Err(result) = tx.send(GetAddrInfoResponse(result)) {
-                error!("couldn't send result to caller {result:?}");
-            }
+        if let Err(result) = tx.send(GetAddrInfoResponse(result)) {
+            error!("couldn't send result to caller {result:?}");
+        }
     }
 
     Ok(())

--- a/mirrord/agent/src/dns.rs
+++ b/mirrord/agent/src/dns.rs
@@ -5,7 +5,7 @@ use std::{
 
 use mirrord_protocol::{
     dns::{DnsLookup, GetAddrInfoRequest, GetAddrInfoResponse},
-    RemoteResult,
+    DnsLookupError, RemoteResult, ResolveErrorKindInternal, ResponseError,
 };
 use tokio::sync::{
     mpsc::{self, Receiver, Sender},
@@ -67,10 +67,20 @@ pub async fn dns_worker(mut rx: Receiver<DnsRequest>, pid: Option<u64>) -> Resul
     while let Some(DnsRequest { request, tx }) = rx.recv().await {
         trace!("dns_worker -> request {:#?}", request);
 
-        let result = dns_lookup(root_path.as_path(), request.node);
-        if let Err(result) = tx.send(GetAddrInfoResponse(result.await)) {
-            error!("couldn't send result to caller {result:?}");
-        }
+        let result = dns_lookup(root_path.as_path(), request.node)
+            .await
+            .inspect_err(|err| {
+                error!("dns_lookup -> ResponseError:: {err:?}");
+            })
+            .map_err(|err| match err {
+                ResponseError::DnsLookup(err) => ResponseError::DnsLookup(err),
+                _ => ResponseError::DnsLookup(DnsLookupError {
+                    kind: ResolveErrorKindInternal::Unknown,
+                }),
+            });
+            if let Err(result) = tx.send(GetAddrInfoResponse(result)) {
+                error!("couldn't send result to caller {result:?}");
+            }
     }
 
     Ok(())


### PR DESCRIPTION
closes #1809 

Just converted other errors to be DnsLookup errors so we always send ResponseError::DnsLookup as an error