### PR TITLE
Send pings on fixed schedule (intproxy)

### DIFF
--- a/changelog.d/+layer-comm-timeout.fixed.md
+++ b/changelog.d/+layer-comm-timeout.fixed.md
@@ -1,0 +1,1 @@
+Fixed ping pong logic for intproxy-agent communication. Intproxy now sends pings on a fixed schedule, regardless of any other messages.


### PR DESCRIPTION
Pings must be sent constantly, regardless of received agent->intproxy messages. Otherwise, we can be hitting layer communication timeouts in the operator