### PR TITLE
Fix ephemeral agent creation api using agent namespace 

### DIFF
--- a/changelog.d/+ephemeral-namespace.fixed.md
+++ b/changelog.d/+ephemeral-namespace.fixed.md
@@ -1,0 +1,2 @@
+Fix ephemeral agent creation api using agent namespace instead of target.
+Add note about agent namespace being irrelevant in ephemeral.

--- a/mirrord-schema.json
+++ b/mirrord-schema.json
@@ -310,7 +310,7 @@
         },
         "namespace": {
           "title": "agent.namespace {#agent-namespace}",
-          "description": "Namespace where the agent shall live.\n\nDefaults to the current kubernetes namespace.",
+          "description": "Namespace where the agent shall live. Note: Doesn't work with ephemeral containers. Defaults to the current kubernetes namespace.",
           "type": [
             "string",
             "null"

--- a/mirrord/config/src/agent.rs
+++ b/mirrord/config/src/agent.rs
@@ -76,7 +76,7 @@ pub struct AgentConfig {
     /// ### agent.namespace {#agent-namespace}
     ///
     /// Namespace where the agent shall live.
-    ///
+    /// Note: Doesn't work with ephemeral containers.
     /// Defaults to the current kubernetes namespace.
     #[config(env = "MIRRORD_AGENT_NAMESPACE")]
     pub namespace: Option<String>,

--- a/mirrord/config/src/lib.rs
+++ b/mirrord/config/src/lib.rs
@@ -333,6 +333,14 @@ impl LayerConfig {
                 warnings.push(PAUSE_WITHOUT_STEAL_WARNING.to_string());
             }
         }
+
+        if self.agent.ephemeral && self.agent.namespace.is_some() {
+            warnings.push(
+                "Agent namespace is ignored when using an ephemeral container for the agent."
+                    .to_string(),
+            );
+        }
+
         if self
             .feature
             .network

--- a/mirrord/kube/src/api/container.rs
+++ b/mirrord/kube/src/api/container.rs
@@ -175,7 +175,7 @@ impl ContainerApi for JobContainer {
         connection_port: u16,
         progress: &P,
         agent_gid: u16,
-        pod_namespace: Option<String>,
+        _pod_namespace: Option<String>,
     ) -> Result<String>
     where
         P: Progress + Send + Sync,

--- a/mirrord/kube/src/api/container.rs
+++ b/mirrord/kube/src/api/container.rs
@@ -52,6 +52,7 @@ pub trait ContainerApi {
         connection_port: u16,
         progress: &P,
         agent_gid: u16,
+        pod_namespace: Option<String>,
     ) -> Result<String>
     where
         P: Progress + Send + Sync;
@@ -174,6 +175,7 @@ impl ContainerApi for JobContainer {
         connection_port: u16,
         progress: &P,
         agent_gid: u16,
+        pod_namespace: Option<String>,
     ) -> Result<String>
     where
         P: Progress + Send + Sync,
@@ -393,6 +395,7 @@ impl ContainerApi for EphemeralContainer {
         connection_port: u16,
         progress: &P,
         agent_gid: u16,
+        pod_namespace: Option<String>,
     ) -> Result<String>
     where
         P: Progress + Send + Sync,
@@ -437,7 +440,7 @@ impl ContainerApi for EphemeralContainer {
         }))?;
         debug!("Requesting ephemeral_containers_subresource");
 
-        let pod_api = get_k8s_resource_api(client, agent.namespace.as_deref());
+        let pod_api = get_k8s_resource_api(client, pod_namespace.as_deref());
         let pod: Pod = pod_api.get(&runtime_data.pod_name).await?;
         let pod_spec = pod.spec.ok_or(KubeApiError::PodSpecNotFound)?;
 

--- a/mirrord/kube/src/api/container.rs
+++ b/mirrord/kube/src/api/container.rs
@@ -52,7 +52,6 @@ pub trait ContainerApi {
         connection_port: u16,
         progress: &P,
         agent_gid: u16,
-        pod_namespace: Option<String>,
     ) -> Result<String>
     where
         P: Progress + Send + Sync;
@@ -175,7 +174,6 @@ impl ContainerApi for JobContainer {
         connection_port: u16,
         progress: &P,
         agent_gid: u16,
-        _pod_namespace: Option<String>,
     ) -> Result<String>
     where
         P: Progress + Send + Sync,
@@ -395,7 +393,6 @@ impl ContainerApi for EphemeralContainer {
         connection_port: u16,
         progress: &P,
         agent_gid: u16,
-        pod_namespace: Option<String>,
     ) -> Result<String>
     where
         P: Progress + Send + Sync,
@@ -440,7 +437,7 @@ impl ContainerApi for EphemeralContainer {
         }))?;
         debug!("Requesting ephemeral_containers_subresource");
 
-        let pod_api = get_k8s_resource_api(client, pod_namespace.as_deref());
+        let pod_api = get_k8s_resource_api(client, runtime_data.pod_namespace.as_deref());
         let pod: Pod = pod_api.get(&runtime_data.pod_name).await?;
         let pod_spec = pod.spec.ok_or(KubeApiError::PodSpecNotFound)?;
 

--- a/mirrord/kube/src/api/kubernetes.rs
+++ b/mirrord/kube/src/api/kubernetes.rs
@@ -164,7 +164,7 @@ impl AgentManagment for KubernetesAPI {
                 agent_port,
                 progress,
                 agent_gid,
-                self.target.namespace,
+                self.target.namespace.clone(),
             )
             .await?
         } else {

--- a/mirrord/kube/src/api/kubernetes.rs
+++ b/mirrord/kube/src/api/kubernetes.rs
@@ -164,6 +164,7 @@ impl AgentManagment for KubernetesAPI {
                 agent_port,
                 progress,
                 agent_gid,
+                self.target.namespace,
             )
             .await?
         } else {

--- a/mirrord/kube/src/api/kubernetes.rs
+++ b/mirrord/kube/src/api/kubernetes.rs
@@ -175,6 +175,7 @@ impl AgentManagment for KubernetesAPI {
                 agent_port,
                 progress,
                 agent_gid,
+                None,
             )
             .await?
         };

--- a/mirrord/kube/src/api/kubernetes.rs
+++ b/mirrord/kube/src/api/kubernetes.rs
@@ -164,7 +164,6 @@ impl AgentManagment for KubernetesAPI {
                 agent_port,
                 progress,
                 agent_gid,
-                self.target.namespace.clone(),
             )
             .await?
         } else {
@@ -175,7 +174,6 @@ impl AgentManagment for KubernetesAPI {
                 agent_port,
                 progress,
                 agent_gid,
-                None,
             )
             .await?
         };

--- a/mirrord/kube/src/api/runtime.rs
+++ b/mirrord/kube/src/api/runtime.rs
@@ -40,6 +40,7 @@ impl Display for ContainerRuntime {
 #[derive(Debug)]
 pub struct RuntimeData {
     pub pod_name: String,
+    pub pod_namespace: Option<String>,
     pub node_name: String,
     pub container_id: String,
     pub container_runtime: ContainerRuntime,
@@ -103,6 +104,7 @@ impl RuntimeData {
 
         Ok(RuntimeData {
             pod_name,
+            pod_namespace: pod.metadata.namespace.clone(),
             node_name,
             container_id,
             container_runtime,


### PR DESCRIPTION
Fix ephemeral agent creation api using agent namespace instead of  target.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Bug Fix: Fixed the creation of ephemeral agents by correctly using the agent namespace instead of the target. This ensures that the correct namespace is used when retrieving the Pod resource from the Kubernetes API.
- Documentation: Added a note to the `AgentConfig` struct's `namespace` field documentation, stating that it doesn't work with ephemeral containers. Also, introduced a warning message when using an ephemeral container for the agent and specifying an agent namespace, informing users that the agent namespace is ignored in this case.
- Refactor: Introduced a new parameter `pod_namespace` to the `ContainerApi` trait and its implementations, allowing the namespace to be specified when creating or updating an agent. Also added a new field `pod_namespace` in the `RuntimeData` struct to store the namespace of the associated pod.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->