### PR TITLE
Fix dirfd crashing on macOS by hooking dirfd

### DIFF
--- a/changelog.d/+dirfd-crash-handled.fixed.md
+++ b/changelog.d/+dirfd-crash-handled.fixed.md
@@ -1,0 +1,1 @@
+Fix dirfd crashing on macOS

--- a/mirrord/layer/src/file/hooks.rs
+++ b/mirrord/layer/src/file/hooks.rs
@@ -260,6 +260,13 @@ pub(crate) unsafe extern "C" fn closedir_detour(dirp: *mut DIR) -> c_int {
         .unwrap_or_bypass_with(|_| FN_CLOSEDIR(dirp))
 }
 
+#[hook_guard_fn]
+pub(crate) unsafe extern "C" fn dirfd_detour(dirp: *mut DIR) -> c_int {
+    OPEN_DIRS
+        .get_fd(dirp as usize)
+        .unwrap_or_bypass_with(|_| FN_DIRFD(dirp))
+}
+
 /// Equivalent to `open_detour`, **except** when `raw_path` specifies a relative path.
 ///
 /// If `fd == AT_FDCWD`, the current working directory is used, and the behavior is the same as
@@ -957,6 +964,8 @@ pub(crate) unsafe fn enable_file_hooks(hook_manager: &mut HookManager) {
         FnClosedir,
         FN_CLOSEDIR
     );
+
+    replace!(hook_manager, "dirfd", dirfd_detour, FnDirfd, FN_DIRFD);
 
     replace!(hook_manager, "pread", pread_detour, FnPread, FN_PREAD);
     replace!(

--- a/mirrord/layer/src/file/ops.rs
+++ b/mirrord/layer/src/file/ops.rs
@@ -223,10 +223,9 @@ pub(crate) fn fdopendir(fd: RawFd) -> Detour<usize> {
         common::make_proxy_request_with_response(open_dir_request)??;
 
     let local_dir_fd = create_local_fake_file(remote_dir_fd)?;
-    OPEN_DIRS.insert(local_dir_fd as usize, remote_dir_fd);
+    OPEN_DIRS.insert(local_dir_fd as usize, remote_dir_fd, fd);
 
-    // According to docs, when using fdopendir, the fd is now managed by OS - i.e closed
-    OPEN_FILES.remove(&fd);
+    // Let it stay in OPEN_FILES, as some functions might use it in comibination with dirfd
 
     Detour::Success(local_dir_fd as usize)
 }

--- a/mirrord/layer/tests/issue2001.rs
+++ b/mirrord/layer/tests/issue2001.rs
@@ -54,8 +54,6 @@ async fn test_issue2001(
         ))))
         .await;
 
-    intproxy.expect_file_close(10).await;
-
     assert_eq!(
         intproxy.recv().await,
         ClientMessage::FileRequest(FileRequest::ReadDir(ReadDirRequest { remote_fd: 11 })),


### PR DESCRIPTION
Happened when running
```
mirrord exec -t pod/pod sh
ls -la /run
```