### PR TITLE
Copy targets in operator status

### DIFF
--- a/changelog.d/+copies-in-status.changed.md
+++ b/changelog.d/+copies-in-status.changed.md
@@ -1,0 +1,1 @@
+`mirrord operator status` reports active copy targets.

--- a/mirrord/cli/src/operator.rs
+++ b/mirrord/cli/src/operator.rs
@@ -184,6 +184,38 @@ Operator License
         return Ok(());
     };
 
+    if let Some(copy_targets) = status.copy_targets {
+        if copy_targets.is_empty() {
+            println!("No active copy targets.");
+        } else {
+            println!("Active Copy Targets:");
+            let mut copy_targets_table = Table::new();
+
+            copy_targets_table.add_row(row![
+                "Original Target",
+                "Namespace",
+                "Copy Pod Name",
+                "Scale Down?"
+            ]);
+
+            for (pod_name, copy_target_resource) in copy_targets {
+                copy_targets_table.add_row(row![
+                    copy_target_resource.spec.target.to_string(),
+                    copy_target_resource.metadata.namespace.unwrap_or_default(),
+                    pod_name,
+                    if copy_target_resource.spec.scale_down {
+                        "*"
+                    } else {
+                        ""
+                    },
+                ]);
+            }
+
+            copy_targets_table.printstd();
+        }
+        println!();
+    }
+
     if let Some(statistics) = status.statistics {
         println!("Operator Daily Users: {}", statistics.dau);
         println!("Operator Monthly Users: {}", statistics.mau);

--- a/mirrord/operator/src/crd.rs
+++ b/mirrord/operator/src/crd.rs
@@ -99,6 +99,10 @@ pub struct MirrordOperatorSpec {
 pub struct MirrordOperatorStatus {
     pub sessions: Vec<Session>,
     pub statistics: Option<MirrordOperatorStatusStatistics>,
+
+    /// Option because added later.
+    /// (copy-target pod name, copy-target resource)
+    pub copy_targets: Option<Vec<(String, CopyTargetCrd)>>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, JsonSchema)]


### PR DESCRIPTION
For https://github.com/metalbear-co/operator/issues/394.

New cli manually tested with old operator and there was no problem.

The new section of the status output looks like this:

```
No active copy targets.
```

or like this:

```
Active Copy Targets:
+-------------------------------+-----------+------------------------------+-------------+
| Original Target               | Namespace | Copy Pod Name                | Scale Down? |
+-------------------------------+-----------+------------------------------+-------------+
| deployment/py-serv-deployment | default   | mirrord-copy-job-wd8kj-2gvd4 | *           |
+-------------------------------+-----------+------------------------------+-------------+
```