### PR TITLE
Added userextras/oid to mirrord operator role to solve issues in some AKS Clusters

### DIFF
--- a/changelog.d/2152.fixed.md
+++ b/changelog.d/2152.fixed.md
@@ -1,0 +1,1 @@
+Added userextras/oid to mirrord operator role to solve issues in some AKS clusters

--- a/mirrord/operator/src/setup.rs
+++ b/mirrord/operator/src/setup.rs
@@ -430,6 +430,7 @@ impl OperatorRole {
                         "userextras/iam.gke.io/user-assertion".to_owned(),
                         "userextras/user-assertion.cloud.google.com".to_owned(),
                         "userextras/principalid".to_owned(),
+                        "userextras/oid".to_owned(),
                     ]),
                     verbs: vec!["impersonate".to_owned()],
                     ..Default::default()


### PR DESCRIPTION
Added userextras/oid to mirrord operator role to solve issues in some AKS Clusters


closes #2152 