### PR TITLE
Add hook for opendir, issue #1899

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -265,6 +265,9 @@ jobs:
       - run: |
           cd mirrord/layer/tests/apps/issue1776portnot53
           cargo build
+      - run: |
+          cd mirrord/layer/tests/apps/issue1899
+          cargo build
       - run: ./scripts/build_c_apps.sh
       - run: cargo test --target x86_64-unknown-linux-gnu -p mirrord-layer
       - name: mirrord protocol UT
@@ -350,6 +353,9 @@ jobs:
           cargo build
       - run: |
           cd mirrord/layer/tests/apps/issue1776portnot53
+          cargo build
+      - run: |
+          cd mirrord/layer/tests/apps/issue1899
           cargo build
       - run: ./scripts/build_c_apps.sh
       # For the `java_temurin_sip` test.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2731,6 +2731,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "issue1899"
+version = "3.64.1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "mirrord/layer/tests/apps/recv_from",
     "mirrord/layer/tests/apps/issue1776",
     "mirrord/layer/tests/apps/issue1776portnot53",
+    "mirrord/layer/tests/apps/issue1899",
     "sample/rust",
     "medschool",
     "tests",

--- a/changelog.d/1899.added.md
+++ b/changelog.d/1899.added.md
@@ -1,0 +1,1 @@
+Add hook for opendir.

--- a/changelog.d/1899.added.md
+++ b/changelog.d/1899.added.md
@@ -1,1 +1,1 @@
-Add hook for `opendir`, `readdir64_r`, `__lxstat`, `__lxstat64`, `__xstat64`.
+Add hook for `opendir`, `readdir64_r`, `__lxstat`, `__lxstat64`, `__xstat64`. Also contains a refactor of the `*stat` family of hooks (they now call a shared function), and `openat64` as its own function.

--- a/changelog.d/1899.added.md
+++ b/changelog.d/1899.added.md
@@ -1,1 +1,1 @@
-Add hook for opendir.
+Add hook for `opendir`, `readdir64_r`, `__lxstat`, `__lxstat64`, `__xstat64`.

--- a/mirrord/layer/src/file/hooks.rs
+++ b/mirrord/layer/src/file/hooks.rs
@@ -11,7 +11,7 @@ use std::{ffi::CString, os::unix::io::RawFd, ptr, slice, time::Duration};
 use errno::{set_errno, Errno};
 use libc::{
     self, c_char, c_int, c_void, dirent, off_t, size_t, ssize_t, stat, statfs, AT_EACCESS,
-    AT_FDCWD, DIR, O_RDONLY,
+    AT_FDCWD, DIR, O_DIRECTORY, O_RDONLY,
 };
 #[cfg(target_os = "linux")]
 use libc::{dirent64, stat64, EBADF, EINVAL, ENOENT, ENOTDIR};
@@ -143,7 +143,7 @@ pub(super) unsafe extern "C" fn open_nocancel_detour(
 /// [`fdopendir`] to convert the [`RawFd`] into a `*DIR` stream (which we treat as `usize`).
 #[hook_guard_fn]
 pub(super) unsafe extern "C" fn opendir_detour(raw_filename: *const c_char) -> usize {
-    open_logic(raw_filename, O_RDONLY, 0)
+    open_logic(raw_filename, O_RDONLY, O_DIRECTORY)
         .and_then(fdopendir)
         .unwrap_or_bypass_with(|_| FN_OPENDIR(raw_filename))
 }

--- a/mirrord/layer/src/file/hooks.rs
+++ b/mirrord/layer/src/file/hooks.rs
@@ -133,7 +133,10 @@ pub(super) unsafe extern "C" fn open_nocancel_detour(
     }
 }
 
-/// TODO(alex) [mid] 2023-09-04: Docs.
+/// Hook for [`libc::opendir`].
+///
+/// Opens the directory with `read` permission using the [`open_logic`] flow, then calls
+/// [`fdopendir`] to convert the [`RawFd`] into a `*DIR` stream (which we treat as `usize`).
 #[hook_guard_fn]
 pub(super) unsafe extern "C" fn opendir_detour(raw_filename: *const c_char) -> usize {
     open_logic(raw_filename, O_RDONLY, 0)

--- a/mirrord/layer/src/file/hooks.rs
+++ b/mirrord/layer/src/file/hooks.rs
@@ -242,6 +242,7 @@ pub(crate) unsafe extern "C" fn readdir_r_detour(
         .unwrap_or_bypass_with(|_| FN_READDIR_R(dirp, entry, result))
 }
 
+#[cfg(target_os = "linux")]
 #[hook_guard_fn]
 pub(crate) unsafe extern "C" fn readdir64_r_detour(
     dirp: *mut DIR,

--- a/mirrord/layer/src/file/hooks.rs
+++ b/mirrord/layer/src/file/hooks.rs
@@ -40,6 +40,9 @@ use crate::{
     replace,
 };
 
+#[cfg(target_os = "macos")]
+type stat64 = stat;
+
 /// Take the original raw c_char pointer and a resulting bypass, and either the original pointer or
 /// a different one according to the bypass.
 /// We pass reference to bypass to make sure the bypass lives with the pointer.
@@ -245,7 +248,6 @@ pub(crate) unsafe extern "C" fn readdir64_r_detour(
     entry: *mut dirent64,
     result: *mut *mut dirent64,
 ) -> c_int {
-    warn!("cake");
     readdir_r(dirp as usize)
         .map(|resp| {
             if let Some(direntry) = resp {

--- a/mirrord/layer/src/file/hooks.rs
+++ b/mirrord/layer/src/file/hooks.rs
@@ -11,7 +11,7 @@ use std::{ffi::CString, os::unix::io::RawFd, ptr, slice, time::Duration};
 use errno::{set_errno, Errno};
 use libc::{
     self, c_char, c_int, c_void, dirent, off_t, size_t, ssize_t, stat, statfs, AT_EACCESS,
-    AT_FDCWD, DIR, O_RDONLY, O_RDWR,
+    AT_FDCWD, DIR, O_RDONLY,
 };
 #[cfg(target_os = "linux")]
 use libc::{EBADF, EINVAL, ENOENT, ENOTDIR};

--- a/mirrord/layer/src/file/hooks.rs
+++ b/mirrord/layer/src/file/hooks.rs
@@ -200,7 +200,7 @@ unsafe fn assign_direntry64(
         // The structs written by the kernel for the getdents syscall do not have a fixed size.
         in_entry.get_d_reclen64()
     } else {
-        std::mem::size_of::<dirent>() as u16
+        std::mem::size_of::<dirent64>() as u16
     };
     (*out_entry).d_type = in_entry.file_type;
 

--- a/mirrord/layer/src/file/hooks.rs
+++ b/mirrord/layer/src/file/hooks.rs
@@ -10,11 +10,11 @@ use std::{ffi::CString, os::unix::io::RawFd, ptr, slice, time::Duration};
 #[cfg(target_os = "linux")]
 use errno::{set_errno, Errno};
 use libc::{
-    self, c_char, c_int, c_void, dirent, off_t, size_t, ssize_t, stat, stat64, statfs, AT_EACCESS,
+    self, c_char, c_int, c_void, dirent, off_t, size_t, ssize_t, stat, statfs, AT_EACCESS,
     AT_FDCWD, DIR, O_RDONLY,
 };
 #[cfg(target_os = "linux")]
-use libc::{dirent64, EBADF, EINVAL, ENOENT, ENOTDIR};
+use libc::{dirent64, stat64, EBADF, EINVAL, ENOENT, ENOTDIR};
 use mirrord_layer_macro::{hook_fn, hook_guard_fn};
 use mirrord_protocol::file::{
     DirEntryInternal, FsMetadataInternal, MetadataInternal, ReadFileResponse, WriteFileResponse,
@@ -41,6 +41,7 @@ use crate::{
 };
 
 #[cfg(target_os = "macos")]
+#[allow(non_camel_case_types)]
 type stat64 = stat;
 
 /// Take the original raw c_char pointer and a resulting bypass, and either the original pointer or

--- a/mirrord/layer/tests/apps/issue1899/Cargo.toml
+++ b/mirrord/layer/tests/apps/issue1899/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "issue1899"
+version.workspace = true
+authors.workspace = true
+description.workspace = true
+documentation.workspace = true
+readme.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+publish.workspace = true
+edition.workspace = true
+
+[dependencies]
+libc.workspace = true

--- a/mirrord/layer/tests/apps/issue1899/src/main.rs
+++ b/mirrord/layer/tests/apps/issue1899/src/main.rs
@@ -1,0 +1,14 @@
+use std::ffi::CString;
+
+/// Test the `opendir` hook.
+fn main() {
+    println!("test issue 1899: START");
+
+    unsafe {
+        let dir_path = CString::new("/fake_dir").expect("Valid C string.");
+        let dir = libc::opendir(dir_path.into_raw() as *const _);
+        assert!(!dir.is_null());
+    }
+
+    println!("test issue 1899: SUCCESS");
+}

--- a/mirrord/layer/tests/apps/issue1899/src/main.rs
+++ b/mirrord/layer/tests/apps/issue1899/src/main.rs
@@ -5,7 +5,7 @@ fn main() {
     println!("test issue 1899: START");
 
     unsafe {
-        let dir_path = CString::new("/tmp/test_file.txt").expect("Valid C string.");
+        let dir_path = CString::new("/tmp").expect("Valid C string.");
         let dir = libc::opendir(dir_path.into_raw() as *const _);
         assert!(!dir.is_null());
     }

--- a/mirrord/layer/tests/apps/issue1899/src/main.rs
+++ b/mirrord/layer/tests/apps/issue1899/src/main.rs
@@ -5,7 +5,7 @@ fn main() {
     println!("test issue 1899: START");
 
     unsafe {
-        let dir_path = CString::new("/fake_dir").expect("Valid C string.");
+        let dir_path = CString::new("/tmp/test_file.txt").expect("Valid C string.");
         let dir = libc::opendir(dir_path.into_raw() as *const _);
         assert!(!dir.is_null());
     }

--- a/mirrord/layer/tests/common/mod.rs
+++ b/mirrord/layer/tests/common/mod.rs
@@ -632,6 +632,7 @@ pub enum Application {
     RustIssue1458PortNot53,
     RustIssue1776,
     RustIssue1776PortNot53,
+    RustIssue1899,
     RustDnsResolve,
     RustRecvFrom,
     RustListenPorts,
@@ -753,6 +754,13 @@ impl Application {
                     "../../target/debug/issue1776portnot53"
                 )
             }
+            Application::RustIssue1899 => {
+                format!(
+                    "{}/{}",
+                    env!("CARGO_MANIFEST_DIR"),
+                    "../../target/debug/issue1899"
+                )
+            }
             Application::OpenFile => format!(
                 "{}/{}",
                 env!("CARGO_MANIFEST_DIR"),
@@ -836,6 +844,7 @@ impl Application {
             | Application::RustIssue1458PortNot53
             | Application::RustIssue1776
             | Application::RustIssue1776PortNot53
+            | Application::RustIssue1899
             | Application::RustDnsResolve
             | Application::RustRecvFrom
             | Application::RustListenPorts
@@ -904,6 +913,7 @@ impl Application {
             | Application::RustIssue1458PortNot53
             | Application::RustIssue1776
             | Application::RustIssue1776PortNot53
+            | Application::RustIssue1899
             | Application::RustListenPorts
             | Application::RustRecvFrom
             | Application::OpenFile

--- a/mirrord/layer/tests/issue1899.rs
+++ b/mirrord/layer/tests/issue1899.rs
@@ -51,11 +51,7 @@ async fn test_issue1899(
         // lstat test
         assert_eq!(
             layer_connection.codec.next().await.unwrap().unwrap(),
-            ClientMessage::FileRequest(FileRequest::Xstat(XstatRequest {
-                path: Some("/tmp".to_string().into()),
-                fd: None,
-                follow_symlink: false
-            }))
+            ClientMessage::FileRequest(FileRequest::XstatFs(XstatFsRequest { fd }))
         );
 
         let metadata = MetadataInternal {

--- a/mirrord/layer/tests/issue1899.rs
+++ b/mirrord/layer/tests/issue1899.rs
@@ -45,55 +45,55 @@ async fn test_issue1899(
         )
         .await;
 
-    // Rust compiles with newer libc on Linux that uses statx
-    #[cfg(target_os = "macos")]
-    {
-        // lstat test
-        assert_eq!(
-            layer_connection.codec.next().await.unwrap().unwrap(),
-            ClientMessage::FileRequest(FileRequest::XstatFs(XstatFsRequest { fd }))
-        );
+    // // Rust compiles with newer libc on Linux that uses statx
+    // #[cfg(target_os = "macos")]
+    // {
+    //     // lstat test
+    //     assert_eq!(
+    //         layer_connection.codec.next().await.unwrap().unwrap(),
+    //         ClientMessage::FileRequest(FileRequest::XstatFs(XstatFsRequest { fd }))
+    //     );
 
-        let metadata = MetadataInternal {
-            device_id: 0,
-            size: 1,
-            user_id: 2,
-            blocks: 3,
-            ..Default::default()
-        };
-        layer_connection
-            .codec
-            .send(DaemonMessage::File(FileResponse::Xstat(Ok(
-                XstatResponse { metadata },
-            ))))
-            .await
-            .unwrap();
+    //     let metadata = MetadataInternal {
+    //         device_id: 0,
+    //         size: 1,
+    //         user_id: 2,
+    //         blocks: 3,
+    //         ..Default::default()
+    //     };
+    //     layer_connection
+    //         .codec
+    //         .send(DaemonMessage::File(FileResponse::Xstat(Ok(
+    //             XstatResponse { metadata },
+    //         ))))
+    //         .await
+    //         .unwrap();
 
-        // fstat test
-        assert_eq!(
-            layer_connection.codec.next().await.unwrap().unwrap(),
-            ClientMessage::FileRequest(FileRequest::Xstat(XstatRequest {
-                path: Some("/tmp".to_string().into()),
-                fd: None,
-                follow_symlink: true
-            }))
-        );
+    //     // fstat test
+    //     assert_eq!(
+    //         layer_connection.codec.next().await.unwrap().unwrap(),
+    //         ClientMessage::FileRequest(FileRequest::Xstat(XstatRequest {
+    //             path: Some("/tmp".to_string().into()),
+    //             fd: None,
+    //             follow_symlink: true
+    //         }))
+    //     );
 
-        let metadata = MetadataInternal {
-            device_id: 4,
-            size: 5,
-            user_id: 6,
-            blocks: 7,
-            ..Default::default()
-        };
-        layer_connection
-            .codec
-            .send(DaemonMessage::File(FileResponse::Xstat(Ok(
-                XstatResponse { metadata },
-            ))))
-            .await
-            .unwrap();
-    }
+    //     let metadata = MetadataInternal {
+    //         device_id: 4,
+    //         size: 5,
+    //         user_id: 6,
+    //         blocks: 7,
+    //         ..Default::default()
+    //     };
+    //     layer_connection
+    //         .codec
+    //         .send(DaemonMessage::File(FileResponse::Xstat(Ok(
+    //             XstatResponse { metadata },
+    //         ))))
+    //         .await
+    //         .unwrap();
+    // }
 
     assert_eq!(
         layer_connection.codec.next().await.unwrap().unwrap(),

--- a/mirrord/layer/tests/issue1899.rs
+++ b/mirrord/layer/tests/issue1899.rs
@@ -45,6 +45,60 @@ async fn test_issue1899(
         )
         .await;
 
+    // Rust compiles with newer libc on Linux that uses statx
+    #[cfg(target_os = "macos")]
+    {
+        // lstat test
+        assert_eq!(
+            layer_connection.codec.next().await.unwrap().unwrap(),
+            ClientMessage::FileRequest(FileRequest::Xstat(XstatRequest {
+                path: Some("/tmp".to_string().into()),
+                fd: None,
+                follow_symlink: false
+            }))
+        );
+
+        let metadata = MetadataInternal {
+            device_id: 0,
+            size: 1,
+            user_id: 2,
+            blocks: 3,
+            ..Default::default()
+        };
+        layer_connection
+            .codec
+            .send(DaemonMessage::File(FileResponse::Xstat(Ok(
+                XstatResponse { metadata },
+            ))))
+            .await
+            .unwrap();
+
+        // fstat test
+        assert_eq!(
+            layer_connection.codec.next().await.unwrap().unwrap(),
+            ClientMessage::FileRequest(FileRequest::Xstat(XstatRequest {
+                path: Some("/tmp".to_string().into()),
+                fd: None,
+                follow_symlink: true
+            }))
+        );
+
+        let metadata = MetadataInternal {
+            device_id: 4,
+            size: 5,
+            user_id: 6,
+            blocks: 7,
+            ..Default::default()
+        };
+        layer_connection
+            .codec
+            .send(DaemonMessage::File(FileResponse::Xstat(Ok(
+                XstatResponse { metadata },
+            ))))
+            .await
+            .unwrap();
+    }
+
     assert_eq!(
         layer_connection.codec.next().await.unwrap().unwrap(),
         ClientMessage::FileRequest(FileRequest::FdOpenDir(FdOpenDirRequest { remote_fd: 1 }))

--- a/mirrord/layer/tests/issue1899.rs
+++ b/mirrord/layer/tests/issue1899.rs
@@ -60,9 +60,9 @@ async fn test_issue1899(
 
     test_process.wait_assert_success().await;
     test_process
-        .assert_stdout_contains("test issue 1776: START")
+        .assert_stdout_contains("test issue 1899: START")
         .await;
     test_process
-        .assert_stdout_contains("test issue 1776: SUCCESS")
+        .assert_stdout_contains("test issue 1899: SUCCESS")
         .await;
 }

--- a/mirrord/layer/tests/issue1899.rs
+++ b/mirrord/layer/tests/issue1899.rs
@@ -1,0 +1,65 @@
+#![feature(assert_matches)]
+#![warn(clippy::indexing_slicing)]
+use std::{path::PathBuf, time::Duration};
+
+use futures::{stream::StreamExt, SinkExt};
+use mirrord_protocol::{file::*, *};
+use rstest::rstest;
+
+mod common;
+
+pub use common::*;
+
+/// Verify that issue [#1776](https://github.com/metalbear-co/mirrord/issues/1776) is fixed.
+///
+/// We test this with `outgoing.udp = false`, as we're just trying to resolve DNS, and not full UDP
+/// outgoing traffic.
+#[rstest]
+#[tokio::test]
+#[timeout(Duration::from_secs(60))]
+async fn test_issue1899(
+    #[values(Application::RustIssue1899)] application: Application,
+    dylib_path: &PathBuf,
+) {
+    let (mut test_process, mut layer_connection) = application
+        .start_process_with_layer(dylib_path, vec![], None)
+        .await;
+
+    let fd = 1;
+
+    layer_connection
+        .expect_file_open_with_options(
+            "/tmp/test_file.txt",
+            fd,
+            OpenOptionsInternal {
+                read: true,
+                write: false,
+                append: false,
+                truncate: false,
+                create: false,
+                create_new: false,
+            },
+        )
+        .await;
+
+    assert_eq!(
+        layer_connection.codec.next().await.unwrap().unwrap(),
+        ClientMessage::FileRequest(FileRequest::FdOpenDir(FdOpenDirRequest { remote_fd: 1 }))
+    );
+
+    layer_connection
+        .codec
+        .send(DaemonMessage::File(FileResponse::OpenDir(Ok(
+            OpenDirResponse { fd: 2 },
+        ))))
+        .await
+        .unwrap();
+
+    test_process.wait_assert_success().await;
+    test_process
+        .assert_stdout_contains("test issue 1776: START")
+        .await;
+    test_process
+        .assert_stdout_contains("test issue 1776: SUCCESS")
+        .await;
+}

--- a/mirrord/layer/tests/issue1899.rs
+++ b/mirrord/layer/tests/issue1899.rs
@@ -10,10 +10,9 @@ mod common;
 
 pub use common::*;
 
-/// Verify that issue [#1776](https://github.com/metalbear-co/mirrord/issues/1776) is fixed.
+/// Verify that issue [#1899](https://github.com/metalbear-co/mirrord/issues/1899) is fixed.
 ///
-/// We test this with `outgoing.udp = false`, as we're just trying to resolve DNS, and not full UDP
-/// outgoing traffic.
+/// Test the `opendir` hook by calling it and asserting that `*DIR` is not `null`.
 #[rstest]
 #[tokio::test]
 #[timeout(Duration::from_secs(60))]
@@ -22,14 +21,18 @@ async fn test_issue1899(
     dylib_path: &PathBuf,
 ) {
     let (mut test_process, mut layer_connection) = application
-        .start_process_with_layer(dylib_path, vec![], None)
+        .start_process_with_layer(
+            dylib_path,
+            vec![("MIRRORD_FILE_READ_WRITE_PATTERN", "/tmp")],
+            None,
+        )
         .await;
 
     let fd = 1;
 
     layer_connection
         .expect_file_open_with_options(
-            "/tmp/test_file.txt",
+            "/tmp",
             fd,
             OpenOptionsInternal {
                 read: true,

--- a/mirrord/layer/tests/issue1899.rs
+++ b/mirrord/layer/tests/issue1899.rs
@@ -45,56 +45,6 @@ async fn test_issue1899(
         )
         .await;
 
-    // // Rust compiles with newer libc on Linux that uses statx
-    // #[cfg(target_os = "macos")]
-    // {
-    //     // lstat test
-    //     assert_eq!(
-    //         layer_connection.codec.next().await.unwrap().unwrap(),
-    //         ClientMessage::FileRequest(FileRequest::XstatFs(XstatFsRequest { fd }))
-    //     );
-
-    //     let metadata = MetadataInternal {
-    //         device_id: 0,
-    //         size: 1,
-    //         user_id: 2,
-    //         blocks: 3,
-    //         ..Default::default()
-    //     };
-    //     layer_connection
-    //         .codec
-    //         .send(DaemonMessage::File(FileResponse::Xstat(Ok(
-    //             XstatResponse { metadata },
-    //         ))))
-    //         .await
-    //         .unwrap();
-
-    //     // fstat test
-    //     assert_eq!(
-    //         layer_connection.codec.next().await.unwrap().unwrap(),
-    //         ClientMessage::FileRequest(FileRequest::Xstat(XstatRequest {
-    //             path: Some("/tmp".to_string().into()),
-    //             fd: None,
-    //             follow_symlink: true
-    //         }))
-    //     );
-
-    //     let metadata = MetadataInternal {
-    //         device_id: 4,
-    //         size: 5,
-    //         user_id: 6,
-    //         blocks: 7,
-    //         ..Default::default()
-    //     };
-    //     layer_connection
-    //         .codec
-    //         .send(DaemonMessage::File(FileResponse::Xstat(Ok(
-    //             XstatResponse { metadata },
-    //         ))))
-    //         .await
-    //         .unwrap();
-    // }
-
     assert_eq!(
         layer_connection.codec.next().await.unwrap().unwrap(),
         ClientMessage::FileRequest(FileRequest::FdOpenDir(FdOpenDirRequest { remote_fd: 1 }))


### PR DESCRIPTION
- Issue: #1899

Add hook for `opendir` by leveraging our `open` and `fdopendir` hooks.

Also adds hooks for `readdir64_r`, `__lxstat`, `__lxstat64`, `__xstat64`.

Refactors `*stat` hooks to use a common function.

Adds an integration test for `opendir`.