### PR TITLE
use_proxy configuration now applies to more commands

### DIFF
--- a/changelog.d/+use-proxy-applies-to-more.changed.md
+++ b/changelog.d/+use-proxy-applies-to-more.changed.md
@@ -1,0 +1,1 @@
+use_proxy configuration now applies to mirrord operator status, and mirrord ls

--- a/mirrord/cli/src/execution.rs
+++ b/mirrord/cli/src/execution.rs
@@ -24,6 +24,7 @@ use crate::{
     connection::{create_and_connect, AgentConnection, AGENT_CONNECT_INFO_ENV_KEY},
     error::CliError,
     extract::extract_library,
+    util::remove_proxy_env,
     Result,
 };
 
@@ -134,12 +135,7 @@ impl MirrordExecution {
         let lib_path = extract_library(None, progress, true)?;
 
         if !config.use_proxy {
-            for (key, _val) in std::env::vars() {
-                let lower_key = key.to_lowercase();
-                if lower_key == "http_proxy" || lower_key == "https_proxy" {
-                    std::env::remove_var(key)
-                }
-            }
+            remove_proxy_env();
         }
 
         let (connect_info, mut connection) = create_and_connect(config, progress, analytics)

--- a/mirrord/cli/src/main.rs
+++ b/mirrord/cli/src/main.rs
@@ -47,10 +47,13 @@ mod extract;
 mod internal_proxy;
 mod operator;
 mod teams;
+mod util;
 mod verify_config;
 
 pub(crate) use error::{CliError, Result};
 use verify_config::verify_config;
+
+use crate::util::remove_proxy_env;
 
 async fn exec_process<P>(
     config: LayerConfig,
@@ -339,6 +342,9 @@ async fn print_pod_targets(args: &ListTargetArgs) -> Result<()> {
     {
         let mut cfg_context = ConfigContext::default();
         let layer_config = LayerFileConfig::from_path(config)?.generate_config(&mut cfg_context)?;
+        if !layer_config.use_proxy {
+            remove_proxy_env();
+        }
         (
             layer_config.accept_invalid_certificates,
             layer_config.kubeconfig,

--- a/mirrord/cli/src/operator.rs
+++ b/mirrord/cli/src/operator.rs
@@ -20,6 +20,7 @@ use tracing::warn;
 use crate::{
     config::{OperatorArgs, OperatorCommand},
     error::CliError,
+    util::remove_proxy_env,
     Result,
 };
 
@@ -111,6 +112,9 @@ async fn get_status_api(config: Option<String>) -> Result<Api<MirrordOperatorCrd
     let kube_api = if let Some(config_path) = config {
         let mut cfg_context = ConfigContext::default();
         let config = LayerFileConfig::from_path(config_path)?.generate_config(&mut cfg_context)?;
+        if !config.use_proxy {
+            remove_proxy_env();
+        }
         create_kube_api(
             config.accept_invalid_certificates,
             config.kubeconfig,

--- a/mirrord/cli/src/util.rs
+++ b/mirrord/cli/src/util.rs
@@ -1,0 +1,9 @@
+/// Removes `HTTP_PROXY` and `https_proxy` from the environment
+pub(crate) fn remove_proxy_env() {
+    for (key, _val) in std::env::vars() {
+        let lower_key = key.to_lowercase();
+        if lower_key == "http_proxy" || lower_key == "https_proxy" {
+            std::env::remove_var(key)
+        }
+    }
+}


### PR DESCRIPTION
use_proxy configuration now applies to mirrord operator status, and mirrord ls