### PR TITLE
Call `FN_STAT`, not `FN_LSTAT` from `stat` bypass

### DIFF
--- a/changelog.d/1967.fixed.md
+++ b/changelog.d/1967.fixed.md
@@ -1,0 +1,1 @@
+Running `mix` works now (bug was calling `lstat` in `stat` bypass).

--- a/mirrord/layer/src/file/hooks.rs
+++ b/mirrord/layer/src/file/hooks.rs
@@ -753,7 +753,7 @@ unsafe extern "C" fn stat_detour(raw_path: *const c_char, out_stat: *mut stat) -
         |_bypass| {
             #[cfg(target_os = "macos")]
             let raw_path = update_ptr_from_bypass(raw_path, _bypass);
-            FN_LSTAT(raw_path, out_stat)
+            FN_STAT(raw_path, out_stat)
         },
     )
 }


### PR DESCRIPTION
Fixes #1967