### PR TITLE
Fix Netty native + macOS

### DIFF
--- a/changelog.d/2400.fixed.md
+++ b/changelog.d/2400.fixed.md
@@ -1,0 +1,1 @@
+Fix DNS resolving case on macOS + Java Netty


### PR DESCRIPTION
implement dns_configuration_copy and dns_configuration_free on macOS to return null resolver, make it fallback to standard resolver in Netty situations
Closes #2400 