### PR TITLE
Better config for agent image.

### DIFF
--- a/changelog.d/+50-better-agent-image-config.changed.md
+++ b/changelog.d/+50-better-agent-image-config.changed.md
@@ -1,0 +1,1 @@
+Changed `agent.image` config to also accept an extended version where you may specify both _registry_ and _tag_ with `agent.image.registry` and `agent.image.tag`.

--- a/mirrord-schema.json
+++ b/mirrord-schema.json
@@ -264,10 +264,13 @@
         },
         "image": {
           "title": "agent.image {#agent-image}",
-          "description": "Name of the agent's docker image.\n\nUseful when a custom build of mirrord-agent is required, or when using an internal registry.\n\nDefaults to the latest stable image `\"ghcr.io/metalbear-co/mirrord:latest\"`.\n\n```json { \"agent\": { \"image\": \"internal.repo/images/mirrord:latest\" } } ```",
-          "type": [
-            "string",
-            "null"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AgentImageFileConfig"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "image_pull_policy": {
@@ -377,6 +380,37 @@
         }
       },
       "additionalProperties": false
+    },
+    "AgentImageFileConfig": {
+      "description": "<!--${internal}--> Allows us to support the dual configuration for the agent image.\n\nWhatever values missing are replaced with our defaults.",
+      "anyOf": [
+        {
+          "description": "The shortened version of: `image: \"repo/mirrord:latest\"`.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        {
+          "description": "Expanded version: `image: { registry: \"repo/mirrord\", tag: \"latest\" }`.",
+          "type": "object",
+          "properties": {
+            "registry": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "tag": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
     },
     "ConcurrentSteal": {
       "description": "(Operator Only): Allows overriding port locks\n\nCan be set to either `\"continue\"` or `\"override\"`.\n\n- `\"continue\"`: Continue with normal execution - `\"override\"`: If port lock detected then override it with new lock and force close the original locking connection.",

--- a/mirrord/config/src/agent.rs
+++ b/mirrord/config/src/agent.rs
@@ -448,7 +448,6 @@ mod tests {
 
                 assert_eq!(agent.log_level, log_level.1);
                 assert_eq!(agent.namespace.as_deref(), namespace.1);
-                // TODO(alex) [mid]: Fix this.
                 assert_eq!(agent.image, right_image);
                 assert_eq!(agent.image_pull_policy, image_pull_policy.1);
                 assert_eq!(agent.ttl, ttl.1);

--- a/mirrord/config/src/lib.rs
+++ b/mirrord/config/src/lib.rs
@@ -656,6 +656,8 @@ mod tests {
     fn full(
         #[values(ConfigType::Json, ConfigType::Toml, ConfigType::Yaml)] config_type: ConfigType,
     ) {
+        use crate::agent::{AgentImageConfig, AgentImageFileConfig};
+
         let input = config_type.full();
 
         let config = config_type.parse(input);
@@ -678,7 +680,7 @@ mod tests {
                 privileged: None,
                 log_level: Some("info".to_owned()),
                 namespace: Some("default".to_owned()),
-                image: Some("".to_owned()),
+                image: Some(AgentImageFileConfig::Simple(Some("".to_owned()))),
                 image_pull_policy: Some("".to_owned()),
                 image_pull_secrets: Some(vec![HashMap::from([(
                     "name".to_owned(),

--- a/mirrord/config/src/lib.rs
+++ b/mirrord/config/src/lib.rs
@@ -656,7 +656,7 @@ mod tests {
     fn full(
         #[values(ConfigType::Json, ConfigType::Toml, ConfigType::Yaml)] config_type: ConfigType,
     ) {
-        use crate::agent::{AgentImageConfig, AgentImageFileConfig};
+        use crate::agent::AgentImageFileConfig;
 
         let input = config_type.full();
 

--- a/mirrord/config/src/lib.rs
+++ b/mirrord/config/src/lib.rs
@@ -3,7 +3,7 @@
 #![warn(clippy::indexing_slicing)]
 //! <!--${internal}-->
 //! To generate the `mirrord-schema.json` file see
-//! [`tests::check_schema_file_exists_and_is_valid_or_create_it`].
+//! `tests::check_schema_file_exists_and_is_valid_or_create_it`.
 //!
 //! Remember to re-generate the `mirrord-schema.json` if you make **ANY** changes to this lib,
 //! including if you only made documentation changes.

--- a/mirrord/kube/src/api/container/ephemeral.rs
+++ b/mirrord/kube/src/api/container/ephemeral.rs
@@ -14,7 +14,7 @@ use tracing::debug;
 use crate::{
     api::{
         container::{
-            util::{base_command_line, get_agent_image, get_capabilities, wait_for_agent_startup},
+            util::{base_command_line, get_capabilities, wait_for_agent_startup},
             ContainerParams, ContainerVariant,
         },
         kubernetes::{get_k8s_resource_api, AgentKubernetesConnectInfo},
@@ -201,7 +201,7 @@ impl ContainerVariant for EphemeralTargetedVariant<'_> {
 
         serde_json::from_value(json!({
             "name": params.name,
-            "image": get_agent_image(agent),
+            "image": agent.image(),
             "securityContext": {
                 "runAsGroup": params.gid,
                 "capabilities": {

--- a/mirrord/kube/src/api/container/job.rs
+++ b/mirrord/kube/src/api/container/job.rs
@@ -18,8 +18,7 @@ use crate::{
     api::{
         container::{
             util::{
-                base_command_line, get_agent_image, get_capabilities, wait_for_agent_startup,
-                DEFAULT_TOLERATIONS,
+                base_command_line, get_capabilities, wait_for_agent_startup, DEFAULT_TOLERATIONS,
             },
             ContainerParams, ContainerVariant,
         },
@@ -205,7 +204,7 @@ impl ContainerVariant for JobVariant<'_> {
                         "containers": [
                             {
                                 "name": "mirrord-agent",
-                                "image": get_agent_image(agent),
+                                "image": agent.image(),
                                 "imagePullPolicy": agent.image_pull_policy,
                                 "command": command_line,
                                 "env": [
@@ -388,7 +387,7 @@ mod test {
                         "containers": [
                             {
                                 "name": "mirrord-agent",
-                                "image": get_agent_image(&agent),
+                                "image": agent.image(),
                                 "imagePullPolicy": agent.image_pull_policy,
                                 "command": ["./mirrord-agent", "-l", "3000", "targetless"],
                                 "env": [
@@ -496,7 +495,7 @@ mod test {
                         "containers": [
                             {
                                 "name": "mirrord-agent",
-                                "image": get_agent_image(&agent),
+                                "image": agent.image(),
                                 "imagePullPolicy": agent.image_pull_policy,
                                 "securityContext": {
                                     "runAsGroup": 13,

--- a/mirrord/kube/src/api/container/util.rs
+++ b/mirrord/kube/src/api/container/util.rs
@@ -20,13 +20,6 @@ pub(super) static DEFAULT_TOLERATIONS: LazyLock<Vec<Toleration>> = LazyLock::new
     }]
 });
 
-pub fn get_agent_image(agent: &AgentConfig) -> String {
-    match &agent.image {
-        Some(image) => image.clone(),
-        None => concat!("ghcr.io/metalbear-co/mirrord:", env!("CARGO_PKG_VERSION")).to_owned(),
-    }
-}
-
 /// Retrieve a list of Linux capabilities for the agent container.
 pub(super) fn get_capabilities(agent: &AgentConfig) -> Vec<LinuxCapability> {
     let disabled = agent.disabled_capabilities.clone().unwrap_or_default();

--- a/mirrord/layer/src/detour.rs
+++ b/mirrord/layer/src/detour.rs
@@ -131,7 +131,7 @@ pub(crate) enum Bypass {
     /// [`SOCKETS`](crate::socket::SOCKETS).
     LocalFdNotFound(RawFd),
 
-    /// Similar to `LocalFdNotFound`, but for [`OPEN_DIRS`](crate::file::OPEN_DIRS).
+    /// Similar to `LocalFdNotFound`, but for [`OPEN_DIRS`](crate::file::open_dirs::OPEN_DIRS).
     LocalDirStreamNotFound(usize),
 
     /// A conversion from [`SockAddr`](socket2::sockaddr::SockAddr) to
@@ -155,9 +155,9 @@ pub(crate) enum Bypass {
     /// Some operations only handle absolute [`PathBuf`]s.
     RelativePath(PathBuf),
 
-    /// Started mirrord with [`FsModeConfig`](mirrord_config::fs::mode::FsModeConfig) set to
-    /// [`FsModeConfig::Read`](mirrord_config::fs::mode::FsModeConfig::Read), but operation
-    /// requires more file permissions.
+    /// Started mirrord with [`FsModeConfig`](mirrord_config::feature::fs::mode::FsModeConfig) set
+    /// to [`FsModeConfig::Read`](mirrord_config::feature::fs::FsModeConfig::Read), but
+    /// operation requires more file permissions.
     ///
     /// The user will reach this case if they started mirrord with file operations as _read-only_,
     /// but tried to perform a file operation that requires _write_ permissions (for example).

--- a/mirrord/layer/src/error.rs
+++ b/mirrord/layer/src/error.rs
@@ -111,7 +111,7 @@ pub(crate) enum HookError {
 /// Errors internal to mirrord-layer.
 ///
 /// You'll encounter these when the layer is performing some of its internal operations, mostly when
-/// handling [`ProxyToLayerMessage`](mirrord_intproxy::protocol::ProxyToLayerMessage).
+/// handling [`ProxyToLayerMessage`](mirrord_intproxy_protocol::ProxyToLayerMessage).
 #[derive(Error, Debug)]
 pub(crate) enum LayerError {
     #[error("mirrord-layer: Failed while getting a response!")]

--- a/mirrord/layer/src/file/ops.rs
+++ b/mirrord/layer/src/file/ops.rs
@@ -26,7 +26,7 @@ use crate::{
 const MAX_READ_SIZE: u64 = 1024 * 1024;
 
 /// Helper macro for checking if the given path should be handled remotely.
-/// Uses global [`crate::setup`].
+/// Uses global [`crate::setup()`].
 ///
 /// Should the file be ignored, this macro exists current context with [`Bypass::IgnoredFile`].
 ///
@@ -55,7 +55,7 @@ impl RemoteFile {
         Self { fd, path }
     }
 
-    /// Sends a [`FileOperation::Open`] message, opening the file in the agent.
+    /// Sends a [`OpenFileRequest`] message, opening the file in the agent.
     #[tracing::instrument(level = "trace")]
     pub(crate) fn remote_open(
         path: PathBuf,
@@ -68,7 +68,7 @@ impl RemoteFile {
         Detour::Success(response)
     }
 
-    /// Sends a [`FileOperation::Read`] message, reading the file in the agent.
+    /// Sends a [`ReadFileRequest`] message, reading the file in the agent.
     ///
     /// Blocking request and wait on already found remote_fd
     #[tracing::instrument(level = "trace")]
@@ -86,7 +86,7 @@ impl RemoteFile {
         Detour::Success(response)
     }
 
-    /// Sends a [`FileOperation::Close`] message, closing the file in the agent.
+    /// Sends a [`CloseFileRequest`] message, closing the file in the agent.
     #[tracing::instrument(level = "trace")]
     pub(crate) fn remote_close(fd: u64) -> Result<()> {
         common::make_proxy_request_no_response(CloseFileRequest { fd })?;


### PR DESCRIPTION
- Issue: [#50](https://github.com/metalbear-co/charts/issues/50)


Changes the `agent.image` config to take an _advanced_ mode where you can specify `image.registry` and/or `image.tag`.