### PR TITLE
Change flaky test to using with_env_vars

### DIFF
--- a/changelog.d/2163.internal.md
+++ b/changelog.d/2163.internal.md
@@ -1,0 +1,1 @@
+Use `with_env_vars` in flaky `fs_config_default` test

--- a/mirrord/config/src/feature/fs.rs
+++ b/mirrord/config/src/feature/fs.rs
@@ -126,20 +126,23 @@ mod tests {
     use rstest::rstest;
 
     use super::*;
-    use crate::config::MirrordConfig;
+    use crate::{config::MirrordConfig, util::testing::with_env_vars};
 
     #[rstest]
     fn fs_config_default() {
-        let mut cfg_context = ConfigContext::default();
         let expect = FsConfig {
             mode: FsModeConfig::Read,
             ..Default::default()
         };
 
-        let fs_config = FsUserConfig::default()
-            .generate_config(&mut cfg_context)
-            .unwrap();
+        with_env_vars(vec![], || {
+            let mut cfg_context = ConfigContext::default();
 
-        assert_eq!(fs_config, expect);
+            let fs_config = FsUserConfig::default()
+                .generate_config(&mut cfg_context)
+                .unwrap();
+
+            assert_eq!(fs_config, expect);
+        });
     }
 }


### PR DESCRIPTION
Closes #2163

Other tests already use the function [with_env_vars](https://github.com/metalbear-co/mirrord/blob/9b9ec7d8d84689a46d63fc768a906bd152ccb2d8/mirrord/config/src/util.rs#L204), it looks like this test was just forgotten. The test was accessing environment variables without a lock, causing it to fail if the environment was polluted by other tests.