### PR TITLE
Make operator config optional

### DIFF
--- a/changelog.d/+operator-bogus-errors.fixed.md
+++ b/changelog.d/+operator-bogus-errors.fixed.md
@@ -1,0 +1,1 @@
+Changed `operator` config to be optional. If the option is set to `true`, mirrord always uses the operator and aborts in case of failure. If the option is set to `false`, mirrord does not attempt to use the operator. If the option is not set at all, mirrord attempts to use the operator, but does not abort in case it could not be found.

--- a/mirrord-schema.json
+++ b/mirrord-schema.json
@@ -71,7 +71,7 @@
     },
     "operator": {
       "title": "operator {#root-operator}",
-      "description": "Allow to lookup if operator is installed on cluster and use it.\n\nDefaults to `true`.",
+      "description": "Whether mirrord should use the operator. If not set, mirrord will first attempt to use the operator, but continue without it in case of failure.",
       "type": [
         "boolean",
         "null"

--- a/mirrord/cli/src/connection.rs
+++ b/mirrord/cli/src/connection.rs
@@ -25,8 +25,9 @@ trait OperatorApiErrorExt {
 impl OperatorApiErrorExt for OperatorApiError {
     fn should_abort_cli(&self) -> bool {
         match self {
-            Self::KubeError { .. } => false, /* This can happen due to RBAC if the operator is
-                                               * not installed. */
+            // Various kube errors can happen due to RBAC if the operator is not installed.
+            Self::KubeError { .. } => false,
+            // These should either never happen or can happen only if the operator is installed.
             Self::ConcurrentStealAbort
             | Self::ConnectRequestBuildError(..)
             | Self::CreateApiError(..)

--- a/mirrord/cli/src/connection.rs
+++ b/mirrord/cli/src/connection.rs
@@ -25,8 +25,8 @@ trait OperatorApiErrorExt {
 impl OperatorApiErrorExt for OperatorApiError {
     fn should_abort_cli(&self) -> bool {
         match self {
-            Self::KubeError { .. } => false, /* This can happen due to RBAC if the operator is */
-            // not installed.
+            Self::KubeError { .. } => false, /* This can happen due to RBAC if the operator is
+                                               * not installed. */
             Self::ConcurrentStealAbort
             | Self::ConnectRequestBuildError(..)
             | Self::CreateApiError(..)

--- a/mirrord/cli/src/connection.rs
+++ b/mirrord/cli/src/connection.rs
@@ -73,10 +73,7 @@ where
             }
             Err(e) if config.operator == Some(true) || e.should_abort_cli() => return Err(e.into()),
             Err(e) => {
-                subtask.warning(&format!(
-                    "connecting failed, proceeding without the operator"
-                ));
-                subtask.failure(Some(&e.to_string()))
+                subtask.failure(Some(&format!("connecting to the operator failed: {e}")));
             }
         }
     }

--- a/mirrord/cli/src/connection.rs
+++ b/mirrord/cli/src/connection.rs
@@ -4,7 +4,7 @@ use mirrord_analytics::AnalyticsReporter;
 use mirrord_config::{feature::network::outgoing::OutgoingFilterConfig, LayerConfig};
 use mirrord_intproxy::agent_conn::AgentConnectInfo;
 use mirrord_kube::api::{kubernetes::KubernetesAPI, AgentManagment};
-use mirrord_operator::client::OperatorApi;
+use mirrord_operator::client::{OperatorApi, OperatorApiError};
 use mirrord_progress::Progress;
 use mirrord_protocol::{ClientMessage, DaemonMessage};
 use tokio::sync::mpsc;
@@ -14,6 +14,26 @@ use crate::{CliError, Result};
 pub(crate) struct AgentConnection {
     pub sender: mpsc::Sender<ClientMessage>,
     pub receiver: mpsc::Receiver<DaemonMessage>,
+}
+
+trait OperatorApiErrorExt {
+    /// Whether this error should abort the execution, even if the user did not specify whether to
+    /// use the operator or not.
+    fn should_abort_cli(&self) -> bool;
+}
+
+impl OperatorApiErrorExt for OperatorApiError {
+    fn should_abort_cli(&self) -> bool {
+        match self {
+            Self::KubeError { .. } => false, /* This can happen due to RBAC if the operator is */
+            // not installed.
+            Self::ConcurrentStealAbort
+            | Self::ConnectRequestBuildError(..)
+            | Self::CreateApiError(..)
+            | Self::InvalidTarget { .. }
+            | Self::UnsupportedFeature { .. } => true,
+        }
+    }
 }
 
 /// Creates an agent if needed then connects to it.
@@ -37,11 +57,11 @@ where
         }
     }
 
-    if config.operator {
+    if config.operator != Some(false) {
         let mut subtask = progress.subtask("checking operator");
 
-        match OperatorApi::create_session(config, &subtask, analytics).await? {
-            Some(session) => {
+        match OperatorApi::create_session(config, &subtask, analytics).await {
+            Ok(session) => {
                 subtask.success(Some("connected to the operator"));
                 return Ok((
                     AgentConnectInfo::Operator(session.info),
@@ -51,7 +71,13 @@ where
                     },
                 ));
             }
-            None => subtask.success(Some("no operator detected")),
+            Err(e) if config.operator == Some(true) || e.should_abort_cli() => return Err(e.into()),
+            Err(e) => {
+                subtask.warning(&format!(
+                    "connecting failed, proceeding without the operator"
+                ));
+                subtask.failure(Some(&e.to_string()))
+            }
         }
     }
 

--- a/mirrord/config/src/lib.rs
+++ b/mirrord/config/src/lib.rs
@@ -227,11 +227,11 @@ pub struct LayerConfig {
 
     /// ## operator {#root-operator}
     ///
-    /// Allow to lookup if operator is installed on cluster and use it.
-    ///
-    /// Defaults to `true`.
+    /// Whether mirrord should use the operator.
+    /// If not set, mirrord will first attempt to use the operator, but continue without it in case
+    /// of failure.
     #[config(env = "MIRRORD_OPERATOR_ENABLE", default = true)]
-    pub operator: bool,
+    pub operator: Option<bool>,
 
     /// ## kubeconfig {#root-kubeconfig}
     ///
@@ -434,7 +434,7 @@ impl LayerConfig {
         }
 
         if self.feature.copy_target.enabled {
-            if !self.operator {
+            if self.operator == Some(false) {
                 return Err(ConfigError::Conflict(
                     "The copy target feature requires a mirrord operator, \
                    please either disable this option or use the operator."

--- a/mirrord/config/src/lib.rs
+++ b/mirrord/config/src/lib.rs
@@ -230,7 +230,7 @@ pub struct LayerConfig {
     /// Whether mirrord should use the operator.
     /// If not set, mirrord will first attempt to use the operator, but continue without it in case
     /// of failure.
-    #[config(env = "MIRRORD_OPERATOR_ENABLE", default = true)]
+    #[config(env = "MIRRORD_OPERATOR_ENABLE")]
     pub operator: Option<bool>,
 
     /// ## kubeconfig {#root-kubeconfig}


### PR DESCRIPTION
`LayerConfig::operator` is now an `Option` - if the user is not explicit about the operator, try to use it but don't fail on errors that may occur when the operator is not installed