### PR TITLE
Remove guard from dlopen

### DIFF
--- a/changelog.d/+dlopen-fix.fixed.md
+++ b/changelog.d/+dlopen-fix.fixed.md
@@ -1,0 +1,1 @@
+Remove guard from dlopen, making calls from within dlopen hookable, potentially fixing issues

--- a/mirrord/layer/src/exec_utils.rs
+++ b/mirrord/layer/src/exec_utils.rs
@@ -10,7 +10,7 @@ use std::{
 };
 
 use libc::{c_char, c_int, pid_t};
-use mirrord_layer_macro::hook_guard_fn;
+use mirrord_layer_macro::{hook_fn, hook_guard_fn};
 use mirrord_sip::{
     sip_patch, SipError, MIRRORD_TEMP_BIN_DIR_CANONIC_STRING, MIRRORD_TEMP_BIN_DIR_STRING,
 };
@@ -294,7 +294,8 @@ pub(crate) unsafe extern "C" fn _nsget_executable_path_detour(
 }
 
 /// Just strip the sip patch dir out of the path if there.
-#[hook_guard_fn]
+/// Don't use guard since we want the original function to be able to call back to our detours.
+#[hook_fn]
 pub(crate) unsafe extern "C" fn dlopen_detour(
     raw_path: *const c_char,
     mode: c_int,

--- a/mirrord/layer/src/exec_utils.rs
+++ b/mirrord/layer/src/exec_utils.rs
@@ -296,7 +296,7 @@ pub(crate) unsafe extern "C" fn _nsget_executable_path_detour(
 /// Just strip the sip patch dir out of the path if there.
 /// Don't use guard since we want the original function to be able to call back to our detours.
 /// For example, `dlopen` loads library `funlibrary.dylib` which then calls `dlopen` as part
-/// of it's initialization sequence, cuasing the second dlopen to fail since we don't patch
+/// of it's initialization sequence, causing the second dlopen to fail since we don't patch
 /// the path for the second call.
 #[hook_fn]
 pub(crate) unsafe extern "C" fn dlopen_detour(

--- a/mirrord/layer/src/exec_utils.rs
+++ b/mirrord/layer/src/exec_utils.rs
@@ -295,6 +295,9 @@ pub(crate) unsafe extern "C" fn _nsget_executable_path_detour(
 
 /// Just strip the sip patch dir out of the path if there.
 /// Don't use guard since we want the original function to be able to call back to our detours.
+/// For example, `dlopen` loads library `funlibrary.dylib` which then calls `dlopen` as part
+/// of it's initialization sequence, cuasing the second dlopen to fail since we don't patch
+/// the path for the second call.
 #[hook_fn]
 pub(crate) unsafe extern "C" fn dlopen_detour(
     raw_path: *const c_char,


### PR DESCRIPTION
Remove guard from dlopen, making calls from within dlopen hookable, potentially fixing issues
