### PR TITLE
Disable opendir hook on aarch macOS 

### DIFF
--- a/changelog.d/1920.fixed.md
+++ b/changelog.d/1920.fixed.md
@@ -1,0 +1,1 @@
+Disable opendir hook on aarch macOS since it crashes due to arm64e issues

--- a/mirrord/layer/src/file/hooks.rs
+++ b/mirrord/layer/src/file/hooks.rs
@@ -142,6 +142,7 @@ pub(super) unsafe extern "C" fn open_nocancel_detour(
 ///
 /// Opens the directory with `read` permission using the [`open_logic`] flow, then calls
 /// [`fdopendir`] to convert the [`RawFd`] into a `*DIR` stream (which we treat as `usize`).
+#[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
 #[hook_guard_fn]
 pub(super) unsafe extern "C" fn opendir_detour(raw_filename: *const c_char) -> usize {
     open_logic(raw_filename, O_RDONLY, O_DIRECTORY)

--- a/mirrord/layer/src/file/hooks.rs
+++ b/mirrord/layer/src/file/hooks.rs
@@ -1080,6 +1080,12 @@ pub(crate) unsafe fn enable_file_hooks(hook_manager: &mut HookManager) {
             FnReaddir64_r,
             FN_READDIR64_R
         );
+        // aarch + macOS hooks fail
+        // because macOs internally calls this with pointer authentication
+        // and we don't compile to arm64e yet, so it breaks.
+        // but it seems we'll be able to compile to arm64e soon.
+        // https://github.com/rust-lang/rust/pull/115526
+        #[cfg(target_os = "linux")]
         replace!(
             hook_manager,
             "opendir",

--- a/mirrord/layer/src/file/hooks.rs
+++ b/mirrord/layer/src/file/hooks.rs
@@ -15,6 +15,8 @@ use libc::{
 };
 #[cfg(target_os = "linux")]
 use libc::{dirent64, stat64, EBADF, EINVAL, ENOENT, ENOTDIR};
+#[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
+use libc::{O_DIRECTORY, O_RDONLY};
 use mirrord_layer_macro::{hook_fn, hook_guard_fn};
 use mirrord_protocol::file::{
     DirEntryInternal, FsMetadataInternal, MetadataInternal, ReadFileResponse, WriteFileResponse,
@@ -27,12 +29,13 @@ use tracing::trace;
 use tracing::{error, info, warn};
 
 use super::{ops::*, OpenOptionsInternalExt};
+#[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
+use crate::close_layer_fd;
 #[cfg(target_os = "macos")]
 use crate::detour::Bypass;
 #[cfg(target_os = "linux")]
 use crate::error::HookError::ResponseError;
 use crate::{
-    close_layer_fd,
     common::CheckedInto,
     detour::{Detour, DetourGuard},
     error::HookError,

--- a/mirrord/layer/src/file/hooks.rs
+++ b/mirrord/layer/src/file/hooks.rs
@@ -11,7 +11,7 @@ use std::{ffi::CString, os::unix::io::RawFd, ptr, slice, time::Duration};
 use errno::{set_errno, Errno};
 use libc::{
     self, c_char, c_int, c_void, dirent, off_t, size_t, ssize_t, stat, statfs, AT_EACCESS,
-    AT_FDCWD, DIR, O_DIRECTORY, O_RDONLY,
+    AT_FDCWD, DIR,
 };
 #[cfg(target_os = "linux")]
 use libc::{dirent64, stat64, EBADF, EINVAL, ENOENT, ENOTDIR};


### PR DESCRIPTION
Disable opendir hook on aarch macOS since it crashes due to arm64e issues
Closes #1920 