### PR TITLE
Change configuration parsing to be strict unallowing unknown fields

### DIFF
--- a/changelog.d/+strict-config.changed.md
+++ b/changelog.d/+strict-config.changed.md
@@ -1,0 +1,1 @@
+Change configuration parsing to be strict unallowing unknown fields

--- a/mirrord-schema.json
+++ b/mirrord-schema.json
@@ -410,7 +410,8 @@
                 "null"
               ]
             }
-          }
+          },
+          "additionalProperties": false
         }
       ]
     },
@@ -431,7 +432,8 @@
           "description": "<!--${internal}--> Deployment to mirror.",
           "type": "string"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "EnvFileConfig": {
       "description": "Allows the user to set or override the local process' environment variables with the ones from the remote pod.\n\nWhich environment variables to load from the remote pod are controlled by setting either [`include`](#feature-env-include) or [`exclude`](#feature-env-exclude).\n\nSee the environment variables [reference](https://mirrord.dev/docs/reference/env/) for more details.\n\n```json { \"feature\": { \"env\": { \"include\": \"DATABASE_USER;PUBLIC_ENV;MY_APP_*\", \"exclude\": \"DATABASE_PASSWORD;SECRET_ENV\", \"override\": { \"DATABASE_CONNECTION\": \"db://localhost:7777/my-db\", \"LOCAL_BEAR\": \"panda\" } } } } ```",
@@ -733,7 +735,8 @@
             "minItems": 2
           }
         }
-      }
+      },
+      "additionalProperties": false
     },
     "IncomingFileConfig": {
       "title": "incoming (network)",
@@ -956,7 +959,8 @@
           "description": "<!--${internal}--> Pod to mirror.",
           "type": "string"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "PortList": {
       "description": "<!--${internal}--> Helper struct for setting up ports configuration (part of the HTTP traffic stealer feature).\n\nDefaults to a list of ports `[80, 8080]`.\n\nWe use this to allow implementing a custom [`Default`] initialization, as the [`MirrordConfig`] macro (currently) doesn't support more intricate expressions.",
@@ -983,7 +987,8 @@
           "description": "<!--${internal}--> Rollout to mirror.",
           "type": "string"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "Target": {
       "description": "<!--${internal}--> ## path\n\nSpecifies the running pod (or deployment) to mirror.\n\nSupports: - `pod/{sample-pod}`; - `podname/{sample-pod}`; - `deployment/{sample-deployment}`; - `container/{sample-container}`; - `containername/{sample-container}`.",
@@ -1051,7 +1056,8 @@
                 }
               ]
             }
-          }
+          },
+          "additionalProperties": false
         }
       ]
     },

--- a/mirrord/config/src/feature/copy_target.rs
+++ b/mirrord/config/src/feature/copy_target.rs
@@ -12,7 +12,7 @@ use crate::config::{ConfigContext, FromMirrordConfig, MirrordConfig, Result};
 
 #[derive(Clone, Debug, Deserialize, JsonSchema)]
 #[cfg_attr(test, derive(PartialEq, Eq))]
-#[serde(untagged)]
+#[serde(untagged, deny_unknown_fields)]
 pub enum CopyTargetFileConfig {
     Simple(bool),
     Advanced { scale_down: Option<bool> },

--- a/mirrord/config/src/feature/fs.rs
+++ b/mirrord/config/src/feature/fs.rs
@@ -54,7 +54,7 @@ pub mod mode;
 /// }
 /// ```
 #[derive(Deserialize, PartialEq, Eq, Clone, Debug, JsonSchema)]
-#[serde(untagged, rename_all = "lowercase")]
+#[serde(untagged, deny_unknown_fields, rename_all = "lowercase")]
 pub enum FsUserConfig {
     /// <!--${internal}-->
     /// Basic configuration that controls the env vars `MIRRORD_FILE_OPS` and `MIRRORD_FILE_RO_OPS`

--- a/mirrord/config/src/feature/fs/mode.rs
+++ b/mirrord/config/src/feature/fs/mode.rs
@@ -21,7 +21,7 @@ use crate::{
 ///
 /// The accepted values are: `"local"`, `"localwithoverrides`, `"read"`, or `"write`.
 #[derive(Serialize, Deserialize, Default, PartialEq, Eq, Clone, Debug, Copy, JsonSchema)]
-#[serde(rename_all = "lowercase")]
+#[serde(deny_unknown_fields, rename_all = "lowercase")]
 pub enum FsModeConfig {
     /// #### feature.fs.mode.local {#feature-fs-mode-local}
     ///

--- a/mirrord/config/src/feature/network/incoming.rs
+++ b/mirrord/config/src/feature/network/incoming.rs
@@ -67,7 +67,7 @@ use http_filter::*;
 /// ```
 #[derive(Deserialize, Clone, Debug, JsonSchema)]
 #[cfg_attr(test, derive(PartialEq, Eq))]
-#[serde(untagged, rename_all = "lowercase")]
+#[serde(untagged, deny_unknown_fields, rename_all = "lowercase")]
 pub enum IncomingFileConfig {
     Simple(Option<IncomingMode>),
     Advanced(Box<IncomingAdvancedFileConfig>),
@@ -167,6 +167,7 @@ impl MirrordToggleableConfig for IncomingFileConfig {
 /// Advanced user configuration for network incoming traffic.
 #[derive(Deserialize, Clone, Debug, JsonSchema)]
 #[cfg_attr(test, derive(PartialEq, Eq))]
+#[serde(deny_unknown_fields)]
 pub struct IncomingAdvancedFileConfig {
     /// ### mode
     ///
@@ -350,7 +351,7 @@ impl IncomingConfig {
 /// data on a port is HTTP (in a best-effort kind of way, not guaranteed to be HTTP), and
 /// steals the traffic on the port if it is HTTP;
 #[derive(Deserialize, PartialEq, Eq, Clone, Copy, Debug, JsonSchema, Default)]
-#[serde(rename_all = "lowercase")]
+#[serde(deny_unknown_fields, rename_all = "lowercase")]
 pub enum IncomingMode {
     /// <!--${internal}-->
     /// ### mirror
@@ -409,7 +410,7 @@ impl FromStr for IncomingMode {
 /// - `"override"`: If port lock detected then override it with new lock and force close the
 ///   original locking connection.
 #[derive(Default, Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, JsonSchema)]
-#[serde(rename_all = "lowercase")]
+#[serde(deny_unknown_fields, rename_all = "lowercase")]
 pub enum ConcurrentSteal {
     /// <!--${internal}-->
     /// ### override

--- a/mirrord/config/src/feature/network/incoming/http_filter.rs
+++ b/mirrord/config/src/feature/network/incoming/http_filter.rs
@@ -75,6 +75,7 @@ pub struct HttpFilterConfig {
 /// We use this to allow implementing a custom [`Default`] initialization, as the [`MirrordConfig`]
 /// macro (currently) doesn't support more intricate expressions.
 #[derive(PartialEq, Eq, Clone, Debug, JsonSchema, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct PortList(VecOrSingle<u16>);
 
 impl MirrordToggleableConfig for HttpFilterFileConfig {

--- a/mirrord/config/src/feature/network/outgoing.rs
+++ b/mirrord/config/src/feature/network/outgoing.rs
@@ -55,7 +55,7 @@ use crate::{
 ///
 /// Valid values follow this pattern: `[protocol]://[name|address|subnet/mask]:[port]`.
 #[derive(Deserialize, PartialEq, Eq, Clone, Debug, JsonSchema)]
-#[serde(rename_all = "lowercase")]
+#[serde(deny_unknown_fields, rename_all = "lowercase")]
 pub enum OutgoingFilterConfig {
     /// Traffic that matches what's specified here will go through the remote pod, everything else
     /// will go through local.

--- a/mirrord/config/src/target.rs
+++ b/mirrord/config/src/target.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 
 #[derive(Deserialize, PartialEq, Eq, Clone, Debug, JsonSchema)]
-#[serde(untagged, rename_all = "lowercase")]
+#[serde(untagged, rename_all = "lowercase", deny_unknown_fields)]
 pub enum TargetFileConfig {
     // Generated when the value of the `target` field is a string, or when there is no target.
     // we need default else target value will be required in some scenarios.
@@ -67,6 +67,7 @@ pub enum TargetFileConfig {
 /// ```
 #[derive(Serialize, Deserialize, Clone, Eq, PartialEq, Hash, Debug)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(deny_unknown_fields)]
 pub struct TargetConfig {
     /// ### target.path {#target-path}
     ///
@@ -171,7 +172,7 @@ mirrord-layer failed to parse the provided target!
 /// - `container/{sample-container}`;
 /// - `containername/{sample-container}`.
 #[derive(Serialize, Deserialize, Clone, Eq, PartialEq, Hash, Debug, JsonSchema)]
-#[serde(untagged)]
+#[serde(untagged, deny_unknown_fields)]
 pub enum Target {
     /// <!--${internal}-->
     /// Mirror a deployment.
@@ -281,6 +282,7 @@ impl fmt::Display for Target {
 /// <!--${internal}-->
 /// Mirror the pod specified by [`PodTarget::pod`].
 #[derive(Serialize, Deserialize, Clone, Eq, PartialEq, Hash, Debug, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct PodTarget {
     /// <!--${internal}-->
     /// Pod to mirror.
@@ -312,6 +314,7 @@ impl FromSplit for PodTarget {
 /// <!--${internal}-->
 /// Mirror the deployment specified by [`DeploymentTarget::deployment`].
 #[derive(Serialize, Deserialize, Clone, Eq, PartialEq, Hash, Debug, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct DeploymentTarget {
     /// <!--${internal}-->
     /// Deployment to mirror.
@@ -343,6 +346,7 @@ impl FromSplit for DeploymentTarget {
 /// <!--${internal}-->
 /// Mirror the rollout specified by [`RolloutTarget::rollout`].
 #[derive(Serialize, Deserialize, Clone, Eq, PartialEq, Hash, Debug, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct RolloutTarget {
     /// <!--${internal}-->
     /// Rollout to mirror.

--- a/mirrord/config/src/util.rs
+++ b/mirrord/config/src/util.rs
@@ -17,7 +17,7 @@ pub trait MirrordToggleableConfig: MirrordConfig + Default {
 }
 
 #[derive(Deserialize, PartialEq, Eq, Clone, Debug, JsonSchema)]
-#[serde(untagged)]
+#[serde(untagged, deny_unknown_fields)]
 pub enum ToggleableConfig<T> {
     Enabled(bool),
     Config(T),
@@ -52,7 +52,7 @@ where
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Eq, Clone, Debug, JsonSchema)]
-#[serde(untagged)]
+#[serde(untagged, deny_unknown_fields)]
 pub enum VecOrSingle<T> {
     Single(T),
     Multiple(Vec<T>),


### PR DESCRIPTION
We had some users complaining about `http_header_filter` not working, while we removed it - many structs in our configuration already have the `deny_unknown_fields` flag but seems not all - we should keep adding this to any struct that is part of the mirrord configuration if not using `MirrordConfig` derive macro which does it automatically.