### PR TITLE
Fixed fork and gethostname with `MIRRORD_LAYER_TRACE_ONLY`

### DIFF
--- a/changelog.d/+layer-trace-only.fixed.md
+++ b/changelog.d/+layer-trace-only.fixed.md
@@ -1,0 +1,1 @@
+Fixed layer bugs when `MIRRORD_LAYER_TRACE_ONLY` is set.

--- a/mirrord/layer/src/detour.rs
+++ b/mirrord/layer/src/detour.rs
@@ -201,6 +201,10 @@ pub(crate) enum Bypass {
 
     /// Incoming traffic is disabled, bypass.
     DisabledIncoming,
+
+    /// Hostname should be resolved locally.
+    /// Currently this is the case only when the layer operates in the `trace only` mode.
+    LocalHostname,
 }
 
 /// [`ControlFlow`](std::ops::ControlFlow)-like enum to be used by hooks.

--- a/mirrord/layer/src/lib.rs
+++ b/mirrord/layer/src/lib.rs
@@ -328,7 +328,7 @@ fn sip_only_layer_start(mut config: LayerConfig, patch_binaries: Vec<String>) {
         not_found: None,
     };
     let debugger_ports = DebuggerPorts::from_env();
-    let setup = LayerSetup::new(config, debugger_ports);
+    let setup = LayerSetup::new(config, debugger_ports, true);
 
     SETUP.set(setup).expect("SETUP set failed");
 

--- a/mirrord/layer/src/socket/ops.rs
+++ b/mirrord/layer/src/socket/ops.rs
@@ -837,6 +837,10 @@ pub(super) fn getaddrinfo(
 
 /// Retrieves the `hostname` from the agent's `/etc/hostname` to be used by [`gethostname`]
 fn remote_hostname_string() -> Detour<CString> {
+    if crate::setup().trace_only() {
+        return Detour::Bypass(Bypass::LocalHostname);
+    }
+
     let hostname_path = PathBuf::from("/etc/hostname");
 
     let OpenFileResponse { fd } = file::ops::RemoteFile::remote_open(


### PR DESCRIPTION
`fork` and `gethostname` detours still tried to talk to the internal proxy