### PR TITLE
Fixed concurrent DNS requests mixing up

### DIFF
--- a/changelog.d/+concurrent-dns-race.fixed.md
+++ b/changelog.d/+concurrent-dns-race.fixed.md
@@ -1,0 +1,1 @@
+Fixed an issue where concurrent DNS requests would mix their responses

--- a/mirrord/agent/src/error.rs
+++ b/mirrord/agent/src/error.rs
@@ -8,6 +8,7 @@ use mirrord_protocol::{
     FileRequest, FileResponse,
 };
 use thiserror::Error;
+use trust_dns_resolver::error::ResolveError;
 
 use crate::{
     cgroup::CgroupError, namespace::NamespaceError, sniffer::SnifferCommand, steal::StealerCommand,
@@ -146,6 +147,9 @@ pub(crate) enum AgentError {
 
     #[error(transparent)]
     FailedNamespaceEnter(#[from] NamespaceError),
+
+    #[error("DNS Resovler failed starting, try to run agent privileged or report issue {0}")]
+    DnsResolveError(#[from] ResolveError),
 }
 
 pub(crate) type Result<T, E = AgentError> = std::result::Result<T, E>;


### PR DESCRIPTION
Change agent resolver to be re-used among different queries to avoid an issue where it mixes up responses