### PR TITLE
Fix intproxy timeouts with lengthy build tools

### DIFF
--- a/changelog.d/2101.fixed.md
+++ b/changelog.d/2101.fixed.md
@@ -1,0 +1,1 @@
+Fixed an issue with internal proxy timing out when the user application spawns lengthy build processes.

--- a/mirrord/layer/src/lib.rs
+++ b/mirrord/layer/src/lib.rs
@@ -65,7 +65,7 @@
 extern crate alloc;
 extern crate core;
 
-use std::{cmp::Ordering, ffi::OsString, panic, sync::OnceLock, time::Duration};
+use std::{cmp::Ordering, ffi::OsString, panic, sync::OnceLock, time::Duration, net::SocketAddr};
 
 use ctor::ctor;
 use error::{LayerError, Result};
@@ -184,14 +184,35 @@ fn layer_pre_initialization() -> Result<(), LayerError> {
         }
     }
 
-    match given_process.load_type(config) {
-        LoadType::Full(config) => layer_start(*config),
+    match given_process.load_type(&config) {
+        LoadType::Full => layer_start(config),
         #[cfg(target_os = "macos")]
-        LoadType::SIPOnly(config) => sip_only_layer_start(*config, patch_binaries),
-        LoadType::Skip => {}
+        LoadType::SIPOnly => sip_only_layer_start(config, patch_binaries),
+        LoadType::Skip => load_only_layer_start(config),
     }
 
     Ok(())
+}
+
+fn load_only_layer_start(config: LayerConfig) {
+    let address: SocketAddr = config
+        .connect_tcp
+        .as_ref()
+        .expect("missing internal proxy address")
+        .parse()
+        .expect("failed to parse internal proxy address");
+
+    let new_connection =
+        ProxyConnection::new(address, NewSessionRequest::New, Duration::from_secs(5))
+            .expect("failed to initialize proxy connection");
+
+    unsafe {
+        // SAFETY
+        // Called only from library constructor.
+        PROXY_CONNECTION
+            .set(new_connection)
+            .expect("setting PROXY_CONNECTION singleton")
+    }
 }
 
 /// The one true start of mirrord-layer.

--- a/mirrord/layer/src/load.rs
+++ b/mirrord/layer/src/load.rs
@@ -152,7 +152,8 @@ pub enum LoadType {
     #[cfg(target_os = "macos")]
     SIPOnly,
 
-    /// Skip on current process, make only a dummy connection to the internal proxy (to prevent timeouts)
+    /// Skip on current process, make only a dummy connection to the internal proxy (to prevent
+    /// timeouts)
     Skip,
 }
 

--- a/mirrord/layer/src/load.rs
+++ b/mirrord/layer/src/load.rs
@@ -97,7 +97,7 @@ impl ExecutableName {
     }
 
     /// Determine the [`LoadType`] for this process.
-    pub fn load_type(&self, config: LayerConfig) -> LoadType {
+    pub fn load_type(&self, config: &LayerConfig) -> LoadType {
         let skip_processes = config
             .skip_processes
             .as_ref()
@@ -106,12 +106,12 @@ impl ExecutableName {
 
         if self.should_load(skip_processes, config.skip_build_tools) {
             trace!("Loading into process: {self}.");
-            LoadType::Full(Box::new(config))
+            LoadType::Full
         } else {
             #[cfg(target_os = "macos")]
             if sip::is_sip_only(self) {
                 trace!("Loading into process: {self}, but only hooking exec/spawn.");
-                return LoadType::SIPOnly(Box::new(config));
+                return LoadType::SIPOnly;
             }
 
             trace!("Not loading into process: {self}.");
@@ -146,12 +146,13 @@ mod sip {
 /// Load Type of mirrord-layer
 pub enum LoadType {
     /// Mirrord is loaded fully and layer should connect to agent
-    Full(Box<LayerConfig>),
+    Full,
+
     /// Only load sip patch required hooks
     #[cfg(target_os = "macos")]
-    SIPOnly(Box<LayerConfig>),
+    SIPOnly,
 
-    /// Skip on current process
+    /// Skip on current process, make only a dummy connection to the internal proxy (to prevent timeouts)
     Skip,
 }
 


### PR DESCRIPTION
Closes #2101 

The layer now initializes a new session with the internal proxy with every load (full, skipped, sip-only).
This could be further optimized by leaking the TCP socket descriptor across execs (no default CLOEXEC) and making the connection only once (storing the flag in env). However, the assumption that processes wouldn't close this descriptor brings us back to the first proposed solution. Not sure about it