### PR TITLE
Fixed layer making process zombie by calling panic from hookerror

### DIFF
--- a/changelog.d/+fix-panic.fixed.md
+++ b/changelog.d/+fix-panic.fixed.md
@@ -1,1 +1,1 @@
-Fixed layer making process zombie by calling panic from hookerror
+Fixed layer making process zombie by calling panic from hookerror, also use `sigkill` instead of `sigterm`

--- a/changelog.d/+fix-panic.fixed.md
+++ b/changelog.d/+fix-panic.fixed.md
@@ -1,0 +1,1 @@
+Fixed layer making process zombie by calling panic from hookerror

--- a/mirrord/layer/src/error.rs
+++ b/mirrord/layer/src/error.rs
@@ -215,7 +215,7 @@ impl From<HookError> for i64 {
             HookError::SocketUnsuportedIpv6 => {
                 info!("{fail}")
             }
-            HookError::ProxyError(err) => {
+            HookError::ProxyError(ref err) => {
                 graceful_exit!(
                     "Proxy error, connectivity issue or a bug. \n\
                     You may report it to us on https://github.com/metalbear-co/mirrord/issues/new?assignees=&labels=bug&projects=&template=bug_report.yml \n{err}"
@@ -263,7 +263,8 @@ impl From<HookError> for i64 {
                 err @ ResponseError::Forbidden { .. } => {
                     graceful_exit!(
                         "Stopping mirrord run. Please adjust your mirrord configuration.\n{err}"
-                    )
+                    );
+                    libc::EINVAL
                 }
             },
             HookError::DNSNoName => libc::EFAULT,

--- a/mirrord/layer/src/macros.rs
+++ b/mirrord/layer/src/macros.rs
@@ -185,8 +185,7 @@ macro_rules! graceful_exit {
             nix::unistd::Pid::from_raw(std::process::id() as i32),
             nix::sys::signal::Signal::SIGTERM,
         )
-        .expect("unable to graceful exit");
-        panic!()
+        .expect("unable to graceful exit")
     }};
 }
 

--- a/mirrord/layer/src/macros.rs
+++ b/mirrord/layer/src/macros.rs
@@ -183,7 +183,7 @@ macro_rules! graceful_exit {
     () => {{
         nix::sys::signal::kill(
             nix::unistd::Pid::from_raw(std::process::id() as i32),
-            nix::sys::signal::Signal::SIGTERM,
+            nix::sys::signal::Signal::SIGKILL,
         )
         .expect("unable to graceful exit")
     }};


### PR DESCRIPTION
User shared a crash report when process was stuck in a Panic<-> Frida loop, assumed to be caused by the panic from this flow.