### PR TITLE
Extend copy target crd

### DIFF
--- a/changelog.d/+copy-target-ttl.fixed.md
+++ b/changelog.d/+copy-target-ttl.fixed.md
@@ -1,0 +1,1 @@
+Extended `CopyTargetCrd`, allowing to specify different timeouts pre and post connection.

--- a/mirrord/operator/src/client.rs
+++ b/mirrord/operator/src/client.rs
@@ -553,6 +553,7 @@ impl OperatorApi {
             CopyTargetSpec {
                 target: raw_target,
                 idle_ttl: Some(Self::COPIED_POD_IDLE_TTL),
+                post_connection_ttl: None,
                 scale_down,
             },
         );

--- a/mirrord/operator/src/crd.rs
+++ b/mirrord/operator/src/crd.rs
@@ -141,9 +141,10 @@ pub enum OperatorFeatures {
 pub struct CopyTargetSpec {
     /// Original target. Only [`Target::Pod`] and [`Target::Deployment`] are accepted.
     pub target: Target,
-    /// How long should the operator keep this pod alive after its creation.
-    /// The pod is deleted when this timout has expired and there are no connected clients.
+    /// How long should the operator keep this pod alive, waiting for a client connection.
     pub idle_ttl: Option<u32>,
+    /// How long should the operator keep this pod alive after the client has disconnected.
+    pub post_connection_ttl: Option<u32>,
     /// Should the operator scale down target deployment to 0 while this pod is alive.
     /// Ignored if [`Target`] is not [`Target::Deployment`].
     pub scale_down: bool,


### PR DESCRIPTION
Added separate timeouts for the job running the copied pod:
1. Before any client connects
2. When all clients have disconnected