### PR TITLE
feat: `config_file` Shell Completions Hint for Files

### DIFF
--- a/changelog.d/+value-hint-shell-completions-config-file.added.md
+++ b/changelog.d/+value-hint-shell-completions-config-file.added.md
@@ -1,0 +1,2 @@
+Provide value hint to Clap for generating shell completions for config_file to
+only resolve to files, not just first match.

--- a/mirrord/cli/src/config.rs
+++ b/mirrord/cli/src/config.rs
@@ -2,7 +2,7 @@
 
 use std::{fmt::Display, path::PathBuf};
 
-use clap::{ArgGroup, Args, Parser, Subcommand, ValueEnum};
+use clap::{ArgGroup, Args, Parser, Subcommand, ValueEnum, ValueHint};
 use clap_complete::Shell;
 use mirrord_operator::setup::OperatorNamespace;
 
@@ -178,7 +178,7 @@ pub(super) struct ExecArgs {
     pub disable_version_check: bool,
 
     /// Load config from config file
-    #[arg(short = 'f', long)]
+    #[arg(short = 'f', long, value_hint = ValueHint::FilePath)]
     pub config_file: Option<PathBuf>,
 
     /// Kube context to use from Kubeconfig


### PR DESCRIPTION
Currently, shell completions for `mirrord exec --config-file <TAB><TAB>` only will complete to the next match of the path provided, and then assume it is done and append a space. We can provide a value_hint to the macro so that the generated completions only finish for a real file. Test like:

```bash
source <(cargo run completions bash)
mirrord exec --config-file ~/partial/path-<TAB><TAB>
```

*Open Question for Maintainers*: I only did this for the `exec` subcommand - is it the same config file used in all the other subcommands as well? If so, I can also add this value hint for them, just wasn't sure.