### PR TITLE
Fix openshift detection taking too long by querying a subset 

### DIFF
--- a/changelog.d/+open-shift-detect.fixed.md
+++ b/changelog.d/+open-shift-detect.fixed.md
@@ -1,0 +1,1 @@
+Fix openshift detection taking too long by querying a subset instead of all APIs

--- a/mirrord/kube/src/api/kubernetes.rs
+++ b/mirrord/kube/src/api/kubernetes.rs
@@ -63,7 +63,9 @@ impl KubernetesAPI {
     where
         P: Progress + Send + Sync,
     {
+        // filter openshift to make it a lot faster
         if Discovery::new(self.client.clone())
+            .filter(&["route.openshift.io"])
             .run()
             .await?
             .has_group("route.openshift.io")


### PR DESCRIPTION
Fix openshift detection taking too long by querying a subset instead of all APIs
