### PR TITLE
Added new configuration 'use_proxy'

### DIFF
--- a/changelog.d/+use_proxy.added.md
+++ b/changelog.d/+use_proxy.added.md
@@ -1,0 +1,1 @@
+Added new configuration 'use_proxy' that lets user disable usage of http/s proxy by mirrord even when env is set

--- a/mirrord-schema.json
+++ b/mirrord-schema.json
@@ -138,7 +138,7 @@
     },
     "use_proxy": {
       "title": "use_proxy {#root-use_proxy}",
-      "description": "When disabled, mirrord will remove `HTTP/S_PROXY` env variables before doing any network requests. This is useful when the system sets a proxy but you don't want mirrord to use it. ```",
+      "description": "When disabled, mirrord will remove `HTTP[S]_PROXY` env variables before doing any network requests. This is useful when the system sets a proxy but you don't want mirrord to use it. This also applies to the mirrord process (as it just removes the env). If the remote pod sets this env, the mirrord process will still use it.",
       "type": [
         "boolean",
         "null"

--- a/mirrord-schema.json
+++ b/mirrord-schema.json
@@ -135,6 +135,14 @@
         "boolean",
         "null"
       ]
+    },
+    "use_proxy": {
+      "title": "use_proxy {#root-use_proxy}",
+      "description": "When disabled, mirrord will remove `HTTP/S_PROXY` env variables before doing any network requests. This is useful when the system sets a proxy but you don't want mirrord to use it. ```",
+      "type": [
+        "boolean",
+        "null"
+      ]
     }
   },
   "additionalProperties": false,

--- a/mirrord/agent/src/steal/connection.rs
+++ b/mirrord/agent/src/steal/connection.rs
@@ -125,7 +125,7 @@ impl TcpConnectionStealer {
             command_rx,
             clients: HashMap::with_capacity(8),
             index_allocator: Default::default(),
-            stealer: TcpListener::bind((Ipv4Addr::UNSPECIFIED, 15555)).await?,
+            stealer: TcpListener::bind((Ipv4Addr::UNSPECIFIED, 0)).await?,
             iptables: None, // Initialize on first subscription.
             write_streams: HashMap::with_capacity(8),
             read_streams: StreamMap::with_capacity(8),

--- a/mirrord/agent/src/steal/connection.rs
+++ b/mirrord/agent/src/steal/connection.rs
@@ -125,7 +125,7 @@ impl TcpConnectionStealer {
             command_rx,
             clients: HashMap::with_capacity(8),
             index_allocator: Default::default(),
-            stealer: TcpListener::bind((Ipv4Addr::UNSPECIFIED, 0)).await?,
+            stealer: TcpListener::bind((Ipv4Addr::UNSPECIFIED, 15555)).await?,
             iptables: None, // Initialize on first subscription.
             write_streams: HashMap::with_capacity(8),
             read_streams: StreamMap::with_capacity(8),

--- a/mirrord/cli/src/execution.rs
+++ b/mirrord/cli/src/execution.rs
@@ -132,6 +132,15 @@ impl MirrordExecution {
     {
         let lib_path = extract_library(None, progress, true)?;
 
+        if !config.use_proxy {
+            for (key, _val) in std::env::vars() {
+                let lower_key = key.to_lowercase();
+                if lower_key == "http_proxy" || lower_key == "https_proxy" {
+                    std::env::remove_var(key)
+                }
+            }
+        }
+
         let (connect_info, mut connection) = create_and_connect(config, progress, analytics)
             .await
             .inspect_err(|_| analytics.set_error(AnalyticsError::AgentConnection))?;

--- a/mirrord/config/src/lib.rs
+++ b/mirrord/config/src/lib.rs
@@ -305,7 +305,8 @@ pub struct LayerConfig {
     /// When disabled, mirrord will remove `HTTP[S]_PROXY` env variables before
     /// doing any network requests. This is useful when the system sets a proxy
     /// but you don't want mirrord to use it.
-    /// ```
+    /// This also applies to the mirrord process (as it just removes the env).
+    /// If the remote pod sets this env, the mirrord process will still use it.
     #[config(env = "MIRRORD_PROXY", default = true)]
     pub use_proxy: bool,
 }

--- a/mirrord/config/src/lib.rs
+++ b/mirrord/config/src/lib.rs
@@ -753,6 +753,7 @@ mod tests {
             sip_binaries: None,
             kube_context: None,
             internal_proxy: None,
+            use_proxy: None
         };
 
         assert_eq!(config, expect);

--- a/mirrord/config/src/lib.rs
+++ b/mirrord/config/src/lib.rs
@@ -302,7 +302,7 @@ pub struct LayerConfig {
 
     /// ## use_proxy {#root-use_proxy}
     ///
-    /// When disabled, mirrord will remove `HTTP/S_PROXY` env variables before
+    /// When disabled, mirrord will remove `HTTP[S]_PROXY` env variables before
     /// doing any network requests. This is useful when the system sets a proxy
     /// but you don't want mirrord to use it.
     /// ```

--- a/mirrord/config/src/lib.rs
+++ b/mirrord/config/src/lib.rs
@@ -754,7 +754,7 @@ mod tests {
             sip_binaries: None,
             kube_context: None,
             internal_proxy: None,
-            use_proxy: None
+            use_proxy: None,
         };
 
         assert_eq!(config, expect);

--- a/mirrord/config/src/lib.rs
+++ b/mirrord/config/src/lib.rs
@@ -299,6 +299,15 @@ pub struct LayerConfig {
     /// # internal_proxy {#root-internal_proxy}
     #[config(nested)]
     pub internal_proxy: InternalProxyConfig,
+
+    /// ## use_proxy {#root-use_proxy}
+    ///
+    /// When disabled, mirrord will remove `HTTP/S_PROXY` env variables before
+    /// doing any network requests. This is useful when the system sets a proxy
+    /// but you don't want mirrord to use it.
+    /// ```
+    #[config(env = "MIRRORD_PROXY", default = true)]
+    pub use_proxy: bool,
 }
 
 impl LayerConfig {


### PR DESCRIPTION
Added new configuration 'use_proxy' that lets user disable usage of http/s proxy by mirrord even when env is set.