### PR TITLE
Remove confusing operator error (when user does not specify `config.operator`)

### DIFF
--- a/changelog.d/2115.fixed.md
+++ b/changelog.d/2115.fixed.md
@@ -1,0 +1,1 @@
+Removed confusing error from `mirrord exec` progress.

--- a/mirrord/cli/src/operator.rs
+++ b/mirrord/cli/src/operator.rs
@@ -7,7 +7,7 @@ use mirrord_config::{
 };
 use mirrord_kube::api::kubernetes::create_kube_api;
 use mirrord_operator::{
-    client::OperatorApiError,
+    client::{OperatorApiError, OperatorOperation},
     crd::{LicenseInfoOwned, MirrordOperatorCrd, MirrordOperatorSpec, OPERATOR_STATUS_NAME},
     setup::{LicenseType, Operator, OperatorNamespace, OperatorSetup, SetupOptions},
 };
@@ -138,7 +138,7 @@ async fn operator_status(config: Option<String>) -> Result<()> {
         .await
         .map_err(|error| OperatorApiError::KubeError {
             error,
-            operation: "getting operator status".into(),
+            operation: OperatorOperation::GettingStatus,
         })
         .map_err(CliError::from)
     {

--- a/mirrord/operator/src/client.rs
+++ b/mirrord/operator/src/client.rs
@@ -1,4 +1,7 @@
-use std::io;
+use std::{
+    fmt::{self, Display},
+    io,
+};
 
 use base64::{engine::general_purpose, Engine as _};
 use chrono::{DateTime, Utc};
@@ -36,6 +39,29 @@ static CONNECTION_CHANNEL_SIZE: usize = 1000;
 
 pub use http::Error as HttpError;
 
+#[derive(Debug)]
+pub enum OperatorOperation {
+    FindingOperator,
+    FindingTarget,
+    WebsocketConnection,
+    CopyingTarget,
+    GettingStatus,
+}
+
+impl Display for OperatorOperation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let as_str = match self {
+            Self::FindingOperator => "finding operator",
+            Self::FindingTarget => "finding target",
+            Self::WebsocketConnection => "creating a websocket connection",
+            Self::CopyingTarget => "copying target",
+            Self::GettingStatus => "getting status",
+        };
+
+        f.write_str(as_str)
+    }
+}
+
 #[derive(Debug, Error)]
 pub enum OperatorApiError {
     #[error("invalid target: {reason}")]
@@ -47,7 +73,7 @@ pub enum OperatorApiError {
     #[error("{operation} failed: {error}")]
     KubeError {
         error: kube::Error,
-        operation: String,
+        operation: OperatorOperation,
     },
     #[error("can't start proccess because other locks exist on target")]
     ConcurrentStealAbort,
@@ -349,7 +375,7 @@ impl OperatorApi {
             .await
             .map_err(|error| OperatorApiError::KubeError {
                 error,
-                operation: "finding operator in the cluster".into(),
+                operation: OperatorOperation::FindingOperator,
             })
     }
 
@@ -362,7 +388,7 @@ impl OperatorApi {
             .await
             .map_err(|error| OperatorApiError::KubeError {
                 error,
-                operation: "finding target in the cluster".into(),
+                operation: OperatorOperation::FindingTarget,
             })
     }
 
@@ -491,7 +517,7 @@ impl OperatorApi {
                 .await
                 .map_err(|error| OperatorApiError::KubeError {
                     error,
-                    operation: "creating a websocket connection".into(),
+                    operation: OperatorOperation::WebsocketConnection,
                 })?;
 
         let (tx, rx) =
@@ -535,7 +561,7 @@ impl OperatorApi {
             .await
             .map_err(|error| OperatorApiError::KubeError {
                 error,
-                operation: "copying target".into(),
+                operation: OperatorOperation::CopyingTarget,
             })
     }
 }

--- a/mirrord/operator/src/client.rs
+++ b/mirrord/operator/src/client.rs
@@ -39,6 +39,7 @@ static CONNECTION_CHANNEL_SIZE: usize = 1000;
 
 pub use http::Error as HttpError;
 
+/// Operations performed on the operator via [`kube`] API.
 #[derive(Debug)]
 pub enum OperatorOperation {
     FindingOperator,


### PR DESCRIPTION
Closes #2115 

What it looks like when the operator is not installed:

### `{"operator": false}`
```
⠤ mirrord exec
    ✓ Running on latest (3.78.0)!
    ✓ ready to launch process
      ✓ layer extracted
      ✓ agent pod created
      ✓ pod is ready 
```
### `{"operator": true}`
```
  x mirrord exec
    ✓ Running on latest (3.78.0)!
    x preparing to launch process
      ✓ layer extracted
      x checking operator
Error:   × Failed to connect to the operator, probably due to RBAC: finding operator failed: ApiError: "404 page not found\n": Failed to parse error data (ErrorResponse { status: "404 Not Found",
  │ message: "\"404 page not found\\n\"", reason: "Failed to parse error data", code: 404 })
  help: 
            Please check the following:
            1. The operator is running and the logs are not showing any errors.
            2. You have sufficient permissions to port forward to the operator.
        
            If you want to run without the operator, please set the following in the mirrord configuration file:
            {
                "operator": false
            }
        
            Please remember that some features are supported only when using mirrord operator (https://mirrord.dev/docs/teams/introduction/#supported-features).
        
        
        - If you're still stuck:
        
        >> Please open a new bug report at https://github.com/metalbear-co/mirrord/issues/new/choose
        
        >> Or join our Discord https://discord.gg/metalbear and request help in #mirrord-help
        
        >> Or email us at hi@metalbear.co
```
### `{}`
```
⠠ mirrord exec
    ✓ Running on latest (3.78.0)!
    ✓ ready to launch process
      ✓ layer extracted
      ✓ operator not found
      ✓ agent pod created
      ✓ pod is ready
```
(error is traced)