### PR TITLE
Don't drop mutex in child on fork_detour, fixes bug with elixir

### DIFF
--- a/changelog.d/2047.fixed.md
+++ b/changelog.d/2047.fixed.md
@@ -1,0 +1,1 @@
+Don't drop mutex in child on fork_detour, fixes bug with elixir.


### PR DESCRIPTION
Don't drop mutex in child on fork_detour, fixes bug with elixir. Closes #2047.
