### PR TITLE
Add --ide flag to verify-config, changing some errors into warnings.

### DIFF
--- a/changelog.d/1979.fixed.md
+++ b/changelog.d/1979.fixed.md
@@ -1,0 +1,1 @@
+Adds the optional `--ide` flag to `mirrord verify-config [--ide] --path {/config/path}`, turning some errors into warnings (target related).

--- a/mirrord/cli/src/config.rs
+++ b/mirrord/cli/src/config.rs
@@ -292,6 +292,9 @@ fn email_parse(email: &str) -> Result<EmailAddress, String> {
 #[derive(Args, Debug)]
 pub(super) struct VerifyConfigArgs {
     /// Config file path.
+    pub(super) ide: bool,
+
+    /// Config file path.
     pub(super) path: PathBuf,
 }
 

--- a/mirrord/cli/src/config.rs
+++ b/mirrord/cli/src/config.rs
@@ -62,6 +62,7 @@ pub(super) enum Commands {
     InternalProxy,
 
     /// Verify config file without starting mirrord.
+    #[command(hide = true)]
     VerifyConfig(VerifyConfigArgs),
 }
 

--- a/mirrord/cli/src/config.rs
+++ b/mirrord/cli/src/config.rs
@@ -62,7 +62,6 @@ pub(super) enum Commands {
     InternalProxy,
 
     /// Verify config file without starting mirrord.
-    #[command(hide = true)]
     VerifyConfig(VerifyConfigArgs),
 }
 
@@ -290,11 +289,14 @@ fn email_parse(email: &str) -> Result<EmailAddress, String> {
 
 /// Args for the [`super::verify_config`] mirrord-cli command.
 #[derive(Args, Debug)]
+#[command(group(ArgGroup::new("verify-config")))]
 pub(super) struct VerifyConfigArgs {
     /// Config file path.
+    #[arg(long)]
     pub(super) ide: bool,
 
     /// Config file path.
+    #[arg(long)]
     pub(super) path: PathBuf,
 }
 

--- a/mirrord/cli/src/extension.rs
+++ b/mirrord/cli/src/extension.rs
@@ -61,7 +61,7 @@ pub(crate) async fn extension_exec(args: ExtensionExecArgs, watch: drain::Watch)
 
     let mut analytics = AnalyticsReporter::only_error(config.telemetry, watch);
 
-    config.verify(&mut context, false)?;
+    config.verify(&mut context)?;
     for warning in context.get_warnings() {
         progress.warning(warning);
     }

--- a/mirrord/cli/src/extension.rs
+++ b/mirrord/cli/src/extension.rs
@@ -61,7 +61,7 @@ pub(crate) async fn extension_exec(args: ExtensionExecArgs, watch: drain::Watch)
 
     let mut analytics = AnalyticsReporter::only_error(config.telemetry, watch);
 
-    config.verify(&mut context)?;
+    config.verify(&mut context, false)?;
     for warning in context.get_warnings() {
         progress.warning(warning);
     }

--- a/mirrord/cli/src/main.rs
+++ b/mirrord/cli/src/main.rs
@@ -224,7 +224,7 @@ async fn exec(args: &ExecArgs, watch: drain::Watch) -> Result<()> {
     let mut analytics = AnalyticsReporter::only_error(config.telemetry, watch);
     (&config).collect_analytics(analytics.get_mut());
 
-    config.verify(&mut context, false)?;
+    config.verify(&mut context)?;
     for warning in context.get_warnings() {
         progress.warning(warning);
     }

--- a/mirrord/cli/src/main.rs
+++ b/mirrord/cli/src/main.rs
@@ -22,7 +22,6 @@ use miette::JSONReportHandler;
 use mirrord_analytics::{AnalyticsError, AnalyticsReporter, CollectAnalytics};
 use mirrord_config::{
     config::{ConfigContext, MirrordConfig},
-    target::TargetConfig,
     LayerConfig, LayerFileConfig,
 };
 use mirrord_kube::{
@@ -35,7 +34,7 @@ use mirrord_kube::{
 use mirrord_progress::{Progress, ProgressTracker};
 use operator::operator_command;
 use semver::Version;
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde::de::DeserializeOwned;
 use serde_json::json;
 use tracing::{error, info, warn};
 use tracing_subscriber::{fmt, prelude::*, registry, EnvFilter};
@@ -49,8 +48,10 @@ mod extension;
 mod extract;
 mod internal_proxy;
 mod operator;
+mod verify_config;
 
 pub(crate) use error::{CliError, Result};
+use verify_config::verify_config;
 
 async fn exec_process<P>(
     config: LayerConfig,
@@ -223,7 +224,7 @@ async fn exec(args: &ExecArgs, watch: drain::Watch) -> Result<()> {
     let mut analytics = AnalyticsReporter::only_error(config.telemetry, watch);
     (&config).collect_analytics(analytics.get_mut());
 
-    config.verify(&mut context)?;
+    config.verify(&mut context, false)?;
     for warning in context.get_warnings() {
         progress.warning(warning);
     }
@@ -403,86 +404,6 @@ async fn register_to_waitlist(email: EmailAddress) -> Result<()> {
 
     Ok(())
 }
-
-/// Produced by calling `verify_config`.
-///
-/// It's consumed by the IDEs to check if a config is valid, or missing something, without starting
-/// mirrord fully.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(tag = "type")]
-enum VerifiedConfig {
-    /// mirrord is able to run with this config, but it might have some issues or weird behavior
-    /// depending on the `warnings`.
-    Success {
-        /// A valid, verified config for the `target` part of mirrord.
-        config: TargetConfig,
-        /// Improper combination of features was requested, but mirrord can still run.
-        warnings: Vec<String>,
-    },
-    /// Invalid config was detected, mirrord cannot run.
-    ///
-    /// May be triggered by extra/lacking `,`, or invalid fields, etc.
-    Fail { errors: Vec<String> },
-}
-
-/// Verifies a config file specified by `path`.
-///
-/// ## Usage
-///
-/// ```sh
-/// mirrord verify-config [path]
-/// ```
-///
-/// - Example:
-///
-/// ```sh
-/// mirrord verify-config ./valid-config.json
-///
-///
-/// {
-///   "type": "Success",
-///   "config": {
-///     "path": {
-///       "deployment": "sample-deployment",
-///     },
-///     "namespace": null
-///   },
-///   "warnings": []
-/// }
-/// ```
-///
-/// ```sh
-/// mirrord verify-config ./broken-config.json
-///
-///
-/// {
-///   "type": "Fail",
-///   "errors": ["mirrord-config: IO operation failed with `No such file or directory (os error 2)`"]
-/// }
-/// ```
-async fn verify_config(VerifyConfigArgs { path }: VerifyConfigArgs) -> Result<()> {
-    let mut config_context = ConfigContext::default();
-
-    let verified = match LayerFileConfig::from_path(path)
-        .and_then(|config| config.generate_config(&mut config_context))
-        .and_then(|config| {
-            config.verify(&mut config_context)?;
-            Ok(config)
-        }) {
-        Ok(config) => VerifiedConfig::Success {
-            config: config.target,
-            warnings: config_context.get_warnings().to_owned(),
-        },
-        Err(fail) => VerifiedConfig::Fail {
-            errors: vec![fail.to_string()],
-        },
-    };
-
-    println!("{}", serde_json::to_string_pretty(&verified)?);
-
-    Ok(())
-}
-
 const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 fn main() -> miette::Result<()> {

--- a/mirrord/cli/src/verify_config.rs
+++ b/mirrord/cli/src/verify_config.rs
@@ -67,12 +67,12 @@ enum VerifiedConfig {
 /// }
 /// ```
 pub(super) async fn verify_config(VerifyConfigArgs { ide, path }: VerifyConfigArgs) -> Result<()> {
-    let mut config_context = ConfigContext::default();
+    let mut config_context = ConfigContext::new(ide);
 
     let verified = match LayerFileConfig::from_path(path)
         .and_then(|config| config.generate_config(&mut config_context))
         .and_then(|config| {
-            config.verify(&mut config_context, ide)?;
+            config.verify(&mut config_context)?;
             Ok(config)
         }) {
         Ok(config) => VerifiedConfig::Success {

--- a/mirrord/cli/src/verify_config.rs
+++ b/mirrord/cli/src/verify_config.rs
@@ -1,0 +1,90 @@
+//! `mirrord verify-config [--ide] {path}` builds a [`VerifyConfig`] enum after checking the
+//! config file passed in `path`. It's used by the IDE plugins to display errors/warnings quickly,
+//! without having to start mirrord-layer.
+use error::Result;
+use mirrord_config::{
+    config::{ConfigContext, MirrordConfig},
+    target::TargetConfig,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::{config::VerifyConfigArgs, error, LayerFileConfig};
+
+/// Produced by calling `verify_config`.
+///
+/// It's consumed by the IDEs to check if a config is valid, or missing something, without starting
+/// mirrord fully.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type")]
+enum VerifiedConfig {
+    /// mirrord is able to run with this config, but it might have some issues or weird behavior
+    /// depending on the `warnings`.
+    Success {
+        /// A valid, verified config for the `target` part of mirrord.
+        config: TargetConfig,
+        /// Improper combination of features was requested, but mirrord can still run.
+        warnings: Vec<String>,
+    },
+    /// Invalid config was detected, mirrord cannot run.
+    ///
+    /// May be triggered by extra/lacking `,`, or invalid fields, etc.
+    Fail { errors: Vec<String> },
+}
+
+/// Verifies a config file specified by `path`.
+///
+/// ## Usage
+///
+/// ```sh
+/// mirrord verify-config [path]
+/// ```
+///
+/// - Example:
+///
+/// ```sh
+/// mirrord verify-config ./valid-config.json
+///
+///
+/// {
+///   "type": "Success",
+///   "config": {
+///     "path": {
+///       "deployment": "sample-deployment",
+///     },
+///     "namespace": null
+///   },
+///   "warnings": []
+/// }
+/// ```
+///
+/// ```sh
+/// mirrord verify-config ./broken-config.json
+///
+///
+/// {
+///   "type": "Fail",
+///   "errors": ["mirrord-config: IO operation failed with `No such file or directory (os error 2)`"]
+/// }
+/// ```
+pub(super) async fn verify_config(VerifyConfigArgs { ide, path }: VerifyConfigArgs) -> Result<()> {
+    let mut config_context = ConfigContext::default();
+
+    let verified = match LayerFileConfig::from_path(path)
+        .and_then(|config| config.generate_config(&mut config_context))
+        .and_then(|config| {
+            config.verify(&mut config_context, ide)?;
+            Ok(config)
+        }) {
+        Ok(config) => VerifiedConfig::Success {
+            config: config.target,
+            warnings: config_context.get_warnings().to_owned(),
+        },
+        Err(fail) => VerifiedConfig::Fail {
+            errors: vec![fail.to_string()],
+        },
+    };
+
+    println!("{}", serde_json::to_string_pretty(&verified)?);
+
+    Ok(())
+}

--- a/mirrord/config/src/config.rs
+++ b/mirrord/config/src/config.rs
@@ -55,16 +55,32 @@ pub enum ConfigError {
 
 pub type Result<T, E = ConfigError> = std::result::Result<T, E>;
 
-/// Struct used for storing context during building of configuration
+/// Struct used for storing context during building of configuration.
 #[derive(Default)]
 pub struct ConfigContext {
+    /// Are we in a IDE context?
+    ///
+    /// Used by `Config::verify` to change some errors into warnings.
+    pub ide: bool,
+
+    /// The warnings when a config value conflicts with another, but mirrord can keep going.
+    ///
+    /// Some _target_ related errors become warning when `ide == true`.
     warnings: Vec<String>,
 }
 
 impl ConfigContext {
+    pub fn new(ide: bool) -> Self {
+        Self {
+            ide,
+            ..Default::default()
+        }
+    }
+
     pub fn add_warning(&mut self, warning: String) {
         self.warnings.push(warning);
     }
+
     pub fn get_warnings(&self) -> &Vec<String> {
         &self.warnings
     }
@@ -78,7 +94,7 @@ pub trait MirrordConfig {
     type Generated;
 
     /// <!--${internal}-->
-    /// Load configuration from all sources and output as [Self::Generated]
+    /// Load configuration from all sources and output as `Self::Generated`
     /// Pass reference to list of warnings which callee can add warnings into.
     fn generate_config(self, context: &mut ConfigContext) -> Result<Self::Generated>;
 }

--- a/mirrord/config/src/lib.rs
+++ b/mirrord/config/src/lib.rs
@@ -327,7 +327,7 @@ impl LayerConfig {
     /// - `ide`: Identifies if this is being called from an IDE context, when using
     /// `mirrord verify-config`. Turns some _target missing_ errors into warnings, as the target can
     /// be selected after `verify-config` is run.
-    pub fn verify(&self, context: &mut ConfigContext, ide: bool) -> Result<(), ConfigError> {
+    pub fn verify(&self, context: &mut ConfigContext) -> Result<(), ConfigError> {
         if self.pause {
             if self.agent.ephemeral && !self.agent.privileged {
                 context.add_warning("The target pause feature with ephemeral requires to enable the privileged flag on the agent.".to_string());
@@ -393,7 +393,7 @@ impl LayerConfig {
             // In the IDE, a target may be selected after `mirrord verify-config` is run, so we
             // for this case we treat these as warnings. They'll become errors once mirrord proper
             // tries to start (if the user somehow managed to not select a target by then).
-            if ide {
+            if context.ide {
                 if self.target.namespace.is_some() {
                     context.add_warning(
                         "A target namespace was specified, but no target was specified. \

--- a/mirrord/config/src/lib.rs
+++ b/mirrord/config/src/lib.rs
@@ -393,39 +393,7 @@ impl LayerConfig {
             // In the IDE, a target may be selected after `mirrord verify-config` is run, so we
             // for this case we treat these as warnings. They'll become errors once mirrord proper
             // tries to start (if the user somehow managed to not select a target by then).
-            if context.ide {
-                if self.target.namespace.is_some() {
-                    context.add_warning(
-                        "A target namespace was specified, but no target was detected in config. \
-                        The IDE will prompt you to select a target."
-                            .into(),
-                    );
-                }
-
-                if self.feature.network.incoming.is_steal() {
-                    context.add_warning(
-                        "Steal mode is not compatible with a targetless agent.\
-                        The IDE will prompt you to select a target."
-                            .into(),
-                    );
-                }
-
-                if self.agent.ephemeral {
-                    context.add_warning(
-                        "Using an ephemeral container for the agent is not compatible with a \
-                        targetless agent. The IDE will prompt you to select a target."
-                            .into(),
-                    );
-                }
-
-                if self.pause {
-                    context.add_warning(
-                        "The target pause feature is not compatible with a targetless agent. \
-                        The IDE will prompt you to select a target."
-                            .into(),
-                    );
-                }
-            } else {
+            if !context.ide {
                 if self.target.namespace.is_some() {
                     Err(ConfigError::TargetNamespaceWithoutTarget)?
                 }

--- a/mirrord/config/src/lib.rs
+++ b/mirrord/config/src/lib.rs
@@ -396,30 +396,33 @@ impl LayerConfig {
             if context.ide {
                 if self.target.namespace.is_some() {
                     context.add_warning(
-                        "A target namespace was specified, but no target was specified. \
-                            The IDE will prompt you to select a target."
+                        "A target namespace was specified, but no target was detected in config. \
+                        The IDE will prompt you to select a target."
                             .into(),
                     );
                 }
 
                 if self.feature.network.incoming.is_steal() {
-                    context.add_warning("Steal mode is not compatible with a targetless agent, please either disable this option or specify a target.".into());
+                    context.add_warning(
+                        "Steal mode is not compatible with a targetless agent.\
+                        The IDE will prompt you to select a target."
+                            .into(),
+                    );
                 }
 
                 if self.agent.ephemeral {
                     context.add_warning(
-                        "Using an ephemeral container for the agent is not \
-                        compatible with a targetless agent, please either disable this option or \
-                        specify a target."
+                        "Using an ephemeral container for the agent is not compatible with a \
+                        targetless agent. The IDE will prompt you to select a target."
                             .into(),
                     );
                 }
 
                 if self.pause {
                     context.add_warning(
-                        "The target pause feature is not compatible with a targetless agent, please \
-                        either disable this option or specify a target."
-                            .into()
+                        "The target pause feature is not compatible with a targetless agent. \
+                        The IDE will prompt you to select a target."
+                            .into(),
                     );
                 }
             } else {

--- a/mirrord/config/src/lib.rs
+++ b/mirrord/config/src/lib.rs
@@ -389,35 +389,33 @@ impl LayerConfig {
             Err(ConfigError::Conflict("Cannot use old http filter and new http filter at the same time. Use only `http_filter` instead of `http_header_filter`".to_string()))?
         }
 
-        if self.target.path.is_none() {
+        if self.target.path.is_none() && !context.ide {
             // In the IDE, a target may be selected after `mirrord verify-config` is run, so we
             // for this case we treat these as warnings. They'll become errors once mirrord proper
             // tries to start (if the user somehow managed to not select a target by then).
-            if !context.ide {
-                if self.target.namespace.is_some() {
-                    Err(ConfigError::TargetNamespaceWithoutTarget)?
-                }
+            if self.target.namespace.is_some() {
+                Err(ConfigError::TargetNamespaceWithoutTarget)?
+            }
 
-                if self.feature.network.incoming.is_steal() {
-                    Err(ConfigError::Conflict("Steal mode is not compatible with a targetless agent, please either disable this option or specify a target.".into()))?
-                }
+            if self.feature.network.incoming.is_steal() {
+                Err(ConfigError::Conflict("Steal mode is not compatible with a targetless agent, please either disable this option or specify a target.".into()))?
+            }
 
-                if self.agent.ephemeral {
-                    Err(ConfigError::Conflict(
-                        "Using an ephemeral container for the agent is not \
+            if self.agent.ephemeral {
+                Err(ConfigError::Conflict(
+                    "Using an ephemeral container for the agent is not \
                          compatible with a targetless agent, please either disable this option or \
                         specify a target."
-                            .into(),
-                    ))?
-                }
+                        .into(),
+                ))?
+            }
 
-                if self.pause {
-                    Err(ConfigError::Conflict(
-                        "The target pause feature is not compatible with a \
+            if self.pause {
+                Err(ConfigError::Conflict(
+                    "The target pause feature is not compatible with a \
                         targetless agent, please either disable this option or specify a target."
-                            .into(),
-                    ))?
-                }
+                        .into(),
+                ))?
             }
         }
         Ok(())

--- a/mirrord/config/src/lib.rs
+++ b/mirrord/config/src/lib.rs
@@ -394,6 +394,7 @@ impl LayerConfig {
             // for this case we treat these as warnings. They'll become errors once mirrord proper
             // tries to start (if the user somehow managed to not select a target by then).
             if ide {
+                println!("IDE");
                 if self.target.namespace.is_some() {
                     context.add_warning(
                         "A target namespace was specified, but no target was specified. \

--- a/mirrord/config/src/lib.rs
+++ b/mirrord/config/src/lib.rs
@@ -394,7 +394,6 @@ impl LayerConfig {
             // for this case we treat these as warnings. They'll become errors once mirrord proper
             // tries to start (if the user somehow managed to not select a target by then).
             if ide {
-                println!("IDE");
                 if self.target.namespace.is_some() {
                     context.add_warning(
                         "A target namespace was specified, but no target was specified. \


### PR DESCRIPTION
- Issue: #1979 

Adds the optional `--ide` flag to `mirrord verify-config [--ide] --path {/config/path}`.

Creates a special case for `config::verify` where we may turn some errors (target related) to warnings when we're in an IDE context, as the user may select a target instead of putting on in the config file.