### PR TITLE
More CI improvements

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,11 +1,19 @@
+# Hello traveler!
+# This is the CI workflow for mirrord.
+# It is a bit complicated, but it is also very powerful.
+# We try to optimize for speed, but sometimes there are limitations.
+# Please try to document it here so people won't try repeating your errors.
+# 1. GitHub cache is limited to 10GB, so we try to have less jobs to not exceed it, since if we get over 10GB
+#    the cache will be evicted then builds will be slower, so it's better to have less jobs.
+# 2. I (Aviram) tried to use a container to build the Linux stuff, but couldn't get the e2e to work and (minikube in container)
+#    and the benefit seemed little.
 name: CI
 
 on:
   workflow_dispatch:
   push:
-    branches-ignore: [staging-squash-merge.tmp]
   pull_request:
-    branches: [main, staging, trying]
+    branches: [main]
     types: [opened, synchronize, reopened, ready_for_review]
 
 # Cancel previous runs on the same PR.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -154,46 +154,6 @@ jobs:
       - run: cargo clippy -p mirrord -p mirrord-sip --target=x86_64-apple-darwin -- -Wclippy::indexing_slicing -D warnings
       - run: cargo clippy -p mirrord -p mirrord-sip --target=aarch64-apple-darwin -- -Wclippy::indexing_slicing -D warnings
 
-  test_mirrord_protocol:
-    runs-on: ubuntu-latest
-    needs: changed_files
-    if: ${{needs.changed_files.outputs.rs_changed == 'true' || needs.changed_files.outputs.ci_changed == 'true'}}
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
-      - run: |
-          cargo test -p mirrord-protocol
-
-  test_mirrord_config:
-    runs-on: ubuntu-latest
-    needs: changed_files
-    if: ${{needs.changed_files.outputs.rs_changed == 'true' || needs.changed_files.outputs.ci_changed == 'true'}}
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
-      - run: |
-          cargo test -p mirrord-config
-
-  test_mirrord_kube:
-    runs-on: ubuntu-latest
-    needs: changed_files
-    if: ${{needs.changed_files.outputs.rs_changed == 'true' || needs.changed_files.outputs.ci_changed == 'true'}}
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
-      - run: |
-          cargo test -p mirrord-kube --all-features
-
-  test_mirrord_sip:
-    runs-on: macos-latest
-    needs: changed_files
-    if: ${{needs.changed_files.outputs.rs_changed == 'true' || needs.changed_files.outputs.ci_changed == 'true'}}
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
-      - run: |
-          cargo test -p mirrord-sip
-
   test_agent:
     runs-on: ubuntu-latest
     needs: changed_files
@@ -342,6 +302,12 @@ jobs:
           name: mirrord-artifacts
           path: target/debug/
       - run: cargo test -p mirrord-layer
+      - name: mirrord protocol UT
+        run: cargo test -p mirrord-protocol
+      - name: mirrord config UT
+        run: cargo test -p mirrord-config
+      - name: mirrord kube UT
+        run: cargo test -p mirrord-kube --all-features
 
   integration_tests_macos:
     runs-on: macos-13
@@ -430,7 +396,10 @@ jobs:
       - uses: actions/setup-node@v3 # version 19 spawns processes with `posix_spawn`, so test that also.
         with:
           node-version: 19
-      - run: cargo test -p mirrord-layer
+      - name: mirrord layer tests
+        run: cargo test -p mirrord-layer
+      - name: mirrord SIP UT
+        run: cargo test -p mirrord-sip
 
   e2e:
     runs-on: ubuntu-latest
@@ -495,9 +464,6 @@ jobs:
         test_agent,
         lint,
         lint_macos,
-        test_mirrord_config,
-        test_mirrord_protocol,
-        test_mirrord_sip,
         lint_markdown,
       ]
     runs-on: ubuntu-latest
@@ -516,8 +482,5 @@ jobs:
             (needs.test_agent.result == 'success' || needs.test_agent.result == 'skipped') &&
             (needs.lint.result == 'success' || needs.lint.result == 'skipped') &&
             (needs.lint_macos.result == 'success' || needs.lint_macos.result == 'skipped') &&
-            (needs.test_mirrord_config.result == 'success' || needs.test_mirrord_config.result == 'skipped') &&
-            (needs.test_mirrord_protocol.result == 'success' || needs.test_mirrord_protocol.result == 'skipped') &&
-            (needs.test_mirrord_sip.result == 'success' || needs.test_mirrord_sip.result == 'skipped') &&
             (needs.lint_markdown.result == 'success' || needs.lint_markdown.result == 'skipped') }}
         run: echo $CI_SUCCESS && if [ "$CI_SUCCESS" == "true" ]; then echo "SUCCESS" && exit 0; else echo "Failure" && exit 1; fi

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -113,11 +113,11 @@ jobs:
           components: rustfmt, clippy
           target: aarch64-unknown-linux-gnu,x86_64-unknown-linux-gnu
       - run: python3 -m pip install cargo-zigbuild
-      # Needed for agent
       - run: cargo fmt --all -- --check
+      # x64
       - run: cargo-zigbuild clippy --lib --bins --all-features -- -Wclippy::indexing_slicing -D warnings
-      # Check that agent compiles for the supported targets (aarch64)
-      - run: cargo-zigbuild clippy -p mirrord-agent --target aarch64-unknown-linux-gnu -- -Wclippy::indexing_slicing -D warnings
+      # Check that compiles for the supported linux targets (aarch64)
+      - run: cargo-zigbuild clippy --lib --bins --all-features --target aarch64-unknown-linux-gnu -- -Wclippy::indexing_slicing -D warnings
 
   check-rust-docs:
     runs-on: ubuntu-latest
@@ -442,6 +442,7 @@ jobs:
       MIRRORD_AGENT_RUST_LOG: "warn,mirrord=debug"
     steps:
       - uses: actions/checkout@v3
+      - uses: actions-rust-lang/setup-rust-toolchain@v1 # Install Rust.
       - uses: metalbear-co/ci/e2e-setup-action@main
         with:
           container-runtime: ${{matrix.container-runtime}}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -230,38 +230,6 @@ jobs:
           name: test
           path: /tmp/test.tar
 
-  test_mirrord_layer_cli:
-    needs: changed_files
-    if: ${{needs.changed_files.outputs.rs_changed == 'true' || needs.changed_files.outputs.ci_changed == 'true'}}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-13]
-        target:
-          [x86_64-unknown-linux-gnu, x86_64-apple-darwin, aarch64-apple-darwin]
-        exclude:
-          - os: ubuntu-latest
-            target: x86_64-apple-darwin
-          - os: ubuntu-latest
-            target: aarch64-apple-darwin
-          - os: macos-13
-            target: x86_64-unknown-linux-gnu
-          - os: macos-11
-            target: aarch64-apple-darwin
-          - os: macos-11
-            target: x86_64-unknown-linux-gnu
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v3
-      # the setup rust toolchain action ignores the input if file exists.. so remove it
-      - if: ${{matrix.target == 'aarch64-apple-darwin'}}
-        run: rm rust-toolchain.toml
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          target: ${{matrix.target}}
-          toolchain: nightly-2023-04-19
-      # For now, just verify it compiles.
-      - run: cargo build -p mirrord-layer -p mirrord --target=${{matrix.target}}
-
   build_mirrord:
     runs-on: ubuntu-latest
     name: build mirrord
@@ -521,7 +489,6 @@ jobs:
         integration_tests_macos,
         integration_tests,
         e2e,
-        test_mirrord_layer_cli,
         test_agent,
         lint,
         lint_macos,
@@ -543,7 +510,6 @@ jobs:
             (needs.integration_tests_macos.result == 'success' || needs.integration_tests_macos.result == 'skipped') &&
             (needs.integration_tests.result == 'success' || needs.integration_tests.result == 'skipped') &&
             (needs.e2e.result == 'success' || needs.e2e.result == 'skipped') &&
-            (needs.test_mirrord_layer_cli.result == 'success' || needs.test_mirrord_layer_cli.result == 'skipped') &&
             (needs.test_agent.result == 'success' || needs.test_agent.result == 'skipped') &&
             (needs.lint.result == 'success' || needs.lint.result == 'skipped') &&
             (needs.lint_macos.result == 'success' || needs.lint_macos.result == 'skipped') &&

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -297,10 +297,11 @@ jobs:
           go version
       - run: | # Build Go test apps.
           ./scripts/build_go_apps.sh 18
+      # don't use "cache" for other Gos since it will try to overwrite and have bad results.
       - uses: actions/setup-go@v4
         with:
           go-version: "1.19"
-          cache-dependency-path: tests/go-e2e/go.sum
+          cache: false
       - run: |
           go version
       - run: | # Build Go test apps.
@@ -308,7 +309,7 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: "1.20"
-          cache-dependency-path: tests/go-e2e/go.sum
+          cache: false
       - run: |
           go version
       - run: | # Build Go test apps.
@@ -372,12 +373,13 @@ jobs:
           cache-dependency-path: tests/go-e2e/go.sum
       - run: |
           go version
+      # don't use "cache" for other Gos since it will try to overwrite and have bad results.
       - run: | # Build Go test apps.
           ./scripts/build_go_apps.sh 18
       - uses: actions/setup-go@v4
         with:
           go-version: "1.19"
-          cache-dependency-path: tests/go-e2e/go.sum
+          cache: false
       - run: |
           go version
       - run: | # Build Go test apps.
@@ -385,7 +387,7 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: "1.20"
-          cache-dependency-path: tests/go-e2e/go.sum
+          cache: false
       - run: |
           go version
       - run: | # Build Go test apps.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,8 @@
 #    the cache will be evicted then builds will be slower, so it's better to have less jobs.
 # 2. I (Aviram) tried to use a container to build the Linux stuff, but couldn't get the e2e to work and (minikube in container)
 #    and the benefit seemed little.
+# 3. Please be mindful, we try to target less than 30 minutes for the CI to run. In a perfect world it'd be less than 5m.
+#     If you're adding something, please make sure it doesn't impact too much, and if you're reviewing please have it in mind.
 name: CI
 
 on:

--- a/changelog.d/+ci-improvements-more2.internal.md
+++ b/changelog.d/+ci-improvements-more2.internal.md
@@ -1,0 +1,3 @@
+Reorganize the CI with the following objective of unifying as much as we can CI that can run on the same host, this is to have less caches and have better compilation time (as there's overlap). Things done
+
+- Remove the build layer CI, since we now have an integration tests that check it + clippy for aarch darwin / Linux

--- a/changelog.d/+ci-improvements-more2.internal.md
+++ b/changelog.d/+ci-improvements-more2.internal.md
@@ -3,3 +3,4 @@ Reorganize the CI with the following objective of unifying as much as we can CI 
 - Remove the build layer CI, since we now have an integration tests that check it + clippy for aarch darwin / Linux
 - Make clippy run for all of the project for aarch64 linux instead of agent only
 - Revert removal of Rust cache from e2e (was by mistake)
+- Don't use "cache" for other Gos since it will try to overwrite and have bad results.

--- a/changelog.d/+ci-improvements-more2.internal.md
+++ b/changelog.d/+ci-improvements-more2.internal.md
@@ -1,3 +1,5 @@
-Reorganize the CI with the following objective of unifying as much as we can CI that can run on the same host, this is to have less caches and have better compilation time (as there's overlap). Things done
+Reorganize the CI with the following objective of unifying as much as we can CI that can run on the same host, this is to have less caches and have better compilation time (as there's overlap). Things done:
 
 - Remove the build layer CI, since we now have an integration tests that check it + clippy for aarch darwin / Linux
+- Make clippy run for all of the project for aarch64 linux instead of agent only
+- Revert removal of Rust cache from e2e (was by mistake)

--- a/tests/rust-e2e-fileops/src/main.rs
+++ b/tests/rust-e2e-fileops/src/main.rs
@@ -76,7 +76,10 @@ fn fgets() {
 
     unsafe {
         let mode = CString::new("r").expect("valid C string");
+        #[cfg(not(all(target_os = "linux", target_arch = "aarch64")))]
         let (buffer, _length, _capacity) = vec![0i8; 1500].into_raw_parts();
+        #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
+        let (buffer, _length, _capacity) = vec![0u8; 1500].into_raw_parts();
         let file_stream = libc::fdopen(fd, mode.as_ptr());
 
         if libc::fgets(buffer, 12, file_stream).is_null() {


### PR DESCRIPTION
Reorganize the CI with the following objective of unifying as much as we can CI that can run on the same host, this is to have less caches and have better compilation time (as there's overlap). Things done:

- Remove the build layer CI, since we now have an integration tests that check it + clippy for aarch darwin / Linux
- Make clippy run for all of the project for aarch64 linux instead of agent only
- Revert removal of Rust cache from e2e (was by mistake)
- Don't use "cache" for other Gos since it will try to overwrite and have bad results.
- Added some docs on CI.