### PR TITLE
Cluster DNS resolving now happens by nameserver order 

### DIFF
--- a/changelog.d/+ordered-dns.changed.md
+++ b/changelog.d/+ordered-dns.changed.md
@@ -1,0 +1,1 @@
+Cluster DNS resolving now happens by nameserver order rather by statistics

--- a/mirrord/agent/src/dns.rs
+++ b/mirrord/agent/src/dns.rs
@@ -40,7 +40,10 @@ async fn dns_lookup(root_path: &Path, host: String) -> RemoteResult<DnsLookup> {
     let resolv_conf = fs::read(resolv_conf_path)?;
     let hosts_file = File::open(hosts_path)?;
 
-    let (config, options) = parse_resolv_conf(resolv_conf)?;
+    let (config, mut options) = parse_resolv_conf(resolv_conf)?;
+    options.server_ordering_strategy =
+        trust_dns_resolver::config::ServerOrderingStrategy::UserProvidedOrder;
+
     let mut resolver = AsyncResolver::tokio(config, options)?;
 
     let hosts = Hosts::default().read_hosts_conf(hosts_file)?;


### PR DESCRIPTION
Cluster DNS resolving now happens by nameserver order rather by statistics