### PR TITLE
Support copying rollouts

### DIFF
--- a/changelog.d/+removed-copy-target-checks.changed.md
+++ b/changelog.d/+removed-copy-target-checks.changed.md
@@ -1,0 +1,2 @@
+1. mirrord CLI now does not check target type when the `copy_target` feature is enabled. The check is now done only in the operator.
+2. `mirrord operator setup` not includes permissions to read and change rollouts scale.

--- a/mirrord/config/src/lib.rs
+++ b/mirrord/config/src/lib.rs
@@ -20,7 +20,6 @@ use config::{ConfigContext, ConfigError, MirrordConfig};
 use mirrord_analytics::CollectAnalytics;
 use mirrord_config_derive::MirrordConfig;
 use schemars::JsonSchema;
-use target::Target;
 use tera::Tera;
 use tracing::warn;
 
@@ -432,20 +431,6 @@ impl LayerConfig {
                     and therefore not running in the copied pod"
                         .into(),
                 );
-            }
-
-            if self.feature.copy_target.scale_down {
-                match (context.ide, self.target.path.as_ref()) {
-                    (_, Some(Target::Deployment(..))) => {}
-                    (true, None) => {}
-                    _ => {
-                        return Err(ConfigError::Conflict(
-                            "The scale down feature is compatible only with deployment targets, \
-                            please either disable this option or specify a deployment target."
-                                .into(),
-                        ));
-                    }
-                }
             }
         }
 

--- a/mirrord/operator/src/client.rs
+++ b/mirrord/operator/src/client.rs
@@ -181,23 +181,12 @@ impl OperatorApi {
 
     /// Checks used config against operator specification.
     fn check_config(config: &LayerConfig, operator: &MirrordOperatorCrd) -> Result<()> {
-        if config.feature.copy_target.enabled {
-            let feature_enabled = operator.spec.copy_target_enabled.unwrap_or(false);
-
-            if !feature_enabled {
-                return Err(OperatorApiError::UnsupportedFeature {
-                    feature: "copy target".into(),
-                    operator_version: operator.spec.operator_version.clone(),
-                });
-            }
-
-            if config.feature.copy_target.scale_down
-                && !matches!(config.target.path, Some(Target::Deployment(..)))
-            {
-                return Err(OperatorApiError::InvalidTarget {
-                    reason: "scale down feature is enabled, but target is not a deployment".into(),
-                });
-            }
+        if config.feature.copy_target.enabled && !operator.spec.copy_target_enabled.unwrap_or(false)
+        {
+            return Err(OperatorApiError::UnsupportedFeature {
+                feature: "copy target".into(),
+                operator_version: operator.spec.operator_version.clone(),
+            });
         }
 
         Ok(())
@@ -299,16 +288,6 @@ impl OperatorApi {
 
         let target_to_connect = if config.feature.copy_target.enabled {
             let mut copy_progress = progress.subtask("copying target");
-
-            if config.feature.copy_target.scale_down {
-                let is_deployment = matches!(config.target.path, Some(Target::Deployment(..)));
-                if !is_deployment {
-                    progress.warning(
-                        "cannot scale down while copying target - target is not a deployment",
-                    )
-                }
-            }
-
             let copied = operator_api
                 .copy_target(
                     &metadata,

--- a/mirrord/operator/src/setup.rs
+++ b/mirrord/operator/src/setup.rs
@@ -407,13 +407,17 @@ impl OperatorRole {
                         "deployments/scale".to_owned(),
                         "jobs".to_owned(),
                         "rollouts".to_owned(),
+                        "rollouts/scale".to_owned(),
                     ]),
                     verbs: vec!["get".to_owned(), "list".to_owned(), "watch".to_owned()],
                     ..Default::default()
                 },
                 PolicyRule {
-                    api_groups: Some(vec!["apps".to_owned()]),
-                    resources: Some(vec!["deployments/scale".to_owned()]),
+                    api_groups: Some(vec!["apps".to_owned(), "argoproj.io".to_owned()]),
+                    resources: Some(vec![
+                        "deployments/scale".to_owned(),
+                        "rollouts/scale".to_owned(),
+                    ]),
                     verbs: vec!["patch".to_owned()],
                     ..Default::default()
                 },


### PR DESCRIPTION
1. Removed target type checks from the `copy_target` flow, because these are done in the operator anyway. Thanks to removing the checks from the CLI, we don't have to add another `feature` to operator status (whether copying rollouts is enabled)
2. Added permissions for `rollouts/scale` to operator setup