### PR TITLE
Missing `readdir` and `readdir64` detours

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -300,6 +300,9 @@ jobs:
       - run: |
           cd mirrord/layer/tests/apps/issue1899
           cargo build
+      - run: |
+          cd mirrord/layer/tests/apps/issue2001
+          cargo build
       - run: ./scripts/build_c_apps.sh
       - run: cargo test --target x86_64-unknown-linux-gnu -p mirrord-layer
       - name: mirrord protocol UT
@@ -392,6 +395,9 @@ jobs:
           cargo build
       - run: |
           cd mirrord/layer/tests/apps/issue1899
+          cargo build
+      - run: |
+          cd mirrord/layer/tests/apps/issue2001
           cargo build
       - run: ./scripts/build_c_apps.sh
       # For the `java_temurin_sip` test.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3081,6 +3081,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "issue2001"
+version = "3.71.1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3082,7 +3082,7 @@ dependencies = [
 
 [[package]]
 name = "issue2001"
-version = "3.71.1"
+version = "3.71.2"
 dependencies = [
  "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "mirrord/layer/tests/apps/issue1776",
     "mirrord/layer/tests/apps/issue1776portnot53",
     "mirrord/layer/tests/apps/issue1899",
+    "mirrord/layer/tests/apps/issue2001",
     "sample/rust",
     "medschool",
     "tests",

--- a/changelog.d/2001.fixed.md
+++ b/changelog.d/2001.fixed.md
@@ -1,0 +1,1 @@
+Implemented missing hooks for `readdir` and `readdir64`.

--- a/mirrord/layer/src/file.rs
+++ b/mirrord/layer/src/file.rs
@@ -40,6 +40,7 @@ use crate::{
 
 pub(crate) mod filter;
 pub(crate) mod hooks;
+pub(crate) mod open_dirs;
 pub(crate) mod ops;
 
 type LocalFd = RawFd;
@@ -56,9 +57,6 @@ pub(crate) struct DirStream {
 /// Opens file `A`, receives fd 1, then dups, receives 2 - both stay open, until both are closed.
 /// Previously in such scenario we would close the remote, causing issues.
 pub(crate) static OPEN_FILES: LazyLock<DashMap<LocalFd, Arc<ops::RemoteFile>>> =
-    LazyLock::new(|| DashMap::with_capacity(4));
-
-pub(crate) static OPEN_DIRS: LazyLock<DashMap<DirStreamFd, RemoteFd>> =
     LazyLock::new(|| DashMap::with_capacity(4));
 
 /// Extension trait for [`OpenOptionsInternal`], used to convert between `libc`-ish open options and

--- a/mirrord/layer/src/file/hooks.rs
+++ b/mirrord/layer/src/file/hooks.rs
@@ -11,10 +11,10 @@ use std::{os::unix::io::RawFd, ptr, slice, time::Duration};
 use errno::{set_errno, Errno};
 use libc::{
     self, c_char, c_int, c_void, dirent, off_t, size_t, ssize_t, stat, statfs, AT_EACCESS,
-    AT_FDCWD, DIR,
+    AT_FDCWD, DIR, EINVAL,
 };
 #[cfg(target_os = "linux")]
-use libc::{dirent64, stat64, EBADF, EINVAL, ENOENT, ENOTDIR};
+use libc::{dirent64, stat64, EBADF, ENOENT, ENOTDIR};
 #[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
 use libc::{O_DIRECTORY, O_RDONLY};
 use mirrord_layer_macro::{hook_fn, hook_guard_fn};

--- a/mirrord/layer/src/file/hooks.rs
+++ b/mirrord/layer/src/file/hooks.rs
@@ -7,7 +7,6 @@ use core::ffi::{c_size_t, c_ssize_t};
 /// that is not being hooked (`strace` the program to check).
 use std::{os::unix::io::RawFd, ptr, slice, time::Duration};
 
-#[cfg(target_os = "linux")]
 use errno::{set_errno, Errno};
 use libc::{
     self, c_char, c_int, c_void, dirent, off_t, size_t, ssize_t, stat, statfs, AT_EACCESS,

--- a/mirrord/layer/src/file/hooks.rs
+++ b/mirrord/layer/src/file/hooks.rs
@@ -1127,6 +1127,13 @@ pub(crate) unsafe fn enable_file_hooks(hook_manager: &mut HookManager) {
         );
         replace!(
             hook_manager,
+            "readdir",
+            readdir_detour,
+            FnReaddir_r,
+            FN_READDIR
+        );
+        replace!(
+            hook_manager,
             "opendir$INODE64",
             opendir_detour,
             FnOpendir,

--- a/mirrord/layer/src/file/hooks.rs
+++ b/mirrord/layer/src/file/hooks.rs
@@ -242,12 +242,11 @@ pub(crate) unsafe extern "C" fn readdir64_detour(dirp: *mut DIR) -> usize {
     }
 }
 
-#[cfg(target_os = "linux")]
 #[hook_guard_fn]
 pub(crate) unsafe extern "C" fn readdir_detour(dirp: *mut DIR) -> usize {
     match OPEN_DIRS.read(dirp as usize) {
         Detour::Success(entry) => entry as usize,
-        Detour::Bypass(..) => FN_READDIR64(dirp),
+        Detour::Bypass(..) => FN_READDIR(dirp),
         Detour::Error(e) => {
             set_errno(Errno(e.into()));
             std::ptr::null::<dirent>() as usize

--- a/mirrord/layer/src/file/hooks.rs
+++ b/mirrord/layer/src/file/hooks.rs
@@ -1129,7 +1129,7 @@ pub(crate) unsafe fn enable_file_hooks(hook_manager: &mut HookManager) {
             hook_manager,
             "readdir",
             readdir_detour,
-            FnReaddir_r,
+            FnReaddir,
             FN_READDIR
         );
         replace!(

--- a/mirrord/layer/src/file/hooks.rs
+++ b/mirrord/layer/src/file/hooks.rs
@@ -1127,7 +1127,7 @@ pub(crate) unsafe fn enable_file_hooks(hook_manager: &mut HookManager) {
         );
         replace!(
             hook_manager,
-            "readdir",
+            "readdir$INODE64",
             readdir_detour,
             FnReaddir,
             FN_READDIR

--- a/mirrord/layer/src/file/open_dirs.rs
+++ b/mirrord/layer/src/file/open_dirs.rs
@@ -162,7 +162,7 @@ impl OpenDir {
         #[cfg(target_os = "macos")]
         let dirent = libc::dirent {
             d_ino: 0,
-            reclen: 0,
+            d_reclen: 0,
             d_type: 0,
             d_name: [0; 1024],
             d_seekoff: 0,

--- a/mirrord/layer/src/file/open_dirs.rs
+++ b/mirrord/layer/src/file/open_dirs.rs
@@ -198,18 +198,18 @@ pub fn assign_direntry(
     out_entry: &mut libc::dirent,
     getdents: bool,
 ) -> Result<(), HookError> {
-    (*out_entry).d_ino = in_entry.inode;
-    (*out_entry).d_reclen = if getdents {
+    out_entry.d_ino = in_entry.inode;
+    out_entry.d_reclen = if getdents {
         // The structs written by the kernel for the getdents syscall do not have a fixed size.
         in_entry.get_d_reclen64()
     } else {
         std::mem::size_of::<libc::dirent>() as u16
     };
-    (*out_entry).d_type = in_entry.file_type;
+    out_entry.d_type = in_entry.file_type;
 
     let dir_name = CString::new(in_entry.name)?;
     let dir_name_bytes = dir_name.as_bytes_with_nul();
-    (*out_entry)
+    out_entry
         .d_name
         .get_mut(..dir_name_bytes.len())
         .expect("directory name length exceeds limit")
@@ -217,14 +217,14 @@ pub fn assign_direntry(
 
     #[cfg(target_os = "macos")]
     {
-        (*out_entry).d_seekoff = in_entry.position;
+        out_entry.d_seekoff = in_entry.position;
         // name length should be without null
-        (*out_entry).d_namlen = dir_name.to_bytes().len() as u16;
+        out_entry.d_namlen = dir_name.to_bytes().len() as u16;
     }
 
     #[cfg(target_os = "linux")]
     {
-        (*out_entry).d_off = in_entry.position as i64;
+        out_entry.d_off = in_entry.position as i64;
     }
     Ok(())
 }
@@ -236,24 +236,24 @@ pub fn assign_direntry64(
     out_entry: &mut libc::dirent64,
     getdents: bool,
 ) -> Result<(), HookError> {
-    (*out_entry).d_ino = in_entry.inode;
-    (*out_entry).d_reclen = if getdents {
+    out_entry.d_ino = in_entry.inode;
+    out_entry.d_reclen = if getdents {
         // The structs written by the kernel for the getdents syscall do not have a fixed size.
         in_entry.get_d_reclen64()
     } else {
         std::mem::size_of::<libc::dirent64>() as u16
     };
-    (*out_entry).d_type = in_entry.file_type;
+    out_entry.d_type = in_entry.file_type;
 
     let dir_name = CString::new(in_entry.name)?;
     let dir_name_bytes = dir_name.as_bytes_with_nul();
-    (*out_entry)
+    out_entry
         .d_name
         .get_mut(..dir_name_bytes.len())
         .expect("directory name length exceeds limit")
         .copy_from_slice(bytemuck::cast_slice(dir_name_bytes));
 
-    (*out_entry).d_off = in_entry.position as i64;
+    out_entry.d_off = in_entry.position as i64;
 
     Ok(())
 }

--- a/mirrord/layer/src/file/open_dirs.rs
+++ b/mirrord/layer/src/file/open_dirs.rs
@@ -1,0 +1,259 @@
+//! Implementation of directory listing in the layer. Used in hooks like `opendir`, `closedir` or
+//! `readdir` family.
+
+use std::{
+    ffi::CString,
+    sync::{Arc, LazyLock, Mutex},
+};
+
+use dashmap::DashMap;
+use mirrord_protocol::file::{DirEntryInternal, ReadDirResponse};
+use tokio::sync::oneshot;
+
+use super::{CloseDir, DirStreamFd, FileOperation, ReadDir, RemoteFd};
+use crate::{
+    common::{blocking_send_hook_message, HookMessage},
+    detour::{Bypass, Detour},
+    error::HookError,
+};
+
+/// Global instance of [`OpenDirs`]. Used in hooks.
+pub static OPEN_DIRS: LazyLock<OpenDirs> = LazyLock::new(OpenDirs::new);
+
+/// State related to open remote directories.
+pub struct OpenDirs {
+    inner: DashMap<DirStreamFd, Arc<Mutex<OpenDir>>>,
+}
+
+impl OpenDirs {
+    /// Creates an empty state.
+    fn new() -> Self {
+        Self {
+            inner: DashMap::with_capacity(4),
+        }
+    }
+
+    /// Inserts a new entry into this state.
+    ///
+    /// # Arguments
+    ///
+    /// * `local_dir_fd` - opaque identifier
+    /// * `remote_fd` - descriptor of the remote directory (received from the agent)
+    pub fn insert(&self, local_dir_fd: DirStreamFd, remote_fd: RemoteFd) {
+        self.inner.insert(
+            local_dir_fd,
+            Mutex::new(OpenDir::new(local_dir_fd, remote_fd)).into(),
+        );
+    }
+
+    /// Reads next entry from the open directory with the given [`DirStreamFd`].
+    pub fn read_r(&self, local_dir_fd: DirStreamFd) -> Detour<Option<DirEntryInternal>> {
+        let dir = self
+            .inner
+            .get(&local_dir_fd)
+            .ok_or(Bypass::LocalDirStreamNotFound(local_dir_fd))?
+            .clone();
+
+        let guard = dir.lock().expect("lock poisoned");
+
+        guard.read_r()
+    }
+
+    /// Reads next entry from the open directory with the given [`DirStreamFd`] and copies the data
+    /// into an internal buffer. Returns a raw pointer to that buffer.
+    ///
+    /// If there are no more entries, returns [`std::ptr::null`].
+    ///
+    /// # Notes
+    ///
+    /// 1. There is exactly one buffer of this type for each open directory.
+    /// 2. The returned pointer is valid as long as the directory remains open.
+    /// 3. Consecutive calls of this method overwrite the buffer.
+    ///
+    /// Given above, the returned pointer is good enough to be used as a result of `readdir`.
+    pub fn read(&self, local_dir_fd: DirStreamFd) -> Detour<*const libc::dirent> {
+        let dir = self
+            .inner
+            .get(&local_dir_fd)
+            .ok_or(Bypass::LocalDirStreamNotFound(local_dir_fd))?
+            .clone();
+
+        let mut guard = dir.lock().expect("lock poisoned");
+
+        let Some(entry) = guard.read_r()? else {
+            return Detour::Success(std::ptr::null());
+        };
+
+        assign_direntry(entry, &mut guard.dirent, false)?;
+
+        Detour::Success(&guard.dirent)
+    }
+
+    /// Reads next entry from the open directory with the given [`DirStreamFd`] and copies the data
+    /// into an internal buffer. Returns a raw pointer to that buffer.
+    ///
+    /// If there are no more entries, returns [`std::ptr::null`].
+    ///
+    /// # Notes
+    ///
+    /// 1. There is exactly one buffer of this type for each open directory.
+    /// 2. The returned pointer is valid as long as the directory remains open.
+    /// 3. Consecutive calls of this method overwrite the buffer.
+    ///
+    /// Given above, the returned pointer is good enough to be used as a result of `readdir64`.
+    #[cfg(target_os = "linux")]
+    pub fn read64(&self, local_dir_fd: DirStreamFd) -> Detour<*const libc::dirent64> {
+        let dir = self
+            .inner
+            .get(&local_dir_fd)
+            .ok_or(Bypass::LocalDirStreamNotFound(local_dir_fd))?
+            .clone();
+
+        let mut guard = dir.lock().expect("lock poisoned");
+
+        let Some(entry) = guard.read_r()? else {
+            return Detour::Success(std::ptr::null());
+        };
+
+        assign_direntry64(entry, &mut guard.dirent64, false)?;
+
+        Detour::Success(&guard.dirent64)
+    }
+
+    /// Closes the open directory with the given [`DirStreamFd`].
+    pub fn close(&self, local_dir_fd: DirStreamFd) -> Detour<libc::c_int> {
+        let (_, dir) = self
+            .inner
+            .remove(&local_dir_fd)
+            .ok_or(Bypass::LocalDirStreamNotFound(local_dir_fd))?;
+
+        let mut guard = dir.lock().expect("lock poisoned");
+        guard.closed = true;
+        let requesting_dir = CloseDir {
+            fd: guard.remote_fd,
+        };
+
+        blocking_send_hook_message(HookMessage::File(FileOperation::CloseDir(requesting_dir)))?;
+
+        Detour::Success(0)
+    }
+}
+
+struct OpenDir {
+    closed: bool,
+    local_fd: DirStreamFd,
+    remote_fd: RemoteFd,
+    dirent: libc::dirent,
+    #[cfg(target_os = "linux")]
+    dirent64: libc::dirent64,
+}
+
+impl OpenDir {
+    fn new(local_fd: DirStreamFd, remote_fd: RemoteFd) -> Self {
+        Self {
+            closed: false,
+            local_fd,
+            remote_fd,
+            dirent: libc::dirent {
+                d_ino: 0,
+                d_off: 0,
+                d_reclen: 0,
+                d_type: 0,
+                d_name: [0; 256],
+            },
+            #[cfg(target_os = "linux")]
+            dirent64: libc::dirent64 {
+                d_ino: 0,
+                d_off: 0,
+                d_reclen: 0,
+                d_type: 0,
+                d_name: [0; 256],
+            },
+        }
+    }
+
+    fn read_r(&self) -> Detour<Option<DirEntryInternal>> {
+        if self.closed {
+            // This thread got this struct from `OpenDirs` before `close` removed it.
+            return Detour::Bypass(Bypass::LocalDirStreamNotFound(self.local_fd));
+        }
+
+        let (dir_channel_tx, dir_channel_rx) = oneshot::channel();
+
+        let requesting_dir = ReadDir {
+            remote_fd: self.remote_fd,
+            dir_channel_tx,
+        };
+
+        blocking_send_hook_message(HookMessage::File(FileOperation::ReadDir(requesting_dir)))?;
+
+        let ReadDirResponse { direntry } = dir_channel_rx.blocking_recv()??;
+        Detour::Success(direntry)
+    }
+}
+
+/// Moves [`DirEntryInternal`] content to the given [`libc::dirent`].
+pub fn assign_direntry(
+    in_entry: DirEntryInternal,
+    out_entry: &mut libc::dirent,
+    getdents: bool,
+) -> Result<(), HookError> {
+    (*out_entry).d_ino = in_entry.inode;
+    (*out_entry).d_reclen = if getdents {
+        // The structs written by the kernel for the getdents syscall do not have a fixed size.
+        in_entry.get_d_reclen64()
+    } else {
+        std::mem::size_of::<libc::dirent>() as u16
+    };
+    (*out_entry).d_type = in_entry.file_type;
+
+    let dir_name = CString::new(in_entry.name)?;
+    let dir_name_bytes = dir_name.as_bytes_with_nul();
+    (*out_entry)
+        .d_name
+        .get_mut(..dir_name_bytes.len())
+        .expect("directory name length exceeds limit")
+        .copy_from_slice(bytemuck::cast_slice(dir_name_bytes));
+
+    #[cfg(target_os = "macos")]
+    {
+        (*out_entry).d_seekoff = in_entry.position;
+        // name length should be without null
+        (*out_entry).d_namlen = dir_name.to_bytes().len() as u16;
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        (*out_entry).d_off = in_entry.position as i64;
+    }
+    Ok(())
+}
+
+/// Moves [`DirEntryInternal`] content to the given [`libc::dirent64`].
+#[cfg(target_os = "linux")]
+pub fn assign_direntry64(
+    in_entry: DirEntryInternal,
+    out_entry: &mut libc::dirent64,
+    getdents: bool,
+) -> Result<(), HookError> {
+    (*out_entry).d_ino = in_entry.inode;
+    (*out_entry).d_reclen = if getdents {
+        // The structs written by the kernel for the getdents syscall do not have a fixed size.
+        in_entry.get_d_reclen64()
+    } else {
+        std::mem::size_of::<libc::dirent64>() as u16
+    };
+    (*out_entry).d_type = in_entry.file_type;
+
+    let dir_name = CString::new(in_entry.name)?;
+    let dir_name_bytes = dir_name.as_bytes_with_nul();
+    (*out_entry)
+        .d_name
+        .get_mut(..dir_name_bytes.len())
+        .expect("directory name length exceeds limit")
+        .copy_from_slice(bytemuck::cast_slice(dir_name_bytes));
+
+    (*out_entry).d_off = in_entry.position as i64;
+
+    Ok(())
+}

--- a/mirrord/layer/src/file/open_dirs.rs
+++ b/mirrord/layer/src/file/open_dirs.rs
@@ -150,17 +150,30 @@ struct OpenDir {
 
 impl OpenDir {
     fn new(local_fd: DirStreamFd, remote_fd: RemoteFd) -> Self {
+        #[cfg(not(target_os = "macos"))]
+        let dirent = libc::dirent {
+            d_ino: 0,
+            d_off: 0,
+            d_reclen: 0,
+            d_type: 0,
+            d_name: [0; 256],
+        };
+
+        #[cfg(target_os = "macos")]
+        let dirent = libc::dirent {
+            d_ino: 0,
+            reclen: 0,
+            d_type: 0,
+            d_name: [0; 1024],
+            d_seekoff: 0,
+            d_namlen: 0,
+        };
+
         Self {
             closed: false,
             local_fd,
             remote_fd,
-            dirent: libc::dirent {
-                d_ino: 0,
-                d_off: 0,
-                d_reclen: 0,
-                d_type: 0,
-                d_name: [0; 256],
-            },
+            dirent,
             #[cfg(target_os = "linux")]
             dirent64: libc::dirent64 {
                 d_ino: 0,

--- a/mirrord/layer/tests/apps/issue2001/Cargo.toml
+++ b/mirrord/layer/tests/apps/issue2001/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "issue2001"
+version.workspace = true
+authors.workspace = true
+description.workspace = true
+documentation.workspace = true
+readme.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+publish.workspace = true
+edition.workspace = true
+
+[dependencies]
+libc.workspace = true

--- a/mirrord/layer/tests/apps/issue2001/src/main.rs
+++ b/mirrord/layer/tests/apps/issue2001/src/main.rs
@@ -1,0 +1,30 @@
+use std::ffi::{CStr, CString};
+
+/// Test the `readdir` and `readdir64` hooks.
+fn main() {
+    println!("test issue 2001: START");
+
+    let dir_path = CString::new("/tmp").unwrap();
+
+    unsafe {
+        let dir = libc::opendir(dir_path.into_raw() as *const _);
+
+        let dirent_1 = libc::readdir(dir);
+        let name = CStr::from_ptr((*dirent_1).d_name.as_ptr())
+            .to_str()
+            .unwrap();
+        assert_eq!(name, "file1");
+
+        #[cfg(not(target_os = "macos"))]
+        let dirent_2 = libc::readdir64(dir);
+        #[cfg(target_os = "macos")]
+        let dirent_2 = libc::readdir(dir);
+
+        let name = CStr::from_ptr((*dirent_2).d_name.as_ptr())
+            .to_str()
+            .unwrap();
+        assert_eq!(name, "file2");
+    }
+
+    println!("test issue 2001: SUCCESS");
+}

--- a/mirrord/layer/tests/apps/issue2001/src/main.rs
+++ b/mirrord/layer/tests/apps/issue2001/src/main.rs
@@ -8,8 +8,10 @@ fn main() {
 
     unsafe {
         let dir = libc::opendir(dir_path.into_raw() as *const _);
+        assert!(!dir.is_null());
 
         let dirent_1 = libc::readdir(dir);
+        assert!(!dirent_1.is_null());
         let name = CStr::from_ptr((*dirent_1).d_name.as_ptr())
             .to_str()
             .unwrap();
@@ -19,7 +21,7 @@ fn main() {
         let dirent_2 = libc::readdir64(dir);
         #[cfg(target_os = "macos")]
         let dirent_2 = libc::readdir(dir);
-
+        assert!(!dirent_2.is_null());
         let name = CStr::from_ptr((*dirent_2).d_name.as_ptr())
             .to_str()
             .unwrap();

--- a/mirrord/layer/tests/common/mod.rs
+++ b/mirrord/layer/tests/common/mod.rs
@@ -633,6 +633,7 @@ pub enum Application {
     RustIssue1776,
     RustIssue1776PortNot53,
     RustIssue1899,
+    RustIssue2001,
     RustDnsResolve,
     RustRecvFrom,
     RustListenPorts,
@@ -761,6 +762,13 @@ impl Application {
                     "../../target/debug/issue1899"
                 )
             }
+            Application::RustIssue2001 => {
+                format!(
+                    "{}/{}",
+                    env!("CARGO_MANIFEST_DIR"),
+                    "../../target/debug/issue2001"
+                )
+            }
             Application::OpenFile => format!(
                 "{}/{}",
                 env!("CARGO_MANIFEST_DIR"),
@@ -845,6 +853,7 @@ impl Application {
             | Application::RustIssue1776
             | Application::RustIssue1776PortNot53
             | Application::RustIssue1899
+            | Application::RustIssue2001
             | Application::RustDnsResolve
             | Application::RustRecvFrom
             | Application::RustListenPorts
@@ -914,6 +923,7 @@ impl Application {
             | Application::RustIssue1776
             | Application::RustIssue1776PortNot53
             | Application::RustIssue1899
+            | Application::RustIssue2001
             | Application::RustListenPorts
             | Application::RustRecvFrom
             | Application::OpenFile

--- a/mirrord/layer/tests/issue2001.rs
+++ b/mirrord/layer/tests/issue2001.rs
@@ -1,0 +1,111 @@
+#![feature(assert_matches)]
+#![warn(clippy::indexing_slicing)]
+
+use std::{path::PathBuf, time::Duration};
+
+use futures::{stream::StreamExt, SinkExt};
+use mirrord_protocol::{file::*, *};
+use rstest::rstest;
+
+mod common;
+
+pub use common::*;
+
+/// Verify that issue [#2001](https://github.com/metalbear-co/mirrord/issues/2001) is fixed.
+///
+/// Test the `readdir` (linux and macos) and `readdir64` (linux) hooks.
+#[rstest]
+#[tokio::test]
+#[timeout(Duration::from_secs(60))]
+async fn test_issue2001(
+    #[values(Application::RustIssue2001)] application: Application,
+    dylib_path: &PathBuf,
+) {
+    let (mut test_process, mut layer_connection) = application
+        .start_process_with_layer(
+            dylib_path,
+            vec![("MIRRORD_FILE_READ_WRITE_PATTERN", "/tmp")],
+            None,
+        )
+        .await;
+
+    let fd = 1;
+
+    layer_connection
+        .expect_file_open_with_options(
+            "/tmp",
+            fd,
+            OpenOptionsInternal {
+                read: true,
+                write: false,
+                append: false,
+                truncate: false,
+                create: false,
+                create_new: false,
+            },
+        )
+        .await;
+
+    assert_eq!(
+        layer_connection.codec.next().await.unwrap().unwrap(),
+        ClientMessage::FileRequest(FileRequest::FdOpenDir(FdOpenDirRequest { remote_fd: 1 }))
+    );
+
+    layer_connection
+        .codec
+        .send(DaemonMessage::File(FileResponse::OpenDir(Ok(
+            OpenDirResponse { fd: 2 },
+        ))))
+        .await
+        .unwrap();
+
+    layer_connection.expect_file_close(1).await;
+
+    assert_eq!(
+        layer_connection.codec.next().await.unwrap().unwrap(),
+        ClientMessage::FileRequest(FileRequest::ReadDir(ReadDirRequest { remote_fd: 2 })),
+    );
+
+    layer_connection
+        .codec
+        .send(DaemonMessage::File(FileResponse::ReadDir(Ok(
+            ReadDirResponse {
+                direntry: Some(DirEntryInternal {
+                    inode: 1,
+                    position: 0,
+                    name: "file1".into(),
+                    file_type: libc::DT_REG,
+                }),
+            },
+        ))))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        layer_connection.codec.next().await.unwrap().unwrap(),
+        ClientMessage::FileRequest(FileRequest::ReadDir(ReadDirRequest { remote_fd: 2 })),
+    );
+
+    layer_connection
+        .codec
+        .send(DaemonMessage::File(FileResponse::ReadDir(Ok(
+            ReadDirResponse {
+                direntry: Some(DirEntryInternal {
+                    inode: 2,
+                    position: 1,
+                    name: "file2".into(),
+                    file_type: libc::DT_REG,
+                }),
+            },
+        ))))
+        .await
+        .unwrap();
+
+    test_process.wait_assert_success().await;
+    test_process
+        .assert_stdout_contains("test issue 2001: START")
+        .await;
+    test_process
+        .assert_stdout_contains("test issue 2001: SUCCESS")
+        .await;
+}

--- a/mirrord/layer/tests/issue2001.rs
+++ b/mirrord/layer/tests/issue2001.rs
@@ -29,12 +29,10 @@ async fn test_issue2001(
         )
         .await;
 
-    let fd = 1;
-
     layer_connection
         .expect_file_open_with_options(
             "/tmp",
-            fd,
+            10,
             OpenOptionsInternal {
                 read: true,
                 write: false,
@@ -48,22 +46,22 @@ async fn test_issue2001(
 
     assert_eq!(
         layer_connection.codec.next().await.unwrap().unwrap(),
-        ClientMessage::FileRequest(FileRequest::FdOpenDir(FdOpenDirRequest { remote_fd: 1 }))
+        ClientMessage::FileRequest(FileRequest::FdOpenDir(FdOpenDirRequest { remote_fd: 10 }))
     );
 
     layer_connection
         .codec
         .send(DaemonMessage::File(FileResponse::OpenDir(Ok(
-            OpenDirResponse { fd: 2 },
+            OpenDirResponse { fd: 11 },
         ))))
         .await
         .unwrap();
 
-    layer_connection.expect_file_close(1).await;
+    layer_connection.expect_file_close(10).await;
 
     assert_eq!(
         layer_connection.codec.next().await.unwrap().unwrap(),
-        ClientMessage::FileRequest(FileRequest::ReadDir(ReadDirRequest { remote_fd: 2 })),
+        ClientMessage::FileRequest(FileRequest::ReadDir(ReadDirRequest { remote_fd: 11 })),
     );
 
     layer_connection
@@ -83,7 +81,7 @@ async fn test_issue2001(
 
     assert_eq!(
         layer_connection.codec.next().await.unwrap().unwrap(),
-        ClientMessage::FileRequest(FileRequest::ReadDir(ReadDirRequest { remote_fd: 2 })),
+        ClientMessage::FileRequest(FileRequest::ReadDir(ReadDirRequest { remote_fd: 11 })),
     );
 
     layer_connection


### PR DESCRIPTION
Closes #2001 

User application was crashing, because while opening the directory was hooked, `readdir64` - used by JVM - was not. libc was getting our opaque identifier as a pointer to `DIR` and segfaulting.
