### PR TITLE
New config env.unset that allows user to unset environment variables

### DIFF
--- a/changelog.d/2260.added.md
+++ b/changelog.d/2260.added.md
@@ -1,0 +1,3 @@
+New config `env.unset` that allows user to unset environment variables in the executed process.
+This is useful for unsetting env like `HTTP_PROXY`, `AWS_PROFILE` that come from the local environment
+and cause undesired behavior (because those aren't needed for deployed apps).

--- a/mirrord-schema.json
+++ b/mirrord-schema.json
@@ -523,6 +523,18 @@
           "additionalProperties": {
             "type": "string"
           }
+        },
+        "unset": {
+          "title": "feature.env.unset {#feature-env-unset}",
+          "description": "Allows unsetting environment variables in the executed process.\n\nThis is useful for when some system/user-defined environment like `AWS_PROFILE` make the application behave as if it's running locally, instead of using the remote settings.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/VecOrSingle_for_String"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "additionalProperties": false

--- a/mirrord/cli/src/execution.rs
+++ b/mirrord/cli/src/execution.rs
@@ -45,6 +45,8 @@ pub(crate) struct MirrordExecution {
 
     /// The path to the patched binary, if patched for SIP sidestepping.
     pub patched_path: Option<String>,
+
+    pub env_to_unset: Vec<String>,
 }
 
 /// Struct that when dropped will cancel the token and wait on the join handle
@@ -236,6 +238,13 @@ impl MirrordExecution {
             environment: env_vars,
             child: proxy_process,
             patched_path,
+            env_to_unset: config
+                .feature
+                .env
+                .unset
+                .clone()
+                .map(|unset| unset.to_vec())
+                .unwrap_or_default(),
         })
     }
 

--- a/mirrord/cli/src/main.rs
+++ b/mirrord/cli/src/main.rs
@@ -91,6 +91,10 @@ where
         std::env::set_var(key, value);
     }
 
+    for key in &execution_info.env_to_unset {
+        std::env::remove_var(key);
+    }
+
     let mut binary_args = args.binary_args.clone();
     // Put original executable in argv[0] even if actually running patched version.
     binary_args.insert(0, args.binary.clone());

--- a/mirrord/config/src/feature/env.rs
+++ b/mirrord/config/src/feature/env.rs
@@ -78,6 +78,14 @@ pub struct EnvConfig {
     /// This setting is meant to resolve issues when using mirrord via the IntelliJ plugin on WSL
     /// and the remote environment contains a lot of variables.
     pub load_from_process: Option<bool>,
+
+    /// ### feature.env.unset {#feature-env-unset}
+    ///
+    /// Allows unsetting environment variables in the executed process.
+    ///
+    /// This is useful for when some system/user-defined environment like `AWS_PROFILE` make the
+    /// application behave as if it's running locally, instead of using the remote settings.
+    pub unset: Option<VecOrSingle<String>>,
 }
 
 impl MirrordToggleableConfig for EnvFileConfig {
@@ -92,6 +100,7 @@ impl MirrordToggleableConfig for EnvFileConfig {
                 .or_else(|| Some(VecOrSingle::Single("*".to_owned()))),
             load_from_process: None,
             r#override: None,
+            unset: None,
         })
     }
 }
@@ -115,6 +124,13 @@ impl CollectAnalytics for &EnvConfig {
         analytics.add(
             "overrides_count",
             self.r#override
+                .as_ref()
+                .map(|v| v.len() as u32)
+                .unwrap_or_default(),
+        );
+        analytics.add(
+            "unset_count",
+            self.unset
                 .as_ref()
                 .map(|v| v.len() as u32)
                 .unwrap_or_default(),


### PR DESCRIPTION
New config env.unset that allows user to unset environment variables in the executed process.


Closes #2260 