### PR TITLE
Changed config verify to return aggregated warnings 

### DIFF
--- a/changelog.d/+config-verify-aggregated.changed.md
+++ b/changelog.d/+config-verify-aggregated.changed.md
@@ -1,0 +1,1 @@
+Changed config verify to return aggregated warnings list for user to print instead of warn in current progress - can fix issues with extension where we printed to stderr.

--- a/mirrord/cli/src/execution.rs
+++ b/mirrord/cli/src/execution.rs
@@ -53,8 +53,8 @@ impl MirrordExecution {
         P: Progress + Send + Sync,
     {
         let warnings = config.verify()?;
-        for &warning in warnings {
-            progress.warning(warning);
+        for warning in warnings {
+            progress.warning(&warning);
         }
 
         let lib_path = extract_library(None, progress, true)?;

--- a/mirrord/cli/src/execution.rs
+++ b/mirrord/cli/src/execution.rs
@@ -52,7 +52,11 @@ impl MirrordExecution {
     where
         P: Progress + Send + Sync,
     {
-        config.verify()?;
+        let warnings = config.verify()?;
+        for &warning in warnings {
+            progress.warning(warning);
+        }
+
         let lib_path = extract_library(None, progress, true)?;
         let mut env_vars = HashMap::new();
         let (connect_info, mut connection) = create_and_connect(config, progress).await?;

--- a/mirrord/config/src/lib.rs
+++ b/mirrord/config/src/lib.rs
@@ -394,7 +394,7 @@ impl LayerConfig {
                 ))?;
             }
         }
-        Ok(())
+        Ok(warnings)
     }
 }
 

--- a/mirrord/config/src/lib.rs
+++ b/mirrord/config/src/lib.rs
@@ -321,14 +321,16 @@ impl LayerConfig {
 
     /// Verify that there are no conflicting settings.
     /// We don't call it from `from_env` since we want to verify it only once (from cli)
-    pub fn verify(&self) -> Result<(), ConfigError> {
+    /// Returns vec of warnings
+    pub fn verify(&self) -> Result<Vec<String>, ConfigError> {
+        let mut warnings = Vec::new();
         if self.pause {
             if self.agent.ephemeral {
                 Err(ConfigError::Conflict("Pausing is not yet supported together with an ephemeral agent container.
                 Mutually exclusive arguments `--pause` and `--ephemeral-container` passed together.".to_string()))?;
             }
             if !self.feature.network.incoming.is_steal() {
-                warn!("{PAUSE_WITHOUT_STEAL_WARNING}");
+                warnings.push(PAUSE_WITHOUT_STEAL_WARNING.to_string());
             }
         }
         if self


### PR DESCRIPTION
Changed config verify to return aggregated warnings list for user to print instead of warn in current progress - can fix issues with extension where we printed to stderr.

Might fix issues where config is wrong and weird message will be seen in extension (since it sends it to stderr)
