### PR TITLE
Fixes go syscallN being broken for mmap (and adds a few more file system sycalls for go).

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3980,6 +3980,7 @@ dependencies = [
  "serde_json",
  "socket2 0.5.5",
  "streammap-ext",
+ "syscalls",
  "test-cdylib",
  "tests",
  "thiserror",
@@ -6096,6 +6097,16 @@ dependencies = [
  "quote",
  "syn 1.0.109",
  "unicode-xid",
+]
+
+[[package]]
+name = "syscalls"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56b389b38331a454883a34fd19f25cbd1510b3510ff7aa28cb8d6de85d888439"
+dependencies = [
+ "serde",
+ "serde_repr",
 ]
 
 [[package]]

--- a/changelog.d/2099.fixed.md
+++ b/changelog.d/2099.fixed.md
@@ -1,0 +1,1 @@
+Uses the `syscalls` crate to handle calling the syscalls for go. And adds `pwrite64`, `pread64`, `fsync` and `fdatasync` hooks for go.

--- a/mirrord/layer/Cargo.toml
+++ b/mirrord/layer/Cargo.toml
@@ -52,6 +52,7 @@ bimap.workspace = true
 dashmap = "5.4"
 hashbrown = "0.14"
 exec.workspace = true
+syscalls = { version = "0.6", features = ["full"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 mirrord-sip = { path = "../sip" }

--- a/mirrord/layer/src/go/linux_aarch64.rs
+++ b/mirrord/layer/src/go/linux_aarch64.rs
@@ -7,31 +7,6 @@ use crate::{go::c_abi_syscall6_handler, macros::hook_symbol, HookManager};
 type VoidFn = unsafe extern "C" fn() -> ();
 static mut FN_ASMCGOCALL: Option<VoidFn> = None;
 
-/// [Naked function] 6 param version, used by Rawsyscall & Syscall
-#[naked]
-pub(crate) unsafe extern "C" fn syscall_6(
-    syscall: i64,
-    param1: i64,
-    param2: i64,
-    param3: i64,
-    param4: i64,
-    param5: i64,
-    param6: i64,
-) -> i64 {
-    asm!(
-        "mov    x8, x0",
-        "mov    x0, x1",
-        "mov    x1, x2",
-        "mov    x2, x3",
-        "mov    x3, x4",
-        "mov    x4, x5",
-        "mov    x5, x6",
-        "svc 0x0",
-        "ret",
-        options(noreturn)
-    )
-}
-
 /// asmcgocall can only pass a pointer argument, so it sends us the SP
 /// which layouts to this struct.
 #[repr(C)]

--- a/mirrord/layer/src/go/mod.rs
+++ b/mirrord/layer/src/go/mod.rs
@@ -17,7 +17,6 @@ use crate::{close_detour, file::hooks::*, socket::hooks::*};
 )]
 pub(crate) mod go_hooks;
 
-use go_hooks::syscall_6;
 /// Syscall & Syscall6 handler - supports upto 6 params, mainly used for
 /// accept4 Note: Depending on success/failure Syscall may or may not call this handler
 #[no_mangle]
@@ -34,7 +33,7 @@ unsafe extern "C" fn c_abi_syscall6_handler(
         "c_abi_syscall6_handler: syscall={} param1={} param2={} param3={} param4={} param5={} param6={}",
         syscall, param1, param2, param3, param4, param5, param6
     );
-    let res = match syscall {
+    let syscall_result = match syscall {
         libc::SYS_accept4 => {
             accept4_detour(param1 as _, param2 as _, param3 as _, param4 as _) as i64
         }
@@ -75,9 +74,23 @@ unsafe extern "C" fn c_abi_syscall6_handler(
                 libc::SYS_newfstatat => {
                     fstatat_logic(param1 as _, param2 as _, param3 as _, param4 as _)
                         .unwrap_or_bypass_with(|_| {
-                            syscall_6(syscall, param1, param2, param3, param4, param5, param6)
-                                .try_into()
-                                .unwrap()
+                            let (Ok(result) | Err(result)) = syscalls::syscall!(
+                                syscalls::Sysno::from(syscall as i32),
+                                param1,
+                                param2,
+                                param3,
+                                param4,
+                                param5,
+                                param6
+                            )
+                            .map(|success| success as i64)
+                            .map_err(|fail| {
+                                let raw_errno = fail.into_raw();
+                                errno::set_errno(errno::Errno(raw_errno));
+
+                                -(raw_errno as i64)
+                            });
+                            result as i32
                         })
                         .into()
                 }
@@ -85,13 +98,52 @@ unsafe extern "C" fn c_abi_syscall6_handler(
                 libc::SYS_getdents64 => {
                     getdents64_detour(param1 as _, param2 as _, param3 as _) as i64
                 }
-                _ => syscall_6(syscall, param1, param2, param3, param4, param5, param6),
+                _ => {
+                    let (Ok(result) | Err(result)) = syscalls::syscall!(
+                        syscalls::Sysno::from(syscall as i32),
+                        param1,
+                        param2,
+                        param3,
+                        param4,
+                        param5,
+                        param6
+                    )
+                    .map(|success| success as i64)
+                    .map_err(|fail| {
+                        let raw_errno = fail.into_raw();
+                        errno::set_errno(errno::Errno(raw_errno));
+
+                        -(raw_errno as i64)
+                    });
+                    result
+                }
             }
         }
-        _ => syscall_6(syscall, param1, param2, param3, param4, param5, param6),
+        _ => {
+            let (Ok(result) | Err(result)) = syscalls::syscall!(
+                syscalls::Sysno::from(syscall as i32),
+                param1,
+                param2,
+                param3,
+                param4,
+                param5,
+                param6
+            )
+            .map(|success| success as i64)
+            .map_err(|fail| {
+                let raw_errno = fail.into_raw();
+                errno::set_errno(errno::Errno(raw_errno));
+
+                -(raw_errno as i64)
+            });
+            result
+        }
     };
-    match res {
-        -1 => -errno().0 as i64,
-        _ => res,
+
+    if syscall_result.is_negative() {
+        // Might not be an exact mapping, but it should be good enough.
+        -errno().0 as i64
+    } else {
+        syscall_result
     }
 }

--- a/mirrord/layer/src/go/mod.rs
+++ b/mirrord/layer/src/go/mod.rs
@@ -47,7 +47,13 @@ unsafe extern "C" fn c_abi_syscall6_handler(
         _ if crate::setup().fs_config().is_active() => {
             match syscall {
                 libc::SYS_read => read_detour(param1 as _, param2 as _, param3 as _) as i64,
+                libc::SYS_pread64 => {
+                    pread_detour(param1 as _, param2 as _, param3 as _, param4 as _) as i64
+                }
                 libc::SYS_write => write_detour(param1 as _, param2 as _, param3 as _) as i64,
+                libc::SYS_pwrite64 => {
+                    pwrite_detour(param1 as _, param2 as _, param3 as _, param4 as _) as i64
+                }
                 libc::SYS_lseek => lseek_detour(param1 as _, param2 as _, param3 as _),
                 // Note(syscall_linux.go)
                 // if flags == 0 {
@@ -94,6 +100,9 @@ unsafe extern "C" fn c_abi_syscall6_handler(
                         })
                         .into()
                 }
+                libc::SYS_fstat => fstat_detour(param1 as _, param2 as _) as i64,
+                libc::SYS_fsync => fsync_detour(param1 as _) as i64,
+                libc::SYS_fdatasync => fsync_detour(param1 as _) as i64,
                 libc::SYS_openat => openat_detour(param1 as _, param2 as _, param3 as _) as i64,
                 libc::SYS_getdents64 => {
                     getdents64_detour(param1 as _, param2 as _, param3 as _) as i64


### PR DESCRIPTION
- Issue: #2099

Does not solve the issue itself, instead this allow mirrord to work with a boltdb app when the db file is bypassed.

Uses the [`syscalls`](https://docs.rs/syscalls/latest/syscalls/) crate to handle calling the syscalls for go.

Adds `pwrite64`, `pread64`, `fsync` and `fdatasync` hooks for go; found these out while testing a boltdb app with mirrord.

```go
package main

import (
	"C"
	bolt "go.etcd.io/bbolt"
)

func main() {
	db, err := bolt.Open("/tmp/mirrord.db", 0600, nil)

	if err != nil {
		print("bolt.Open: ")
		println(err.Error())
	} else {
		println(db)
		println("done!")
	}
}
```