### PR TITLE
Hook gethosbyname to resolve DNS for erlang/elixir.

### DIFF
--- a/changelog.d/2055.fixed.md
+++ b/changelog.d/2055.fixed.md
@@ -1,0 +1,1 @@
+Add a hook for [gethostbyname](https://www.man7.org/linux/man-pages/man3/gethostbyname.3.html) to allow erlang/elixir to resolve DNS.

--- a/mirrord/layer/src/lib.rs
+++ b/mirrord/layer/src/lib.rs
@@ -9,8 +9,6 @@
 #![feature(pointer_byte_offsets)]
 #![feature(lazy_cell)]
 #![feature(once_cell_try)]
-#![feature(vec_into_raw_parts)]
-#![feature(sync_unsafe_cell)]
 #![allow(rustdoc::private_intra_doc_links)]
 #![warn(clippy::indexing_slicing)]
 

--- a/mirrord/layer/src/socket/hooks.rs
+++ b/mirrord/layer/src/socket/hooks.rs
@@ -1,48 +1,18 @@
 use alloc::ffi::CString;
 use core::{cmp, ffi::CStr, mem};
-use std::{
-    mem::size_of,
-    net::IpAddr,
-    os::unix::io::RawFd,
-    ptr,
-    sync::{LazyLock, Mutex},
-};
+use std::{os::unix::io::RawFd, sync::LazyLock};
 
 use dashmap::DashSet;
 use errno::{set_errno, Errno};
-use libc::{
-    c_char, c_int, c_void, hostent, in_addr, size_t, sockaddr, socklen_t, ssize_t, AF_INET, EINVAL,
-};
+use libc::{c_char, c_int, c_void, hostent, size_t, sockaddr, socklen_t, ssize_t, EINVAL};
 use mirrord_layer_macro::{hook_fn, hook_guard_fn};
 
 use super::ops::*;
-use crate::{
-    detour::{Detour, DetourGuard},
-    hooks::HookManager,
-    replace,
-};
+use crate::{detour::DetourGuard, hooks::HookManager, replace};
 
 /// Here we keep addr infos that we allocated so we'll know when to use the original
 /// freeaddrinfo function and when to use our implementation
 pub(crate) static MANAGED_ADDRINFO: LazyLock<DashSet<usize>> = LazyLock::new(DashSet::new);
-
-static mut GLOBAL_HOSTENT: hostent = hostent {
-    h_name: ptr::null_mut(),
-    h_aliases: ptr::null_mut(),
-    h_addrtype: 0,
-    h_length: 0,
-    h_addr_list: ptr::null_mut(),
-};
-
-static mut GLOBAL_HOSTNAME: Option<Vec<u8>> = None;
-
-pub static mut HOST_ALIASES: Option<Vec<Vec<u8>>> = None;
-static mut _HOST_ALIASES: Option<Vec<*mut i8>> = None;
-pub static mut GLOBAL_HOST_ADDR: Option<IpAddr> = None;
-pub static mut HOST_ADDR_LIST: [*mut c_char; 2] = [ptr::null_mut(); 2];
-pub static mut _HOST_ADDR_LIST: [u8; 4] = [0u8; 4];
-static mut H_POS: usize = 0;
-pub static mut HOST_STAYOPEN: c_int = 0;
 
 #[hook_guard_fn]
 pub(crate) unsafe extern "C" fn socket_detour(
@@ -138,6 +108,12 @@ pub(crate) unsafe extern "C" fn gethostname_detour(
         .unwrap_or_bypass_with(|_| FN_GETHOSTNAME(raw_name, name_length))
 }
 
+/// Hook for `libc::gethostbyname` (you won't find this in rust's `libc` as it's been deprecated and
+/// removed).
+///
+/// Resolves DNS `raw_name` and allocates a `static` [`libc::hostent`] that we change the inner
+/// values whenever this function is called. The address itself of `*mut hostent` has to remain the
+/// same (thus why it's a `static`).
 #[hook_guard_fn]
 unsafe extern "C" fn gethostbyname_detour(raw_name: *const c_char) -> *mut hostent {
     let rawish_name = (!raw_name.is_null()).then(|| CStr::from_ptr(raw_name));

--- a/mirrord/layer/src/socket/ops.rs
+++ b/mirrord/layer/src/socket/ops.rs
@@ -947,9 +947,9 @@ pub(super) fn gethostbyname(raw_name: Option<&CStr>) -> Detour<*mut hostent> {
             },
         );
 
-    let mut aliases_ptrs = aliases
+    let mut aliases_ptrs: Vec<*const i8> = aliases
         .iter()
-        .map(|alias| alias.as_ptr() as *const i8)
+        .map(|alias| alias.as_ptr())
         .collect::<Vec<_>>();
     let mut ips_ptrs = ips.iter_mut().map(|ip| ip.as_mut_ptr()).collect::<Vec<_>>();
 

--- a/mirrord/layer/src/socket/ops.rs
+++ b/mirrord/layer/src/socket/ops.rs
@@ -908,7 +908,7 @@ pub(super) fn gethostbyname(raw_name: Option<&CStr>) -> Detour<*mut hostent> {
         .bypass(Bypass::NullNode)?
         .to_str()
         .map_err(|fail| {
-            warn!("Failed converting `node` from `CStr` with {:#?}", fail);
+            warn!("Failed converting `name` from `CStr` with {:#?}", fail);
 
             Bypass::CStrConversion
         })?
@@ -949,7 +949,7 @@ pub(super) fn gethostbyname(raw_name: Option<&CStr>) -> Detour<*mut hostent> {
 
     let mut aliases_ptrs: Vec<*const i8> = aliases
         .iter()
-        .map(|alias| alias.as_ptr())
+        .map(|alias| alias.as_ptr().cast())
         .collect::<Vec<_>>();
     let mut ips_ptrs = ips.iter_mut().map(|ip| ip.as_mut_ptr()).collect::<Vec<_>>();
 

--- a/mirrord/layer/src/socket/ops.rs
+++ b/mirrord/layer/src/socket/ops.rs
@@ -902,7 +902,7 @@ fn remote_hostname_string() -> Detour<CString> {
 /// **Safety**:
 /// See the [`GETHOSTBYNAME_ALIASES_PTR`] docs. If you see this function being called and some weird
 /// issue is going on, assume that you might've triggered the UB.
-#[tracing::instrument(level = "debug", ret)]
+#[tracing::instrument(level = "trace", ret)]
 pub(super) fn gethostbyname(raw_name: Option<&CStr>) -> Detour<*mut hostent> {
     let name: String = raw_name
         .bypass(Bypass::NullNode)?

--- a/mirrord/layer/src/socket/ops.rs
+++ b/mirrord/layer/src/socket/ops.rs
@@ -773,7 +773,7 @@ pub(super) fn remote_getaddrinfo(node: String) -> HookResult<Vec<(String, IpAddr
 ///
 /// `-layer` sends a request to `-agent` asking for the `-agent`'s list of `addrinfo`s (remote call
 /// for the equivalent of this function).
-#[tracing::instrument(level = "debug", ret)]
+#[tracing::instrument(level = "trace", ret)]
 pub(super) fn getaddrinfo(
     rawish_node: Option<&CStr>,
     rawish_service: Option<&CStr>,
@@ -834,9 +834,7 @@ pub(super) fn getaddrinfo(
 
             // Must outlive this function, as it is stored as a pointer in `libc::addrinfo`.
             let ai_addr = Box::into_raw(Box::new(unsafe { *rawish_sock_addr.as_ptr() }));
-            tracing::debug!("whats the name {name:?}");
             let ai_canonname = CString::new(name).unwrap().into_raw();
-            tracing::debug!("ai_canonname {:?}", unsafe { CStr::from_ptr(ai_canonname) });
 
             libc::addrinfo {
                 ai_flags: 0,
@@ -858,7 +856,6 @@ pub(super) fn getaddrinfo(
             raw
         })
         .reduce(|current, previous| {
-            tracing::debug!("ai_next called");
             // Safety: These pointers were just allocated using `Box::new`, so they should be
             // fine regarding memory layout, and are not dangling.
             unsafe { (*previous).ai_next = current };

--- a/mirrord/layer/src/socket/ops.rs
+++ b/mirrord/layer/src/socket/ops.rs
@@ -949,7 +949,7 @@ pub(super) fn gethostbyname(raw_name: Option<&CStr>) -> Detour<*mut hostent> {
 
     let mut aliases_ptrs = aliases
         .iter()
-        .map(|alias| alias.as_ptr())
+        .map(|alias| alias.as_ptr() as *const i8)
         .collect::<Vec<_>>();
     let mut ips_ptrs = ips.iter_mut().map(|ip| ip.as_mut_ptr()).collect::<Vec<_>>();
 

--- a/mirrord/layer/src/socket/ops.rs
+++ b/mirrord/layer/src/socket/ops.rs
@@ -886,8 +886,10 @@ fn remote_hostname_string() -> Detour<CString> {
     .map(Detour::Success)?
 }
 
-/// Resolves a hostname and set result to static global like `gethostbyname` does.
-#[tracing::instrument(level = "trace", ret)]
+/// Resolves a hostname and set result to static global like the original `gethostbyname` does.
+///
+/// Used by erlang/elixir to resolve DNS.
+#[tracing::instrument(level = "debug", ret)]
 pub(super) fn gethostbyname(raw_name: Option<&CStr>) -> Detour<*mut hostent> {
     let name: String = raw_name
         .bypass(Bypass::NullNode)?

--- a/mirrord/layer/tests/apps/gethostbyname/gethostbyname.c
+++ b/mirrord/layer/tests/apps/gethostbyname/gethostbyname.c
@@ -1,0 +1,34 @@
+#include <stdio.h>
+#include <netdb.h>
+#include <strings.h>
+#include <arpa/inet.h>
+
+void try_gethostbyname(const char name[]) {
+  struct hostent *result = gethostbyname(name);
+
+  if (result) {
+    printf("result %p\n\t", result);
+    printf("h_name %s\n\t", result->h_name);
+    printf("h_length %i\n\t", result->h_length);
+    printf("h_addrtype %i\n\t", result->h_addrtype);
+
+    for (int i = 0; result->h_addr_list[i]; i++) {
+      char str[INET6_ADDRSTRLEN];
+      struct in_addr address = {};
+      bcopy(result->h_addr_list[i], (char *)&address, sizeof(address));
+      printf("h_addresses[%i] %s\n\t", i, inet_ntoa(address));
+    }
+
+    for (int i = 0; result->h_aliases[i]; i++) {
+      printf("h_aliases[%i] %s\n\t", i, result->h_aliases[i]);
+    }
+  }
+}
+
+int main(int argc, char *argv[]) {
+  printf("test issue 2055: START\n");
+  try_gethostbyname("www.mirrord.dev");
+  try_gethostbyname("www.invalid.dev");
+  printf("test issue 2055: SUCCESS\n");
+  printf("\n");
+}

--- a/mirrord/layer/tests/common/mod.rs
+++ b/mirrord/layer/tests/common/mod.rs
@@ -651,6 +651,7 @@ pub enum Application {
     RustListenPorts,
     Fork,
     OpenFile,
+    CIssue2055,
     RustIssue2058,
     // For running applications with the executable and arguments determined at runtime.
     DynamicApp(String, Vec<String>),
@@ -787,6 +788,11 @@ impl Application {
                 env!("CARGO_MANIFEST_DIR"),
                 "tests/apps/open_file/out.c_test_app",
             ),
+            Application::CIssue2055 => format!(
+                "{}/{}",
+                env!("CARGO_MANIFEST_DIR"),
+                "tests/apps/gethostbyname/out.c_test_app",
+            ),
             Application::RustIssue2058 => String::from("tests/apps/issue2058/target/issue2058"),
             Application::DynamicApp(exe, _) => exe.clone(),
         }
@@ -877,7 +883,8 @@ impl Application {
             | Application::Go19DirBypass
             | Application::Go20DirBypass
             | Application::RustIssue2058
-            | Application::OpenFile => vec![],
+            | Application::OpenFile
+            | Application::CIssue2055 => vec![],
             Application::RustOutgoingUdp => ["--udp", RUST_OUTGOING_LOCAL, RUST_OUTGOING_PEERS]
                 .into_iter()
                 .map(Into::into)
@@ -943,6 +950,7 @@ impl Application {
             | Application::RustListenPorts
             | Application::RustRecvFrom
             | Application::OpenFile
+            | Application::CIssue2055
             | Application::DynamicApp(..) => unimplemented!("shouldn't get here"),
             Application::PythonSelfConnect => 1337,
             Application::RustIssue2058 => 1234,

--- a/mirrord/layer/tests/issue2055.rs
+++ b/mirrord/layer/tests/issue2055.rs
@@ -1,0 +1,62 @@
+#![feature(assert_matches)]
+use std::{net::IpAddr, path::PathBuf, time::Duration};
+
+use mirrord_protocol::{
+    dns::{DnsLookup, GetAddrInfoRequest, GetAddrInfoResponse, LookupRecord},
+    ClientMessage, DaemonMessage, DnsLookupError,
+    ResolveErrorKindInternal::NoRecordsFound,
+    ResponseError,
+};
+use rstest::rstest;
+
+mod common;
+pub use common::*;
+
+/// Verify that issue [#2055](https://github.com/metalbear-co/mirrord/issues/2055) is fixed.
+/// "DNS Issue on Elixir macOS"
+#[rstest]
+#[tokio::test]
+#[timeout(Duration::from_secs(60))]
+async fn issue_2055(dylib_path: &PathBuf) {
+    let application = Application::CIssue2055;
+    let (mut test_process, mut intproxy) = application
+        .start_process_with_layer(dylib_path, Default::default(), None)
+        .await;
+
+    println!("Application started, waiting for `GetAddrInfoRequest`.");
+
+    let msg = intproxy.recv().await;
+    let ClientMessage::GetAddrInfoRequest(GetAddrInfoRequest { node }) = msg else {
+        panic!("Invalid message received from layer: {msg:?}");
+    };
+
+    intproxy
+        .send(DaemonMessage::GetAddrInfoResponse(GetAddrInfoResponse(Ok(
+            DnsLookup(vec![LookupRecord {
+                name: node,
+                ip: "93.184.216.34".parse::<IpAddr>().unwrap(),
+            }]),
+        ))))
+        .await;
+
+    let msg = intproxy.recv().await;
+    let ClientMessage::GetAddrInfoRequest(GetAddrInfoRequest { node: _ }) = msg else {
+        panic!("Invalid message received from layer: {msg:?}");
+    };
+
+    intproxy
+        .send(DaemonMessage::GetAddrInfoResponse(GetAddrInfoResponse(
+            Err(ResponseError::DnsLookup(DnsLookupError {
+                kind: NoRecordsFound(3),
+            })),
+        )))
+        .await;
+
+    test_process.wait_assert_success().await;
+    test_process
+        .assert_stdout_contains("test issue 2055: START")
+        .await;
+    test_process
+        .assert_stdout_contains("test issue 2055: SUCCESS")
+        .await;
+}


### PR DESCRIPTION
- Issue: #2055 

Adds a hook for [`gethostbyname`](https://www.man7.org/linux/man-pages/man3/gethostbyname.3.html) (yeah it's deprecated).

@aviramha found out that erlang/elixir uses this when resolving DNS.

There is a potential UB in how we cast some pointers that should be `*mut _` from `*const _`, but the manual of the function says that you should do a deep copy of the `*mut hostent` pointer we pass back to the user, so this shouldn't be a problem.