### PR TITLE
Fixed DNS resolution in `OutgoingSelector`

### DIFF
--- a/changelog.d/2283.fixed.md
+++ b/changelog.d/2283.fixed.md
@@ -1,0 +1,1 @@
+Fixed a bug where non-existent hosts in outgoing filter would prevent the application from making initiating outgoing connections.

--- a/changelog.d/2283.fixed.md
+++ b/changelog.d/2283.fixed.md
@@ -1,1 +1,1 @@
-Fixed a bug where non-existent hosts in outgoing filter would prevent the application from making initiating outgoing connections.
+Fixed a bug where non-existent hosts in outgoing filter would prevent the application from initiating outgoing connections.

--- a/mirrord/intproxy/src/proxies/simple.rs
+++ b/mirrord/intproxy/src/proxies/simple.rs
@@ -1,11 +1,11 @@
 //! The most basic proxying logic. Handles cases when the only job to do in the internal proxy is to
 //! pass requests and responses between the layer and the agent.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 
 use mirrord_intproxy_protocol::{LayerId, MessageId, ProxyToLayerMessage};
 use mirrord_protocol::{
-    dns::{GetAddrInfoRequest, GetAddrInfoResponse},
+    dns::{DnsLookup, GetAddrInfoRequest, GetAddrInfoResponse},
     file::{CloseDirRequest, CloseFileRequest, OpenDirResponse, OpenFileResponse},
     ClientMessage, FileRequest, FileResponse, GetEnvVarsRequest, RemoteResult,
 };
@@ -47,6 +47,8 @@ pub struct SimpleProxy {
     addr_info_reqs: RequestQueue,
     /// For [`GetEnvVarsRequest`]s.
     get_env_reqs: RequestQueue,
+    /// Cache for resolved domain names.
+    addr_info_cache: AddrInfoCache,
 }
 
 impl BackgroundTask for SimpleProxy {
@@ -132,14 +134,31 @@ impl BackgroundTask for SimpleProxy {
                         .await;
                 }
                 SimpleProxyMessage::AddrInfoReq(message_id, session_id, req) => {
-                    self.addr_info_reqs.insert(message_id, session_id);
-                    message_bus
-                        .send(ProxyMessage::ToAgent(ClientMessage::GetAddrInfoRequest(
-                            req,
-                        )))
-                        .await;
+                    if let Some(cached_response) = self.addr_info_cache.get_cached(&req.node) {
+                        message_bus
+                            .send(ProxyMessage::ToLayer(ToLayer {
+                                message_id,
+                                layer_id: session_id,
+                                message: ProxyToLayerMessage::GetAddrInfo(GetAddrInfoResponse(Ok(
+                                    cached_response,
+                                ))),
+                            }))
+                            .await;
+                    } else {
+                        self.addr_info_reqs.insert(message_id, session_id);
+                        self.addr_info_cache.request_sent(req.node.clone());
+                        message_bus
+                            .send(ProxyMessage::ToAgent(ClientMessage::GetAddrInfoRequest(
+                                req,
+                            )))
+                            .await;
+                    }
                 }
                 SimpleProxyMessage::AddrInfoRes(res) => {
+                    if let Ok(lookup) = res.0.as_ref() {
+                        self.addr_info_cache.response_came(lookup.clone());
+                    }
+
                     let (message_id, layer_id) = self.addr_info_reqs.get()?;
                     message_bus
                         .send(ToLayer {
@@ -185,5 +204,45 @@ impl BackgroundTask for SimpleProxy {
 
         tracing::trace!("message bus closed, exiting");
         Ok(())
+    }
+}
+
+/// Cache for successful [`DnsLookup`]s done by the agent.
+/// DNS mappings should not change very often, so it should be safe to cache these for the time of
+/// one mirrord session.
+#[derive(Default)]
+struct AddrInfoCache {
+    /// [`GetAddrInfoRequest::node`]s from the DNS requests that still require a response from the
+    /// agent.
+    outstanding_requests: VecDeque<String>,
+    /// Agent's successful responses to previous requests.
+    responses: HashMap<String, DnsLookup>,
+}
+
+impl AddrInfoCache {
+    /// Notifies this cache that a new [`GetAddrInfoRequest`] has been sent.
+    fn request_sent(&mut self, host: String) {
+        self.outstanding_requests.push_back(host);
+    }
+
+    /// Notifies this cache that the agent has responded with success to a [`GetAddrInfoRequest`].
+    /// The given [`DnsLookup`] is matched against the `host` from the oldest incomplete
+    /// [`GetAddrInfoRequest`] this struct knows of.
+    ///
+    /// # Panic
+    ///
+    /// This method panics if this struct does not now of any incomplete [`GetAddrInfoRequest`].
+    fn response_came(&mut self, lookup: DnsLookup) {
+        let host = self
+            .outstanding_requests
+            .pop_front()
+            .expect("received too many GetAddrInfoResponses");
+
+        self.responses.insert(host, lookup);
+    }
+
+    /// Returns a cached response for the given `host`.
+    fn get_cached(&mut self, host: &str) -> Option<DnsLookup> {
+        self.responses.get(host).cloned()
     }
 }

--- a/mirrord/intproxy/src/proxies/simple.rs
+++ b/mirrord/intproxy/src/proxies/simple.rs
@@ -231,7 +231,7 @@ impl AddrInfoCache {
     ///
     /// # Panic
     ///
-    /// This method panics if this struct does not now of any incomplete [`GetAddrInfoRequest`].
+    /// This method panics if this struct does not know of any incomplete [`GetAddrInfoRequest`].
     fn response_came(&mut self, lookup: DnsLookup) {
         let host = self
             .outstanding_requests

--- a/mirrord/layer/src/error.rs
+++ b/mirrord/layer/src/error.rs
@@ -3,7 +3,7 @@ use std::{env::VarError, net::SocketAddr, ptr, str::ParseBoolError};
 use errno::set_errno;
 use ignore_codes::*;
 use libc::{c_char, hostent, DIR, FILE};
-use mirrord_config::{config::ConfigError, feature::network::outgoing::OutgoingFilterError};
+use mirrord_config::config::ConfigError;
 use mirrord_protocol::{ResponseError, SerializationError};
 #[cfg(target_os = "macos")]
 use mirrord_sip::SipError;
@@ -148,9 +148,6 @@ pub(crate) enum LayerError {
     #[cfg(target_os = "macos")]
     #[error("Exec failed with error {0:?}, please report this error!")]
     ExecFailed(exec::Error),
-
-    #[error("mirrord-layer: Something went wrong with the outgoing filter `{0}`.")]
-    OutgoingFilterError(#[from] OutgoingFilterError),
 }
 
 impl From<SerializationError> for LayerError {

--- a/mirrord/layer/src/socket.rs
+++ b/mirrord/layer/src/socket.rs
@@ -388,7 +388,10 @@ impl OutgoingFilterExt for OutgoingFilter {
                                 kind: ResolveErrorKindInternal::NoRecordsFound(..),
                             },
                         ))) => vec![],
-                        Err(e) => return Err(e),
+                        Err(e) => {
+                            tracing::error!(error = ?e, "Remote resolution of OutgoingFilter failed");
+                            return Err(e);
+                        }
                     }
                 } else {
                     let _guard = DetourGuard::new();
@@ -402,7 +405,10 @@ impl OutgoingFilterExt for OutgoingFilter {
                         {
                             vec![]
                         }
-                        Err(e) => return Err(e.into()),
+                        Err(e) => {
+                            tracing::error!(error = ?e, "Local resolution of OutgoingFilter failed");
+                            return Err(e.into());
+                        }
                     }
                 };
 

--- a/mirrord/layer/tests/apps/issue2883.js
+++ b/mirrord/layer/tests/apps/issue2883.js
@@ -1,0 +1,29 @@
+const net = require("net")
+
+const client = net.createConnection(
+    80,
+    'test-server',
+    () => console.log("connection established"),
+);
+
+const expected = 20;
+let received = 0;
+
+client.on('data', (data) => {
+    console.log(`received ${data.length} bytes of data`);
+    received += data.length
+});
+
+client.on('close', (hadError) => {
+    console.log(`connection closed with ${hadError ? 'error' : 'no error'}, received ${received} bytes, expected ${expected} bytes`);
+
+    if (hadError || received !== expected) {
+        process.exit(-1);
+    } else {
+        process.exit(0);
+    }
+});
+
+client.on('error', (error) => {
+    console.log(`connection error: ${error.message}`);
+});

--- a/mirrord/layer/tests/common/mod.rs
+++ b/mirrord/layer/tests/common/mod.rs
@@ -655,6 +655,7 @@ pub enum Application {
     CIssue2178,
     RustIssue2058,
     Realpath,
+    NodeIssue2283,
     // For running applications with the executable and arguments determined at runtime.
     DynamicApp(String, Vec<String>),
 }
@@ -689,7 +690,7 @@ impl Application {
             Application::PythonFastApiHTTP => String::from("uvicorn"),
             Application::Fork => String::from("tests/apps/fork/out.c_test_app"),
             Application::Realpath => String::from("tests/apps/realpath/out.c_test_app"),
-            Application::NodeHTTP => String::from("node"),
+            Application::NodeHTTP | Application::NodeIssue2283 => String::from("node"),
             Application::JavaTemurinSip => format!(
                 "{}/.sdkman/candidates/java/17.0.6-tem/bin/java",
                 std::env::var("HOME").unwrap(),
@@ -847,6 +848,10 @@ impl Application {
                 app_path.push("node_spawn.mjs");
                 vec![app_path.to_string_lossy().to_string()]
             }
+            Application::NodeIssue2283 => {
+                app_path.push("issue2883.js");
+                vec![app_path.to_string_lossy().to_string()]
+            }
             Application::PythonSelfConnect => {
                 app_path.push("self_connect.py");
                 vec![String::from("-u"), app_path.to_string_lossy().to_string()]
@@ -963,6 +968,7 @@ impl Application {
             | Application::OpenFile
             | Application::CIssue2055
             | Application::CIssue2178
+            | Application::NodeIssue2283
             | Application::DynamicApp(..) => unimplemented!("shouldn't get here"),
             Application::PythonSelfConnect => 1337,
             Application::RustIssue2058 => 1234,

--- a/mirrord/layer/tests/configs/outgoing_filter_local_not_existing_host.json
+++ b/mirrord/layer/tests/configs/outgoing_filter_local_not_existing_host.json
@@ -1,0 +1,14 @@
+{
+    "feature": {
+        "network": {
+            "dns": true,
+            "outgoing": {
+                "tcp": true,
+                "filter": {
+                    "local": ["i-do-not-exist-at-all"]
+                }
+            }
+        },
+        "fs": "local"
+    }
+}

--- a/mirrord/layer/tests/issue2283.rs
+++ b/mirrord/layer/tests/issue2283.rs
@@ -36,6 +36,14 @@ async fn test_issue2283(
         )
         .await;
 
+    if cfg!(target_os = "macos") {
+        intproxy
+            .expect_file_open_for_reading("/etc/hostname", 2137)
+            .await;
+        intproxy.expect_file_read("metalbear-hostname", 2137).await;
+        intproxy.expect_file_close(2137).await;
+    }
+
     let message = intproxy.recv().await;
     assert_matches!(message, ClientMessage::GetAddrInfoRequest(GetAddrInfoRequest { node }) if node == "test-server");
 

--- a/mirrord/layer/tests/issue2283.rs
+++ b/mirrord/layer/tests/issue2283.rs
@@ -1,0 +1,94 @@
+#![feature(assert_matches)]
+#![warn(clippy::indexing_slicing)]
+use std::{assert_matches::assert_matches, net::SocketAddr, path::PathBuf, time::Duration};
+
+use mirrord_protocol::{
+    dns::{DnsLookup, GetAddrInfoRequest, GetAddrInfoResponse, LookupRecord},
+    outgoing::{
+        tcp::{DaemonTcpOutgoing, LayerTcpOutgoing},
+        DaemonConnect, DaemonRead, LayerConnect, SocketAddress,
+    },
+    ClientMessage, DaemonMessage,
+};
+use rstest::rstest;
+
+mod common;
+
+pub use common::*;
+
+/// Verify that issue [#2283](https://github.com/metalbear-co/mirrord/issues/2283) is fixed.
+#[rstest]
+#[tokio::test]
+#[timeout(Duration::from_secs(60))]
+async fn test_issue2283(
+    #[values(Application::NodeIssue2283)] application: Application,
+    dylib_path: &PathBuf,
+    config_dir: &PathBuf,
+) {
+    let mut config_path = config_dir.clone();
+    config_path.push("outgoing_filter_local_not_existing_host.json");
+
+    let (mut test_process, mut intproxy) = application
+        .start_process_with_layer(
+            dylib_path,
+            vec![("MIRRORD_REMOTE_DNS", "true")],
+            Some(config_path.to_str().unwrap()),
+        )
+        .await;
+
+    let message = intproxy.recv().await;
+    assert_matches!(message, ClientMessage::GetAddrInfoRequest(GetAddrInfoRequest { node }) if node == "test-server");
+
+    let address = "1.2.3.4:80".parse::<SocketAddr>().unwrap();
+
+    intproxy
+        .send(DaemonMessage::GetAddrInfoResponse(GetAddrInfoResponse(Ok(
+            DnsLookup(vec![LookupRecord {
+                name: "test-server".to_string(),
+                ip: address.ip(),
+            }]),
+        ))))
+        .await;
+
+    let message = intproxy.recv().await;
+    assert_matches!(
+        message,
+        ClientMessage::TcpOutgoing(LayerTcpOutgoing::Connect(LayerConnect { remote_address}))
+        if remote_address == SocketAddress::from(address)
+    );
+
+    let local_address = "2.3.4.5:9122".parse::<SocketAddr>().unwrap();
+    intproxy
+        .send(DaemonMessage::TcpOutgoing(DaemonTcpOutgoing::Connect(Ok(
+            DaemonConnect {
+                connection_id: 0,
+                remote_address: address.into(),
+                local_address: local_address.into(),
+            },
+        ))))
+        .await;
+    intproxy
+        .send(DaemonMessage::TcpOutgoing(DaemonTcpOutgoing::Read(Ok(
+            DaemonRead {
+                connection_id: 0,
+                bytes: vec![b'A'; 20],
+            },
+        ))))
+        .await;
+    intproxy
+        .send(DaemonMessage::TcpOutgoing(DaemonTcpOutgoing::Close(0)))
+        .await;
+
+    test_process.wait_assert_success().await;
+    test_process
+        .assert_stdout_contains("connection established")
+        .await;
+    test_process
+        .assert_stdout_contains("received 20 bytes of data")
+        .await;
+    test_process
+        .assert_stdout_contains(
+            "connection closed with no error, received 20 bytes, expected 20 bytes",
+        )
+        .await;
+}

--- a/mirrord/layer/tests/issue2283.rs
+++ b/mirrord/layer/tests/issue2283.rs
@@ -40,7 +40,10 @@ async fn test_issue2283(
         intproxy
             .expect_file_open_for_reading("/etc/hostname", 2137)
             .await;
-        intproxy.expect_file_read("metalbear-hostname", 2137).await;
+        intproxy.expect_only_file_read(2137).await;
+        intproxy
+            .answer_file_read("metalbear-hostname".as_bytes().to_vec())
+            .await;
         intproxy.expect_file_close(2137).await;
     }
 

--- a/tests/src/utils.rs
+++ b/tests/src/utils.rs
@@ -284,11 +284,13 @@ impl TestProcess {
         args: Vec<String>,
         env: HashMap<&str, &str>,
     ) -> TestProcess {
+        println!("EXECUTING: {executable}");
         let child = Command::new(executable)
             .args(args)
             .envs(env)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
+            .kill_on_drop(true)
             .spawn()
             .unwrap();
         println!("Started application.");
@@ -449,6 +451,7 @@ pub async fn run_mirrord(args: Vec<&str>, env: HashMap<&str, &str>) -> TestProce
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
+        .kill_on_drop(true)
         .spawn()
         .unwrap();
     println!(


### PR DESCRIPTION
Closes #2283 

When the user app wants to initiate an outgoing connection, all outgoing filters are resolved in order to determine whether the connection should be done remotely or locally. The issue was that all resolution failures were treated as fatal errors (and were aborting the `connect` call). This PR filters out resolution errors which mean only that the name does not map to any known IP address (which is the case when the user puts a non-existent host in the filter).

Also, this PR adds a `GetAddrInfoResponse` cache on the internal proxy level. No need to do multiple dns queries each time an outgoing connection is initiated