### PR TITLE
Improve tera templating error, by digging into the source.

### DIFF
--- a/changelog.d/+261-improve-tera-error.changed.md
+++ b/changelog.d/+261-improve-tera-error.changed.md
@@ -1,0 +1,1 @@
+Improve tera templating config error to dig into source and give out more details.

--- a/mirrord/config/src/config.rs
+++ b/mirrord/config/src/config.rs
@@ -3,6 +3,8 @@ pub mod from_env;
 pub mod source;
 pub mod unstable;
 
+use std::error::Error;
+
 use thiserror::Error;
 
 /// <!--${internal}-->
@@ -49,8 +51,23 @@ pub enum ConfigError {
     )]
     TargetNamespaceWithoutTarget,
 
-    #[error("Template rendering failed, check your config file `{0}`.")]
-    TemplateRenderingFailed(#[from] tera::Error),
+    #[error("Template rendering failed with: `{0}`! Please check your config file!")]
+    TemplateRenderingFailed(String),
+}
+
+impl From<tera::Error> for ConfigError {
+    fn from(fail: tera::Error) -> Self {
+        let mut fail_message = fail.to_string();
+        let mut source = fail.source();
+
+        while let Some(fail_source) = source {
+            fail_message.push_str(" -> ");
+            fail_message.push_str(&fail_source.to_string());
+            source = fail_source.source();
+        }
+
+        Self::TemplateRenderingFailed(fail_message)
+    }
 }
 
 pub type Result<T, E = ConfigError> = std::result::Result<T, E>;

--- a/mirrord/config/src/config.rs
+++ b/mirrord/config/src/config.rs
@@ -61,8 +61,7 @@ impl From<tera::Error> for ConfigError {
         let mut source = fail.source();
 
         while let Some(fail_source) = source {
-            fail_message.push_str(" -> ");
-            fail_message.push_str(&fail_source.to_string());
+            fail_message.push_str(&format!(" -> {fail_source}"));
             source = fail_source.source();
         }
 

--- a/mirrord/config/src/lib.rs
+++ b/mirrord/config/src/lib.rs
@@ -476,9 +476,7 @@ impl LayerFileConfig {
     {
         let mut template_engine = Tera::default();
         template_engine.add_template_file(path.as_ref(), Some("main"))?;
-        let rendered = template_engine
-            .render("main", &tera::Context::new())
-            .inspect_err(|fail| eprintln!("{fail:?}"))?;
+        let rendered = template_engine.render("main", &tera::Context::new())?;
 
         match path.as_ref().extension().and_then(|os_val| os_val.to_str()) {
             Some("json") => Ok(serde_json::from_str::<Self>(&rendered)?),

--- a/mirrord/config/src/lib.rs
+++ b/mirrord/config/src/lib.rs
@@ -476,7 +476,9 @@ impl LayerFileConfig {
     {
         let mut template_engine = Tera::default();
         template_engine.add_template_file(path.as_ref(), Some("main"))?;
-        let rendered = template_engine.render("main", &tera::Context::new())?;
+        let rendered = template_engine
+            .render("main", &tera::Context::new())
+            .inspect_err(|fail| eprintln!("{fail:?}"))?;
 
         match path.as_ref().extension().and_then(|os_val| os_val.to_str()) {
             Some("json") => Ok(serde_json::from_str::<Self>(&rendered)?),


### PR DESCRIPTION
- Issue: [#261](https://github.com/metalbear-co/mirrord-intellij/issues/261)

Improves the error message we get when a tera template config error happens.