### PR TITLE
CLI now sends machine host + username to show in mirrord operator status

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2474,16 +2474,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gethostname"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0176e0459c2e4a1fe232f984bca6890e681076abb9934f6cea7c326f3fc47818"
-dependencies = [
- "libc",
- "windows-targets 0.48.5",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3781,7 +3771,6 @@ version = "3.84.1"
 dependencies = [
  "chrono",
  "fs4",
- "gethostname",
  "home",
  "k8s-openapi",
  "kube",
@@ -3792,6 +3781,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "whoami",
  "x509-certificate 0.19.0",
 ]
 
@@ -3813,7 +3803,7 @@ dependencies = [
  "serde_yaml",
  "tera",
  "thiserror",
- "toml 0.7.8",
+ "toml 0.8.8",
  "tracing",
 ]
 
@@ -3891,7 +3881,7 @@ dependencies = [
  "mirrord-protocol",
  "rand",
  "regex",
- "rstest 0.17.0",
+ "rstest 0.18.2",
  "serde",
  "serde_json",
  "shellexpand",
@@ -3940,7 +3930,7 @@ dependencies = [
  "os_info",
  "rand",
  "regex",
- "rstest 0.17.0",
+ "rstest 0.18.2",
  "serde",
  "serde_json",
  "socket2 0.5.5",
@@ -6455,9 +6445,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.7.8"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
+checksum = "a1a195ec8c9da26928f773888e0742ca3ca1040c6cd859c919c9f59c1954ab35"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -6476,9 +6466,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.19.15"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
+checksum = "d34d383cd00a163b4a5b85053df514d45bc330f6de7737edfe0a93311d1eaa03"
 dependencies = [
  "indexmap 2.1.0",
  "serde",
@@ -7125,6 +7115,16 @@ dependencies = [
  "home",
  "once_cell",
  "rustix",
+]
+
+[[package]]
+name = "whoami"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22fc3756b8a9133049b26c7f61ab35416c130e8c09b660f5b3958b446f52cc50"
+dependencies = [
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]

--- a/changelog.d/+better-name-in-operator.added.md
+++ b/changelog.d/+better-name-in-operator.added.md
@@ -1,0 +1,2 @@
+CLI now sends machine host + username to show in mirrord operator status
+(not sent to our cloud!)

--- a/mirrord/auth/Cargo.toml
+++ b/mirrord/auth/Cargo.toml
@@ -16,20 +16,20 @@ edition.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = []
+default = ["client"]
 client = [
-	"dep:gethostname",
 	"dep:home",
 	"dep:fs4",
 	"dep:k8s-openapi",
 	"dep:kube",
 	"dep:serde_yaml",
-	"dep:tokio"
+	"dep:tokio",
+	"dep:whoami"
 ]
 
 [dependencies]
 chrono = "0.4"
-gethostname = { version = "0.4", optional = true }
+whoami = { version = "1", optional = true }
 home = { version = "0.5", optional = true }
 pem = "2"
 fs4 = { version = "0.6", features = ["tokio-async"], optional = true }

--- a/mirrord/auth/src/credential_store.rs
+++ b/mirrord/auth/src/credential_store.rs
@@ -108,7 +108,7 @@ impl CredentialStore {
             let common_name = self
                 .common_name
                 .clone()
-                .unwrap_or_else(|| whoami::hostname());
+                .unwrap_or_else(whoami::hostname);
 
             credentials
                 .get_client_certificate::<R>(client.clone(), &common_name)

--- a/mirrord/auth/src/credential_store.rs
+++ b/mirrord/auth/src/credential_store.rs
@@ -40,6 +40,27 @@ pub struct CredentialStore {
     credentials: HashMap<String, Credentials>,
 }
 
+/// Information about user gathered from the local system to be shared with the operator
+/// for better status reporting.
+#[derive(Default, Debug)]
+pub struct UserIdentity {
+    /// User's name
+    pub name: Option<String>,
+    /// User's hostname
+    pub hostname: Option<String>,
+}
+
+impl UserIdentity {
+    pub fn load() -> Self {
+        Self {
+            // next release of whoami (v2) will have fallible types
+            // so keep this Option for then :)
+            name: Some(whoami::realname()),
+            hostname: Some(whoami::hostname()),
+        }
+    }
+}
+
 impl CredentialStore {
     /// Load contents of store from file
     async fn load<R: AsyncRead + Unpin>(source: &mut R) -> Result<Self> {
@@ -87,8 +108,7 @@ impl CredentialStore {
             let common_name = self
                 .common_name
                 .clone()
-                .or_else(|| gethostname::gethostname().into_string().ok())
-                .unwrap_or_default();
+                .unwrap_or_else(|| whoami::hostname());
 
             credentials
                 .get_client_certificate::<R>(client.clone(), &common_name)

--- a/mirrord/auth/src/credential_store.rs
+++ b/mirrord/auth/src/credential_store.rs
@@ -105,10 +105,7 @@ impl CredentialStore {
         };
 
         if !credentials.is_ready() {
-            let common_name = self
-                .common_name
-                .clone()
-                .unwrap_or_else(whoami::hostname);
+            let common_name = self.common_name.clone().unwrap_or_else(whoami::hostname);
 
             credentials
                 .get_client_certificate::<R>(client.clone(), &common_name)

--- a/mirrord/config/Cargo.toml
+++ b/mirrord/config/Cargo.toml
@@ -22,7 +22,7 @@ serde_json.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 serde_yaml = "0.9"
-toml = "0.7"
+toml = "0.8"
 schemars = { version = "0.8.11" }
 bimap.workspace = true
 nom = "7.1"


### PR DESCRIPTION
```
No active copy targets.

Operator Daily Users: 1
Operator Monthly Users: 1
+------------------+-------------------+-----------+---------------------------------------------------------------+------------------+
| Session ID       | Target            | Namespace | User                                                          | Session Duration |
+------------------+-------------------+-----------+---------------------------------------------------------------+------------------+
| A7F36DD7C9432798 | namespace/default | N/A       | Aviram Hassan/aviram@metalbear.co@avirams-macbook-pro-2.local | 1s               |
+------------------+-------------------+-----------+---------------------------------------------------------------+------------------+
```