### PR TITLE
Allow x86_64 and arm64 when patching a thin binary

### DIFF
--- a/changelog.d/2186.fixed.md
+++ b/changelog.d/2186.fixed.md
@@ -1,0 +1,1 @@
+Running R on macOS.

--- a/changelog.d/2186.internal.md
+++ b/changelog.d/2186.internal.md
@@ -1,0 +1,1 @@
+Allow both `x86_64` and `arm64` when patching thin binaries.


### PR DESCRIPTION
In a thin binay there is no arch choice anyway, so patch if we know how to patch that binary type (we know how to patch `x86_64` and `arm_64`).

Up until now we would try to (imperfectly) forbid patching thin `arm64` binaries on `x86_64` systems, but there is no point in that, as that is not a valid situation anyways, so it should not happen, and if it does happen, that's not a mirrord error, so we can let it fail naturally as it would without mirrord.

Addresses the specific case mentioned in #2186, but binary choice in fat binaries is still not correct.