### PR TITLE
Make mirror (in mesh) capture on the lo interface, instead of eth0 (or equivalent) by default (user setting takes priority).

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3922,7 +3922,7 @@ dependencies = [
 
 [[package]]
 name = "mirrord-protocol"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "actix-codec",
  "bincode",

--- a/changelog.d/1963.fixed.md
+++ b/changelog.d/1963.fixed.md
@@ -1,0 +1,1 @@
+Propagate to the agent that we're in a mesh context (moved `MeshVendor` to a common crate), and handle the special case for `istio`, where the sniffer should capture traffic on the `lo` interface.

--- a/mirrord/agent/src/cli.rs
+++ b/mirrord/agent/src/cli.rs
@@ -73,8 +73,8 @@ impl Mode {
 
     /// Digs into `Mode::Targeted` to get the `MeshVendor`.
     pub(super) fn mesh(&self) -> Option<MeshVendor> {
-        match self {
-            Mode::Targeted { mesh, .. } => mesh.clone(),
+        match *self {
+            Mode::Targeted { mesh, .. } => mesh,
             _ => None,
         }
     }

--- a/mirrord/agent/src/cli.rs
+++ b/mirrord/agent/src/cli.rs
@@ -73,6 +73,10 @@ impl Mode {
         matches!(self, Mode::Targetless)
     }
 
+    /// Converts a mesh `Option<String>` to an `Option<MeshVendor>`.
+    ///
+    /// Keep in mind that the [`FromStr`] implementation for [`MeshVendor`] `panic`s if we feed it
+    /// anything other than `"Istio"` or `"Linkerd"`.
     pub(super) fn mesh(&self) -> Option<MeshVendor> {
         match self {
             Mode::Targeted { mesh, .. } => mesh

--- a/mirrord/agent/src/cli.rs
+++ b/mirrord/agent/src/cli.rs
@@ -56,6 +56,7 @@ pub enum Mode {
         #[arg(short = 'r', long, default_value = DEFAULT_RUNTIME)]
         container_runtime: String,
 
+        /// Which kind of mesh the remote pod is in, see [`MeshVendor`].
         #[arg(long)]
         mesh: Option<String>,
     },
@@ -83,6 +84,5 @@ impl Mode {
 }
 
 pub fn parse_args() -> Args {
-    tracing::debug!("args: {:?}", std::env::args_os());
     Args::try_parse().unwrap_or_else(|err| err.exit())
 }

--- a/mirrord/agent/src/cli.rs
+++ b/mirrord/agent/src/cli.rs
@@ -1,7 +1,5 @@
 #![deny(missing_docs)]
 
-use std::str::FromStr;
-
 use clap::{Parser, Subcommand};
 use mirrord_protocol::MeshVendor;
 
@@ -58,7 +56,7 @@ pub enum Mode {
 
         /// Which kind of mesh the remote pod is in, see [`MeshVendor`].
         #[arg(long)]
-        mesh: Option<String>,
+        mesh: Option<MeshVendor>,
     },
     /// Inform the agent to use `proc/1/root` as the root directory.
     Ephemeral,
@@ -73,15 +71,10 @@ impl Mode {
         matches!(self, Mode::Targetless)
     }
 
-    /// Converts a mesh `Option<String>` to an `Option<MeshVendor>`.
-    ///
-    /// Keep in mind that the [`FromStr`] implementation for [`MeshVendor`] `panic`s if we feed it
-    /// anything other than `"Istio"` or `"Linkerd"`.
+    /// Digs into `Mode::Targeted` to get the `MeshVendor`.
     pub(super) fn mesh(&self) -> Option<MeshVendor> {
         match self {
-            Mode::Targeted { mesh, .. } => mesh
-                .as_ref()
-                .and_then(|mesh| MeshVendor::from_str(mesh).ok()),
+            Mode::Targeted { mesh, .. } => mesh.clone(),
             _ => None,
         }
     }

--- a/mirrord/agent/src/main.rs
+++ b/mirrord/agent/src/main.rs
@@ -545,7 +545,7 @@ impl ClientConnectionHandler {
 }
 
 /// Initializes the agent's [`State`], channels, threads, and runs [`ClientConnectionHandler`]s.
-#[tracing::instrument(level = "info", ret)]
+#[tracing::instrument(level = "trace", ret)]
 async fn start_agent(args: Args, watch: drain::Watch) -> Result<()> {
     trace!("Starting agent with args: {args:?}");
 

--- a/mirrord/agent/src/sniffer.rs
+++ b/mirrord/agent/src/sniffer.rs
@@ -513,7 +513,7 @@ impl TcpConnectionSniffer {
     /// detected, then the agent should start mirroring as if it was a new connection.
     ///
     /// tl;dr: checks packet flags, or if it's an HTTP packet, then begins a new sniffing session.
-    #[tracing::instrument(level = "debug", ret, skip(bytes))]
+    #[tracing::instrument(level = "trace", ret, skip(bytes))]
     fn treat_as_new_session(tcp_flags: u16, bytes: &[u8]) -> bool {
         is_new_connection(tcp_flags)
             || matches!(HttpVersion::new(bytes), HttpVersion::V1 | HttpVersion::V2)

--- a/mirrord/agent/src/sniffer.rs
+++ b/mirrord/agent/src/sniffer.rs
@@ -513,7 +513,7 @@ impl TcpConnectionSniffer {
     /// detected, then the agent should start mirroring as if it was a new connection.
     ///
     /// tl;dr: checks packet flags, or if it's an HTTP packet, then begins a new sniffing session.
-    #[tracing::instrument(level = "trace", ret, skip(bytes))]
+    #[tracing::instrument(level = "debug", ret, skip(bytes))]
     fn treat_as_new_session(tcp_flags: u16, bytes: &[u8]) -> bool {
         is_new_connection(tcp_flags)
             || matches!(HttpVersion::new(bytes), HttpVersion::V1 | HttpVersion::V2)

--- a/mirrord/agent/src/steal/ip_tables.rs
+++ b/mirrord/agent/src/steal/ip_tables.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use enum_dispatch::enum_dispatch;
-use mirrord_protocol::Port;
+use mirrord_protocol::{MeshVendor, Port};
 use rand::distributions::{Alphanumeric, DistString};
 use tracing::warn;
 
@@ -12,7 +12,7 @@ use crate::{
     error::{AgentError, Result},
     steal::ip_tables::{
         flush_connections::FlushConnections,
-        mesh::{MeshRedirect, MeshVendor},
+        mesh::{MeshRedirect, MeshVendorExt},
         redirect::{PreroutingRedirect, Redirect},
         standard::StandardRedirect,
     },

--- a/mirrord/kube/src/api/container/ephemeral.rs
+++ b/mirrord/kube/src/api/container/ephemeral.rs
@@ -167,6 +167,9 @@ impl<'c> EphemeralTargetedVariant<'c> {
         let mut command_line = base_command_line(agent, params);
 
         command_line.extend(["ephemeral".to_string()]);
+        if let Some(mesh) = runtime_data.mesh {
+            command_line.extend(["--mesh".to_string(), mesh.to_string()]);
+        }
 
         EphemeralTargetedVariant {
             agent,

--- a/mirrord/kube/src/api/container/job.rs
+++ b/mirrord/kube/src/api/container/job.rs
@@ -235,6 +235,10 @@ impl<'c> JobTargetedVariant<'c> {
             runtime_data.container_runtime.to_string(),
         ]);
 
+        if let Some(mesh) = runtime_data.mesh {
+            command_line.extend(["--mesh".to_string(), mesh.to_string()]);
+        }
+
         let inner = JobVariant::with_command_line(agent, params, command_line);
 
         JobTargetedVariant {
@@ -418,7 +422,7 @@ mod test {
             &agent,
             &params,
             &RuntimeData {
-                is_mesh: false,
+                mesh: None,
                 pod_name: "pod".to_string(),
                 pod_namespace: None,
                 node_name: "foobaz".to_string(),

--- a/mirrord/kube/src/api/kubernetes.rs
+++ b/mirrord/kube/src/api/kubernetes.rs
@@ -92,7 +92,7 @@ impl KubernetesAPI {
         Ok(())
     }
 
-    /// Checks if any [`ContainerStatus`] matches a mesh/sidecar name from our `MESH_LIST`, and the
+    /// Checks if any `ContainerStatus` matches a mesh/sidecar name from our `MESH_LIST`, and the
     /// user is running incoming traffic in `IncomigMode::Mirror` mode, printing a warning if it
     /// does.
     #[tracing::instrument(level = "trace", ret, skip(self, progress))]

--- a/mirrord/kube/src/api/kubernetes.rs
+++ b/mirrord/kube/src/api/kubernetes.rs
@@ -215,7 +215,7 @@ impl AgentManagment for KubernetesAPI {
 
         let is_mesh = runtime_data
             .as_ref()
-            .map(|runtime| runtime.is_mesh)
+            .map(|runtime| runtime.mesh.is_some())
             .unwrap_or_default();
 
         if self

--- a/mirrord/kube/src/api/runtime.rs
+++ b/mirrord/kube/src/api/runtime.rs
@@ -14,6 +14,7 @@ use k8s_openapi::{
 };
 use kube::{api::ListParams, Api, Client};
 use mirrord_config::target::{DeploymentTarget, PodTarget, RolloutTarget, Target};
+use mirrord_protocol::MeshVendor;
 
 use crate::{
     api::{
@@ -50,7 +51,7 @@ pub struct RuntimeData {
     pub container_name: String,
 
     /// Used to check if we're running with a mesh/sidecar in `detect_mesh_mirror_mode`.
-    pub is_mesh: bool,
+    pub mesh: Option<MeshVendor>,
 }
 
 impl RuntimeData {
@@ -76,7 +77,7 @@ impl RuntimeData {
             .container_statuses
             .clone()
             .ok_or(KubeApiError::ContainerStatusNotFound)?;
-        let (chosen_container, is_mesh) =
+        let (chosen_container, mesh) =
             choose_container(container_name, container_statuses.as_ref());
 
         let chosen_status = chosen_container.ok_or_else(|| {
@@ -117,7 +118,7 @@ impl RuntimeData {
             container_id,
             container_runtime,
             container_name,
-            is_mesh,
+            mesh,
         })
     }
 

--- a/mirrord/protocol/Cargo.toml
+++ b/mirrord/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mirrord-protocol"
-version = "1.3.1"
+version = "1.3.2"
 authors.workspace = true
 description.workspace = true
 documentation.workspace = true

--- a/mirrord/protocol/src/error.rs
+++ b/mirrord/protocol/src/error.rs
@@ -17,6 +17,11 @@ pub enum SerializationError {
     SocketAddress,
 }
 
+/// Error when parsing a `MeshVendor` from the `agent/cli` arguments.
+#[derive(Debug, PartialEq, Clone, Eq, Error)]
+#[error("Failed parsing `MeshVendor` from `{0}`!")]
+pub struct MeshVendorParseError(pub String);
+
 #[derive(Encode, Decode, Debug, PartialEq, Clone, Eq, Error)]
 pub enum ResponseError {
     #[error("Index allocator is full, operation `{0}` failed!")]

--- a/mirrord/protocol/src/lib.rs
+++ b/mirrord/protocol/src/lib.rs
@@ -56,7 +56,7 @@ impl Deref for EnvVars {
 ///   when we're mirroring with `istio`;
 /// - Used in the stealer iptables handling to add/detect special rules for meshes;
 ///
-/// Can be converted to and from `String`, but the [`from_str`] just `panics` if you pass an invalid
+/// Can be converted to and from `String`, but the `from_str` just `panics` if you pass an invalid
 /// value (this use-case is hand-written, so it can't fail unless you add a new value and forget to
 /// handle it in the [`FromStr`] implementation).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]

--- a/mirrord/protocol/src/lib.rs
+++ b/mirrord/protocol/src/lib.rs
@@ -56,9 +56,10 @@ impl Deref for EnvVars {
 ///   when we're mirroring with `istio`;
 /// - Used in the stealer iptables handling to add/detect special rules for meshes;
 ///
-/// Can be converted to and from `String`, but the `from_str` just `panics` if you pass an invalid
-/// value (this use-case is hand-written, so it can't fail unless you add a new value and forget to
-/// handle it in the [`FromStr`] implementation).
+/// ## Internal
+///
+/// Can be converted to, and from `String`, if you add a new value here, don't forget to add it to
+/// the `FromStr` implementation!
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum MeshVendor {
     Linkerd,
@@ -75,15 +76,13 @@ impl fmt::Display for MeshVendor {
 }
 
 impl FromStr for MeshVendor {
-    type Err = ();
+    type Err = MeshVendorParseError;
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         match s {
-            "Linkerd" => Ok(MeshVendor::Linkerd),
-            "Istio" => Ok(MeshVendor::Istio),
-            invalid => panic!(
-                "Invalid mesh name {invalid} found! Did you forget to add a conversion here?"
-            ),
+            "Linkerd" => Ok(Self::Linkerd),
+            "Istio" => Ok(Self::Istio),
+            invalid => Err(MeshVendorParseError(invalid.into())),
         }
     }
 }

--- a/mirrord/protocol/src/lib.rs
+++ b/mirrord/protocol/src/lib.rs
@@ -69,8 +69,8 @@ pub enum MeshVendor {
 impl fmt::Display for MeshVendor {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            MeshVendor::Linkerd => write!(f, "Linkerd"),
-            MeshVendor::Istio => write!(f, "Istio"),
+            MeshVendor::Linkerd => write!(f, "linkerd"),
+            MeshVendor::Istio => write!(f, "istio"),
         }
     }
 }
@@ -80,8 +80,8 @@ impl FromStr for MeshVendor {
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         match s {
-            "Linkerd" => Ok(Self::Linkerd),
-            "Istio" => Ok(Self::Istio),
+            "linkerd" => Ok(Self::Linkerd),
+            "istio" => Ok(Self::Istio),
             invalid => Err(MeshVendorParseError(invalid.into())),
         }
     }

--- a/mirrord/protocol/src/lib.rs
+++ b/mirrord/protocol/src/lib.rs
@@ -12,7 +12,8 @@ pub mod outgoing;
 pub mod pause;
 pub mod tcp;
 
-use std::{collections::HashSet, ops::Deref, sync::LazyLock};
+use core::fmt;
+use std::{collections::HashSet, ops::Deref, str::FromStr, sync::LazyLock};
 
 pub use codec::*;
 pub use error::*;
@@ -46,5 +47,43 @@ impl Deref for EnvVars {
 
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+
+/// Used to identify if the remote pod is in a mesh context.
+///
+/// - Passed to the agent so we can handle the special case for selecting a network interface `lo`
+///   when we're mirroring with `istio`;
+/// - Used in the stealer iptables handling to add/detect special rules for meshes;
+///
+/// Can be converted to and from `String`, but the [`from_str`] just `panics` if you pass an invalid
+/// value (this use-case is hand-written, so it can't fail unless you add a new value and forget to
+/// handle it in the [`FromStr`] implementation).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum MeshVendor {
+    Linkerd,
+    Istio,
+}
+
+impl fmt::Display for MeshVendor {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            MeshVendor::Linkerd => write!(f, "Linkerd"),
+            MeshVendor::Istio => write!(f, "Istio"),
+        }
+    }
+}
+
+impl FromStr for MeshVendor {
+    type Err = ();
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s {
+            "Linkerd" => Ok(MeshVendor::Linkerd),
+            "Istio" => Ok(MeshVendor::Istio),
+            invalid => panic!(
+                "Invalid mesh name {invalid} found! Did you forget to add a conversion here?"
+            ),
+        }
     }
 }


### PR DESCRIPTION
- Issue: #1963

Moved `MeshVendor` from the agent crate to the protocol crate, as it's now being used by both kube and agent. The previous implementation stuff we had in `steal/iptables` for it is still there, as an extension trait.

Instead of just detecting that we're in a mesh (kube crate), we now propagate the type of mesh to the agent through the `--mesh` arg, and if it's `istio`, sniffer captures traffic on `lo`, instead of `eth0` (steal should be unaffected by this change).