### PR TITLE
Fixed config verification in IDEs with 'copy_target' feature

### DIFF
--- a/changelog.d/+fix-verification.fixed.md
+++ b/changelog.d/+fix-verification.fixed.md
@@ -1,0 +1,1 @@
+Fixed config verification in IDE context when `copy_target` feature is used.

--- a/mirrord/config/src/config.rs
+++ b/mirrord/config/src/config.rs
@@ -58,7 +58,7 @@ pub type Result<T, E = ConfigError> = std::result::Result<T, E>;
 /// Struct used for storing context during building of configuration.
 #[derive(Default)]
 pub struct ConfigContext {
-    /// Are we in a IDE context?
+    /// Are we in an IDE context?
     ///
     /// Used by `Config::verify` to change some errors into warnings.
     pub ide: bool,

--- a/mirrord/config/src/lib.rs
+++ b/mirrord/config/src/lib.rs
@@ -442,7 +442,8 @@ impl LayerConfig {
                 ));
             }
 
-            if self.target.path.is_none() {
+            // Target may also be set later in the UI.
+            if self.target.path.is_none() && !context.ide {
                 return Err(ConfigError::Conflict(
                     "The copy target feature is not compatible with a targetless agent, \
                     please either disable this option or specify a target."


### PR DESCRIPTION
Very small change - handled the same way as other potential errors related to `target` (see logic above in the same function)

Closes https://github.com/metalbear-co/mirrord-intellij/issues/208
Closes https://github.com/metalbear-co/mirrord-vscode/issues/85