### PR TITLE
add `mirrord diagnose latency`

### DIFF
--- a/changelog.d/+add-diagnose-command-latency.added.md
+++ b/changelog.d/+add-diagnose-command-latency.added.md
@@ -1,0 +1,1 @@
+Add a new diagnostic command to calculate mirrord session latency

--- a/mirrord/cli/src/config.rs
+++ b/mirrord/cli/src/config.rs
@@ -334,6 +334,7 @@ pub(super) struct DiagnoseArgs {
 }
 
 #[derive(Subcommand, Debug)]
+/// Commands for diagnosing potential issues introduced by mirrord.
 pub(super) enum DiagnoseCommand {
     /// Check network connectivity and provide RTT (latency) statistics.
     Latency {

--- a/mirrord/cli/src/config.rs
+++ b/mirrord/cli/src/config.rs
@@ -53,6 +53,9 @@ pub(super) enum Commands {
 
     /// Try out mirrord for Teams.
     Teams,
+
+    /// Diagnostic commands
+    Diagnose(Box<DiagnoseArgs>),
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum, Debug)]
@@ -322,4 +325,20 @@ pub(super) struct VerifyConfigArgs {
 #[derive(Args, Debug)]
 pub(super) struct CompletionsArgs {
     pub(super) shell: Shell,
+}
+
+#[derive(Args, Debug)]
+pub(super) struct DiagnoseArgs {
+    #[command(subcommand)]
+    pub command: DiagnoseCommand,
+}
+
+#[derive(Subcommand, Debug)]
+pub(super) enum DiagnoseCommand {
+    /// Check network connectivity and provide RTT (latency) statistics.
+    Latency {
+        /// Specify config file to use
+        #[arg(short = 'f')]
+        config_file: Option<String>,
+    },
 }

--- a/mirrord/cli/src/connection.rs
+++ b/mirrord/cli/src/connection.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashSet, time::Duration};
 
-use mirrord_analytics::AnalyticsReporter;
+use mirrord_analytics::Reporter;
 use mirrord_config::{feature::network::outgoing::OutgoingFilterConfig, LayerConfig};
 use mirrord_intproxy::agent_conn::AgentConnectInfo;
 use mirrord_kube::api::{kubernetes::KubernetesAPI, AgentManagment};
@@ -55,10 +55,10 @@ impl OperatorApiErrorExt for OperatorApiError {
 ///
 /// Here is where we start interactions with the kubernetes API.
 #[tracing::instrument(level = "trace", skip_all)]
-pub(crate) async fn create_and_connect<P>(
+pub(crate) async fn create_and_connect<P, R: Reporter>(
     config: &LayerConfig,
     progress: &mut P,
-    analytics: &mut AnalyticsReporter,
+    analytics: &mut R,
 ) -> Result<(AgentConnectInfo, AgentConnection)>
 where
     P: Progress + Send + Sync,

--- a/mirrord/cli/src/diagnose.rs
+++ b/mirrord/cli/src/diagnose.rs
@@ -1,0 +1,39 @@
+use mirrord_analytics::AnalyticsReporter;
+use mirrord_config::{config::{ConfigContext, MirrordConfig}, LayerConfig, LayerFileConfig};
+use mirrord_progress::ProgressTracker;
+
+use crate::{connection::create_and_connect, util::remove_proxy_env, DiagnoseArgs, DiagnoseCommand, Result};
+
+
+
+/// Create a targetless session and run pings to diagnose network latency.
+#[tracing::instrument(level = "trace", ret)]
+async fn diagnose_latency(config: Option<String>) -> Result<()> {
+    let mut progress = ProgressTracker::from_env("mirrord network diagnosis");
+    
+    let mut cfg_context = ConfigContext::default();
+    let config = if let Some(path) = config {
+        LayerFileConfig::from_path(path)?.generate_config(&mut cfg_context)
+    } else {
+        LayerFileConfig::default().generate_config(&mut cfg_context)
+    }?;
+
+    if !config.use_proxy {
+        remove_proxy_env();
+    }
+
+    let analytics = AnalyticsReporter::new(false, )
+    let (connect_info, mut connection) = create_and_connect(config, progress, analytics)
+        .await
+        .inspect_err(|_| analytics.set_error(AnalyticsError::AgentConnection))?;
+    
+    Ok(())
+
+}
+
+/// Handle commands related to the operator `mirrord diagnose ...`
+pub(crate) async fn diagnose_command(args: DiagnoseArgs) -> Result<()> {
+    match args.command {
+        DiagnoseCommand::Latency { config_file } => diagnose_latency(config_file).await,
+    }
+}

--- a/mirrord/cli/src/diagnose.rs
+++ b/mirrord/cli/src/diagnose.rs
@@ -1,16 +1,38 @@
+use std::time::Duration;
+
 use mirrord_analytics::NullReporter;
-use mirrord_config::{config::{ConfigContext, MirrordConfig}, LayerConfig, LayerFileConfig};
-use mirrord_progress::ProgressTracker;
+use mirrord_config::{
+    config::{ConfigContext, MirrordConfig},
+    LayerFileConfig,
+};
+use mirrord_progress::{Progress, ProgressTracker};
+use mirrord_protocol::{ClientMessage, DaemonMessage};
+use tokio::{sync::mpsc, time::Instant};
 
-use crate::{connection::create_and_connect, util::remove_proxy_env, DiagnoseArgs, DiagnoseCommand, Result};
+use crate::{
+    connection::create_and_connect, util::remove_proxy_env, DiagnoseArgs, DiagnoseCommand, Result,
+};
 
-
+/// Sends a ping the connection and expects a pong.
+async fn ping(
+    sender: &mpsc::Sender<ClientMessage>,
+    receiver: &mut mpsc::Receiver<DaemonMessage>,
+) -> Result<()> {
+    sender
+        .send(ClientMessage::Ping)
+        .await
+        .map_err(|_| crate::CliError::CantSendPing)?;
+    match receiver.recv().await {
+        Some(DaemonMessage::Pong) => Ok(()),
+        _ => Err(crate::CliError::InvalidPingResponse),
+    }
+}
 
 /// Create a targetless session and run pings to diagnose network latency.
 #[tracing::instrument(level = "trace", ret)]
 async fn diagnose_latency(config: Option<String>) -> Result<()> {
     let mut progress = ProgressTracker::from_env("mirrord network diagnosis");
-    
+
     let mut cfg_context = ConfigContext::default();
     let config = if let Some(path) = config {
         LayerFileConfig::from_path(path)?.generate_config(&mut cfg_context)
@@ -23,10 +45,48 @@ async fn diagnose_latency(config: Option<String>) -> Result<()> {
     }
 
     let mut analytics = NullReporter::default();
-    let (connect_info, mut connection) = create_and_connect(config, progress, &mut analytics).await?;
-    
-    Ok(())
+    let (_, mut connection) = create_and_connect(&config, &mut progress, &mut analytics).await?;
 
+    let mut statistics: Vec<Duration> = Vec::new();
+
+    // ignore first ping as it's part of the initialization.
+    ping(&connection.sender, &mut connection.receiver).await?;
+    // run 100 iterations
+    for i in 0..100 {
+        let start = Instant::now();
+        ping(&connection.sender, &mut connection.receiver).await?;
+        let elapsed = start.elapsed();
+        progress.info(
+            format!(
+                "{i}/100 iterations completed, last iteration took {}ms",
+                elapsed.as_millis()
+            )
+            .as_str(),
+        );
+        statistics.push(elapsed);
+    }
+
+    let min = statistics
+        .iter()
+        .min()
+        .map(|d| d.as_millis().to_string())
+        .unwrap_or("N/A".to_string());
+    let max = statistics
+        .iter()
+        .max()
+        .map(|d| d.as_millis().to_string())
+        .unwrap_or("N/A".to_string());
+    let avg: String = (statistics.iter().sum::<Duration>() / statistics.len() as u32)
+        .as_millis()
+        .to_string();
+    progress.success(Some(
+        format!(
+            "Latency statistics: min={}ms, max={}ms, avg={}ms",
+            min, max, avg
+        )
+        .as_str(),
+    ));
+    Ok(())
 }
 
 /// Handle commands related to the operator `mirrord diagnose ...`

--- a/mirrord/cli/src/diagnose.rs
+++ b/mirrord/cli/src/diagnose.rs
@@ -1,4 +1,4 @@
-use mirrord_analytics::AnalyticsReporter;
+use mirrord_analytics::NullReporter;
 use mirrord_config::{config::{ConfigContext, MirrordConfig}, LayerConfig, LayerFileConfig};
 use mirrord_progress::ProgressTracker;
 
@@ -22,10 +22,8 @@ async fn diagnose_latency(config: Option<String>) -> Result<()> {
         remove_proxy_env();
     }
 
-    let analytics = AnalyticsReporter::new(false, )
-    let (connect_info, mut connection) = create_and_connect(config, progress, analytics)
-        .await
-        .inspect_err(|_| analytics.set_error(AnalyticsError::AgentConnection))?;
+    let mut analytics = NullReporter::default();
+    let (connect_info, mut connection) = create_and_connect(config, progress, &mut analytics).await?;
     
     Ok(())
 

--- a/mirrord/cli/src/error.rs
+++ b/mirrord/cli/src/error.rs
@@ -308,6 +308,18 @@ pub(crate) enum CliError {
         operation: String,
         status: Box<kube::core::Status>,
     },
+
+    #[error("Agent returned invalid response to ping")]
+    #[diagnostic(help(
+        r#"This usually means that connectivity was lost while pinging. {GENERAL_HELP}"#
+    ))]
+    InvalidPingResponse,
+
+    #[error("Couldn't send ping to agent")]
+    #[diagnostic(help(
+        r#"This usually means that connectivity was lost while pinging. {GENERAL_HELP}"#
+    ))]
+    CantSendPing,
 }
 
 impl From<OperatorApiError> for CliError {

--- a/mirrord/cli/src/main.rs
+++ b/mirrord/cli/src/main.rs
@@ -49,6 +49,7 @@ mod operator;
 mod teams;
 mod util;
 mod verify_config;
+mod diagnose;
 
 pub(crate) use error::{CliError, Result};
 use verify_config::verify_config;
@@ -433,6 +434,7 @@ fn main() -> miette::Result<()> {
                 generate(args.shell, &mut cmd, "mirrord", &mut std::io::stdout());
             }
             Commands::Teams => teams::navigate_to_intro().await,
+            Commands::Diagnose(args) => diagnose_command(*args).await?,
         };
         Ok(())
     });

--- a/mirrord/cli/src/main.rs
+++ b/mirrord/cli/src/main.rs
@@ -7,6 +7,7 @@ use std::{collections::HashMap, time::Duration};
 use clap::{CommandFactory, Parser};
 use clap_complete::generate;
 use config::*;
+use diagnose::diagnose_command;
 use exec::execvp;
 use execution::MirrordExecution;
 use extension::extension_exec;
@@ -40,6 +41,7 @@ use which::which;
 
 mod config;
 mod connection;
+mod diagnose;
 mod error;
 mod execution;
 mod extension;
@@ -49,7 +51,6 @@ mod operator;
 mod teams;
 mod util;
 mod verify_config;
-mod diagnose;
 
 pub(crate) use error::{CliError, Result};
 use verify_config::verify_config;


### PR DESCRIPTION
Add a new command `mirrord diagnose latency` that enables users to check their network latency of the mirrord connection.