### PR TITLE
Mirrord console fix

### DIFF
--- a/changelog.d/+mirrord-console-fix.fixed.md
+++ b/changelog.d/+mirrord-console-fix.fixed.md
@@ -1,0 +1,1 @@
+Fixed logging using `mirrord-console`.

--- a/mirrord/console/src/async_logger.rs
+++ b/mirrord/console/src/async_logger.rs
@@ -68,9 +68,8 @@ impl log::Log for AsyncConsoleLogger {
 
     fn log(&self, record: &log::Record) {
         let msg = Record::from(record);
-
-        if self.tx.blocking_send(msg).is_err() {
-            eprintln!("Error sending log message: channel closed");
+        if let Err(e) = self.tx.try_send(msg) {
+            eprintln!("Error sending log message: {e}");
         }
     }
 }


### PR DESCRIPTION
Intproxy fails to send logs to `mirrord-console`, producing following output:
```
razz4780@razz4780-machine:~/MetalBear/mirrord$ ./target/debug/mirrord exec -t pod/py-serv-deployment-5fffb9767c-nvl88 --fs-mode=local -- x-terminal-emulator
⠄ mirrord exec
    ✓ Running on latest (3.74.0)!
    ✓ ready to launch process
      ✓ layer extracted
      ✓ no operator detected
      ✓ agent pod created
      ✓ pod is ready                                                                                                                                                                                  razz4780@razz4780-machine:~/MetalBear/mirrord$ ./target/debug/mirrord exec -t pod/py-serv-deployment-5fffb9767c-nvl88 --fs-mode=local -- terminator
⠠ mirrord exec
    ✓ Running on latest (3.74.0)!
    ✓ ready to launch process
      ✓ layer extracted
      ✓ no operator detected
      ✓ agent pod created
      ✓ pod is ready                                                                                                                                                                                  razz4780@razz4780-machine:~/MetalBear/mirrord$ MIRRORD_CONSOLE_ADDR=127.0.0.1:11233 ./target/debug/mirrord exec -t pod/py-serv-deployment-5fffb9767c-nvl88 --fs-mode=local -- terminator
⠁ mirrord exec
  ⠁ version check                                                                                                                                                                                     thread 'main' panicked at mirrord/console/src/async_logger.rs:72:20:
Cannot block the current thread from within a runtime. This happens because a function attempted to block the current thread while the thread is being used to drive asynchronous tasks.
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```