### PR TITLE
`not-found` file filter

### DIFF
--- a/changelog.d/1694.fixed.md
+++ b/changelog.d/1694.fixed.md
@@ -1,0 +1,1 @@
+Added an extra `not-found` file filter to improve experience when using cloud services under mirrord.

--- a/mirrord-schema.json
+++ b/mirrord-schema.json
@@ -156,7 +156,7 @@
   "additionalProperties": false,
   "definitions": {
     "AdvancedFsUserConfig": {
-      "description": "Allows the user to specify the default behavior for file operations:\n\n1. `\"read\"` - Read from the remote file system (default) 2. `\"write\"` - Read/Write from the remote file system. 3. `\"local\"` - Read from the local file system. 5. `\"disable\"` - Disable file operations.\n\nBesides the default behavior, the user can specify behavior for specific regex patterns. Case insensitive.\n\n1. `\"read_write\"` - List of patterns that should be read/write remotely. 2. `\"read_only\"` - List of patterns that should be read only remotely. 3. `\"local\"` - List of patterns that should be read locally.\n\nThe logic for choosing the behavior is as follows:\n\n1. Check if one of the patterns match the file path, do the corresponding action. There's no specified order if two lists match the same path, we will use the first one (and we do not guarantee what is first).\n\n**Warning**: Specifying the same path in two lists is unsupported and can lead to undefined behaviour.\n\n2. Check our \"special list\" - we have an internal at compile time list for different behavior based on patterns to provide better UX.\n\n3. If none of the above match, use the default behavior (mode).\n\nFor more information, check the file operations [technical reference](https://mirrord.dev/docs/reference/fileops/).\n\n```json { \"feature\": { \"fs\": { \"mode\": \"write\", \"read_write\": \".+\\.json\" , \"read_only\": [ \".+\\.yaml\", \".+important-file\\.txt\" ], \"local\": [ \".+\\.js\", \".+\\.mjs\" ] } } } ```",
+      "description": "Allows the user to specify the default behavior for file operations:\n\n1. `\"read\"` - Read from the remote file system (default) 2. `\"write\"` - Read/Write from the remote file system. 3. `\"local\"` - Read from the local file system. 5. `\"disable\"` - Disable file operations.\n\nBesides the default behavior, the user can specify behavior for specific regex patterns. Case insensitive.\n\n1. `\"read_write\"` - List of patterns that should be read/write remotely. 2. `\"read_only\"` - List of patterns that should be read only remotely. 3. `\"local\"` - List of patterns that should be read locally. 4. `\"not_found\"` - List of patters that should never be read nor written. These files should be treated as non-existent.\n\nThe logic for choosing the behavior is as follows:\n\n1. Check if one of the patterns match the file path, do the corresponding action. There's no specified order if two lists match the same path, we will use the first one (and we do not guarantee what is first).\n\n**Warning**: Specifying the same path in two lists is unsupported and can lead to undefined behaviour.\n\n2. Check our \"special list\" - we have an internal at compile time list for different behavior based on patterns to provide better UX.\n\n3. If none of the above match, use the default behavior (mode).\n\nFor more information, check the file operations [technical reference](https://mirrord.dev/docs/reference/fileops/).\n\n```json { \"feature\": { \"fs\": { \"mode\": \"write\", \"read_write\": \".+\\.json\" , \"read_only\": [ \".+\\.yaml\", \".+important-file\\.txt\" ], \"local\": [ \".+\\.js\", \".+\\.mjs\" ], \"not_found\": [ \"\\.config/gcloud\" ] } } } ```",
       "type": "object",
       "properties": {
         "local": {
@@ -176,6 +176,18 @@
           "anyOf": [
             {
               "$ref": "#/definitions/FsModeConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "not_found": {
+          "title": "feature.fs.not_found {#feature-fs-not_found}",
+          "description": "Specify file path patterns that if matched will be treated as non-existent.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/VecOrSingle_for_String"
             },
             {
               "type": "null"

--- a/mirrord/config/src/feature/fs.rs
+++ b/mirrord/config/src/feature/fs.rs
@@ -87,9 +87,7 @@ impl MirrordConfig for FsUserConfig {
                 local: FromEnv::new("MIRRORD_FILE_LOCAL_PATTERN")
                     .source_value()
                     .transpose()?,
-                not_found: FromEnv::new("MIRRORD_FILE_NOT_FOUND_PATTERN")
-                    .source_value()
-                    .transpose()?,
+                not_found: None,
             },
             FsUserConfig::Advanced(advanced) => advanced.generate_config()?,
         };
@@ -110,16 +108,13 @@ impl MirrordToggleableConfig for FsUserConfig {
         let local = FromEnv::new("MIRRORD_FILE_LOCAL_PATTERN")
             .source_value()
             .transpose()?;
-        let not_found = FromEnv::new("MIRRORD_FILE_NOT_FOUND_PATTERN")
-            .source_value()
-            .transpose()?;
 
         Ok(FsConfig {
             mode,
             read_write,
             read_only,
             local,
-            not_found,
+            not_found: None,
         })
     }
 }

--- a/mirrord/config/src/feature/fs.rs
+++ b/mirrord/config/src/feature/fs.rs
@@ -87,6 +87,9 @@ impl MirrordConfig for FsUserConfig {
                 local: FromEnv::new("MIRRORD_FILE_LOCAL_PATTERN")
                     .source_value()
                     .transpose()?,
+                not_found: FromEnv::new("MIRRORD_FILE_NOT_FOUND_PATTERN")
+                    .source_value()
+                    .transpose()?,
             },
             FsUserConfig::Advanced(advanced) => advanced.generate_config()?,
         };
@@ -107,12 +110,16 @@ impl MirrordToggleableConfig for FsUserConfig {
         let local = FromEnv::new("MIRRORD_FILE_LOCAL_PATTERN")
             .source_value()
             .transpose()?;
+        let not_found = FromEnv::new("MIRRORD_FILE_NOT_FOUND_PATTERN")
+            .source_value()
+            .transpose()?;
 
         Ok(FsConfig {
             mode,
             read_write,
             read_only,
             local,
+            not_found,
         })
     }
 }

--- a/mirrord/config/src/feature/fs/advanced.rs
+++ b/mirrord/config/src/feature/fs/advanced.rs
@@ -105,16 +105,13 @@ impl MirrordToggleableConfig for AdvancedFsUserConfig {
         let local = FromEnv::new("MIRRORD_FILE_LOCAL_PATTERN")
             .source_value()
             .transpose()?;
-        let not_found = FromEnv::new("MIRRORD_FILE_NOT_FOUND_PATTERN")
-            .source_value()
-            .transpose()?;
 
         Ok(Self::Generated {
             mode,
             read_write,
             read_only,
             local,
-            not_found,
+            not_found: None,
         })
     }
 }

--- a/mirrord/config/src/feature/fs/advanced.rs
+++ b/mirrord/config/src/feature/fs/advanced.rs
@@ -90,7 +90,6 @@ pub struct FsConfig {
     /// ### feature.fs.not_found {#feature-fs-not_found}
     ///
     /// Specify file path patterns that if matched will be treated as non-existent.
-    #[config(env = "MIRRORD_FILE_NOT_FOUND_PATTERN")]
     pub not_found: Option<VecOrSingle<String>>,
 }
 

--- a/mirrord/config/src/feature/fs/mode.rs
+++ b/mirrord/config/src/feature/fs/mode.rs
@@ -46,6 +46,10 @@ pub enum FsModeConfig {
 }
 
 impl FsModeConfig {
+    pub fn is_local(self) -> bool {
+        matches!(self, FsModeConfig::Local)
+    }
+
     pub fn is_read(self) -> bool {
         matches!(self, FsModeConfig::Read | FsModeConfig::LocalWithOverrides)
     }

--- a/mirrord/layer/src/error.rs
+++ b/mirrord/layer/src/error.rs
@@ -96,6 +96,11 @@ pub(crate) enum HookError {
 
     #[error("mirrord-layer: Socket address `{0}` is already bound!")]
     AddressAlreadyBound(SocketAddr),
+
+    /// When the user's application tries to access a file filtered out by the `not-found` file
+    /// filter.
+    #[error("mirrord-layer: Ignored file")]
+    FileNotFound,
 }
 
 /// Errors internal to mirrord-layer.
@@ -307,6 +312,7 @@ impl From<HookError> for i64 {
             HookError::UnsupportedSocketType => libc::EAFNOSUPPORT,
             HookError::BadPointer => libc::EFAULT,
             HookError::AddressAlreadyBound(_) => libc::EADDRINUSE,
+            HookError::FileNotFound => libc::ENOENT,
         };
 
         set_errno(errno::Errno(libc_error));

--- a/mirrord/layer/src/file/filter.rs
+++ b/mirrord/layer/src/file/filter.rs
@@ -102,11 +102,6 @@ fn generate_local_set() -> RegexSet {
 /// List of files that mirrord should use remotely read only
 fn generate_remote_ro_set() -> RegexSet {
     let patterns = [
-        // AWS cli cache
-        // "file not exist" for identity caches (AWS)
-        r"\.aws/cli/cache/.+\.json$",
-        r"\.aws/credentials$",
-        r"\.aws/config$",
         // for dns resolving
         r"^/etc/resolv.conf$",
         r"^/etc/hosts$",

--- a/mirrord/layer/src/lib.rs
+++ b/mirrord/layer/src/lib.rs
@@ -546,6 +546,7 @@ fn sip_only_layer_start(patch_binaries: Vec<String>) {
             read_write: None,
             read_only: None,
             local: None,
+            not_found: None,
         }))
         .expect("FILE_FILTER set failed");
     unsafe { file::hooks::enable_file_hooks(&mut hook_manager) };


### PR DESCRIPTION
Closes #1694 

I passed on resolving the `~`, as it's already handled by regexes. Open to suggestions.

~~Also, there is a conflict between our default `remote-readonly` and `not-found` filters. The default `remote-readonly` filter matches paths `\.aws/cli/cache/.+\.json$`, `\.aws/credentials$` and `\.aws/config$`. Not sure how to deal with this. An ideal solution would be to have a list of `(pattern, logic)` entries and stop at the first one matching, but this is not backwards-compatible~~