### PR TITLE
Add ability to configure DNS params for agent (timeout, attempts)

### DIFF
--- a/changelog.d/+add-dns-config.added.md
+++ b/changelog.d/+add-dns-config.added.md
@@ -1,0 +1,1 @@
+Add ability to configure DNS params for agent (timeout, attempts)

--- a/mirrord-schema.json
+++ b/mirrord-schema.json
@@ -246,6 +246,17 @@
             "$ref": "#/definitions/LinuxCapability"
           }
         },
+        "dns": {
+          "title": "agent.dns {#agent-dns}",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/FileAgentDnsConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "ephemeral": {
           "title": "agent.ephemeral {#agent-ephemeral}",
           "description": "Runs the agent as an [ephemeral container](https://kubernetes.io/docs/concepts/workloads/pods/ephemeral-containers/)\n\nDefaults to `false`.",
@@ -595,6 +606,32 @@
               "type": "null"
             }
           ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "FileAgentDnsConfig": {
+      "type": "object",
+      "properties": {
+        "attempts": {
+          "title": "agent.dns.attempts {#agent-dns-attempts}",
+          "description": "When agent resolves DNS, how many attempts before failing. If the value is too high, it might cause internal proxy to timeout and exit.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint32",
+          "minimum": 0.0
+        },
+        "timeout": {
+          "title": "agent.dns.timeout {#agent-dns-timeout}",
+          "description": "When agent resolves DNS, how long to wait for a response before timeout By default this is set to 1 (in the agent). If the value is too high, it might cause internal proxy to timeout and exit.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint32",
+          "minimum": 0.0
         }
       },
       "additionalProperties": false

--- a/mirrord/agent/src/dns.rs
+++ b/mirrord/agent/src/dns.rs
@@ -31,6 +31,8 @@ pub(crate) struct DnsCommand {
 pub(crate) struct DnsWorker {
     etc_path: PathBuf,
     request_rx: Receiver<DnsCommand>,
+    attempts: usize,
+    timeout: Duration,
 }
 
 impl DnsWorker {
@@ -54,6 +56,15 @@ impl DnsWorker {
         Self {
             etc_path,
             request_rx,
+            timeout: std::env::var("MIRRORD_AGENT_DNS_TIMEOUT")
+                .ok()
+                .and_then(|timeout| timeout.parse().ok())
+                .map(Duration::from_secs)
+                .unwrap_or_else(|| Duration::from_secs(1)),
+            attempts: std::env::var("MIRRORD_AGENT_DNS_ATTEMPTS")
+                .ok()
+                .and_then(|attempts| attempts.parse().ok())
+                .unwrap_or(1),
         }
     }
 
@@ -64,7 +75,12 @@ impl DnsWorker {
     ///
     /// We could probably cache results here.
     /// We cannot cache the [`AsyncResolver`] itself, becaues the configuration in `etc` may change.
-    async fn do_lookup(etc_path: PathBuf, host: String) -> RemoteResult<DnsLookup> {
+    async fn do_lookup(
+        etc_path: PathBuf,
+        host: String,
+        attempts: usize,
+        timeout: Duration,
+    ) -> RemoteResult<DnsLookup> {
         let resolv_conf_path = etc_path.join("resolv.conf");
         let hosts_path = etc_path.join("hosts");
 
@@ -74,8 +90,8 @@ impl DnsWorker {
         let (config, mut options) = parse_resolv_conf(resolv_conf)?;
         options.server_ordering_strategy =
             trust_dns_resolver::config::ServerOrderingStrategy::UserProvidedOrder;
-        options.timeout = Duration::from_secs(1);
-        options.attempts = 1;
+        options.timeout = timeout;
+        options.attempts = attempts;
 
         let mut resolver = AsyncResolver::tokio(config, options)?;
 
@@ -96,7 +112,13 @@ impl DnsWorker {
         let etc_path = self.etc_path.clone();
 
         let lookup_future = async move {
-            let result = Self::do_lookup(etc_path, message.request.node).await;
+            let result = Self::do_lookup(
+                etc_path,
+                message.request.node,
+                self.attempts,
+                self.timeout.clone(),
+            )
+            .await;
             if let Err(result) = message.response_tx.send(result) {
                 tracing::error!(?result, "Failed to send query response");
             }

--- a/mirrord/config/src/agent.rs
+++ b/mirrord/config/src/agent.rs
@@ -250,6 +250,10 @@ pub struct AgentConfig {
     #[config(default = false)]
     pub nftables: bool,
 
+    /// ### agent.dns {#agent-dns}
+    #[config(nested)]
+    pub dns: AgentDnsConfig,
+
     /// <!--${internal}-->
     /// Create an agent that returns an error after accepting the first client. For testing
     /// purposes. Only supported with job agents (not with ephemeral agents).
@@ -390,6 +394,24 @@ impl AgentFileConfig {
             _ => Err(ConfigError::UnsupportedFormat),
         }
     }
+}
+
+#[derive(MirrordConfig, Default, PartialEq, Eq, Clone, Debug)]
+#[config(derive = "JsonSchema")]
+#[cfg_attr(test, config(derive = "PartialEq, Eq"))]
+pub struct AgentDnsConfig {
+    /// ### agent.dns.timeout {#agent-dns-timeout}
+    ///
+    /// When agent resolves DNS, how long to wait for a response before timeout
+    /// By default this is set to 1 (in the agent).
+    /// If the value is too high, it might cause internal proxy to timeout and exit.
+    pub timeout: Option<u32>,
+
+    /// ### agent.dns.attempts {#agent-dns-attempts}
+    ///
+    /// When agent resolves DNS, how many attempts before failing.
+    /// If the value is too high, it might cause internal proxy to timeout and exit.
+    pub attempts: Option<u32>,
 }
 
 #[cfg(test)]

--- a/mirrord/config/src/lib.rs
+++ b/mirrord/config/src/lib.rs
@@ -706,6 +706,7 @@ mod tests {
                 check_out_of_pods: None,
                 resources: None,
                 nftables: None,
+                ..Default::default()
             }),
             feature: Some(FeatureFileConfig {
                 env: ToggleableConfig::Enabled(true).into(),

--- a/mirrord/kube/src/api/container/ephemeral.rs
+++ b/mirrord/kube/src/api/container/ephemeral.rs
@@ -11,6 +11,7 @@ use serde_json::json;
 use tokio::pin;
 use tracing::debug;
 
+use super::util::agent_env;
 use crate::{
     api::{
         container::{
@@ -22,8 +23,6 @@ use crate::{
     },
     error::{KubeApiError, Result},
 };
-
-use super::util::agent_env;
 
 fn is_ephemeral_container_running(pod: Pod, container_name: &str) -> bool {
     debug!("pod status: {:?}", &pod.status);

--- a/mirrord/kube/src/api/container/pod.rs
+++ b/mirrord/kube/src/api/container/pod.rs
@@ -1,8 +1,8 @@
 use k8s_openapi::{api::core::v1::Pod, DeepMerge};
 use mirrord_config::agent::AgentConfig;
-use mirrord_protocol::AGENT_OPERATOR_CERT_ENV;
 use serde_json::json;
 
+use super::util::agent_env;
 use crate::{
     api::{
         container::{
@@ -79,26 +79,7 @@ impl ContainerVariant for PodVariant<'_> {
             .expect("Should be valid ResourceRequirements json")
         });
 
-        let env = [
-            ("RUST_LOG".to_string(), agent.log_level.clone()),
-            (
-                "MIRRORD_AGENT_STEALER_FLUSH_CONNECTIONS".to_string(),
-                agent.flush_connections.to_string(),
-            ),
-            (
-                "MIRRORD_AGENT_NFTABLES".to_string(),
-                agent.nftables.to_string(),
-            ),
-        ]
-        .into_iter()
-        .chain(
-            params
-                .tls_cert
-                .clone()
-                .map(|cert| (AGENT_OPERATOR_CERT_ENV.to_string(), cert)),
-        )
-        .map(|(name, value)| json!({ "name": name, "value": value }))
-        .collect::<Vec<_>>();
+        let env = agent_env(agent, params);
 
         serde_json::from_value(json!({
             "metadata": {

--- a/mirrord/kube/src/api/container/util.rs
+++ b/mirrord/kube/src/api/container/util.rs
@@ -56,9 +56,8 @@ pub(super) fn agent_env(agent: &AgentConfig, params: &&ContainerParams) -> Vec<V
     if let Some(timeout) = agent.dns.timeout {
         env.push(("MIRRORD_AGENT_DNS_TIMEOUT".to_string(), timeout.to_string()));
     };
-    
-    env
-        .into_iter()
+
+    env.into_iter()
         .chain(
             params
                 .tls_cert


### PR DESCRIPTION
People reported that specific domains can't resolve anymore post 3.93.1.
I checked the changes and couldn't see anything related besides those parameters, so I decided to make it configurable to see if it helps.