### PR TITLE
Put exception path patterns in their own files so that we can link to them

### DIFF
--- a/changelog.d/2019.internal.md
+++ b/changelog.d/2019.internal.md
@@ -1,0 +1,1 @@
+Move path pattern default sets to separate files so that we can link to them from docs.

--- a/mirrord/layer/src/file/filter/not_found_by_default.rs
+++ b/mirrord/layer/src/file/filter/not_found_by_default.rs
@@ -1,0 +1,5 @@
+/// When running in a mode other than `local`, mirrord will make these paths under the running
+/// user's home directory be not found, unless they are covered by patterns in the
+/// `feature.fs.read_only` or `feature.fs.read_write` pattern sets (and not in the
+/// `feature.fs.not_found` set).
+pub const PATHS: [&str; 4] = [r"\.aws", r"\.config/gcloud", r"\.kube", r"\.azure"];

--- a/mirrord/layer/src/file/filter/read_local_by_default.rs
+++ b/mirrord/layer/src/file/filter/read_local_by_default.rs
@@ -64,8 +64,11 @@ pub fn regex_set_builder() -> RegexSetBuilder {
         r"^/System",
         #[cfg(target_os = "macos")]
         r"^/var/run/com.apple",
+        // Any path under the standard temp directory.
         &format!("^{}", env::temp_dir().to_string_lossy()),
+        // Any path with the current dir's whole path as a substring of its path.
         &format!("^.*{}.*$", env::current_dir().unwrap().to_string_lossy()),
+        // Any path with the current exe's whole path as a substring of its path.
         &format!("^.*{}.*$", env::current_exe().unwrap().to_string_lossy()),
         "^/$", // root
     ])

--- a/mirrord/layer/src/file/filter/read_local_by_default.rs
+++ b/mirrord/layer/src/file/filter/read_local_by_default.rs
@@ -1,0 +1,72 @@
+use std::env;
+
+use regex::RegexSetBuilder;
+
+/// This is the list of path patterns that are read locally by default in all fs modes. If you want
+/// to read or write in the cluster a path covered by those patterns, you need to include it in a
+/// pattern in the `feature.fs.read_only` or `feature.fs.read_write` configuration field,
+/// respectively.
+pub fn regex_set_builder() -> RegexSetBuilder {
+    RegexSetBuilder::new([
+        r"^.+\.so$",
+        r"^.+\.d$",
+        r"^.+\.pyc$",
+        r"^.+\.py$",
+        r"^.+\.jar$",
+        r"^.+\.js$",
+        r"^.+\.pth$",
+        r"^.+\.plist$",
+        r"^.*venv\.cfg$",
+        r"^/proc/.*$",
+        r"^/sys/.*$",
+        r"^/lib/.*$",
+        r"^/etc/.*$",
+        r"^/usr(/|$).*$",
+        r"^/home(/|$).*$",
+        r"^/bin/.*$",
+        r"^/sbin/.*$",
+        r"^/dev/.*$",
+        r"^/opt(/|$)",
+        r"^/tmp(/|$)",
+        r"^/snap/.*$",
+        // support for nixOS.
+        r"^/nix/.*$",
+        r".+\.asdf/.+",
+        r"^/home/iojs/.*$",
+        r"^/home/runner/.*$",
+        // dotnet: `/tmp/clr-debug-pipe-1`
+        r"^.*clr-.*-pipe-.*$",
+        // dotnet: `/home/{username}/{project}.pdb`
+        r"^.*\.pdb$",
+        // dotnet: `/home/{username}/{project}.dll`
+        r"^.*\.dll$",
+        // jvm.cfg or ANYTHING/jvm.cfg
+        r".*(^|/)jvm\.cfg$",
+        // TODO: `node` searches for this file in multiple directories, bypassing some of our
+        // ignore regexes, maybe other "project runners" will do the same.
+        r"^.*/package.json$",
+        // asdf
+        r".*/\.tool-versions$",
+        // macOS
+        #[cfg(target_os = "macos")]
+        "^/Volumes(/|$)",
+        #[cfg(target_os = "macos")]
+        r"^/private(/|$)",
+        #[cfg(target_os = "macos")]
+        r"^/var/folders(/|$)",
+        #[cfg(target_os = "macos")]
+        r"^/Users",
+        #[cfg(target_os = "macos")]
+        r"^/Library",
+        #[cfg(target_os = "macos")]
+        r"^/Applications",
+        #[cfg(target_os = "macos")]
+        r"^/System",
+        #[cfg(target_os = "macos")]
+        r"^/var/run/com.apple",
+        &format!("^{}", env::temp_dir().to_string_lossy()),
+        &format!("^.*{}.*$", env::current_dir().unwrap().to_string_lossy()),
+        &format!("^.*{}.*$", env::current_exe().unwrap().to_string_lossy()),
+        "^/$", // root
+    ])
+}

--- a/mirrord/layer/src/file/filter/read_remote_by_default.rs
+++ b/mirrord/layer/src/file/filter/read_remote_by_default.rs
@@ -1,0 +1,8 @@
+/// These paths will be read remotely by default when `fs.feature.mode` is set to
+/// `localwithoverrides`.
+pub const PATHS: [&str; 3] = [
+    // for dns resolving
+    r"^/etc/resolv.conf$",
+    r"^/etc/hosts$",
+    r"^/etc/hostname$",
+];


### PR DESCRIPTION
Closes #2019

Many users have difficulty using mirrord because they expect all files to be read remotely by default, and their application is trying to read a file that is in our set of exceptions to that rule. We should make it clearer to users that those exceptions exist and make it easier for them to see what they are (many users ask for that).

Having the list of exceptions on the website would be good reader experience, but that would be prone to become outdated, so I think a good compromise is to put those lists alone in their own files, and then link to those files from the documentation/FAQ/wherever.

What do you think?