### PR TITLE
Faster CI + SIP issue

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -320,30 +320,31 @@ jobs:
           node-version: 14
       - run: npm install express # For http mirroring test with node.
       - uses: actions/setup-python@v3 # For http mirroring tests with Flask and FastAPI.
-      - run: pip3 install flask # For http mirroring test with Flask.
-      - run: pip3 install fastapi # For http mirroring test with FastAPI.
-      - run: pip3 install uvicorn[standard] # For http mirroring test with FastAPI.
-      - uses: actions/setup-go@v3
+      - run: pip3 install flask fasatapi uvicorn[standard] # For http mirroring test with Flask.
+      - uses: actions/setup-go@v4
         with:
-          go-version: "1.20.0-rc.3"
-      - run: |
-          go version
-      - run: | # Build Go test apps.
-          ./scripts/build_go_apps.sh 20
-      - uses: actions/setup-go@v3
-        with:
-          go-version: "1.19.5"
-      - run: |
-          go version
-      - run: | # Build Go test apps.
-          ./scripts/build_go_apps.sh 19
-      - uses: actions/setup-go@v3
-        with:
-          go-version: "1.18.10"
+          go-version: "1.18"
+          cache-dependency-path: tests/go-e2e/go.sum
       - run: |
           go version
       - run: | # Build Go test apps.
           ./scripts/build_go_apps.sh 18
+      - uses: actions/setup-go@v4
+        with:
+          go-version: "1.19"
+          cache-dependency-path: tests/go-e2e/go.sum
+      - run: |
+          go version
+      - run: | # Build Go test apps.
+          ./scripts/build_go_apps.sh 19
+      - uses: actions/setup-go@v4
+        with:
+          go-version: "1.20"
+          cache-dependency-path: tests/go-e2e/go.sum
+      - run: |
+          go version
+      - run: | # Build Go test apps.
+          ./scripts/build_go_apps.sh 20
       - run: |
           cd mirrord/layer/tests/apps/fileops
           cargo build
@@ -397,23 +398,26 @@ jobs:
       - run: |
           cd mirrord/layer/tests/apps/issue1458portnot53
           rustc issue1458portnot53.rs --out-dir target
-      - uses: actions/setup-go@v3 # Install Go for http mirroring tests with a Go webserver.
+      - uses: actions/setup-go@v4
         with:
           go-version: "1.18"
+          cache-dependency-path: tests/go-e2e/go.sum
       - run: |
           go version
       - run: | # Build Go test apps.
           ./scripts/build_go_apps.sh 18
-      - uses: actions/setup-go@v3 # Install Go for http mirroring tests with a Go webserver.
+      - uses: actions/setup-go@v4
         with:
           go-version: "1.19"
+          cache-dependency-path: tests/go-e2e/go.sum
       - run: |
           go version
       - run: | # Build Go test apps.
           ./scripts/build_go_apps.sh 19
-      - uses: actions/setup-go@v3 # Install Go for http mirroring tests with a Go webserver.
+      - uses: actions/setup-go@v4
         with:
-          go-version: "1.20.0-rc.3"
+          go-version: "1.20"
+          cache-dependency-path: tests/go-e2e/go.sum
       - run: |
           go version
       - run: | # Build Go test apps.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -235,7 +235,7 @@ jobs:
     if: ${{needs.changed_files.outputs.rs_changed == 'true' || needs.changed_files.outputs.ci_changed == 'true'}}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-12, macos-11]
+        os: [ubuntu-latest, macos-13]
         target:
           [x86_64-unknown-linux-gnu, x86_64-apple-darwin, aarch64-apple-darwin]
         exclude:
@@ -243,7 +243,7 @@ jobs:
             target: x86_64-apple-darwin
           - os: ubuntu-latest
             target: aarch64-apple-darwin
-          - os: macos-12
+          - os: macos-13
             target: x86_64-unknown-linux-gnu
           - os: macos-11
             target: aarch64-apple-darwin
@@ -320,7 +320,7 @@ jobs:
           node-version: 14
       - run: npm install express # For http mirroring test with node.
       - uses: actions/setup-python@v3 # For http mirroring tests with Flask and FastAPI.
-      - run: pip3 install flask fasatapi uvicorn[standard] # For http mirroring test with Flask.
+      - run: pip3 install flask fastapi uvicorn[standard] # For http mirroring test with Flask.
       - uses: actions/setup-go@v4
         with:
           go-version: "1.18"
@@ -375,7 +375,7 @@ jobs:
       - run: cargo test -p mirrord-layer
 
   integration_tests_macos:
-    runs-on: macos-12
+    runs-on: macos-13
     needs: changed_files
     if: ${{needs.changed_files.outputs.rs_changed == 'true' || needs.changed_files.outputs.ci_changed == 'true'}}
     env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,7 +48,7 @@ jobs:
             target/x86_64-unknown-linux-gnu/release/libmirrord_layer.so
           if-no-files-found: error
   build_binaries_macos:
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v3
       - run: rm rust-toolchain.toml

--- a/changelog.d/+ci-improvements-faster.internal.md
+++ b/changelog.d/+ci-improvements-faster.internal.md
@@ -1,0 +1,1 @@
+Use go cache for integration tests

--- a/changelog.d/+ci-improvements-faster.internal.md
+++ b/changelog.d/+ci-improvements-faster.internal.md
@@ -1,1 +1,3 @@
-Use go cache for integration tests
+Changes to the CI to make it fater:
+- Use go cache for integration test
+- use mac-13 runner for tests

--- a/changelog.d/+macos-sip.fixed.md
+++ b/changelog.d/+macos-sip.fixed.md
@@ -1,0 +1,1 @@
+Fix macOS SIP potential issues from exec having mirrord loaded into the code sign binary.

--- a/mirrord/layer/tests/bash.rs
+++ b/mirrord/layer/tests/bash.rs
@@ -34,6 +34,7 @@ use tokio_stream::StreamExt;
 async fn bash_script(dylib_path: &Path, config_dir: &PathBuf) {
     let mut config_path = config_dir.clone();
     config_path.push("bash_script.json");
+    println!("Using config: {}", config_path.to_str().unwrap());
     let application = Application::EnvBashCat;
     let executable = application.get_executable().await; // Own it.
     println!("Using executable: {}", &executable);

--- a/mirrord/layer/tests/bash.rs
+++ b/mirrord/layer/tests/bash.rs
@@ -33,9 +33,6 @@ use tokio_stream::StreamExt;
 async fn bash_script(dylib_path: &Path, config_dir: &PathBuf) {
     let mut config_path = config_dir.clone();
     config_path.push("bash_script.json");
-    println!("Using config: {}", config_path.to_str().unwrap());
-    let config_path = config_path.canonicalize().unwrap();
-    println!("Using config: {}", config_path.to_str().unwrap());
     let application = Application::EnvBashCat;
     let executable = application.get_executable().await; // Own it.
     println!("Using executable: {}", &executable);

--- a/mirrord/layer/tests/bash.rs
+++ b/mirrord/layer/tests/bash.rs
@@ -34,6 +34,7 @@ use tokio_stream::StreamExt;
 async fn bash_script(dylib_path: &Path, config_dir: &PathBuf) {
     let mut config_path = config_dir.clone();
     config_path.push("bash_script.json");
+    println!("Using config: {}", config_path.to_str().unwrap());
     let config_path = config_path.canonicalize().unwrap();
     println!("Using config: {}", config_path.to_str().unwrap());
     let application = Application::EnvBashCat;

--- a/mirrord/layer/tests/bash.rs
+++ b/mirrord/layer/tests/bash.rs
@@ -62,13 +62,13 @@ async fn bash_script(dylib_path: &Path, config_dir: &PathBuf) {
 
     bash_layer_connection.expect_gethostname(fd).await;
 
+    let mut cat_layer_connection = LayerConnection::get_initialized_connection(&listener).await;
     // After the process forks we create a new main loop layer task in the child process.
     // That connection will die as soon as the new process calls execve, then a new layer will be
     // initialized.
     let mut _layer_after_fork_before_exec =
         LayerConnection::get_initialized_connection(&listener).await;
 
-    let mut cat_layer_connection = LayerConnection::get_initialized_connection(&listener).await;
     // TODO: theoretically the connections arrival order could be different, should we handle it?
 
     cat_layer_connection

--- a/mirrord/layer/tests/bash.rs
+++ b/mirrord/layer/tests/bash.rs
@@ -34,6 +34,7 @@ use tokio_stream::StreamExt;
 async fn bash_script(dylib_path: &Path, config_dir: &PathBuf) {
     let mut config_path = config_dir.clone();
     config_path.push("bash_script.json");
+    let config_path = config_path.canonicalize().unwrap();
     println!("Using config: {}", config_path.to_str().unwrap());
     let application = Application::EnvBashCat;
     let executable = application.get_executable().await; // Own it.

--- a/mirrord/layer/tests/bash.rs
+++ b/mirrord/layer/tests/bash.rs
@@ -62,13 +62,13 @@ async fn bash_script(dylib_path: &Path, config_dir: &PathBuf) {
 
     bash_layer_connection.expect_gethostname(fd).await;
 
-    let mut cat_layer_connection = LayerConnection::get_initialized_connection(&listener).await;
     // After the process forks we create a new main loop layer task in the child process.
     // That connection will die as soon as the new process calls execve, then a new layer will be
     // initialized.
     let mut _layer_after_fork_before_exec =
         LayerConnection::get_initialized_connection(&listener).await;
 
+    let mut cat_layer_connection = LayerConnection::get_initialized_connection(&listener).await;
     // TODO: theoretically the connections arrival order could be different, should we handle it?
 
     cat_layer_connection

--- a/mirrord/layer/tests/bash.rs
+++ b/mirrord/layer/tests/bash.rs
@@ -32,6 +32,9 @@ use tokio_stream::StreamExt;
 #[timeout(Duration::from_secs(60))]
 async fn bash_script(dylib_path: &Path, config_dir: &PathBuf) {
     let mut config_path = config_dir.clone();
+    // use a config file since cat sometimes opens some weird paths
+    // before opening the file we want to read, and it makes testing easier
+    // to ignore those paths.
     config_path.push("bash_script.json");
     let application = Application::EnvBashCat;
     let executable = application.get_executable().await; // Own it.

--- a/mirrord/layer/tests/bash.rs
+++ b/mirrord/layer/tests/bash.rs
@@ -16,7 +16,6 @@ use mirrord_protocol::{
 #[cfg(target_os = "macos")]
 use mirrord_sip::sip_patch;
 use rstest::rstest;
-use tests::utils::config_dir;
 use tokio::net::TcpListener;
 
 mod common;

--- a/mirrord/layer/tests/bash.rs
+++ b/mirrord/layer/tests/bash.rs
@@ -40,7 +40,12 @@ async fn bash_script(dylib_path: &Path, config_dir: &PathBuf) {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap().to_string();
     println!("Listening for messages from the layer on {addr}");
-    let env = get_env(dylib_path.to_str().unwrap(), &addr, vec![], config_path);
+    let env = get_env(
+        dylib_path.to_str().unwrap(),
+        &addr,
+        vec![],
+        Some(config_path.to_str().unwrap()),
+    );
     #[cfg(target_os = "macos")]
     let executable = sip_patch(&executable, &Vec::new()).unwrap().unwrap();
     let test_process = TestProcess::start_process(executable, application.get_args(), env).await;

--- a/mirrord/layer/tests/common/mod.rs
+++ b/mirrord/layer/tests/common/mod.rs
@@ -1025,6 +1025,7 @@ pub fn get_env<'a>(
     env.insert("MIRRORD_CONNECT_TCP", addr);
     env.insert("MIRRORD_REMOTE_DNS", "false");
     if let Some(config) = config {
+        println!("using config file: {config}");
         env.insert("MIRRORD_CONFIG_FILE", config);
     }
     env.insert("DYLD_INSERT_LIBRARIES", dylib_path_str);

--- a/mirrord/layer/tests/configs/bash_script.json
+++ b/mirrord/layer/tests/configs/bash_script.json
@@ -2,7 +2,7 @@
     "feature": {
         "fs": {
             "mode": "read",
-            "local": ["/var/db/timezone/icutz"]
+            "local": ["/var/db/"]
         }
     }
 }

--- a/mirrord/layer/tests/configs/bash_script.json
+++ b/mirrord/layer/tests/configs/bash_script.json
@@ -1,0 +1,8 @@
+{
+    "feature": {
+        "fs": {
+            "mode": "read",
+            "local": ["/var/db/timezone/icutz"]
+        }
+    }
+}

--- a/mirrord/sip/src/codesign.rs
+++ b/mirrord/sip/src/codesign.rs
@@ -1,13 +1,15 @@
-use std::{os::unix::process::ExitStatusExt, path::Path, process::Command};
+use std::{collections::HashMap, os::unix::process::ExitStatusExt, path::Path, process::Command};
 
 use crate::error::{Result, SipError};
 
 pub(crate) fn sign<P: AsRef<Path>>(path: P) -> Result<()> {
+    // don't load mirrord into the codesign binary
     let output = Command::new("codesign")
         .arg("-s") // sign with identity
         .arg("-") // adhoc identity
         .arg("-f") // force (might have a signature already)
         .arg(path.as_ref())
+        .env_remove("DYLD_INSERT_LIBRARIES")
         .output()?;
     if output.status.success() {
         Ok(())

--- a/mirrord/sip/src/codesign.rs
+++ b/mirrord/sip/src/codesign.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, os::unix::process::ExitStatusExt, path::Path, process::Command};
+use std::{os::unix::process::ExitStatusExt, path::Path, process::Command};
 
 use crate::error::{Result, SipError};
 

--- a/mirrord/sip/src/codesign.rs
+++ b/mirrord/sip/src/codesign.rs
@@ -2,14 +2,15 @@ use std::{os::unix::process::ExitStatusExt, path::Path, process::Command};
 
 use crate::error::{Result, SipError};
 
+/// Sign the binary at the given path using the host's codesign binary.
+/// Consider using apple-codesign crate instead some day..
 pub(crate) fn sign<P: AsRef<Path>>(path: P) -> Result<()> {
-    // don't load mirrord into the codesign binary
     let output = Command::new("codesign")
         .arg("-s") // sign with identity
         .arg("-") // adhoc identity
         .arg("-f") // force (might have a signature already)
         .arg(path.as_ref())
-        .env_remove("DYLD_INSERT_LIBRARIES")
+        .env_remove("DYLD_INSERT_LIBRARIES") // don't load mirrord into the codesign binary
         .output()?;
     if output.status.success() {
         Ok(())


### PR DESCRIPTION
- use Go cache for integration tests
- Fix macOS SIP potential issues from exec having mirrord loaded into the code sign binary.
- use mac-13 runner for tests