### PR TITLE
Changed keepalive to happen from internal proxy

### DIFF
--- a/changelog.d/1839.changed.md
+++ b/changelog.d/1839.changed.md
@@ -1,0 +1,1 @@
+Changed keep alive to happen from internal proxy to support cases where layer process is stuck [breakpoint/etc]

--- a/mirrord/cli/src/internal_proxy.rs
+++ b/mirrord/cli/src/internal_proxy.rs
@@ -33,9 +33,11 @@ use tokio::{
     time::timeout,
 };
 use tokio_util::sync::CancellationToken;
-use tracing::{error, info, log::trace};
+use tracing::{error, info, log::trace, warn};
 
 use crate::error::{InternalProxyError, Result};
+
+const PING_INTERVAL_DURATION: Duration = Duration::from_secs(30);
 
 unsafe fn redirect_fd_to_dev_null(fd: libc::c_int) {
     let devnull_fd = libc::open(b"/dev/null\0" as *const [u8; 10] as _, libc::O_RDWR);
@@ -73,6 +75,9 @@ fn print_port(listener: &TcpListener) -> Result<()> {
 
 /// Supposed to run as an async detached task, proxying the connection.
 /// We parse the protocol so we might add some logic here in the future?
+/// We also handle pings here, meaning that if layer is too quiet (for example if it has a
+/// breakpoint hit and someone is holding it) It will keep the agent alive and send pings on its
+/// behalf.
 async fn connection_task(config: LayerConfig, stream: TcpStream) {
     let agent_connection = match connect_and_ping(&config).await {
         Ok((agent_connection, _)) => agent_connection,
@@ -83,9 +88,13 @@ async fn connection_task(config: LayerConfig, stream: TcpStream) {
     };
     let mut layer_connection = actix_codec::Framed::new(stream, DaemonCodec::new());
     let (agent_sender, mut agent_receiver) = agent_connection;
+    let mut ping = false;
+    let mut ping_interval = tokio::time::interval(PING_INTERVAL_DURATION);
+    ping_interval.tick().await;
     loop {
         select! {
             layer_message = layer_connection.next() => {
+                ping_interval.reset();
                 match layer_message {
                     Some(Ok(layer_message)) => {
                         if let Err(err) = agent_sender.send(layer_message).await {
@@ -109,16 +118,31 @@ async fn connection_task(config: LayerConfig, stream: TcpStream) {
             },
             agent_message = agent_receiver.recv() => {
                 match agent_message {
+                    Some(DaemonMessage::Pong) => {
+                        ping = false;
+                    },
                     Some(agent_message) => {
                         if let Err(err) = layer_connection.send(agent_message).await {
                             trace!("Error sending agent message to layer: {err:#?}");
                             break;
                         }
-                    },
+                    }
                     None => {
                         trace!("agent connection closed");
                         break;
                     }
+                }
+            },
+            _ = ping_interval.tick() => {
+                if !ping {
+                    if let Err(err) = agent_sender.send(ClientMessage::Ping).await {
+                        trace!("Error sending ping to agent: {err:#?}");
+                        break;
+                    }
+                    ping = true;
+                } else {
+                    warn!("Unmatched ping, timeout!");
+                    break;
                 }
             }
         }

--- a/mirrord/layer/src/error.rs
+++ b/mirrord/layer/src/error.rs
@@ -164,9 +164,6 @@ pub(crate) enum LayerError {
     )]
     NewConnectionAfterSocketClose(ConnectionId),
 
-    #[error("mirrord-layer: Unmatched pong!")]
-    UnmatchedPong,
-
     #[error("mirrord-layer: JSON convert error")]
     JSONConvertError(#[from] serde_json::Error),
 

--- a/mirrord/layer/src/lib.rs
+++ b/mirrord/layer/src/lib.rs
@@ -111,7 +111,6 @@ use tokio::{
     runtime::Runtime,
     select,
     sync::mpsc::{channel, Receiver, Sender},
-    time::{Duration, Interval},
 };
 use tracing::{debug, error, info, trace, warn};
 use tracing_subscriber::{fmt::format::FmtSpan, prelude::*};


### PR DESCRIPTION
Fixes cases where users set a breakpoint and agent dies meanwhile.
Closes #1839 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Introduced an internal proxy to handle keep-alive pings, enhancing support for scenarios where the layer process might be stuck due to breakpoints or debugging.
- Refactor: Removed the heartbeat mechanism from the `Layer` struct in `lib.rs`, shifting the responsibility of maintaining the connection to the new internal proxy. This includes removal of `ping` and `ping_interval` fields, and changes in handling of `DaemonMessage::Pong`.
- Chore: Removed the `UnmatchedPong` variant from the `LayerError` enum as it's no longer relevant with the refactored heartbeat mechanism.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->