### PR TITLE
Fix verify-config command when used with invalid `config.json`.

### DIFF
--- a/changelog.d/1840.fixed.md
+++ b/changelog.d/1840.fixed.md
@@ -1,0 +1,1 @@
+Fix mirrord-cli verify-config command not serializing failures correctly due to serde not being able to serialize newtype pattern in tagged unions.

--- a/mirrord/cli/src/main.rs
+++ b/mirrord/cli/src/main.rs
@@ -421,7 +421,7 @@ enum VerifiedConfig {
     /// Invalid config was detected, mirrord cannot run.
     ///
     /// May be triggered by extra/lacking `,`, or invalid fields, etc.
-    Failed(Vec<String>),
+    Fail { errors: Vec<String> },
 }
 
 /// Verifies a config file specified by `path`.
@@ -435,7 +435,7 @@ enum VerifiedConfig {
 /// - Example:
 ///
 /// ```sh
-/// mirrord verify-config ./config.json
+/// mirrord verify-config ./valid-config.json
 ///
 ///
 /// {
@@ -447,6 +447,16 @@ enum VerifiedConfig {
 ///     "namespace": null
 ///   },
 ///   "warnings": []
+/// }
+/// ```
+///
+/// ```sh
+/// mirrord verify-config ./broken-config.json
+///
+///
+/// {
+///   "type": "Fail",
+///   "errors": ["mirrord-config: IO operation failed with `No such file or directory (os error 2)`"]
 /// }
 /// ```
 async fn verify_config(VerifyConfigArgs { path }: VerifyConfigArgs) -> Result<()> {
@@ -462,7 +472,9 @@ async fn verify_config(VerifyConfigArgs { path }: VerifyConfigArgs) -> Result<()
             config: config.target,
             warnings: config_context.get_warnings().to_owned(),
         },
-        Err(fail) => VerifiedConfig::Failed(vec![fail.to_string()]),
+        Err(fail) => VerifiedConfig::Fail {
+            errors: vec![fail.to_string()],
+        },
     };
 
     println!("{}", serde_json::to_string_pretty(&verified)?);


### PR DESCRIPTION
- Issue: #1840

`mirrord verify-config [path]` command would not produce a correct serialized JSON due to an issue coming from `serde` ((this)[https://github.com/serde-rs/serde/issues/1307]).