### PR TITLE
Flush console loggers after each log

### DIFF
--- a/changelog.d/+flush-console-logs.internal.md
+++ b/changelog.d/+flush-console-logs.internal.md
@@ -1,0 +1,1 @@
+Flush outgoing the console loggers after each logs so that we can see more logs before the layer or the intproxy exit when debugging.

--- a/mirrord/console/src/async_logger.rs
+++ b/mirrord/console/src/async_logger.rs
@@ -41,6 +41,9 @@ impl LoggerTask {
                             eprintln!("Error sending log message: {e:?}");
                             break;
                         }
+                        // Crucial for getting as many of the most interesting logs as possible right before
+                        // the process exits.
+                        let _ = self.encoder.flush().await;
                     }
                 }
             }
@@ -87,6 +90,7 @@ async fn send_hello(stream: &mut TcpStream) -> Result<()> {
 /// Initializes the [`AsyncConsoleLogger`] and sets the global logger to use it.
 pub async fn init_async_logger(address: &str, watch: Watch, channel_size: usize) -> Result<()> {
     let mut stream = TcpStream::connect(address).await?;
+    stream.set_nodelay(true)?;
     send_hello(&mut stream).await?;
 
     let (tx, rx) = mpsc::channel(channel_size);

--- a/mirrord/console/src/logger.rs
+++ b/mirrord/console/src/logger.rs
@@ -40,6 +40,9 @@ impl log::Log for ConsoleLogger {
             if let Err(e) = guard.send(&msg) {
                 eprintln!("Error sending log message: {e:?}");
             }
+            // Crucial for getting as many of the most interesting logs as possible right before
+            // the process exits.
+            let _ = guard.flush();
         }
     }
 
@@ -71,6 +74,7 @@ fn send_hello(stream: &mut TcpStream) -> Result<()> {
 /// Initializes the [`ConsoleLogger`] and sets the global logger to use it.
 pub fn init_logger(address: &str) -> Result<()> {
     let mut stream = TcpStream::connect(address)?;
+    stream.set_nodelay(true)?;
 
     send_hello(&mut stream)?;
 


### PR DESCRIPTION
While using the console alongside a debugger I noticed that some logs from lines that were executed were not showing up in the console. At some point the intproxy would exit without those logs ever being printed. Flushing after every log solved that.
It makes a big difference because the logs right before the process (either user app with layer or intproxy) exits are usually the most important and interesting.

I think efficiency is not a concern since the console is usually only used by us, not by users.