### PR TITLE
Update kube dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3227,7 +3227,7 @@ checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 [[package]]
 name = "kube"
 version = "0.86.0"
-source = "git+https://github.com/Razz4780/kube?branch=support_socks5_proxy#c75200784b2a64a9c0fa4f45815f379aa41d1608"
+source = "git+https://github.com/Razz4780/kube?branch=fixes#4444211c8f70ba7ac4ad59bf089f9c5c3da38fbf"
 dependencies = [
  "k8s-openapi",
  "kube-client",
@@ -3239,7 +3239,7 @@ dependencies = [
 [[package]]
 name = "kube-client"
 version = "0.86.0"
-source = "git+https://github.com/Razz4780/kube?branch=support_socks5_proxy#c75200784b2a64a9c0fa4f45815f379aa41d1608"
+source = "git+https://github.com/Razz4780/kube?branch=fixes#4444211c8f70ba7ac4ad59bf089f9c5c3da38fbf"
 dependencies = [
  "base64 0.20.0",
  "bytes",
@@ -3278,7 +3278,7 @@ dependencies = [
 [[package]]
 name = "kube-core"
 version = "0.86.0"
-source = "git+https://github.com/Razz4780/kube?branch=support_socks5_proxy#c75200784b2a64a9c0fa4f45815f379aa41d1608"
+source = "git+https://github.com/Razz4780/kube?branch=fixes#4444211c8f70ba7ac4ad59bf089f9c5c3da38fbf"
 dependencies = [
  "chrono",
  "form_urlencoded",
@@ -3295,7 +3295,7 @@ dependencies = [
 [[package]]
 name = "kube-derive"
 version = "0.86.0"
-source = "git+https://github.com/Razz4780/kube?branch=support_socks5_proxy#c75200784b2a64a9c0fa4f45815f379aa41d1608"
+source = "git+https://github.com/Razz4780/kube?branch=fixes#4444211c8f70ba7ac4ad59bf089f9c5c3da38fbf"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -3307,7 +3307,7 @@ dependencies = [
 [[package]]
 name = "kube-runtime"
 version = "0.86.0"
-source = "git+https://github.com/Razz4780/kube?branch=support_socks5_proxy#c75200784b2a64a9c0fa4f45815f379aa41d1608"
+source = "git+https://github.com/Razz4780/kube?branch=fixes#4444211c8f70ba7ac4ad59bf089f9c5c3da38fbf"
 dependencies = [
  "ahash",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ futures = "0.3"
 thiserror = "1"
 k8s-openapi = { version = "0.20", features = ["v1_24"] }
 reqwest = { version = "0.11", default-features = false, features = ["blocking", "rustls-tls", "json"] }
-kube = { git = "https://github.com/Razz4780/kube", branch = "support_socks5_proxy", default-features = false, features = ["runtime", "derive", "client", "ws", "rustls-tls", "oidc", "socks5"] }
+kube = { git = "https://github.com/Razz4780/kube", branch = "fixes", default-features = false, features = ["runtime", "derive", "client", "ws", "rustls-tls", "oidc", "socks5"] }
 trust-dns-resolver = { version = "0.22", features = ["serde-config", "tokio-runtime"] }
 tokio-util = { version = "0.7", features = ["net", "codec"] }
 rand = "0.8"

--- a/changelog.d/+kubectl-auth-plugin.fixed.md
+++ b/changelog.d/+kubectl-auth-plugin.fixed.md
@@ -1,0 +1,1 @@
+Fixed `KUBERNETES_EXEC_INFO` environment variable passed to `kubectl` authentication plugins.


### PR DESCRIPTION
Switched `kube` dependency to [new branch](https://github.com/Razz4780/kube/tree/fixes), including both `socks5` proxy support and fix for authentication plugins