### PR TITLE
Fixed wrong errno being set by mirrord

### DIFF
--- a/changelog.d/1828.fixed.md
+++ b/changelog.d/1828.fixed.md
@@ -1,0 +1,1 @@
+Fixed wrong errno being set by mirrord, fixing various flows that rely on errno even when return code is ok

--- a/mirrord/layer/src/socket/hooks.rs
+++ b/mirrord/layer/src/socket/hooks.rs
@@ -383,7 +383,7 @@ pub(super) unsafe extern "C" fn recvmsg_detour(
 ) -> ssize_t {
     let recvmsg_result = FN_RECVMSG(sockfd, message_header, flags);
 
-    if recvmsg_result == -1 && errno::errno() != errno::Errno(libc::EAGAIN) {
+    if recvmsg_result == -1 {
         recvmsg_result
     } else {
         // Fills the address, similar to how `recv_from` works.

--- a/mirrord/layer/src/socket/ops.rs
+++ b/mirrord/layer/src/socket/ops.rs
@@ -915,11 +915,6 @@ pub(super) fn recv_from(
     raw_source: *mut sockaddr,
     source_length: *mut socklen_t,
 ) -> Detour<isize> {
-    if errno::errno() == errno::Errno(libc::EAGAIN) {
-        trace!("recvfrom/recvmsg hit EAGAIN, setting errno to 0");
-        errno::set_errno(errno::Errno(0));
-    }
-
     SOCKETS
         .get(&sockfd)
         .and_then(|socket| match &socket.state {
@@ -931,6 +926,7 @@ pub(super) fn recv_from(
         .map(SocketAddress::try_into)?
         .map(|address| fill_address(raw_source, source_length, address))??;
 
+    errno::set_errno(errno::Errno(0));
     Detour::Success(recv_from_result)
 }
 


### PR DESCRIPTION
Fixed wrong errno being set by mirrord fixing various flows that rely on errno even when return code is ok

Closes #1828 