### PR TITLE
Agent graceful exit

### DIFF
--- a/changelog.d/2427.fixed.md
+++ b/changelog.d/2427.fixed.md
@@ -1,0 +1,1 @@
+mirrord-agent now catches SIGTERM signal and cleans iptables during graceful deletion.

--- a/mirrord/agent/Cargo.toml
+++ b/mirrord/agent/Cargo.toml
@@ -16,7 +16,7 @@ edition.workspace = true
 
 [dependencies]
 containerd-client = {git = "https://github.com/containerd/rust-extensions", rev="35a97f17d55753bb1ef04c28cd7c3203993932b0"}
-tokio = { workspace = true, features = ["rt", "net", "macros", "fs", "process"] }
+tokio = { workspace = true, features = ["rt", "net", "macros", "fs", "process", "signal"] }
 serde.workspace = true
 serde_json.workspace = true
 pnet = "0.33"

--- a/mirrord/agent/src/error.rs
+++ b/mirrord/agent/src/error.rs
@@ -1,3 +1,5 @@
+use std::process::ExitStatus;
+
 use mirrord_protocol::{
     outgoing::{
         tcp::{DaemonTcpOutgoing, LayerTcpOutgoing},
@@ -138,6 +140,10 @@ pub(crate) enum AgentError {
 
     #[error("TLS setup failed: {0}")]
     TlsSetupError(#[from] TlsSetupError),
+
+    /// Child agent process spawned in `main` failed.
+    #[error("Agent child process failed: {0}")]
+    AgentFailed(ExitStatus),
 }
 
 pub(crate) type Result<T, E = AgentError> = std::result::Result<T, E>;


### PR DESCRIPTION
Closes #2427

`ip_tables_guard` in the agent now captures SIGTERM signals. When a signal is captured, child process (running real agent logic) is killed and the iptables are cleaned.
Additionally, `ip_tables_guard` now properly captures child process exit status and reports errors. Previously it would always discard the `.wait()` result, so errors in the agent logic were silenced (not reported in container status)