### PR TITLE
CI: Add quotes to branch name in check_if_release_branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -158,7 +158,7 @@ jobs:
     steps:
       - id: release-branch
         run: |
-          echo "branch=$([[ ${{ github.head_ref || github.ref_name }} =~ "^[0-9]+\.[0-9]+\.[0-9]+$" ]]  && echo "true" || echo "false" )" >> "$GITHUB_OUTPUT"
+          echo "branch=$([[ "${{ github.head_ref || github.ref_name }}" =~ "^[0-9]+\.[0-9]+\.[0-9]+$" ]]  && echo "true" || echo "false" )" >> "$GITHUB_OUTPUT"
       - name: output test
         run: |
           echo ${{ steps.release-branch.outputs.branch }}

--- a/changelog.d/add-quotes-ci.internal.md
+++ b/changelog.d/add-quotes-ci.internal.md
@@ -1,0 +1,1 @@
+CI: Add quotes to branch name in check_if_release_branch


### PR DESCRIPTION
apparently non quoted version works in some cases and in some not, so I have added quotes