### PR TITLE
Fix incoming TCP with multiple pods

### DIFF
--- a/changelog.d/2078.fixed.md
+++ b/changelog.d/2078.fixed.md
@@ -1,0 +1,1 @@
+Fixed issues with mirroring incoming TCP connections when targeting multi-pod deployments.

--- a/mirrord/intproxy/src/lib.rs
+++ b/mirrord/intproxy/src/lib.rs
@@ -270,6 +270,7 @@ impl IntProxy {
 
     /// Routes most messages from the agent to the correct background task.
     /// Some messages are handled here.
+    #[tracing::instrument(level = "trace", skip(self), ret)]
     async fn handle_agent_message(&mut self, message: DaemonMessage) -> Result<(), IntProxyError> {
         self.task_txs
             .ping_pong
@@ -335,6 +336,7 @@ impl IntProxy {
     }
 
     /// Routes a message from the layer to the correct background task.
+    #[tracing::instrument(level = "trace", skip(self), ret)]
     async fn handle_layer_message(&self, message: FromLayer) -> Result<(), IntProxyError> {
         let FromLayer {
             message_id,

--- a/mirrord/intproxy/src/proxies/incoming.rs
+++ b/mirrord/intproxy/src/proxies/incoming.rs
@@ -177,10 +177,7 @@ impl IncomingProxy {
     /// [`BackgroundTasks`] struct.
     const CHANNEL_SIZE: usize = 512;
 
-    /// Stores subscription request id and sends a corresponding request to the agent.
-    /// However, if a subscription for the same port already exists, this method does not make any
-    /// request to the agent. Instead, it immediately responds to the layer and starts
-    /// redirecting connections to the new listener.
+    /// Tries to register the new subscription in the [`SubscriptionsManager`].
     #[tracing::instrument(level = "trace", skip(self, message_bus))]
     async fn handle_port_subscribe(
         &mut self,
@@ -198,7 +195,7 @@ impl IncomingProxy {
         }
     }
 
-    /// Sends a request to the agent to stop sending incoming connections for the specified port.
+    /// Tries to unregister the subscription from the [`SubscriptionManager`].
     #[tracing::instrument(level = "trace", skip(self, message_bus))]
     async fn handle_port_unsubscribe(
         &mut self,

--- a/mirrord/intproxy/src/proxies/incoming/subscriptions.rs
+++ b/mirrord/intproxy/src/proxies/incoming/subscriptions.rs
@@ -1,0 +1,241 @@
+use std::{
+    collections::{hash_map::Entry, HashMap},
+    net::SocketAddr,
+};
+
+use mirrord_intproxy_protocol::{
+    IncomingResponse, LayerId, MessageId, PortSubscribe, PortUnsubscribe, ProxyToLayerMessage,
+};
+use mirrord_protocol::{ClientMessage, Port, RemoteResult, ResponseError};
+
+use super::{port_subscription_ext::PortSubscriptionExt, IncomingProxyError};
+use crate::{
+    main_tasks::{ProxyMessage, ToLayer},
+    remote_resources::RemoteResources,
+};
+
+struct Source {
+    layer: LayerId,
+    message: MessageId,
+    request: PortSubscribe,
+}
+
+struct Subscription {
+    queued_sources: Vec<Source>,
+    active_source: Source,
+    confirmed: bool,
+}
+
+impl Subscription {
+    fn new(source: Source) -> (Self, ClientMessage) {
+        let message = source.request.subscription.agent_subscribe();
+
+        (
+            Self {
+                queued_sources: Default::default(),
+                active_source: source,
+                confirmed: false,
+            },
+            message,
+        )
+    }
+
+    fn push_source(&mut self, source: Source) -> Option<ToLayer> {
+        let message = if self.confirmed {
+            // Agent already confirmed this subscription.
+            Some(ToLayer {
+                message_id: source.message,
+                layer_id: source.layer,
+                message: ProxyToLayerMessage::Incoming(IncomingResponse::PortSubscribe(Ok(()))),
+            })
+        } else {
+            // Waiting for agent confirmation.
+            None
+        };
+
+        let previous_source = std::mem::replace(&mut self.active_source, source);
+        self.queued_sources.push(previous_source);
+
+        message
+    }
+
+    fn confirm(&mut self) -> Vec<ToLayer> {
+        if self.confirmed {
+            return vec![];
+        }
+
+        self.confirmed = true;
+
+        self.queued_sources
+            .iter()
+            .chain(std::iter::once(&self.active_source))
+            .map(|source| ToLayer {
+                layer_id: source.layer,
+                message_id: source.message,
+                message: ProxyToLayerMessage::Incoming(IncomingResponse::PortSubscribe(Ok(()))),
+            })
+            .collect()
+    }
+
+    fn reject(self, reason: ResponseError) -> Result<Vec<ToLayer>, Self> {
+        if self.confirmed {
+            return Err(self);
+        }
+
+        let responses = self
+            .queued_sources
+            .into_iter()
+            .chain(std::iter::once(self.active_source))
+            .map(|source| ToLayer {
+                layer_id: source.layer,
+                message_id: source.message,
+                message: ProxyToLayerMessage::Incoming(IncomingResponse::PortSubscribe(Err(
+                    reason.clone(),
+                ))),
+            })
+            .collect();
+
+        Ok(responses)
+    }
+
+    fn remove_source(mut self, listening_on: SocketAddr) -> Result<ClientMessage, Self> {
+        let queue_size = self.queued_sources.len();
+        self.queued_sources
+            .retain(|source| source.request.listening_on != listening_on);
+        if queue_size != self.queued_sources.len() {
+            return Err(self);
+        }
+
+        if self.active_source.request.listening_on != listening_on {
+            return Err(self);
+        }
+
+        match self.queued_sources.pop() {
+            Some(next_in_queue) => {
+                self.active_source = next_in_queue;
+                Err(self)
+            }
+            None => Ok(self
+                .active_source
+                .request
+                .subscription
+                .wrap_agent_unsubscribe()),
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct SubscriptionsManager {
+    remote_ports: RemoteResources<(Port, SocketAddr)>,
+    subscriptions: HashMap<Port, Subscription>,
+}
+
+impl SubscriptionsManager {
+    pub fn get(&self, port: Port) -> Option<&PortSubscribe> {
+        self.subscriptions
+            .get(&port)
+            .map(|sub| &sub.active_source.request)
+    }
+
+    pub fn layer_subscribed(
+        &mut self,
+        layer_id: LayerId,
+        message_id: MessageId,
+        request: PortSubscribe,
+    ) -> Option<ProxyMessage> {
+        self.remote_ports.add(
+            layer_id,
+            (request.subscription.port(), request.listening_on),
+        );
+
+        let port = request.subscription.port();
+        let source = Source {
+            layer: layer_id,
+            message: message_id,
+            request,
+        };
+
+        match self.subscriptions.entry(port) {
+            Entry::Occupied(mut e) => e.get_mut().push_source(source).map(ProxyMessage::ToLayer),
+            Entry::Vacant(e) => {
+                let (subscription, message) = Subscription::new(source);
+                e.insert(subscription);
+                Some(ProxyMessage::ToAgent(message))
+            }
+        }
+    }
+
+    pub fn layer_unsubscribed(
+        &mut self,
+        layer_id: LayerId,
+        request: PortUnsubscribe,
+    ) -> Option<ClientMessage> {
+        let closed_in_all_forks = self
+            .remote_ports
+            .remove(layer_id, (request.port, request.listening_on));
+        if !closed_in_all_forks {
+            return None;
+        }
+
+        let Some(subscription) = self.subscriptions.remove(&request.port) else {
+            return None;
+        };
+
+        match subscription.remove_source(request.listening_on) {
+            Ok(message) => Some(message),
+            Err(subscription) => {
+                self.subscriptions.insert(request.port, subscription);
+                None
+            }
+        }
+    }
+
+    pub fn agent_responded(
+        &mut self,
+        result: RemoteResult<Port>,
+    ) -> Result<Vec<ToLayer>, IncomingProxyError> {
+        match result {
+            Ok(port) => {
+                let Some(subscription) = self.subscriptions.get_mut(&port) else {
+                    return Ok(vec![]);
+                };
+
+                Ok(subscription.confirm())
+            }
+            Err(ResponseError::PortAlreadyStolen(port)) => {
+                let Some(subscription) = self.subscriptions.remove(&port) else {
+                    return Ok(vec![]);
+                };
+
+                match subscription.reject(ResponseError::PortAlreadyStolen(port)) {
+                    Ok(responses) => Ok(responses),
+                    Err(subscription) => {
+                        self.subscriptions.insert(port, subscription);
+                        Ok(vec![])
+                    }
+                }
+            }
+            Err(err) => Err(IncomingProxyError::SubscriptionFailed(err)),
+        }
+    }
+
+    pub fn layer_closed(&mut self, layer_id: LayerId) -> Vec<ClientMessage> {
+        self.remote_ports
+            .remove_all(layer_id)
+            .filter_map(|(port, listening_on)| {
+                let subscription = self.subscriptions.remove(&port)?;
+                match subscription.remove_source(listening_on) {
+                    Ok(message) => Some(message),
+                    Err(subscription) => {
+                        self.subscriptions.insert(port, subscription);
+                        None
+                    }
+                }
+            })
+            .collect()
+    }
+
+    pub fn layer_forked(&mut self, parent: LayerId, child: LayerId) {
+        self.remote_ports.clone_all(parent, child);
+    }
+}

--- a/mirrord/intproxy/src/remote_resources.rs
+++ b/mirrord/intproxy/src/remote_resources.rs
@@ -30,16 +30,18 @@ where
     /// Used when the layer opens a resource, e.g. with
     /// [`OpenFileRequest`](mirrord_protocol::file::OpenFileRequest).
     pub fn add(&mut self, layer_id: LayerId, resource: T) {
-        self.by_layer
+        let added = self.by_layer
             .entry(layer_id)
             .or_default()
             .insert(resource.clone());
 
-        *self.counts.entry(resource).or_default() += 1;
+        if added {
+            *self.counts.entry(resource).or_default() += 1;
+        }
     }
 
     /// Removes the given resource from the layer instance with the given [`LayerId`].
-    /// Returns whether the resource should be closed on the agent size.
+    /// Returns whether the resource should be closed on the agent side.
     ///
     /// Can be used when the layer closes the resource, e.g. with
     /// [`CloseFileRequest`](mirrord_protocol::file::CloseFileRequest).

--- a/mirrord/intproxy/src/remote_resources.rs
+++ b/mirrord/intproxy/src/remote_resources.rs
@@ -30,7 +30,8 @@ where
     /// Used when the layer opens a resource, e.g. with
     /// [`OpenFileRequest`](mirrord_protocol::file::OpenFileRequest).
     pub fn add(&mut self, layer_id: LayerId, resource: T) {
-        let added = self.by_layer
+        let added = self
+            .by_layer
             .entry(layer_id)
             .or_default()
             .insert(resource.clone());

--- a/mirrord/layer/src/socket.rs
+++ b/mirrord/layer/src/socket.rs
@@ -175,6 +175,7 @@ impl UserSocket {
         {
             let _ = common::make_proxy_request_no_response(PortUnsubscribe {
                 port: bound.requested_address.port(),
+                listening_on: bound.address,
             });
         }
     }


### PR DESCRIPTION
Closes #2078 

## Notable change in logic

Before layer tokio removal PR, TCP subscription failure always terminated user's app. As part of the refactor I changed this behavior to returning regular errors from the `listen` hook. Given the problem described in issue description (intproxy receives multiple responses to a single subscription request) and that most of the time `mirrord_protocol::error::ResponseError` cannot be tracked back to the subscription request, this PR partially restores the previous behavior:

1. Layer makes a subscription request to intproxy.
2. Intproxy makes a subscription request to the agent/s.
3. Intproxy receives the first subscription result. It is either `Ok(port)`, `Err(PortAlreadyStolen(port))` or `Err(some_other_error)`. The first two variants trigger a response to the layer. The last variant terminates intproxy with an error, as we don't know the port. 
4. Intproxy receives subsequent subscription results. First two variants are ignored if they mention port which was already handled. The last variant terminates intproxy.