### PR TITLE
Fixed panic on crash analytics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3305,6 +3305,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "tokio",
  "tracing",
 ]
 

--- a/changelog.d/1872.fixed.md
+++ b/changelog.d/1872.fixed.md
@@ -1,0 +1,1 @@
+Fixed panic on crash analytics

--- a/mirrord/analytics/Cargo.toml
+++ b/mirrord/analytics/Cargo.toml
@@ -17,8 +17,9 @@ edition.workspace = true
 [dependencies]
 base64 = "0.21"
 serde.workspace = true
-reqwest = { workspace = true, features = ["blocking"] }
+reqwest = { workspace = true}
 tracing.workspace = true
+tokio.workspace = true
 
 [dev-dependencies]
 serde_json.workspace = true


### PR DESCRIPTION
Fixed panic on crash analytics by using tokio::spawn instead of blocking in a drop that is in a Tokio context
Closes #1872 