### PR TITLE
Support binding [::] by resolving to ipv4 unspecified

### DIFF
--- a/changelog.d/2117.fixed.md
+++ b/changelog.d/2117.fixed.md
@@ -1,0 +1,1 @@
+Support binding [::] by resolving to ipv4 unspecified. Fix gRPC Python running in Docker

--- a/mirrord/layer/src/socket/ops.rs
+++ b/mirrord/layer/src/socket/ops.rs
@@ -822,6 +822,7 @@ pub(super) fn getaddrinfo(
     // Some apps (gRPC on Python) use `::` to listen on all interfaces, and usually that just means
     // resolve on unspecified. So we just return that in IpV4 because we don't support ipv6.
     let resolved_addr = if node == "::" {
+        // name is "" because that's what happens in real flow.
         vec![("".to_string(), IpAddr::V4(Ipv4Addr::UNSPECIFIED))]
     } else {
         remote_getaddrinfo(node.clone())?

--- a/mirrord/layer/src/socket/ops.rs
+++ b/mirrord/layer/src/socket/ops.rs
@@ -822,7 +822,7 @@ pub(super) fn getaddrinfo(
     // Some apps (gRPC on Python) use `::` to listen on all interfaces, and usually that just means
     // resolve on unspecified. So we just return that in IpV4 because we don't support ipv6.
     let resolved_addr = if node == "::" {
-        vec![("::1".to_string(), IpAddr::V4(Ipv4Addr::UNSPECIFIED))]
+        vec![("".to_string(), IpAddr::V4(Ipv4Addr::UNSPECIFIED))]
     } else {
         remote_getaddrinfo(node.clone())?
     };


### PR DESCRIPTION
Support binding [::] by resolving to ipv4 unspecified.
Fix gRPC Python running in Docker

Closes #2117 