### PR TITLE
Fix spaced shebang bug, remove recursions

### DIFF
--- a/changelog.d/2193.fixed.md
+++ b/changelog.d/2193.fixed.md
@@ -1,0 +1,1 @@
+Running scripts with whitespaces in the shebang.

--- a/mirrord/sip/src/error.rs
+++ b/mirrord/sip/src/error.rs
@@ -33,9 +33,6 @@ pub enum SipError {
     #[error("Can't perform SIP check - executable file not found at `{0}`")]
     FileNotFound(String),
 
-    #[error("Can't perform SIP check - there is a cycle in the shebang graph, found at `{0}`")]
-    CyclicShebangs(String),
-
     #[error("Got invalid string.")]
     NonUtf8Str(#[from] std::str::Utf8Error),
 }

--- a/mirrord/sip/src/lib.rs
+++ b/mirrord/sip/src/lib.rs
@@ -315,10 +315,6 @@ mod main {
         let patched_path = get_output_path(original_path)?;
 
         trace!(
-            "{:?} is a script with a shebang that leads to a SIP protected binary.",
-            original_path
-        );
-        trace!(
             "Shebang points to: {:?}. Patching the interpreter and making a version of {:?} with an altered shebang at: {:?}",
             shebang.interpreter_path,
             original_path,

--- a/mirrord/sip/src/lib.rs
+++ b/mirrord/sip/src/lib.rs
@@ -755,9 +755,8 @@ mod main {
                 .unwrap()
                 .unwrap();
             let new_interpreter_path = new_shebang.interpreter_path.to_str().unwrap();
-            let patched_env_binary_path = &new_interpreter_path[2..];
             // Check DYLD_* features work on it:
-            let output = std::process::Command::new(patched_env_binary_path)
+            let output = std::process::Command::new(new_interpreter_path)
                 .env("DYLD_PRINT_LIBRARIES", "1")
                 .output()
                 .unwrap();

--- a/mirrord/sip/src/lib.rs
+++ b/mirrord/sip/src/lib.rs
@@ -463,7 +463,7 @@ mod main {
     /// suggest)
     /// If file is a script with shebang, the SipStatus is derived from the the SipStatus of the
     /// file the shebang points to.
-    fn get_sip_status(path: &str, patch_binaries: &Vec<String>) -> Result<SipStatus> {
+    fn get_sip_status(path: &str, patch_binaries: &[String]) -> Result<SipStatus> {
         let complete_path = get_complete_path(path)?;
         // If the binary is in our temp bin dir, it's not SIP protected.
         if is_in_mirrord_tmp_dir(&complete_path)? {
@@ -552,7 +552,7 @@ mod main {
     /// If it is, create a non-protected version of the file and return `Ok(Some(patched_path)`.
     /// If it is not, `Ok(None)`.
     /// Propagate errors.
-    pub fn sip_patch(binary_path: &str, patch_binaries: &Vec<String>) -> Result<Option<String>> {
+    pub fn sip_patch(binary_path: &str, patch_binaries: &[String]) -> Result<Option<String>> {
         match get_sip_status(binary_path, patch_binaries) {
             Ok(SipScript { path, shebang }) => {
                 let patched_interpreter = patch_binary(&shebang.interpreter_path)?;

--- a/mirrord/sip/src/lib.rs
+++ b/mirrord/sip/src/lib.rs
@@ -8,8 +8,8 @@ mod rpath;
 
 mod main {
     use std::{
-        collections::HashSet,
         env,
+        ffi::OsStr,
         io::{self, Read},
         os::{macos::fs::MetadataExt, unix::fs::PermissionsExt},
         path::{Path, PathBuf},
@@ -30,7 +30,8 @@ mod main {
     pub use crate::error::SipError;
     use crate::{
         error::Result,
-        SipError::{CyclicShebangs, FileNotFound, UnlikelyError},
+        main::SipStatus::{NoSip, SipBinary, SipScript},
+        SipError::{FileNotFound, UnlikelyError},
     };
 
     /// Where patched files are stored, relative to the temp dir (`/tmp/mirrord-bin/...`).
@@ -259,7 +260,25 @@ mod main {
 
     /// Read the contents (or just the x86_64 section in case of a fat file) from the SIP binary at
     /// `path`, write it into `output`, give it the same permissions, and sign the new binary.
-    fn patch_binary<P: AsRef<Path>, K: AsRef<Path>>(path: P, output: K) -> Result<()> {
+    fn patch_binary(path: &Path) -> Result<PathBuf> {
+        set_fallback_frameworks_path_if_mac_app(path);
+
+        let output = get_output_path(path)?;
+
+        if output.exists() {
+            trace!(
+                "Using existing SIP-patched version of {:?}: {:?}",
+                path,
+                output
+            );
+            return Ok(output);
+        }
+
+        trace!(
+            "{:?} is a SIP protected binary, making non protected version at: {:?}",
+            path,
+            output
+        );
         let data = std::fs::read(&path)?;
 
         // Propagate Err if the binary does not contain any supported architecture (x64/arm64).
@@ -282,64 +301,79 @@ mod main {
 
         // Give the new file the same permissions as the old file.
         std::fs::set_permissions(&output, std::fs::metadata(&path)?.permissions())?;
-        codesign::sign(output)
+        codesign::sign(&output)?;
+        Ok(output)
     }
 
     /// Create a new file at `patched_path` with the same contents as `original_path` except for
     /// the shebang which is `new_shebang`.
-    fn patch_script<P: AsRef<Path>, K: AsRef<Path>>(
-        original_path: P,
-        patched_path: K,
+    fn patch_script(
+        original_path: &Path,
+        shebang: ScriptShebang,
         new_shebang: &str,
-    ) -> Result<()> {
-        read_shebang_from_file(original_path.as_ref())?
-            .map(|original_shebang| -> Result<()> {
-                let data = std::fs::read(original_path.as_ref())?;
-                let contents = data
-                    .get(original_shebang.len()..)
-                    .expect("original shebang size exceeds file size");
-                let mut new_contents = String::from("#!") + new_shebang;
-                new_contents.push_str(std::str::from_utf8(contents).map_err(|_utf| {
-                    UnlikelyError("Can't read script contents as utf8".to_string())
-                })?);
-                std::fs::write(patched_path.as_ref(), new_contents)?;
+    ) -> Result<PathBuf> {
+        let patched_path = get_output_path(original_path)?;
 
-                // We set the permissions of the patched script to be like those of the original
-                // script, but allowing the user to write, so that in the next run, when we are here
-                // again, we have permission to overwrite the patched script (we rewrite the script
-                // every run, in case it is a user script that was changed).
-                let mut permissions = std::fs::metadata(&original_path)?.permissions();
-                let mode = permissions.mode() | 0o200; // user can write.
-                permissions.set_mode(mode);
-                std::fs::set_permissions(patched_path.as_ref(), permissions)?;
-                Ok(())
-            })
-            .ok_or_else(|| UnlikelyError("Can't read shebang anymore.".to_string()))?
+        trace!(
+            "{:?} is a script with a shebang that leads to a SIP protected binary.",
+            original_path
+        );
+        trace!(
+            "Shebang points to: {:?}. Patching the interpreter and making a version of {:?} with an altered shebang at: {:?}",
+            shebang.interpreter_path,
+            original_path,
+            patched_path,
+        );
+
+        let data = std::fs::read(original_path)?;
+        let contents = data
+            .get(shebang.start_of_rest_of_file..)
+            .expect("original shebang size exceeds file size");
+        let mut new_contents = String::from("#!") + new_shebang;
+        new_contents.push_str(
+            from_utf8(contents)
+                .map_err(|_utf| UnlikelyError("Can't read script contents as utf8".to_string()))?,
+        );
+        std::fs::write(&patched_path, new_contents)?;
+
+        // We set the permissions of the patched script to be like those of the original
+        // script, but allowing the user to write, so that in the next run, when we are here
+        // again, we have permission to overwrite the patched script (we rewrite the script
+        // every run, in case it is a user script that was changed).
+        let mut permissions = std::fs::metadata(&original_path)?.permissions();
+        let mode = permissions.mode() | 0o200; // user can write.
+        permissions.set_mode(mode);
+        std::fs::set_permissions(&patched_path, permissions)?;
+        Ok(patched_path)
     }
 
     const SF_RESTRICTED: u32 = 0x00080000; // entitlement required for writing, from stat.h (macos)
 
     /// Extract shebang from file contents.
-    /// "#!/usr/bin/env bash\n..." -> Some("#!/usr/bin/env")
-    fn get_shebang_from_string(file_contents: &str) -> Option<String> {
+    fn get_shebang_from_string(file_contents: &str) -> Option<ScriptShebang> {
         let rest = file_contents.strip_prefix("#!")?;
 
-        let mut char_iter = rest
-            .char_indices()
-            .skip_while(|(_, c)| c.is_whitespace()) // any whitespace directly after #!
-            .skip_while(|(_, c)| !c.is_whitespace()); // Any non-whitespace characters after that (path)
+        let mut char_iter = rest.char_indices().skip_while(|(_, c)| c.is_whitespace()); // any whitespace directly after #!
+        let (start_of_path, _first_char_of_path) = char_iter.next()?;
+        let mut path_char_iter = char_iter.skip_while(|(_, c)| !c.is_whitespace()); // Any non-whitespace characters after that (path)
 
-        let shebang = if let Some((path_len, _next_char)) = char_iter.next() {
-            file_contents.get(..path_len + 2)? // +2 for #! because the index is in `rest`
-        } else {
-            // There is no next character after the shebang, so the whole file is just shebang.
-            file_contents
-        };
-        Some(shebang.to_string())
+        let (interpreter, len_with_whitespace) =
+            if let Some((path_len, _next_char)) = path_char_iter.next() {
+                let total_len = path_len + 2; // +2 for #! because the index is in `rest`
+                (file_contents.get(start_of_path + 2..total_len)?, total_len)
+            } else {
+                // There is no next character after the interpreter, so the whole file is just
+                // magic, whitespace and path.
+                (file_contents.get(start_of_path + 2..)?, file_contents.len())
+            };
+        Some(ScriptShebang {
+            interpreter_path: PathBuf::from(interpreter),
+            start_of_rest_of_file: len_with_whitespace,
+        })
     }
 
     /// Including '#!', just until whitespace, no arguments.
-    fn read_shebang_from_file<P: AsRef<Path>>(path: P) -> Result<Option<String>> {
+    fn read_shebang_from_file<P: AsRef<Path>>(path: P) -> Result<Option<ScriptShebang>> {
         let mut f = std::fs::File::open(path)?;
         let mut buffer = String::new();
         match f.read_to_string(&mut buffer) {
@@ -352,18 +386,34 @@ mod main {
     }
 
     #[derive(Debug)]
+    struct ScriptShebang {
+        interpreter_path: PathBuf,
+
+        /// The index right after where the path of the interpreter ends.
+        /// This is equal to the length of the the magic (`#!`) + any whitespaces + interpreter
+        /// path. E.g.:
+        ///
+        /// !# /usr/bin/env bash
+        ///                ^-- Rest of the file starts at index 15.
+        start_of_rest_of_file: usize,
+    }
+
+    #[derive(Debug)]
     enum SipStatus {
-        /// The binary that ends up being executed is SIP protected.
-        /// The Option is `Some(SipStatus)` when this file is not a SIP binary but a file with a
-        /// shebang which points to a SIP binary (possibly via a chain of files with shebangs).
-        SomeSIP(PathBuf, Option<Box<SipStatus>>),
+        /// The executable is a script with a shebang that points to a SIP-protected binary.
+        SipScript {
+            path: PathBuf,
+            shebang: ScriptShebang,
+        },
+        /// The executable is a SIP-protected binary.
+        SipBinary(PathBuf),
         /// The binary that ends up being executed is not SIP protected.
-        NoSIP,
+        NoSip,
     }
 
     /// Checks if binary is signed with either `RUNTIME` or `RESTRICTED` flags.
     /// The code ignores error to allow smoother fallbacks.
-    fn is_code_signed(path: &PathBuf) -> bool {
+    fn is_code_signed(path: &Path) -> bool {
         let data = match std::fs::read(path) {
             Ok(data) => data,
             Err(_) => return false,
@@ -386,63 +436,31 @@ mod main {
         false
     }
 
-    /// Determine status recursively, keep seen_paths, and return an error if there is a cyclical
-    /// reference.
-    fn get_sip_status_rec(
-        path: &str,
-        seen_paths: &mut HashSet<PathBuf>,
-        patch_binaries: &Vec<String>,
-    ) -> Result<SipStatus> {
+    /// SIP check for binaries.
+    fn is_binary_sip(path: &Path, patch_binaries: &Vec<String>) -> Result<bool> {
+        // Patch binary if it is in the list of binaries to patch.
+        // See `ends_with` docs for understanding better when it returns true.
+        Ok(patch_binaries.iter().any(|x| path.ends_with(x))
+            || is_code_signed(path)
+            || (std::fs::metadata(&path)?.st_flags() & SF_RESTRICTED) > 0)
+    }
+
+    fn get_complete_path<P: AsRef<OsStr> + std::marker::Copy>(path: P) -> Result<PathBuf> {
         // If which fails, try using the given path as is.
         let complete_path = which(path).unwrap_or_else(|_| PathBuf::from(&path));
         if !complete_path.exists() {
             return Err(FileNotFound(complete_path.to_string_lossy().to_string()));
         }
-        let canonical_path = complete_path.canonicalize()?;
+        Ok(complete_path)
+    }
 
-        // If the binary is in our temp bin dir, it's not SIP protected.
-        // unwrap_or_default because path might be non-existent yet.
-        if MIRRORD_TEMP_BIN_DIR_PATH_BUF
+    fn is_in_mirrord_tmp_dir(path: &Path) -> Result<bool> {
+        let canonical_path = path.canonicalize()?;
+        Ok(MIRRORD_TEMP_BIN_DIR_PATH_BUF
             .canonicalize()
             .map(|x| canonical_path.starts_with(x))
-            .unwrap_or_default()
-        {
-            return Ok(SipStatus::NoSIP);
-        }
-
-        // TODO: Don't recursively follow the shebangs, instead only read the first one because on
-        //  macOS a shebang cannot lead to a script only to a binary. Then there should be no danger
-        //  of recursing over a cycle of shebangs until a stack overflow, so this check and keeping
-        //  the seen_paths could all be removed.
-        if seen_paths.contains(&canonical_path) {
-            return Err(CyclicShebangs(canonical_path.to_string_lossy().to_string()));
-        }
-        seen_paths.insert(canonical_path);
-
-        // Patch binary if it is in the list of binaries to patch.
-        // See `ends_with` docs for understanding better when it returns true.
-        if patch_binaries.iter().any(|x| complete_path.ends_with(x)) {
-            return Ok(SipStatus::SomeSIP(complete_path, None));
-        }
-
-        if is_code_signed(&complete_path) {
-            return Ok(SipStatus::SomeSIP(complete_path, None));
-        }
-
-        let metadata = std::fs::metadata(&complete_path)?;
-        if (metadata.st_flags() & SF_RESTRICTED) > 0 {
-            return Ok(SipStatus::SomeSIP(complete_path, None));
-        }
-        if let Some(shebang) = read_shebang_from_file(&complete_path)? {
-            // Start from index 2 of shebang to get only the path.
-            let path = shebang.strip_prefix("#!").unwrap_or(&shebang);
-            return match get_sip_status_rec(path, seen_paths, patch_binaries)? {
-                // The file at the end of the shebang chain is not protected.
-                SipStatus::NoSIP => Ok(SipStatus::NoSIP),
-                some_sip => Ok(SipStatus::SomeSIP(complete_path, Some(Box::new(some_sip)))),
-            };
-        }
-        Ok(SipStatus::NoSIP)
+            // path might be non-existent yet.
+            .unwrap_or_default())
     }
 
     /// Checks the SF_RESTRICTED flags on a file (there might be a better check, feel free to
@@ -450,8 +468,37 @@ mod main {
     /// If file is a script with shebang, the SipStatus is derived from the the SipStatus of the
     /// file the shebang points to.
     fn get_sip_status(path: &str, patch_binaries: &Vec<String>) -> Result<SipStatus> {
-        let mut seen_paths = HashSet::new();
-        get_sip_status_rec(path, &mut seen_paths, patch_binaries)
+        let complete_path = get_complete_path(path)?;
+        // If the binary is in our temp bin dir, it's not SIP protected.
+        if is_in_mirrord_tmp_dir(&complete_path)? {
+            return Ok(NoSip);
+        }
+
+        if let Some(shebang) = read_shebang_from_file(&complete_path)? {
+            let interpreter_complete_path = get_complete_path(&shebang.interpreter_path)?;
+            if is_in_mirrord_tmp_dir(&interpreter_complete_path)? {
+                return Ok(NoSip);
+            }
+            is_binary_sip(&interpreter_complete_path, patch_binaries).map(|is_sip| {
+                if is_sip {
+                    SipScript {
+                        path: complete_path,
+                        shebang,
+                    }
+                } else {
+                    // The interpreter the shebang points to is not protected.
+                    NoSip
+                }
+            })
+        } else {
+            is_binary_sip(&complete_path, patch_binaries).map(|is_sip| {
+                if is_sip {
+                    SipBinary(complete_path)
+                } else {
+                    NoSip
+                }
+            })
+        }
     }
 
     /// When patching a bundled mac application, it try to load libraries from its frameworks
@@ -484,44 +531,16 @@ mod main {
         }
     }
 
-    /// Only call this function on a file that is SomeSIP.
-    /// Patch shebang scripts recursively and patch final binary.
-    fn patch_some_sip(path: &PathBuf, shebang_target: Option<Box<SipStatus>>) -> Result<String> {
+    /// Get new path for patched version, both as PathBuf and as a string, and make the dir
+    /// of the path, recursively.
+    fn get_output_path(path: &Path) -> Result<PathBuf> {
         // TODO: Change output to be with hash of the contents, so that old versions of changed
         //       files do not get used. (Also change back existing file logic to always use.)
 
-        trace!(
-            "Using temp dir: {} for sip patches",
-            MIRRORD_TEMP_BIN_DIR_CANONIC_STRING.as_str()
-        );
-
-        set_fallback_frameworks_path_if_mac_app(path);
-
-        // Strip root path from binary path, as when joined it will clear the previous.
         let output = MIRRORD_TEMP_BIN_DIR_PATH_BUF.join(
+            // Strip root path from binary path, as when joined it will clear the previous.
             path.strip_prefix("/").unwrap_or(path), // No prefix - no problem.
         );
-
-        // A string of the path of new created file to run instead of the SIPed file.
-        let patched_path_string = output
-            .to_str()
-            .ok_or_else(|| UnlikelyError("Failed to convert path to string".to_string()))?
-            .to_string();
-
-        if output.exists() {
-            // TODO: Remove this `if` (leave contents) when we have content hashes in paths.
-            //       For now don't use existing scripts because 1. they're usually not as large as
-            //       binaries so rewriting them is not as bad, and 2. they're more likely to change.
-            if shebang_target.is_none() {
-                // Only use existing if binary (not a script).
-                trace!(
-                    "Using existing SIP-patched version of {:?}: {}",
-                    path,
-                    patched_path_string
-                );
-                return Ok(patched_path_string);
-            }
-        }
 
         std::fs::create_dir_all(
             output
@@ -529,41 +548,7 @@ mod main {
                 .ok_or_else(|| UnlikelyError("Failed to get parent directory".to_string()))?,
         )?;
 
-        match shebang_target {
-            None => {
-                // The file is a sip protected binary.
-                trace!(
-                    "{:?} is a SIP protected binary, making non protected version at: {}",
-                    path,
-                    patched_path_string
-                );
-                patch_binary(path, output)?;
-                Ok(patched_path_string)
-            }
-            // The file is a script with a shebang. Patch recursively.
-            Some(sip_file) => {
-                if let SipStatus::SomeSIP(target_path, shebang_target) = *sip_file {
-                    trace!(
-                        "{:?} is a script with a shebang that leads to a SIP protected binary.",
-                        path
-                    );
-                    trace!(
-                        "Shebang points to: {:?}. Patching it recursively and making a version of {:?} with an altered shebang at: {}",
-                        target_path,
-                        path,
-                        patched_path_string,
-                    );
-                    let new_target = patch_some_sip(&target_path, shebang_target)?;
-                    patch_script(path, output, &new_target)?;
-                    Ok(patched_path_string)
-                } else {
-                    // This function should only be called on a file which has SomeSIP SipStatus.
-                    // If the file has a shebang pointing to a file which is NoSIP, this file should
-                    // not have SomeSIP status in the first place.
-                    Err(UnlikelyError("Internal mirrord error.".to_string()))
-                }
-            }
-        }
+        Ok(output)
     }
 
     /// Check if the file that the user wants to execute is a SIP protected binary (or a script
@@ -573,10 +558,22 @@ mod main {
     /// Propagate errors.
     pub fn sip_patch(binary_path: &str, patch_binaries: &Vec<String>) -> Result<Option<String>> {
         match get_sip_status(binary_path, patch_binaries) {
-            Ok(SipStatus::SomeSIP(path, shebang_target)) => {
-                Some(patch_some_sip(&path, shebang_target)).transpose()
+            Ok(SipScript { path, shebang }) => {
+                let patched_interpreter = patch_binary(&shebang.interpreter_path)?;
+                let patched_script = patch_script(
+                    &path,
+                    shebang,
+                    &patched_interpreter.to_string_lossy().to_string(),
+                )
+                .map(|path| path.to_string_lossy().to_string());
+                Some(patched_script).transpose()
             }
-            Ok(SipStatus::NoSIP) => {
+            Ok(SipBinary(binary)) => {
+                let patched_binary =
+                    patch_binary(&binary).map(|path| path.to_string_lossy().to_string());
+                Some(patched_binary).transpose()
+            }
+            Ok(NoSip) => {
                 trace!("No SIP detected on {:?}", binary_path);
                 Ok(None)
             }
@@ -604,7 +601,7 @@ mod main {
         fn is_sip_true() {
             assert!(matches!(
                 get_sip_status("/bin/ls", &vec![]),
-                Ok(SipStatus::SomeSIP(_, _))
+                Ok(SipBinary(_))
             ));
         }
 
@@ -616,7 +613,7 @@ mod main {
             f.flush().unwrap();
             assert!(matches!(
                 get_sip_status(f.path().to_str().unwrap(), &vec![]).unwrap(),
-                SipStatus::NoSIP
+                NoSip
             ));
         }
 
@@ -630,11 +627,10 @@ mod main {
         #[test]
         fn patch_binary_fat() {
             let path = "/bin/ls";
-            let output = "/tmp/ls_mirrord_test";
-            patch_binary(path, output).unwrap();
+            let output = patch_binary(path.as_ref()).unwrap();
             assert!(matches!(
-                get_sip_status(output, &vec![]).unwrap(),
-                SipStatus::NoSIP
+                get_sip_status(output.to_str().unwrap(), &vec![]).unwrap(),
+                NoSip
             ));
             // Check DYLD_* features work on it:
             let output = std::process::Command::new(output)
@@ -651,11 +647,11 @@ mod main {
         #[test]
         fn patch_binary_fat_with_arm64() {
             let path = "/usr/bin/file";
-            let patched_path = "/tmp/ls_mirrord_test_arm64";
-            patch_binary(path, patched_path).unwrap();
+            let patched_path_buf = patch_binary(path.as_ref()).unwrap();
+            let patched_path = patched_path_buf.to_str().unwrap();
             assert!(matches!(
                 get_sip_status(patched_path, &vec![]).unwrap(),
-                SipStatus::NoSIP
+                SipStatus::NoSip
             ));
             // Check DYLD_* features work on it:
             let output = std::process::Command::new(patched_path)
@@ -676,46 +672,48 @@ mod main {
             assert_eq!(cpu_type, macho::CPU_TYPE_X86_64);
         }
 
-        fn test_patch_script_with_shebang(
-            file_contents: &str,
-            patched_binary_path: &str,
-            new_file_contents: &str,
-        ) {
+        fn test_patch_script(script_contents: &str) {
             let mut original_file = tempfile::NamedTempFile::new().unwrap();
-            let patched_path =
-                env::temp_dir().join(original_file.path().strip_prefix("/").unwrap());
-            original_file.write_all(file_contents.as_ref()).unwrap();
+            original_file.write_all(script_contents.as_ref()).unwrap();
             original_file.flush().unwrap();
-            std::fs::create_dir_all(patched_path.parent().unwrap()).unwrap();
-            patch_script(original_file.path(), &patched_path, patched_binary_path).unwrap();
-            let new_contents = std::fs::read(&patched_path).unwrap();
-            assert_eq!(new_contents, new_file_contents.as_bytes())
+            let permissions = std::fs::Permissions::from_mode(0o700);
+            std::fs::set_permissions(&original_file, permissions).unwrap();
+            let patched_path = sip_patch(original_file.path().to_str().unwrap(), &Vec::new())
+                .unwrap()
+                .unwrap();
+            // Check DYLD_* features work on it:
+            let output = std::process::Command::new(patched_path)
+                .env("DYLD_PRINT_LIBRARIES", "1")
+                .output()
+                .unwrap();
+            assert!(String::from_utf8_lossy(&output.stderr).contains("libsystem_kernel.dylib"));
         }
 
         #[test]
-        fn patch_script_with_shebang() {
-            test_patch_script_with_shebang(
-                "#!/usr/bin/env bash\n",
-                "/test/shebang",
-                "#!/test/shebang bash\n",
-            );
+        fn sip_patch_for_script_with_shebang() {
+            test_patch_script("#!/usr/bin/env bash\necho hello\n")
         }
 
         #[test]
-        fn patch_script_with_shebang_with_space() {
-            test_patch_script_with_shebang(
-                "#!    /usr/bin/env bash\n",
-                "/test/shebang",
-                "#!/test/shebang bash\n",
-            );
+        fn sip_patch_for_script_with_spaced_shebang() {
+            test_patch_script("#! /usr/bin/env bash\necho hello\n")
+        }
+
+        #[test]
+        fn sip_patch_for_script_with_many_spaces_shebang() {
+            test_patch_script("#!    /usr/bin/env bash\necho hello\n")
         }
 
         #[test]
         fn shebang_from_string() {
             let contents = "#!/usr/bin/env bash\n".to_string();
             assert_eq!(
-                get_shebang_from_string(&contents).unwrap(),
-                "#!/usr/bin/env"
+                get_shebang_from_string(&contents)
+                    .unwrap()
+                    .interpreter_path
+                    .to_str()
+                    .unwrap(),
+                "/usr/bin/env"
             )
         }
 
@@ -723,13 +721,21 @@ mod main {
         fn shebang_from_string_with_space() {
             let contents = "#! /usr/bin/env bash\n".to_string();
             assert_eq!(
-                get_shebang_from_string(&contents).unwrap(),
-                "#! /usr/bin/env"
+                get_shebang_from_string(&contents)
+                    .unwrap()
+                    .interpreter_path
+                    .to_str()
+                    .unwrap(),
+                "/usr/bin/env"
             );
             let contents = "#!     /usr/bin/env bash\n".to_string();
             assert_eq!(
-                get_shebang_from_string(&contents).unwrap(),
-                "#!     /usr/bin/env"
+                get_shebang_from_string(&contents)
+                    .unwrap()
+                    .interpreter_path
+                    .to_str()
+                    .unwrap(),
+                "/usr/bin/env"
             )
         }
 
@@ -748,7 +754,8 @@ mod main {
             let new_shebang = read_shebang_from_file(changed_script_path)
                 .unwrap()
                 .unwrap();
-            let patched_env_binary_path = &new_shebang[2..];
+            let new_interpreter_path = new_shebang.interpreter_path.to_str().unwrap();
+            let patched_env_binary_path = &new_interpreter_path[2..];
             // Check DYLD_* features work on it:
             let output = std::process::Command::new(patched_env_binary_path)
                 .env("DYLD_PRINT_LIBRARIES", "1")


### PR DESCRIPTION
Closes #2193 and https://github.com/metalbear-co/mirrord/issues/976

The bug was that now (since #2182) that we also detect shebangs with spaces, when the sip-detection code was using the result of the shebang extraction as a path to the binary, that path contained whitespace, and so no sip was detected.

I changed the return type of the function that extracts the shebang to a struct to avoid further similar bugs.
We now test those cases with the public `sip_patch` function, (previously we only tested those cases with private functions, testing only part of the whole flow). 
I also eliminated all of the recursive-shebang stuff as we found out that's not allowed on darwin after originally writing that code.