### PR TITLE
Remove flakey test label from mirroring_with_http integration test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2268,17 +2268,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
-name = "flaky_test"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479cde5eb168cf5a056dd98f311cbfab7494c216394e4fb9eba0336827a8db93"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "flate2"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3869,7 +3858,6 @@ dependencies = [
  "errno 0.3.5",
  "exec",
  "fancy-regex",
- "flaky_test",
  "frida-gum",
  "futures",
  "hashbrown 0.14.2",

--- a/changelog.d/1627.internal.md
+++ b/changelog.d/1627.internal.md
@@ -1,0 +1,2 @@
+Remove flakey test label from  integration test
+Remove flakey test label from mirroring_with_http integration test

--- a/changelog.d/1627.internal.md
+++ b/changelog.d/1627.internal.md
@@ -1,2 +1,1 @@
-Remove flakey test label from  integration test
 Remove flakey test label from mirroring_with_http integration test

--- a/mirrord/layer/Cargo.toml
+++ b/mirrord/layer/Cargo.toml
@@ -69,7 +69,6 @@ test-cdylib = "*"
 tower = "0.4"
 tokio = { version = "1", features = ["rt", "net", "macros"] }
 tests = { path = "../../tests" }
-flaky_test = "0.1.0"
 futures.workspace = true
 actix-codec.workspace = true
 tokio-stream.workspace = true

--- a/mirrord/layer/tests/http_mirroring.rs
+++ b/mirrord/layer/tests/http_mirroring.rs
@@ -14,14 +14,9 @@ pub use common::*;
 /// the layer, send HTTP requests and verify in the server output that the application received
 /// them. Tests the layer's communication with the agent, the bind hook, and the forwarding of
 /// mirrored traffic to the application.
-///
-/// NOTE: Flask, FastAPI mirroring tests are flaky and have been decorated with the flaky_test
-/// macro. Some speculation is that it is because of lack of mid session mirroring. flaky_test can
-/// be removed once https://github.com/metalbear-co/mirrord/pull/1887 is merged.
 #[rstest]
 #[tokio::test]
 #[timeout(Duration::from_secs(60))]
-#[flaky_test::flaky_test]
 async fn mirroring_with_http(
     #[values(
         Application::PythonFlaskHTTP,


### PR DESCRIPTION
#1627 