### PR TITLE
Improve handling of operator-related errors

### DIFF
--- a/changelog.d/2049.fixed.md
+++ b/changelog.d/2049.fixed.md
@@ -1,0 +1,1 @@
+Improved handling of operator-related errors.

--- a/mirrord/cli/src/error.rs
+++ b/mirrord/cli/src/error.rs
@@ -43,7 +43,7 @@ pub(crate) enum InternalProxySetupError {
 
 #[derive(Debug, Error, Diagnostic)]
 pub(crate) enum CliError {
-    #[error("Failed to connect to the operator. We have found the operator and were unable to connect to it: {0}")]
+    #[error("Failed to connect to the operator, probably due to RBAC: {0}")]
     #[diagnostic(help(
         r#"
     Please check the following:

--- a/mirrord/cli/src/error.rs
+++ b/mirrord/cli/src/error.rs
@@ -55,7 +55,7 @@ pub(crate) enum CliError {
         "operator": false
     }}
 
-    Please remember that some features are supported only with mirrord operator (https://mirrord.dev/docs/teams/introduction/#supported-features).
+    Please remember that some features are supported only when using mirrord operator (https://mirrord.dev/docs/teams/introduction/#supported-features).
     {GENERAL_HELP}"#
     ))]
     OperatorConnectionFailed(String),

--- a/mirrord/cli/src/error.rs
+++ b/mirrord/cli/src/error.rs
@@ -43,19 +43,26 @@ pub(crate) enum InternalProxySetupError {
 
 #[derive(Debug, Error, Diagnostic)]
 pub(crate) enum CliError {
-    #[error("Failed to connect to the operator. We have found the operator and unable to connect to it. {0:#?}")]
+    #[error("Failed to connect to the operator. We have found the operator and were unable to connect to it: {0}")]
     #[diagnostic(help(
         r#"
     Please check the following:
     1. The operator is running and the logs are not showing any errors.
     2. You have sufficient permissions to port forward to the operator.
+
+    If you want to run without the operator, please set the following:
+    {{
+        "operator": false
+    }}
+
+    Please remember that some features are supported only with mirrord operator (https://mirrord.dev/docs/teams/introduction/#supported-features).
     {GENERAL_HELP}"#
     ))]
-    OperatorConnectionFailed(#[from] OperatorApiError),
+    OperatorConnectionFailed(String),
     #[error("Failed to connect to the operator. Someone else is stealing traffic from the requested target")]
     #[diagnostic(help(
         r#"
-    If you want to run anyway please set the following:
+    If you want to run anyway, please set the following:
     
     {{
       "feature": {{
@@ -237,8 +244,33 @@ pub(crate) enum CliError {
     ))]
     FeatureRequiresOperatorError(String),
     #[error("Feature `{feature}` is not supported in mirrord operator {operator_version}.")]
+    #[diagnostic(help("{GENERAL_HELP}"))]
     FeatureNotSupportedInOperatorError {
         feature: String,
         operator_version: String,
     },
+    #[error("Selected mirrord target is not valid: {0}")]
+    #[diagnostic(help("{GENERAL_HELP}"))]
+    InvalidTargetError(String),
+}
+
+impl From<OperatorApiError> for CliError {
+    fn from(value: OperatorApiError) -> Self {
+        match value {
+            OperatorApiError::ConcurrentStealAbort => Self::OperatorConcurrentSteal,
+            OperatorApiError::UnsupportedFeature {
+                feature,
+                operator_version,
+            } => Self::FeatureNotSupportedInOperatorError {
+                feature,
+                operator_version,
+            },
+            OperatorApiError::CreateApiError(e) => Self::KubernetesApiFailed(e),
+            OperatorApiError::InvalidTarget { reason } => Self::InvalidTargetError(reason),
+            OperatorApiError::HttpError(e) => Self::OperatorConnectionFailed(e.to_string()),
+            OperatorApiError::KubeError { error, operation } => {
+                Self::OperatorConnectionFailed(format!("{operation} failed: {error}"))
+            }
+        }
+    }
 }

--- a/mirrord/cli/src/error.rs
+++ b/mirrord/cli/src/error.rs
@@ -50,7 +50,7 @@ pub(crate) enum CliError {
     1. The operator is running and the logs are not showing any errors.
     2. You have sufficient permissions to port forward to the operator.
 
-    If you want to run without the operator, please set the following:
+    If you want to run without the operator, please set the following in the mirrord configuration file:
     {{
         "operator": false
     }}

--- a/mirrord/cli/src/operator.rs
+++ b/mirrord/cli/src/operator.rs
@@ -5,7 +5,7 @@ use mirrord_config::{
     config::{ConfigContext, MirrordConfig},
     LayerFileConfig,
 };
-use mirrord_kube::{api::kubernetes::create_kube_api, error::KubeApiError};
+use mirrord_kube::api::kubernetes::create_kube_api;
 use mirrord_operator::{
     client::OperatorApiError,
     crd::{LicenseInfoOwned, MirrordOperatorCrd, MirrordOperatorSpec, OPERATOR_STATUS_NAME},
@@ -135,9 +135,11 @@ async fn operator_status(config: Option<String>) -> Result<()> {
     let mirrord_status = match status_api
         .get(OPERATOR_STATUS_NAME)
         .await
-        .map_err(KubeApiError::KubeError)
-        .map_err(OperatorApiError::KubeApiError)
-        .map_err(CliError::OperatorConnectionFailed)
+        .map_err(|error| OperatorApiError::KubeError {
+            error,
+            operation: "getting operator status".into(),
+        })
+        .map_err(CliError::from)
     {
         Ok(status) => status,
         Err(err) => {

--- a/mirrord/operator/src/client.rs
+++ b/mirrord/operator/src/client.rs
@@ -3,11 +3,9 @@ use std::io;
 use base64::{engine::general_purpose, Engine as _};
 use futures::{SinkExt, StreamExt};
 use http::request::Request;
-use kube::{api::PostParams, error::ErrorResponse, Api, Client, Resource};
+use kube::{api::PostParams, Api, Client, Resource};
 use mirrord_analytics::{AnalyticsHash, AnalyticsOperatorProperties, AnalyticsReporter};
-use mirrord_auth::{
-    certificate::Certificate, credential_store::CredentialStoreSync, error::AuthenticationError,
-};
+use mirrord_auth::{certificate::Certificate, credential_store::CredentialStoreSync};
 use mirrord_config::{
     feature::network::incoming::ConcurrentSteal,
     target::{Target, TargetConfig},
@@ -39,33 +37,20 @@ pub enum OperatorApiError {
     InvalidTarget { reason: String },
     #[error(transparent)]
     HttpError(#[from] http::Error),
-    #[error(transparent)]
-    WsError(#[from] TungsteniteError),
-    #[error(transparent)]
-    KubeApiError(#[from] KubeApiError),
-    #[error(transparent)]
-    DecodeError(#[from] bincode::error::DecodeError),
-    #[error(transparent)]
-    EncodeError(#[from] bincode::error::EncodeError),
-    #[error("invalid message: {0:?}")]
-    InvalidMessage(Message),
-    #[error("Receiver<DaemonMessage> was dropped")]
-    DaemonReceiverDropped,
-    #[error(transparent)]
-    Authentication(#[from] AuthenticationError),
-    #[error("Can't start proccess because other locks exist on target")]
+    #[error("failed to create mirrord operator API: {0}")]
+    CreateApiError(KubeApiError),
+    #[error("{operation} failed: {error}")]
+    KubeError {
+        error: kube::Error,
+        operation: String,
+    },
+    #[error("can't start proccess because other locks exist on target")]
     ConcurrentStealAbort,
     #[error("mirrord operator {operator_version} does not support feature {feature}")]
     UnsupportedFeature {
         feature: String,
         operator_version: String,
     },
-}
-
-impl From<kube::Error> for OperatorApiError {
-    fn from(value: kube::Error) -> Self {
-        Self::KubeApiError(KubeApiError::from(value))
-    }
 }
 
 type Result<T, E = OperatorApiError> = std::result::Result<T, E>;
@@ -313,7 +298,8 @@ impl OperatorApi {
             config.kubeconfig.clone(),
             config.kube_context.clone(),
         )
-        .await?;
+        .await
+        .map_err(OperatorApiError::CreateApiError)?;
 
         let target_namespace = if target_config.path.is_some() {
             target_config.namespace.clone()
@@ -339,23 +325,23 @@ impl OperatorApi {
 
     async fn fetch_operator(&self) -> Result<Option<MirrordOperatorCrd>> {
         let api: Api<MirrordOperatorCrd> = Api::all(self.client.clone());
-        match api.get(OPERATOR_STATUS_NAME).await {
-            Ok(crd) => return Ok(Some(crd)),
-            Err(kube::Error::Api(ErrorResponse { code: 404, .. })) => {}
-            Err(e) => return Err(e.into()),
-        };
-
-        Ok(None)
+        api.get_opt(OPERATOR_STATUS_NAME)
+            .await
+            .map_err(|error| OperatorApiError::KubeError {
+                error,
+                operation: "finding operator in the cluster".into(),
+            })
     }
 
     async fn fetch_target(&self) -> Result<Option<TargetCrd>> {
         let target_name = TargetCrd::target_name_by_config(&self.target_config);
-
-        match self.target_api.get(&target_name).await {
-            Ok(target) => Ok(Some(target)),
-            Err(kube::Error::Api(ErrorResponse { code: 404, .. })) => Ok(None),
-            Err(err) => Err(err.into()),
-        }
+        self.target_api
+            .get_opt(&target_name)
+            .await
+            .map_err(|error| OperatorApiError::KubeError {
+                error,
+                operation: "finding target in the cluster".into(),
+            })
     }
 
     /// Returns a namespace of the target.
@@ -471,7 +457,14 @@ impl OperatorApi {
             }
         }
 
-        let connection = self.client.connect(builder.body(vec![])?).await?;
+        let connection = self
+            .client
+            .connect(builder.body(vec![])?)
+            .await
+            .map_err(|error| OperatorApiError::KubeError {
+                error,
+                operation: "creating a websocket connection".into(),
+            })?;
 
         let (tx, rx) =
             ConnectionWrapper::wrap(connection, session_info.metadata.protocol_version.clone());
@@ -512,8 +505,25 @@ impl OperatorApi {
         self.copy_target_api
             .create(&PostParams::default(), &requested)
             .await
-            .map_err(Into::into)
+            .map_err(|error| OperatorApiError::KubeError {
+                error,
+                operation: "copying target".into(),
+            })
     }
+}
+
+#[derive(Error, Debug)]
+enum ConnectionWrapperError {
+    #[error(transparent)]
+    DecodeError(#[from] bincode::error::DecodeError),
+    #[error(transparent)]
+    EncodeError(#[from] bincode::error::EncodeError),
+    #[error(transparent)]
+    WsError(#[from] TungsteniteError),
+    #[error("invalid message: {0:?}")]
+    InvalidMessage(Message),
+    #[error("message channel is closed")]
+    ChannelClosed,
 }
 
 pub struct ConnectionWrapper<T> {
@@ -554,7 +564,10 @@ where
         (client_tx, daemon_rx)
     }
 
-    async fn handle_client_message(&mut self, client_message: ClientMessage) -> Result<()> {
+    async fn handle_client_message(
+        &mut self,
+        client_message: ClientMessage,
+    ) -> Result<(), ConnectionWrapperError> {
         let payload = bincode::encode_to_vec(client_message, bincode::config::standard())?;
 
         self.connection.send(payload.into()).await?;
@@ -565,7 +578,7 @@ where
     async fn handle_daemon_message(
         &mut self,
         daemon_message: Result<Message, TungsteniteError>,
-    ) -> Result<()> {
+    ) -> Result<(), ConnectionWrapperError> {
         match daemon_message? {
             Message::Binary(payload) => {
                 let (daemon_message, _) = bincode::decode_from_slice::<DaemonMessage, _>(
@@ -576,13 +589,13 @@ where
                 self.daemon_tx
                     .send(daemon_message)
                     .await
-                    .map_err(|_| OperatorApiError::DaemonReceiverDropped)
+                    .map_err(|_| ConnectionWrapperError::ChannelClosed)
             }
-            message => Err(OperatorApiError::InvalidMessage(message)),
+            message => Err(ConnectionWrapperError::InvalidMessage(message)),
         }
     }
 
-    async fn start(mut self) -> Result<()> {
+    async fn start(mut self) -> Result<(), ConnectionWrapperError> {
         loop {
             tokio::select! {
                 client_message = self.client_rx.recv() => {
@@ -596,7 +609,7 @@ where
                                         "1.2.1".parse().expect("Bad static version"),
                                     ))
                                     .await
-                                    .map_err(|_| OperatorApiError::DaemonReceiverDropped)?;
+                                    .map_err(|_| ConnectionWrapperError::ChannelClosed)?;
                             }
                         }
                         Some(client_message) => self.handle_client_message(client_message).await?,


### PR DESCRIPTION
Closes #2049 

1. CLI now aborts the execution if the operator is successfully detected, but using it's API failed. Previously the CLI was simply continuing the execution without the operator. However, this may lead to various errors and be confusing to the users. When aborting execution in this case, the CLI prints an informative diagnostic message (see `CliError::OperatorConnectionFailed`).
2. Error handling needs further improvement on the operator side, because errors returned from the operator API seem to be malformed. E.g. when the user specifies a non-existent target, `kube` crate returns a very ugly `ErrorResponse` struct:

```
STATUS: 500 Internal Server Error
REASON: Failed to parse error data
CODE: 500
MESSAGE: "ApiError: pods \"py-serv-deployment-5fffb9767c-vwwglxd\" not found: NotFound (ErrorResponse { status: \"Failure\", message: \"pods \\\"py-serv-deployment-5fffb9767c-vwwglxd\\\" not found\", reason: \"NotFound\", code: 404 })"

```