### PR TITLE
Added JetBrains debugger to build tools

### DIFF
--- a/changelog.d/+ignoring-intellij-debug-worker.fixed.md
+++ b/changelog.d/+ignoring-intellij-debug-worker.fixed.md
@@ -1,0 +1,1 @@
+Added `JetBrains.Debugger.Worker` to the list of known build tools, fixing compatibility with Rider 2024.1.

--- a/mirrord/layer/src/load.rs
+++ b/mirrord/layer/src/load.rs
@@ -32,6 +32,7 @@ static BUILD_TOOL_PROCESSES: LazyLock<HashSet<&str>> = LazyLock::new(|| {
         "cargo-watch",
         "debugserver",
         "jspawnhelper",
+        "JetBrains.Debugger.Worker",
     ])
 });
 


### PR DESCRIPTION
Closes https://github.com/metalbear-co/mirrord-intellij/issues/258

Fixes mirrord compatibility with Rider 2024.1