### PR TITLE
Allow to copy not ready targets

### DIFF
--- a/changelog.d/+2239.added.md
+++ b/changelog.d/+2239.added.md
@@ -1,0 +1,1 @@
+Added support for selecting malfunctioning targets with `copy_target` feature.


### PR DESCRIPTION
Closes #2239 

It was enough to simply remove fetching `TargetCrd` before creating `CopyTargetCrd`. This step was not actually necessary, we can construct `TargetCrd` struct without talking to the operator.