### PR TITLE
Improve error message when agent startup fails

### DIFF
--- a/changelog.d/+daemon-close-error.fixed.md
+++ b/changelog.d/+daemon-close-error.fixed.md
@@ -1,0 +1,1 @@
+Fixed the display of agent startup errors to the user.

--- a/mirrord/cli/src/error.rs
+++ b/mirrord/cli/src/error.rs
@@ -145,9 +145,7 @@ pub(crate) enum CliError {
     InvalidMessage(String),
 
     #[error("Initial communication with the agent failed. {0}")]
-    #[diagnostic(help(
-        "Please check agent status and logs.{GENERAL_HELP}"
-    ))]
+    #[diagnostic(help("Please check agent status and logs.{GENERAL_HELP}"))]
     InitialCommFailed(String),
 
     #[error("Failed to execute binary `{0:#?}` with args `{1:#?}`")]

--- a/mirrord/cli/src/error.rs
+++ b/mirrord/cli/src/error.rs
@@ -144,11 +144,11 @@ pub(crate) enum CliError {
     ))]
     InvalidMessage(String),
 
-    #[error("Initial communication with the agent failed. {0:#?}")]
+    #[error("Initial communication with the agent failed. {0}")]
     #[diagnostic(help(
         "Please make sure the agent is running and the logs are not showing any errors.{GENERAL_HELP}"
     ))]
-    InitialCommFailed(&'static str),
+    InitialCommFailed(String),
 
     #[error("Failed to execute binary `{0:#?}` with args `{1:#?}`")]
     #[diagnostic(help(

--- a/mirrord/cli/src/error.rs
+++ b/mirrord/cli/src/error.rs
@@ -146,7 +146,7 @@ pub(crate) enum CliError {
 
     #[error("Initial communication with the agent failed. {0}")]
     #[diagnostic(help(
-        "Please make sure the agent is running and the logs are not showing any errors.{GENERAL_HELP}"
+        "Please check agent status and logs.{GENERAL_HELP}"
     ))]
     InitialCommFailed(String),
 

--- a/mirrord/cli/src/execution.rs
+++ b/mirrord/cli/src/execution.rs
@@ -279,7 +279,9 @@ impl MirrordExecution {
             )
             .await
             .map_err(|_| {
-                CliError::InitialCommFailed("Timeout waiting for remote environment variables.")
+                CliError::InitialCommFailed(
+                    "Timeout waiting for remote environment variables.".to_string(),
+                )
             })??;
             env_vars.extend(remote_env);
             if let Some(overrides) = &config.feature.env.r#override {
@@ -304,7 +306,9 @@ impl MirrordExecution {
             }))
             .await
             .map_err(|_| {
-                CliError::InitialCommFailed("Failed to request remote environment variables.")
+                CliError::InitialCommFailed(
+                    "Failed to request remote environment variables.".to_string(),
+                )
             })?;
 
         match connection.receiver.recv().await {
@@ -312,6 +316,9 @@ impl MirrordExecution {
                 trace!("DaemonMessage::GetEnvVarsResponse {:#?}!", remote_env.len());
                 Ok(remote_env)
             }
+            Some(DaemonMessage::Close(msg)) => Err(CliError::InitialCommFailed(format!(
+                "Connection closed with message: {msg}"
+            ))),
             msg => Err(CliError::InvalidMessage(format!("{msg:#?}"))),
         }
     }

--- a/mirrord/cli/src/execution.rs
+++ b/mirrord/cli/src/execution.rs
@@ -317,7 +317,7 @@ impl MirrordExecution {
                 Ok(remote_env)
             }
             Some(DaemonMessage::Close(msg)) => Err(CliError::InitialCommFailed(format!(
-                "Connection closed with message: {msg}"
+                "Connection closed with message: `{msg}`"
             ))),
             msg => Err(CliError::InvalidMessage(format!("{msg:#?}"))),
         }


### PR DESCRIPTION
Improved error display when something goes wrong with agent setup (agent immediately closes client connection with `DaemonMessage::Close`). We should not report as a bug.

Before:
![Screenshot from 2024-03-21 11-29-43](https://github.com/metalbear-co/mirrord/assets/34063647/be6189db-7710-4c71-b9f3-0d5a26f8abcc)

After:
![Screenshot from 2024-03-21 11-46-12](https://github.com/metalbear-co/mirrord/assets/34063647/db054d3c-6476-4c90-b35f-8ebdeea330d9)
