### PR TITLE
Changed file filter to exclude jar files from being read remote by default

### DIFF
--- a/changelog.d/1968.changed.md
+++ b/changelog.d/1968.changed.md
@@ -1,0 +1,1 @@
+Changed file filter to exclude jar files from being read remote by default

--- a/mirrord/layer/src/file/filter.rs
+++ b/mirrord/layer/src/file/filter.rs
@@ -37,6 +37,7 @@ fn generate_local_set() -> RegexSet {
         r"^.+\.d$",
         r"^.+\.pyc$",
         r"^.+\.py$",
+        r"^.+\.jar$",
         r"^.+\.js$",
         r"^.+\.pth$",
         r"^.+\.plist$",


### PR DESCRIPTION
Changed file filter to exclude jar files from being read remote by default

Closes #1968 