### PR TITLE
Hook `statx`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -241,6 +241,9 @@ jobs:
       - run: |
           cd mirrord/layer/tests/apps/issue2058
           rustc issue2058.rs --out-dir target
+      - run: |
+          cd mirrord/layer/tests/apps/issue2204
+          rustc issue2204.rs --out-dir target
       # For the `java_temurin_sip` test.
       - uses: sdkman/sdkman-action@b1f9b696c79148b66d3d3a06f7ea801820318d0f
         id: sdkman

--- a/changelog.d/2204.added.md
+++ b/changelog.d/2204.added.md
@@ -1,0 +1,1 @@
+Added support for `statx` function.

--- a/mirrord/layer/macro/src/lib.rs
+++ b/mirrord/layer/macro/src/lib.rs
@@ -177,8 +177,10 @@ pub fn hook_guard_fn(
             #[allow(non_camel_case_types)]
             #type_alias;
 
+            #[allow(non_upper_case_globals)]
             #original_fn;
 
+            #[allow(non_upper_case_globals)]
             #modified_function
 
         };

--- a/mirrord/layer/src/error.rs
+++ b/mirrord/layer/src/error.rs
@@ -95,12 +95,15 @@ pub(crate) enum HookError {
     #[error("mirrord-layer: Proxy connection failed: `{0}`")]
     ProxyError(#[from] ProxyError),
 
+    #[cfg(target_os = "linux")]
     #[error("mirrord-layer: Invalid descriptor argument")]
     BadDescriptor,
 
+    #[cfg(target_os = "linux")]
     #[error("mirrord-layer: Bad flag passed in argument")]
     BadFlag,
 
+    #[cfg(target_os = "linux")]
     #[error("mirrord-layer: Empty file path passed in argument")]
     EmptyPath,
 }
@@ -265,8 +268,11 @@ impl From<HookError> for i64 {
             HookError::BadPointer => libc::EFAULT,
             HookError::AddressAlreadyBound(_) => libc::EADDRINUSE,
             HookError::FileNotFound => libc::ENOENT,
+            #[cfg(target_os = "linux")]
             HookError::BadDescriptor => libc::EBADF,
+            #[cfg(target_os = "linux")]
             HookError::BadFlag => libc::EINVAL,
+            #[cfg(target_os = "linux")]
             HookError::EmptyPath => libc::ENOENT,
         };
 

--- a/mirrord/layer/src/error.rs
+++ b/mirrord/layer/src/error.rs
@@ -100,6 +100,9 @@ pub(crate) enum HookError {
 
     #[error("mirrord-layer: Bad flag passed in argument")]
     BadFlag,
+
+    #[error("mirrord-layer: Empty file path passed in argument")]
+    EmptyPath,
 }
 
 /// Errors internal to mirrord-layer.
@@ -264,6 +267,7 @@ impl From<HookError> for i64 {
             HookError::FileNotFound => libc::ENOENT,
             HookError::BadDescriptor => libc::EBADF,
             HookError::BadFlag => libc::EINVAL,
+            HookError::EmptyPath => libc::ENOENT,
         };
 
         set_errno(errno::Errno(libc_error));

--- a/mirrord/layer/src/error.rs
+++ b/mirrord/layer/src/error.rs
@@ -94,6 +94,12 @@ pub(crate) enum HookError {
 
     #[error("mirrord-layer: Proxy connection failed: `{0}`")]
     ProxyError(#[from] ProxyError),
+
+    #[error("mirrord-layer: Invalid descriptor argument")]
+    BadDescriptor,
+
+    #[error("mirrord-layer: Bad flag passed in argument")]
+    BadFlag,
 }
 
 /// Errors internal to mirrord-layer.
@@ -256,6 +262,8 @@ impl From<HookError> for i64 {
             HookError::BadPointer => libc::EFAULT,
             HookError::AddressAlreadyBound(_) => libc::EADDRINUSE,
             HookError::FileNotFound => libc::ENOENT,
+            HookError::BadDescriptor => libc::EBADF,
+            HookError::BadFlag => libc::EINVAL,
         };
 
         set_errno(errno::Errno(libc_error));

--- a/mirrord/layer/src/file/hooks.rs
+++ b/mirrord/layer/src/file/hooks.rs
@@ -961,43 +961,6 @@ unsafe extern "C" fn realpath_darwin_extsn_detour(
         .unwrap_or_bypass_with(|_| FN_REALPATH_DARWIN_EXTSN(source_path, output_path))
 }
 
-// this requires newer libc which we don't link with to support old libc..
-// leaving this in code so we can enable it when libc is updated.
-// #[cfg(target_os = "linux")]
-// /// Hook for `libc::statx`. This is only available on Linux.
-// #[hook_guard_fn]
-// unsafe extern "C" fn statx_detour(
-//     fd: RawFd,
-//     raw_path: *const c_char,
-//     flag: c_int,
-//     out_stat: *mut statx,
-// ) -> c_int { let follow_symlink = (flag & libc::AT_SYMLINK_NOFOLLOW) == 0; let path = if flags &
-//   libc::AT_EMPTYPATH != 0 { None } else { Some((!raw_path.is_null()).then(||
-//   CStr::from_ptr(raw_path))) }; let (Ok(result) | Err(result)) = xstat(path, Some(fd),
-//   follow_symlink) .map(|res| { let res = res.metadata; out_stat.write_bytes(0, 1); let out = &mut
-//   *out_stat; // Set mask for available fields out.stx_mask = libc::STATX_BASIC_STATS;
-//   out.stx_mode = best_effort_cast(metadata.mode); out.stx_size = best_effort_cast(metadata.size);
-//   out.stx_atime.tv_nsec = metadata.access_time; out.stx_mtime.tv_nsec =
-//   metadata.modification_time; out.stx_ctime.tv_nsec = metadata.creation_time;
-//   out.stx_atime.tv_sec = nano_to_secs(metadata.access_time); out.stx_mtime.tv_sec =
-//   nano_to_secs(metadata.modification_time); out.stx_ctime.tv_sec =
-//   nano_to_secs(metadata.creation_time); out.stx_nlink = best_effort_cast(metadata.hard_links);
-//   out.stx_uid = metadata.user_id; out.stx_gid = metadata.group_id; out.stx_ino =
-//   best_effort_cast(metadata.inode); out.stx_blksize = best_effort_cast(metadata.block_size);
-//   out.stx_blocks = best_effort_cast(metadata.blocks);
-
-//             out.stx_dev_major = libc::major(metadata.device_id);
-//             out.stx_dev_minor = libc::minor(metadata.device_id);
-//             out.stx_rdev_major = libc::major(metadata.rdevice_id);
-//             out.stx_rdev_minor = libc::minor(metadata.rdevice_id);
-//             0
-//         })
-//         .unwrap_or_bypass_with(|_| FN_STATX(fd, raw_path, flag, out_stat))
-//         .map_err(From::from);
-
-//     result
-// }
-
 fn vec_to_iovec(bytes: &[u8], iovecs: &[iovec]) {
     let mut copied = 0;
     let mut iov_index = 0;

--- a/mirrord/layer/src/file/hooks.rs
+++ b/mirrord/layer/src/file/hooks.rs
@@ -9,11 +9,11 @@ use std::{ffi::CString, os::unix::io::RawFd, ptr, slice, time::Duration};
 
 use errno::{set_errno, Errno};
 use libc::{
-    self, c_char, c_int, c_void, dirent, iovec, off_t, size_t, ssize_t, stat, statfs, statx,
-    AT_EACCESS, AT_FDCWD, DIR, EINVAL, O_DIRECTORY, O_RDONLY,
+    self, c_char, c_int, c_void, dirent, iovec, off_t, size_t, ssize_t, stat, statfs, AT_EACCESS,
+    AT_FDCWD, DIR, EINVAL, O_DIRECTORY, O_RDONLY,
 };
 #[cfg(target_os = "linux")]
-use libc::{dirent64, stat64, EBADF, ENOENT, ENOTDIR};
+use libc::{dirent64, stat64, statx, EBADF, ENOENT, ENOTDIR};
 use mirrord_layer_macro::{hook_fn, hook_guard_fn};
 use mirrord_protocol::file::{
     FsMetadataInternal, MetadataInternal, ReadFileResponse, WriteFileResponse,
@@ -795,6 +795,7 @@ unsafe extern "C" fn stat_detour(raw_path: *const c_char, out_stat: *mut stat) -
 }
 
 /// Hook for `libc::statx`.
+#[cfg(target_os = "linux")]
 #[hook_guard_fn]
 unsafe extern "C" fn statx_detour(
     dir_fd: RawFd,

--- a/mirrord/layer/src/file/ops.rs
+++ b/mirrord/layer/src/file/ops.rs
@@ -1,9 +1,9 @@
 use core::ffi::CStr;
 use std::{env, ffi::CString, io::SeekFrom, os::unix::io::RawFd, path::PathBuf, time::Duration};
 
-use libc::{c_char, c_int, iovec, unlink, AT_FDCWD, FILE};
 #[cfg(target_os = "linux")]
-use libc::{statx, statx_timestamp};
+use libc::{c_char, statx, statx_timestamp};
+use libc::{c_int, iovec, unlink, AT_FDCWD, FILE};
 use mirrord_protocol::file::{
     OpenFileRequest, OpenFileResponse, OpenOptionsInternal, ReadFileResponse, SeekFileResponse,
     WriteFileResponse, XstatFsResponse, XstatResponse,
@@ -12,8 +12,10 @@ use rand::distributions::{Alphanumeric, DistString};
 use tracing::{error, trace};
 
 use super::{hooks::FN_OPEN, open_dirs::OPEN_DIRS, *};
+#[cfg(target_os = "linux")]
+use crate::common::CheckedInto;
 use crate::{
-    common::{self, CheckedInto},
+    common,
     detour::{Bypass, Detour},
     error::{HookError, HookResult as Result},
 };

--- a/mirrord/layer/src/file/ops.rs
+++ b/mirrord/layer/src/file/ops.rs
@@ -534,10 +534,10 @@ pub(crate) fn statx_logic(
         & libc::STATX_GID
         & libc::STATX_ATIME
         & libc::STATX_MTIME
+        & libc::STATX_CTIME
         & libc::STATX_INO
         & libc::STATX_SIZE
-        & libc::STATX_BLOCKS
-        & libc::STATX_BTIME;
+        & libc::STATX_BLOCKS;
     statx_buf.stx_attributes_mask = 0;
 
     statx_buf.stx_blksize = response.block_size.try_into().unwrap_or(u32::MAX);
@@ -549,7 +549,7 @@ pub(crate) fn statx_logic(
     statx_buf.stx_size = response.size;
     statx_buf.stx_blocks = response.blocks;
     statx_buf.stx_atime = nanos_to_statx(response.access_time);
-    statx_buf.stx_btime = nanos_to_statx(response.creation_time);
+    statx_buf.stx_ctime = nanos_to_statx(response.creation_time);
     statx_buf.stx_mtime = nanos_to_statx(response.modification_time);
     let (major, minor) = device_id_to_statx(response.rdevice_id);
     statx_buf.stx_rdev_major = major;

--- a/mirrord/layer/src/file/ops.rs
+++ b/mirrord/layer/src/file/ops.rs
@@ -1,5 +1,7 @@
 use core::ffi::CStr;
-use std::{env, ffi::CString, io::SeekFrom, os::unix::io::RawFd, path::PathBuf, time::Duration};
+#[cfg(target_os = "linux")]
+use std::time::Duration;
+use std::{env, ffi::CString, io::SeekFrom, os::unix::io::RawFd, path::PathBuf};
 
 #[cfg(target_os = "linux")]
 use libc::{c_char, statx, statx_timestamp};

--- a/mirrord/layer/src/file/ops.rs
+++ b/mirrord/layer/src/file/ops.rs
@@ -474,7 +474,11 @@ pub(crate) fn statx_logic(
     mask: c_int,
     statx_buf: *mut statx,
 ) -> Detour<c_int> {
-    let statx_buf = unsafe { statx_buf.as_mut().ok_or(HookError::BadPointer)? };
+    let statx_buf = unsafe {
+        let as_ref = statx_buf.as_mut().ok_or(HookError::BadPointer)?;
+        *as_ref = std::mem::zeroed();
+        as_ref
+    };
 
     if path_name.is_null() {
         return Detour::Error(HookError::BadPointer);

--- a/mirrord/layer/src/file/ops.rs
+++ b/mirrord/layer/src/file/ops.rs
@@ -485,10 +485,10 @@ pub(crate) fn statx_logic(
         return Detour::Bypass(Bypass::RelativePath(path_name));
     } else if !path_name.as_os_str().is_empty() {
         (Some(get_remote_fd(dir_fd)?), Some(path_name))
-    } else if (flags & libc::AT_EMPTY_PATH) == 0 {
+    } else if (flags & libc::AT_EMPTY_PATH) != 0 {
         (Some(get_remote_fd(dir_fd)?), None)
     } else {
-        return Detour::Error(HookError::FileNotFound);
+        return Detour::Error(HookError::EmptyPath);
     };
 
     let response = {

--- a/mirrord/layer/src/file/ops.rs
+++ b/mirrord/layer/src/file/ops.rs
@@ -1,7 +1,9 @@
 use core::ffi::CStr;
 use std::{env, ffi::CString, io::SeekFrom, os::unix::io::RawFd, path::PathBuf, time::Duration};
 
-use libc::{c_char, c_int, iovec, statx, statx_timestamp, unlink, AT_FDCWD, FILE};
+use libc::{c_char, c_int, iovec, unlink, AT_FDCWD, FILE};
+#[cfg(target_os = "linux")]
+use libc::{statx, statx_timestamp};
 use mirrord_protocol::file::{
     OpenFileRequest, OpenFileResponse, OpenOptionsInternal, ReadFileResponse, SeekFileResponse,
     WriteFileResponse, XstatFsResponse, XstatResponse,
@@ -460,6 +462,7 @@ pub(crate) fn xstat(
 ///
 /// Luckily, [`statx::stx_mask`] and [`statx::stx_attributes_mask`] fields allow us to inform the
 /// caller about respective fields being skipped.
+#[cfg(target_os = "linux")]
 pub(crate) fn statx_logic(
     dir_fd: RawFd,
     path_name: *const c_char,

--- a/mirrord/layer/tests/apps/issue2204/issue2204.rs
+++ b/mirrord/layer/tests/apps/issue2204/issue2204.rs
@@ -1,0 +1,16 @@
+use std::{fs::File, path::PathBuf};
+
+/// Tests `statx` hooks.
+fn main() {
+    // Relative path should be handled locally.
+    let local_exists = PathBuf::from("./some/local/file").exists();
+    assert!(!local_exists);
+
+    // Absolute path should be handled remotely.
+    let remote_exists = PathBuf::from("/some/remote/file/1").exists();
+    assert!(remote_exists);
+
+    // Absolute path should be opened remotely.
+    let file = File::open("/some/remote/file/2").unwrap();
+    let _metadata = file.metadata().unwrap();
+}

--- a/mirrord/layer/tests/common/mod.rs
+++ b/mirrord/layer/tests/common/mod.rs
@@ -656,6 +656,7 @@ pub enum Application {
     RustIssue2058,
     Realpath,
     NodeIssue2283,
+    RustIssue2204,
     // For running applications with the executable and arguments determined at runtime.
     DynamicApp(String, Vec<String>),
 }
@@ -803,6 +804,7 @@ impl Application {
                 "tests/apps/issue2178/out.c_test_app",
             ),
             Application::RustIssue2058 => String::from("tests/apps/issue2058/target/issue2058"),
+            Application::RustIssue2204 => String::from("tests/apps/issue2204/target/issue2204"),
             Application::DynamicApp(exe, _) => exe.clone(),
         }
     }
@@ -899,7 +901,8 @@ impl Application {
             | Application::RustIssue2058
             | Application::OpenFile
             | Application::CIssue2055
-            | Application::CIssue2178 => vec![],
+            | Application::CIssue2178
+            | Application::RustIssue2204 => vec![],
             Application::RustOutgoingUdp => ["--udp", RUST_OUTGOING_LOCAL, RUST_OUTGOING_PEERS]
                 .into_iter()
                 .map(Into::into)
@@ -969,6 +972,7 @@ impl Application {
             | Application::CIssue2055
             | Application::CIssue2178
             | Application::NodeIssue2283
+            | Application::RustIssue2204
             | Application::DynamicApp(..) => unimplemented!("shouldn't get here"),
             Application::PythonSelfConnect => 1337,
             Application::RustIssue2058 => 1234,

--- a/mirrord/layer/tests/issue2204.rs
+++ b/mirrord/layer/tests/issue2204.rs
@@ -1,0 +1,34 @@
+#![cfg(target_os = "linux")]
+#![feature(assert_matches)]
+#![warn(clippy::indexing_slicing)]
+
+use std::{path::PathBuf, time::Duration};
+
+use rstest::rstest;
+
+mod common;
+
+pub use common::*;
+
+#[rstest]
+#[tokio::test]
+#[timeout(Duration::from_secs(20))]
+async fn test_issue2204(
+    #[values(Application::RustIssue2204)] application: Application,
+    dylib_path: &PathBuf,
+) {
+    let (mut test_process, mut intproxy) = application
+        .start_process_with_layer(dylib_path, Default::default(), None)
+        .await;
+
+    intproxy
+        .expect_xstat(Some(PathBuf::from("/some/remote/file/1")), None)
+        .await;
+    intproxy
+        .expect_file_open_for_reading("/some/remote/file/2", 222)
+        .await;
+    intproxy.expect_xstat(None, Some(222)).await;
+    intproxy.expect_file_close(222).await;
+
+    test_process.wait_assert_success().await;
+}


### PR DESCRIPTION
Closes #2204 

`statx` is not supported in Linux kernel prior to 4.11 or glibc prior to glibc 2.28. However, I don't see any problem with having this hooked, regardless of the user app's libc version. Either `statx` symbol is found and we should hook it or it's not found and nothing happens :eyes: 