### PR TITLE
Remove incomplete features

### DIFF
--- a/changelog.d/+removed-incomplete-features.internal.md
+++ b/changelog.d/+removed-incomplete-features.internal.md
@@ -1,0 +1,1 @@
+Removed `#![allow(incomplete_features)]` from the code - no longer needed.

--- a/mirrord/agent/src/main.rs
+++ b/mirrord/agent/src/main.rs
@@ -3,7 +3,6 @@
 #![feature(type_alias_impl_trait)]
 #![feature(tcp_quickack)]
 #![feature(lazy_cell)]
-#![allow(incomplete_features)]
 #![warn(clippy::indexing_slicing)]
 
 use std::{

--- a/mirrord/kube/src/lib.rs
+++ b/mirrord/kube/src/lib.rs
@@ -1,7 +1,6 @@
 #![feature(lazy_cell)]
 #![feature(let_chains)]
 #![feature(try_trait_v2)]
-#![allow(incomplete_features)]
 #![warn(clippy::indexing_slicing)]
 
 pub mod api;


### PR DESCRIPTION
Just something I noticed randomly.
Currently we don't use any incomplete features, so I think we should remove this before someone enables a feature that `may function improperly in some or all cases` and `clippy` silently allows it