### PR TITLE
Fix check-rust-docs warnings

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -169,7 +169,7 @@ jobs:
     if: ${{needs.changed_files.outputs.rs_changed == 'true' || needs.changed_files.outputs.ci_changed == 'true'}}
     env:
       # enables the creation of a workspace index.html page.
-      RUSTDOCFLAGS: "--enable-index-page -Zunstable-options"
+      RUSTDOCFLAGS: "--enable-index-page -Zunstable-options -Dwarnings"
     steps:
       - uses: actions/checkout@v3
       - uses: arduino/setup-protoc@v1
@@ -545,6 +545,7 @@ jobs:
         test_agent,
         lint,
         lint_markdown,
+        check-rust-docs,
       ]
     runs-on: ubuntu-latest
     steps:
@@ -562,5 +563,6 @@ jobs:
             (needs.lint.result == 'success' || needs.lint.result == 'skipped') &&
             (needs.lint_markdown.result == 'success' || needs.lint_markdown.result == 'skipped') &&
             (needs.intellij_e2e_on_release_branch.result == 'success' || needs.intellij_e2e_on_release_branch.result == 'skipped') &&
-            (needs.vscode_e2e_on_release_branch.result == 'success' || needs.vscode_e2e_on_release_branch.result == 'skipped') }}
+            (needs.vscode_e2e_on_release_branch.result == 'success' || needs.vscode_e2e_on_release_branch.result == 'skipped') &&
+            (needs.check-rust-docs.result == 'success' || needs.check-rust-docs.result == 'skipped') }}
         run: echo $CI_SUCCESS && if [ "$CI_SUCCESS" == "true" ]; then echo "SUCCESS" && exit 0; else echo "Failure" && exit 1; fi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,9 @@ once_cell = "1"
 exec = "0.3"
 drain = "0.1"
 
+[workspace.lints.rustdoc]
+private_intra_doc_links = "allow"
+
 [profile.release]
 strip = "debuginfo"
 # Enabling LTO causes this issue https://github.com/metalbear-co/mirrord/issues/906

--- a/changelog.d/1399.internal.md
+++ b/changelog.d/1399.internal.md
@@ -1,0 +1,1 @@
+Fix all check-rust-docs warnings

--- a/medschool/Cargo.toml
+++ b/medschool/Cargo.toml
@@ -13,6 +13,9 @@ categories.workspace = true
 publish.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/medschool/src/main.rs
+++ b/medschool/src/main.rs
@@ -41,7 +41,8 @@ enum DocsError {
     #[error("IO error {0}")]
     IO(#[from] std::io::Error),
 
-    /// May happen (probably never) when [`parse_files`] is reading the source file into a `&str`.
+    /// May happen (probably never) when [`files_to_string`] is reading the source file into a
+    /// `&str`.
     #[error("Read past end of source!")]
     ReadOutOfBounds,
 }
@@ -416,7 +417,7 @@ fn parse_docs_into_tree(files: Vec<syn::File>) -> Result<BTreeSet<PartialType>, 
     Ok(type_docs)
 }
 
-/// Digs into the [`PartialTypes`] building new types that inline the types of their
+/// Digs into the [`PartialType`] building new types that inline the types of their
 /// [`PartialField`]s, turning something like:
 ///
 /// ```no_run
@@ -570,7 +571,7 @@ struct ToolArgs {
 
 /// # Attention when using `RUST_LOG`
 ///
-/// Every function here supports our usual [`tracing::instrument`] setup, with default
+/// Every function here supports our usual [`mod@tracing::instrument`] setup, with default
 /// `log_level = "trace`, but if you dare run with `RUST_LOG=trace` you're going to have a bad time!
 ///
 /// The logging is put in place so you can quickly change whatever function you need to

--- a/mirrord-schema.json
+++ b/mirrord-schema.json
@@ -567,7 +567,7 @@
       "properties": {
         "tcp_ping4_mock": {
           "title": "experimental {#fexperimental-tcp_ping4_mock}",
-          "description": "https://github.com/metalbear-co/mirrord/issues/2421#issuecomment-2093200904",
+          "description": "<https://github.com/metalbear-co/mirrord/issues/2421#issuecomment-2093200904>",
           "type": [
             "boolean",
             "null"
@@ -775,7 +775,7 @@
         },
         "ignore_localhost": {
           "title": "ignore_localhost",
-          "description": "Consider removing when adding https://github.com/metalbear-co/mirrord/issues/702",
+          "description": "Consider removing when adding <https://github.com/metalbear-co/mirrord/issues/702>",
           "type": [
             "boolean",
             "null"

--- a/mirrord/agent/Cargo.toml
+++ b/mirrord/agent/Cargo.toml
@@ -12,6 +12,10 @@ keywords.workspace = true
 categories.workspace = true
 publish.workspace = true
 edition.workspace = true
+
+[lints]
+workspace = true
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/mirrord/agent/src/cgroup.rs
+++ b/mirrord/agent/src/cgroup.rs
@@ -323,8 +323,8 @@ impl CgroupV2 {
     }
 }
 
-/// V1 Docs: https://docs.kernel.org/admin-guide/cgroup-v1/index.html
-/// V2 Docs: https://docs.kernel.org/admin-guide/cgroup-v2.html
+/// V1 Docs: <https://docs.kernel.org/admin-guide/cgroup-v1/index.html>
+/// V2 Docs: <https://docs.kernel.org/admin-guide/cgroup-v2.html>
 #[derive(Debug)]
 pub(crate) enum Cgroup {
     V1(CgroupV1),

--- a/mirrord/agent/src/env.rs
+++ b/mirrord/agent/src/env.rs
@@ -78,7 +78,7 @@ impl EnvFilter {
     }
 }
 
-/// Translate ToIter<AsRef<str>> of "K=V" to HashMap.
+/// Translate `ToIter<AsRef<str>>` of "K=V" to HashMap.
 pub(crate) fn parse_raw_env<'a, S: AsRef<str> + 'a + ?Sized, T: IntoIterator<Item = &'a S>>(
     raw: T,
 ) -> HashMap<String, String> {

--- a/mirrord/agent/src/http.rs
+++ b/mirrord/agent/src/http.rs
@@ -23,9 +23,9 @@ impl HttpVersion {
     pub const MINIMAL_HEADER_SIZE: usize = 10;
 
     /// Checks if `buffer` contains a prefix of a valid HTTP/1.x request, or if it could be an
-    /// HTTP/2 request by comparing it with a slice of [`H2_PREFACE`].
+    /// HTTP/2 request by comparing it with a slice of [`Self::H2_PREFACE`].
     ///
-    /// The given `buffer` must contain at least [`MINIMAL_HEADER_SIZE`] bytes, otherwise this
+    /// The given `buffer` must contain at least [`Self::MINIMAL_HEADER_SIZE`] bytes, otherwise this
     /// function always returns [`None`].
     #[tracing::instrument(level = "trace")]
     pub fn new(buffer: &[u8]) -> Option<Self> {

--- a/mirrord/agent/src/sniffer.rs
+++ b/mirrord/agent/src/sniffer.rs
@@ -48,11 +48,11 @@ pub(crate) struct TcpSessionIdentifier {
     ///
     /// You can get this IP by checking `kubectl get pod -o wide`.
     ///
-    /// ```sh`
+    /// ```sh
     /// $ kubectl get pod -o wide
     /// NAME        READY   STATUS    IP
     /// happy-pod   1/1     Running   1.2.3.4   
-    /// ````
+    /// ```
     dest_addr: Ipv4Addr,
     source_port: u16,
     dest_port: u16,

--- a/mirrord/agent/src/steal/api.rs
+++ b/mirrord/agent/src/steal/api.rs
@@ -85,7 +85,7 @@ impl TcpStealerApi {
     /// Helper function that passes the [`DaemonTcp`] messages we generated in the
     /// [`TcpConnectionStealer`] task, back to the agent.
     ///
-    /// Called in the [`ClientConnectionHandler`].
+    /// Called in the `ClientConnectionHandler`.
     #[tracing::instrument(level = "trace", skip(self))]
     pub(crate) async fn recv(&mut self) -> Result<DaemonTcp> {
         match self.daemon_rx.recv().await {
@@ -122,7 +122,7 @@ impl TcpStealerApi {
             .await
     }
 
-    /// Handles the conversion of [`LayerTcpSteal::TcpData`], that is passed from the
+    /// Handles the conversion of [`TcpData`], that is passed from the
     /// agent, to an internal stealer command [`Command::ResponseData`].
     ///
     /// The actual handling of this message is done in [`TcpConnectionStealer`].

--- a/mirrord/agent/src/steal/connections/filtered.rs
+++ b/mirrord/agent/src/steal/connections/filtered.rs
@@ -342,7 +342,7 @@ pub struct FilteredStealTask<T> {
     /// 3. `None` -> client does not know about this connection at all
     ///
     /// Used to send [`ConnectionMessageOut::Closed`] in [`Self::run`] when
-    /// [`Self::run_until_upgrade`] and [`Self::run_after_upgrade`] have finished.
+    /// [`Self::run_until_http_ends`] and [`Self::run_after_http_ends`] have finished.
     subscribed: HashMap<ClientId, bool>,
 
     /// For receiving [`Request`]s extracted by the [`FilteringService`].

--- a/mirrord/agent/src/steal/http/reversible_stream.rs
+++ b/mirrord/agent/src/steal/http/reversible_stream.rs
@@ -14,7 +14,7 @@ use tokio::{
 /// Wraps a [`TcpStream`] to allow a sort of _peek_ functionality, by reading the first bytes, but
 /// then keeping them for later reads.
 ///
-/// Very useful to the HTTP filter component on [`stealer`], where we have to look at the first
+/// Very useful to the HTTP filter component on `stealer`, where we have to look at the first
 /// message on a [`TcpStream`] to try and identify if this connection is _talking_ HTTP.
 ///
 /// Thanks [finomnis](https://stackoverflow.com/users/2902833/finomnis) for the help!
@@ -31,17 +31,17 @@ pub(crate) struct ReversibleStream<const HEADER_SIZE: usize> {
     /// So we need to always know how many bytes we actually have.
     header_len: usize,
 
-    /// How many bytes out of the [`header`] were already read by the reader of this
+    /// How many bytes out of the `header` were already read by the reader of this
     /// [`ReversibleStream`]. If the reader reads bytes into a buffer that is smaller than
-    /// `HEADER_SIZE`, it would not read the whole [`header`] on the first read, so this is the
-    /// amount of bytes that were already read. After all the bytes from the [`header`] were read,
+    /// `HEADER_SIZE`, it would not read the whole `header` on the first read, so this is the
+    /// amount of bytes that were already read. After all the bytes from the `header` were read,
     /// by the user of this struct, further reads are forwarded to the underlying `TcpStream`.
     num_forwarded: usize,
 }
 
 impl<const HEADER_SIZE: usize> ReversibleStream<HEADER_SIZE> {
-    /// Build a Reversible stream from a TcpStream, move on if not done within given timeout.
-    /// Return an Error if there was an error while reading from the TCP Stream.
+    /// Build a [`ReversibleStream`] from a [`TcpStream`], move on if not done within given timeout.
+    /// Return an Error if there was an error while reading from the [`TcpStream`].
     pub(crate) async fn read_header(stream: TcpStream, timeout: Duration) -> io::Result<Self> {
         let mut this = Self {
             stream,

--- a/mirrord/analytics/Cargo.toml
+++ b/mirrord/analytics/Cargo.toml
@@ -13,6 +13,8 @@ categories.workspace = true
 publish.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
 
 [dependencies]
 base64 = "0.21"

--- a/mirrord/auth/Cargo.toml
+++ b/mirrord/auth/Cargo.toml
@@ -13,6 +13,9 @@ categories.workspace = true
 publish.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]

--- a/mirrord/auth/src/credentials.rs
+++ b/mirrord/auth/src/credentials.rs
@@ -79,7 +79,7 @@ pub trait LicenseValidity {
     /// expiration date of `today + 3` means we have 2 days left until expiry.
     fn days_until_expiration(&self) -> Option<u64>;
 
-    /// Converts a [`NaiveDate`] into a [`NaiveDateTime`], so we can turn it into a
+    /// Converts a [`NaiveDate`] into a [`DateTime`], so we can turn it into a
     /// [`DateTime<UTC>`] to check a license's validity.
     ///
     /// I(alex) think this might cause trouble with potential mismatched timezone offsets, but

--- a/mirrord/cli/Cargo.toml
+++ b/mirrord/cli/Cargo.toml
@@ -13,6 +13,9 @@ categories.workspace = true
 publish.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/mirrord/cli/src/config.rs
+++ b/mirrord/cli/src/config.rs
@@ -169,7 +169,7 @@ pub(super) struct ExecArgs {
     #[arg(long)]
     pub no_udp_outgoing: bool,
 
-    /// Disable telemetry. See https://github.com/metalbear-co/mirrord/blob/main/TELEMETRY.md
+    /// Disable telemetry. See <https://github.com/metalbear-co/mirrord/blob/main/TELEMETRY.md>
     #[arg(long)]
     pub no_telemetry: bool,
 
@@ -199,7 +199,7 @@ pub(super) enum OperatorCommand {
     /// NOTE: You don't need to install the operator to use open source mirrord features.
     #[command(override_usage = "mirrord operator setup [OPTIONS] | kubectl apply -f -")]
     Setup {
-        /// ToS can be read here https://metalbear.co/legal/terms
+        /// ToS can be read here <https://metalbear.co/legal/terms>
         #[arg(long)]
         accept_tos: bool,
 
@@ -310,7 +310,7 @@ pub(super) struct ExtensionExecArgs {
     pub executable: Option<String>,
 }
 
-/// Args for the [`super::verify_config`] mirrord-cli command.
+/// Args for the [`mod@super::verify_config`] mirrord-cli command.
 #[derive(Args, Debug)]
 #[command(group(ArgGroup::new("verify-config")))]
 pub(super) struct VerifyConfigArgs {

--- a/mirrord/cli/src/execution.rs
+++ b/mirrord/cli/src/execution.rs
@@ -207,7 +207,7 @@ impl MirrordExecution {
             format!("127.0.0.1:{port}"),
         );
 
-        // Fix https://github.com/metalbear-co/mirrord/issues/1745
+        // Fix <https://github.com/metalbear-co/mirrord/issues/1745>
         // by disabling the fork safety check in the Objective-C runtime.
         #[cfg(target_os = "macos")]
         env_vars.insert(
@@ -347,7 +347,7 @@ impl MirrordExecution {
     /// Required when called from extension since sometimes the extension
     /// cleans up the process when the parent process exits, so we need the parent to stay alive
     /// while the internal proxy is running.
-    /// See https://github.com/metalbear-co/mirrord/issues/1211
+    /// See <https://github.com/metalbear-co/mirrord/issues/1211>
     pub(crate) async fn wait(mut self) -> Result<()> {
         self.child
             .wait()

--- a/mirrord/cli/src/internal_proxy.rs
+++ b/mirrord/cli/src/internal_proxy.rs
@@ -8,7 +8,7 @@
 //! (previously was solved using envguard which wasn't good enough)
 //!
 //! The proxy will either directly connect to an existing agent (currently only used for tests),
-//! or let the [`OperatorApi`] handle the connection.
+//! or let the [`OperatorApi`](mirrord_operator::client::OperatorApi) handle the connection.
 
 use std::{
     env,
@@ -108,7 +108,7 @@ async fn request_pause(
 /// Creates a listening socket using socket2
 /// to control the backlog and manage scenarios where
 /// the proxy is under heavy load.
-/// https://github.com/metalbear-co/mirrord/issues/1716#issuecomment-1663736500
+/// <https://github.com/metalbear-co/mirrord/issues/1716#issuecomment-1663736500>
 /// in macOS backlog is documented to be hardcoded limited to 128.
 fn create_listen_socket() -> Result<TcpListener, InternalProxySetupError> {
     let socket = socket2::Socket::new(

--- a/mirrord/cli/src/verify_config.rs
+++ b/mirrord/cli/src/verify_config.rs
@@ -1,6 +1,7 @@
-//! `mirrord verify-config [--ide] {path}` builds a [`VerifyConfig`] enum after checking the
-//! config file passed in `path`. It's used by the IDE plugins to display errors/warnings quickly,
-//! without having to start mirrord-layer.
+//! `mirrord verify-config [--ide] {path}` builds a
+//! [`VerifyConfig`](crate::Commands::VerifyConfig) enum after checking the config file passed in
+//! `path`. It's used by the IDE plugins to display errors/warnings quickly, without having to start
+//! mirrord-layer.
 use error::Result;
 use mirrord_config::{
     config::{ConfigContext, MirrordConfig},

--- a/mirrord/config/Cargo.toml
+++ b/mirrord/config/Cargo.toml
@@ -13,6 +13,9 @@ categories.workspace = true
 publish.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 mirrord-config-derive = { path = "./derive"}
 mirrord-analytics = { path = "../analytics"}

--- a/mirrord/config/derive/Cargo.toml
+++ b/mirrord/config/derive/Cargo.toml
@@ -13,6 +13,9 @@ categories.workspace = true
 publish.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]
 proc-macro = true

--- a/mirrord/config/src/experimental.rs
+++ b/mirrord/config/src/experimental.rs
@@ -12,7 +12,7 @@ use crate::config::source::MirrordConfigSource;
 pub struct ExperimentalConfig {
     /// ## experimental {#fexperimental-tcp_ping4_mock}
     ///
-    /// https://github.com/metalbear-co/mirrord/issues/2421#issuecomment-2093200904
+    /// <https://github.com/metalbear-co/mirrord/issues/2421#issuecomment-2093200904>
     #[config(default = true)]
     pub tcp_ping4_mock: bool,
 }

--- a/mirrord/config/src/feature/fs.rs
+++ b/mirrord/config/src/feature/fs.rs
@@ -5,7 +5,7 @@
 //! or disable file operations;
 //!
 //! 2. [`FsUserConfig::Advanced`]: All of the above, plus allows setting up
-//! [`mirrord_layer::file::filter::FileFilter`] to control which files should be opened
+//! `mirrord_layer::file::filter::FileFilter` to control which files should be opened
 //! locally or remotely.
 use schemars::JsonSchema;
 use serde::Deserialize;

--- a/mirrord/config/src/feature/network/incoming.rs
+++ b/mirrord/config/src/feature/network/incoming.rs
@@ -195,7 +195,7 @@ pub struct IncomingAdvancedFileConfig {
 
     /// ### ignore_localhost
     ///
-    /// Consider removing when adding https://github.com/metalbear-co/mirrord/issues/702
+    /// Consider removing when adding <https://github.com/metalbear-co/mirrord/issues/702>
     pub ignore_localhost: Option<bool>,
 
     /// ### ignore_ports

--- a/mirrord/console/Cargo.toml
+++ b/mirrord/console/Cargo.toml
@@ -13,6 +13,9 @@ categories.workspace = true
 publish.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [[bin]]
 name = "mirrord-console"
 required-features = ["binary"]

--- a/mirrord/console/src/async_logger.rs
+++ b/mirrord/console/src/async_logger.rs
@@ -52,8 +52,8 @@ impl LoggerTask {
 }
 
 /// Console logger that sends log messages to the console app using
-/// [`codec`](mirrord_intproxy::codec). It uses a background [`tokio::task`] to send messages with
-/// an [`AsyncEncoder`].
+/// [`codec`](mirrord_intproxy_protocol::codec). It uses a background [`tokio::task`] to send
+/// messages with an [`AsyncEncoder`].
 pub struct AsyncConsoleLogger {
     tx: Sender<Record>,
 }

--- a/mirrord/console/src/logger.rs
+++ b/mirrord/console/src/logger.rs
@@ -9,8 +9,8 @@ use crate::{
 };
 
 /// Console logger that sends log messages to the console app using
-/// [`codec`](mirrord_intproxy::codec). It does not use any additional threads, but simply sends the
-/// log records through a [`SyncEncoder`].
+/// [`codec`](mirrord_intproxy_protocol::codec). It does not use any additional threads, but simply
+/// sends the log records through a [`SyncEncoder`].
 pub struct ConsoleLogger {
     encoder: Mutex<SyncEncoder<Record, BufWriter<TcpStream>>>,
 }

--- a/mirrord/intproxy/Cargo.toml
+++ b/mirrord/intproxy/Cargo.toml
@@ -13,6 +13,9 @@ categories.workspace = true
 publish.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/mirrord/intproxy/protocol/Cargo.toml
+++ b/mirrord/intproxy/protocol/Cargo.toml
@@ -13,6 +13,9 @@ categories.workspace = true
 publish.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/mirrord/intproxy/protocol/src/lib.rs
+++ b/mirrord/intproxy/protocol/src/lib.rs
@@ -260,7 +260,7 @@ pub trait IsLayerRequest: Sized {
 
 /// A helper trait for `layer -> proxy` requests that require a response from the proxy.
 /// Not all layer requests require a response, e.g.
-/// [`CloseFileRequest`](mirrord_protocol::file::CloseFileRequest).
+/// [`CloseFileRequest`].
 ///
 /// # Note
 ///

--- a/mirrord/intproxy/protocol/src/macros.rs
+++ b/mirrord/intproxy/protocol/src/macros.rs
@@ -3,7 +3,7 @@
 /// A helper macro for binding inner-most values from complex enum expressions.
 /// Accepts an identifier and a non-empty sequence of enum paths.
 ///
-/// Used in [`impl_request`] macro for `match` expressions.
+/// Used in [`impl_request`](`macro@crate::impl_request`) macro for `match` expressions.
 ///
 /// # Example
 ///
@@ -34,7 +34,7 @@ macro_rules! bind_nested {
 
 /// A helper macro for implementing [`IsLayerRequest`](super::IsLayerRequest) and
 /// [`IsLayerRequestWithResponse`](super::IsLayerRequestWithResponse) traits. Accepts arguments in
-/// two forms, see invocations in [`crate::protocol`] for
+/// two forms, see invocations in [`protocol`](crate) for
 /// [`OpenFileRequest`](mirrord_protocol::file::OpenFileRequest) and
 /// [`CloseFileRequest`](mirrord_protocol::file::CloseFileRequest) below in this file. Invocation
 /// for [`OpenFileRequest`](mirrord_protocol::file::OpenFileRequest) generates both

--- a/mirrord/intproxy/src/proxies/incoming.rs
+++ b/mirrord/intproxy/src/proxies/incoming.rs
@@ -154,8 +154,9 @@ pub struct IncomingProxy {
 }
 
 impl IncomingProxy {
-    /// Used when registering new [`RawInterceptor`] and [`HttpInterceptor`] tasks in the
+    /// Used when registering new `RawInterceptor` and `HttpInterceptor` tasks in the
     /// [`BackgroundTasks`] struct.
+    // TODO: Update outdated documentation. RawInterceptor, HttpInterceptor do not exist
     const CHANNEL_SIZE: usize = 512;
 
     /// Tries to register the new subscription in the [`SubscriptionsManager`].
@@ -176,7 +177,7 @@ impl IncomingProxy {
         }
     }
 
-    /// Tries to unregister the subscription from the [`SubscriptionManager`].
+    /// Tries to unregister the subscription from the [`SubscriptionsManager`].
     #[tracing::instrument(level = "trace", skip(self, message_bus))]
     async fn handle_port_unsubscribe(
         &mut self,

--- a/mirrord/intproxy/src/proxies/outgoing.rs
+++ b/mirrord/intproxy/src/proxies/outgoing.rs
@@ -27,7 +27,7 @@ mod net_protocol_ext;
 /// Errors that can occur when handling the `outgoing` feature.
 #[derive(Error, Debug)]
 pub enum OutgoingProxyError {
-    /// The agent sent an error not bound to any [`ConnectionId`](mirrord_protocol::ConnectionId).
+    /// The agent sent an error not bound to any [`ConnectionId`].
     /// This is assumed to be a general agent error.
     /// Originates only from the [`RemoteResult<DaemonRead>`] message.
     #[error("agent error: {0}")]

--- a/mirrord/kube/Cargo.toml
+++ b/mirrord/kube/Cargo.toml
@@ -13,6 +13,9 @@ categories.workspace = true
 publish.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [features]
 default = []
 incluster = []

--- a/mirrord/layer/Cargo.toml
+++ b/mirrord/layer/Cargo.toml
@@ -12,6 +12,10 @@ keywords.workspace = true
 categories.workspace = true
 publish.workspace = true
 edition.workspace = true
+
+[lints]
+workspace = true
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/mirrord/layer/macro/Cargo.toml
+++ b/mirrord/layer/macro/Cargo.toml
@@ -13,6 +13,9 @@ categories.workspace = true
 publish.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 proc-macro = true
 

--- a/mirrord/layer/src/detour.rs
+++ b/mirrord/layer/src/detour.rs
@@ -85,7 +85,7 @@ impl Drop for DetourGuard {
     }
 }
 
-/// Wrapper around [`OnceLock`](std::sync::OnceLock), mainly used for the [`Deref`] implementation
+/// Wrapper around [`OnceLock`], mainly used for the [`Deref`] implementation
 /// to simplify calls to the original functions as `FN_ORIGINAL()`, instead of
 /// `FN_ORIGINAL.get().unwrap()`.
 #[derive(Debug)]
@@ -100,7 +100,7 @@ impl<T> Deref for HookFn<T> {
 }
 
 impl<T> HookFn<T> {
-    /// Helper function to set the inner [`OnceLock`](std::sync::OnceLock) `T` of `self`.
+    /// Helper function to set the inner [`OnceLock`] `T` of `self`.
     pub(crate) fn set(&self, value: T) -> Result<(), T> {
         self.0.set(value)
     }
@@ -134,7 +134,7 @@ pub(crate) enum Bypass {
     /// Similar to `LocalFdNotFound`, but for [`OPEN_DIRS`](crate::file::open_dirs::OPEN_DIRS).
     LocalDirStreamNotFound(usize),
 
-    /// A conversion from [`SockAddr`](socket2::sockaddr::SockAddr) to
+    /// A conversion from [`SockAddr`](socket2::SockAddr) to
     /// [`SocketAddr`](std::net::SocketAddr) failed.
     AddressConversion,
 

--- a/mirrord/layer/src/error.rs
+++ b/mirrord/layer/src/error.rs
@@ -12,8 +12,9 @@ use tracing::{error, info};
 
 use crate::{graceful_exit, proxy_connection::ProxyError};
 
-/// Private module for preventing access to the [`IGNORE_ERROR_CODES`] constant.
 mod ignore_codes {
+    //! Private module for preventing access to the [`IGNORE_ERROR_CODES`] constant.
+
     /// Error codes from [`libc`] that are **not** hard errors, meaning the operation may progress.
     ///
     /// Prefer using [`is_ignored_code`] instead of relying on this constant.

--- a/mirrord/layer/src/file/ops.rs
+++ b/mirrord/layer/src/file/ops.rs
@@ -427,8 +427,8 @@ pub(crate) fn xstat(
 ///
 /// Due to backwards compatibility on the [`mirrord_protocol`] level, we use [`XstatRequest`] to get
 /// the remote file metadata.
-/// Because of this, we're not able to fill all field of the [`statx`] structure. Missing fields
-/// are:
+/// Because of this, we're not able to fill all field of the [`struct@statx`] structure. Missing
+/// fields are:
 /// 1. [`statx::stx_attributes`]
 /// 2. [`statx::stx_ctime`]
 /// 3. [`statx::stx_mnt_id`]

--- a/mirrord/layer/src/lib.rs
+++ b/mirrord/layer/src/lib.rs
@@ -476,7 +476,7 @@ fn sip_only_layer_start(mut config: LayerConfig, patch_binaries: Vec<String>) {
 ///   `FsConfig::is_active`, and [`hooks::enable_file_hooks`](file::hooks::enable_file_hooks);
 ///
 /// - `enabled_remote_dns`: replaces [`libc::getaddrinfo`] and [`libc::freeaddrinfo`] when this is
-///   `true`, see [`NetworkConfig`], and
+///   `true`, see [`NetworkConfig`](mirrord_config::feature::network::NetworkConfig), and
 ///   [`hooks::enable_socket_hooks`](socket::hooks::enable_socket_hooks).
 #[mirrord_layer_macro::instrument(level = "trace")]
 fn enable_hooks(enabled_file_ops: bool, enabled_remote_dns: bool, patch_binaries: Vec<String>) {
@@ -582,7 +582,7 @@ pub(crate) unsafe extern "C" fn close_detour(fd: c_int) -> c_int {
 
 /// Hook for `libc::fork`.
 ///
-/// on macOS, be wary what we do in this path as we might trigger https://github.com/metalbear-co/mirrord/issues/1745
+/// on macOS, be wary what we do in this path as we might trigger <https://github.com/metalbear-co/mirrord/issues/1745>
 #[hook_guard_fn]
 pub(crate) unsafe extern "C" fn fork_detour() -> pid_t {
     tracing::debug!("Process {} forking!.", std::process::id());
@@ -645,7 +645,7 @@ pub(crate) unsafe extern "C" fn __close_detour(fd: c_int) -> c_int {
 /// ## Hook
 ///
 /// Needed for libuv that calls the syscall directly.
-/// https://github.dev/libuv/libuv/blob/7b84d5b0ecb737b4cc30ce63eade690d994e00a6/src/unix/core.c#L557-L558
+/// <https://github.dev/libuv/libuv/blob/7b84d5b0ecb737b4cc30ce63eade690d994e00a6/src/unix/core.c#L557-L558>
 #[cfg(target_os = "linux")]
 #[hook_guard_fn]
 pub(crate) unsafe extern "C" fn uv_fs_close_detour(

--- a/mirrord/layer/src/macros.rs
+++ b/mirrord/layer/src/macros.rs
@@ -2,7 +2,7 @@
 //!
 //! ## Macros
 //!
-//! - [`replace!`]
+//! - [`replace!`](`macro@crate::replace`)
 //!
 //! Replaces a [`libc`] function with a hook.
 //!
@@ -10,7 +10,7 @@
 //!
 //! Used to hook go symbols.
 //!
-//! - [`graceful_exit!`]
+//! - [`graceful_exit!`](`macro@crate::graceful_exit`)
 //!
 //! Exits the process with a nice message.
 

--- a/mirrord/layer/src/socket.rs
+++ b/mirrord/layer/src/socket.rs
@@ -56,7 +56,7 @@ pub struct Connected {
     /// impersonated-pod 0/1     Running   1.2.3.4
     /// ```
     ///
-    /// We would set this ip as `1.2.3.4:{port}` in [`bind`], where `{port}` is the user requested
+    /// We would set this ip as `1.2.3.4:{port}` in `bind`, where `{port}` is the user requested
     /// port.
     local_address: SocketAddress,
 
@@ -78,7 +78,7 @@ pub struct Connected {
 /// bound address.
 #[derive(Debug, Clone, Copy)]
 pub struct Bound {
-    /// Address originally requested by the user for [`bind`].
+    /// Address originally requested by the user for `bind`.
     requested_address: SocketAddr,
 
     /// Actual bound address that we use to communicate between the user's listener socket and our
@@ -181,7 +181,7 @@ impl UserSocket {
 /// Holds valid address that we should use to `connect_outgoing`.
 #[derive(Debug, Clone, Copy)]
 enum ConnectionThrough {
-    /// Connect locally, this means just call `FN_CONNECT` on the inner [`SokcetAddr`].
+    /// Connect locally, this means just call `FN_CONNECT` on the inner [`SocketAddr`].
     Local(SocketAddr),
 
     /// Connect through the agent.

--- a/mirrord/layer/src/socket/hooks.rs
+++ b/mirrord/layer/src/socket/hooks.rs
@@ -109,9 +109,9 @@ pub(crate) unsafe extern "C" fn gethostname_detour(
 /// Hook for `libc::gethostbyname` (you won't find this in rust's `libc` as it's been deprecated and
 /// removed).
 ///
-/// Resolves DNS `raw_name` and allocates a `static` [`libc::hostent`] that we change the inner
-/// values whenever this function is called. The address itself of `*mut hostent` has to remain the
-/// same (thus why it's a `static`).
+/// Resolves DNS `raw_name` and allocates a `static` [`libc::hostent`] that we change the
+/// inner values whenever this function is called. The address itself of `*mut hostent` has to
+/// remain the same (thus why it's a `static`).
 #[hook_guard_fn]
 unsafe extern "C" fn gethostbyname_detour(raw_name: *const c_char) -> *mut hostent {
     let rawish_name = (!raw_name.is_null()).then(|| CStr::from_ptr(raw_name));
@@ -319,7 +319,7 @@ unsafe extern "C" fn freeaddrinfo_detour(addrinfo: *mut libc::addrinfo) {
         })
 }
 
-/// Not a faithful reproduction of what [`libc::recv_from`] is supposed to do, see [`recv_from`].
+/// Not a faithful reproduction of what [`libc::recvmsg`] is supposed to do, see [`recv_from`].
 #[hook_guard_fn]
 pub(super) unsafe extern "C" fn recv_from_detour(
     sockfd: i32,
@@ -353,7 +353,7 @@ pub(super) unsafe extern "C" fn recv_from_detour(
     }
 }
 
-/// Not a faithful reproduction of what [`libc::send_to`] is supposed to do, see [`send_to`].
+/// Not a faithful reproduction of what [`libc::sendto`] is supposed to do, see [`send_to`].
 #[hook_guard_fn]
 pub(super) unsafe extern "C" fn send_to_detour(
     sockfd: RawFd,
@@ -415,7 +415,7 @@ pub(super) unsafe extern "C" fn recvmsg_detour(
 
 /// Not a faithful reproduction of what [`libc::sendmsg`] is supposed to do, see [`sendmsg`].
 ///
-/// TODO(alex): We are ignoring the control message header [`libc::cmgshdr`].
+/// TODO(alex): We are ignoring the control message header [`libc::cmsghdr`].
 #[hook_guard_fn]
 pub(super) unsafe extern "C" fn sendmsg_detour(
     sockfd: RawFd,

--- a/mirrord/layer/src/socket/hooks.rs
+++ b/mirrord/layer/src/socket/hooks.rs
@@ -414,8 +414,8 @@ pub(super) unsafe extern "C" fn recvmsg_detour(
 }
 
 /// Not a faithful reproduction of what [`libc::sendmsg`] is supposed to do, see [`sendmsg`].
-///
-/// TODO(alex): We are ignoring the control message header [`libc::cmsghdr`].
+//
+// TODO(alex): We are ignoring the control message header `libc::cmsghdr`.
 #[hook_guard_fn]
 pub(super) unsafe extern "C" fn sendmsg_detour(
     sockfd: RawFd,

--- a/mirrord/layer/src/socket/ops.rs
+++ b/mirrord/layer/src/socket/ops.rs
@@ -769,7 +769,7 @@ pub(super) fn fcntl(orig_fd: c_int, cmd: c_int, fcntl_fd: i32) -> Result<(), Hoo
 }
 
 /// Managed part of our [`dup_detour`], that clones the `Arc<T>` thing we have keyed by `fd`
-/// ([`UserSocket`], or [`RemoteFile`]).
+/// ([`UserSocket`], or [`file::ops::RemoteFile`]).
 ///
 /// - `SWITCH_MAP`:
 ///
@@ -1055,10 +1055,10 @@ pub(super) fn gethostname() -> Detour<&'static CString> {
 /// we don't actually [`libc::connect`] `sockfd`, but we change the respective [`UserSocket`] to
 /// [`SocketState::Connected`].
 ///
-/// Here we check for this invariant, so if a user calls [`libc::recv_from`] without previously
-/// either connecting this `sockfd`, or calling [`libc::send_to`], we're going to panic.
+/// Here we check for this invariant, so if a user calls [`libc::recvmsg`] without previously
+/// either connecting this `sockfd`, or calling [`libc::sendto`], we're going to panic.
 ///
-/// It performs the [`fill_address`] requirement of [`libc::recv_from`] with the correct remote
+/// It performs the [`fill_address`] requirement of [`libc::recvmsg`] with the correct remote
 /// address (instead of using our interceptor address).
 ///
 /// ## Any other port
@@ -1150,7 +1150,7 @@ fn send_dns_patch(
 ///
 /// There is a bit of trickery going on here, as this function first triggers a _semantical_
 /// connection to an interceptor socket (we don't [`libc::connect`] this `sockfd`, just change the
-/// [`UserSocket`] state), and only then calls the actual [`libc::send_to`] to send `raw_message` to
+/// [`UserSocket`] state), and only then calls the actual [`libc::sendto`] to send `raw_message` to
 /// the interceptor address (instead of the `raw_destination`).
 ///
 /// ## Any other port

--- a/mirrord/layer/tests/apps/dns_resolve/Cargo.toml
+++ b/mirrord/layer/tests/apps/dns_resolve/Cargo.toml
@@ -3,6 +3,9 @@ name = "dns_resolve"
 version = "0.1.0"
 edition = "2021"
 
+[lints]
+workspace = true
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/mirrord/layer/tests/apps/issue1776/Cargo.toml
+++ b/mirrord/layer/tests/apps/issue1776/Cargo.toml
@@ -13,6 +13,9 @@ categories.workspace = true
 publish.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 libc.workspace = true
 socket2.workspace = true

--- a/mirrord/layer/tests/apps/issue1776portnot53/Cargo.toml
+++ b/mirrord/layer/tests/apps/issue1776portnot53/Cargo.toml
@@ -13,6 +13,9 @@ categories.workspace = true
 publish.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 libc.workspace = true
 socket2.workspace = true

--- a/mirrord/layer/tests/apps/issue1899/Cargo.toml
+++ b/mirrord/layer/tests/apps/issue1899/Cargo.toml
@@ -13,5 +13,8 @@ categories.workspace = true
 publish.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 libc.workspace = true

--- a/mirrord/layer/tests/apps/issue2001/Cargo.toml
+++ b/mirrord/layer/tests/apps/issue2001/Cargo.toml
@@ -13,5 +13,8 @@ categories.workspace = true
 publish.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 libc.workspace = true

--- a/mirrord/layer/tests/apps/listen_ports/Cargo.toml
+++ b/mirrord/layer/tests/apps/listen_ports/Cargo.toml
@@ -12,3 +12,6 @@ keywords.workspace = true
 categories.workspace = true
 publish.workspace = true
 edition.workspace = true
+
+[lints]
+workspace = true

--- a/mirrord/layer/tests/apps/outgoing/Cargo.toml
+++ b/mirrord/layer/tests/apps/outgoing/Cargo.toml
@@ -12,3 +12,6 @@ keywords.workspace = true
 categories.workspace = true
 publish.workspace = true
 edition.workspace = true
+
+[lints]
+workspace = true

--- a/mirrord/layer/tests/apps/recv_from/Cargo.toml
+++ b/mirrord/layer/tests/apps/recv_from/Cargo.toml
@@ -3,6 +3,9 @@ name = "recv_from"
 version = "0.1.0"
 edition = "2021"
 
+[lints]
+workspace = true
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/mirrord/layer/tests/java_sip.rs
+++ b/mirrord/layer/tests/java_sip.rs
@@ -9,7 +9,7 @@ use tokio::net::TcpListener;
 mod common;
 pub use common::*;
 
-/// Regression test for https://github.com/metalbear-co/mirrord/issues/1459
+/// Regression test for <https://github.com/metalbear-co/mirrord/issues/1459>
 /// Test that Java Termulin installed via SDKMan can run with mirrord.
 ///
 /// This test requires there to be a java binary at ~/.sdkman/candidates/java/17.0.6-tem/bin/java to

--- a/mirrord/macros/Cargo.toml
+++ b/mirrord/macros/Cargo.toml
@@ -13,6 +13,8 @@ categories.workspace = true
 publish.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
 
 [lib]
 proc-macro = true

--- a/mirrord/macros/src/lib.rs
+++ b/mirrord/macros/src/lib.rs
@@ -6,7 +6,7 @@ use proc_macro2_diagnostics::SpanDiagnosticExt;
 use semver::Version;
 use syn::{parse_macro_input, spanned::Spanned};
 
-/// Use [`protocol_break`] to mark code that should be revised when the major version is bumped.
+/// Use [`protocol_break()`] to mark code that should be revised when the major version is bumped.
 /// For example:
 /// #[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
 /// pub enum StealType {

--- a/mirrord/operator/Cargo.toml
+++ b/mirrord/operator/Cargo.toml
@@ -13,6 +13,9 @@ categories.workspace = true
 publish.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [features]
 default = []
 license-fetch = ["dep:reqwest"]

--- a/mirrord/progress/Cargo.toml
+++ b/mirrord/progress/Cargo.toml
@@ -13,6 +13,9 @@ categories.workspace = true
 publish.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 indicatif = "0.17"
 serde.workspace = true

--- a/mirrord/progress/src/lib.rs
+++ b/mirrord/progress/src/lib.rs
@@ -46,8 +46,8 @@ pub trait Progress: Sized {
     fn set_fail_on_drop(&mut self, fail: bool);
 }
 
-/// `ProgressMode` specifies the way progress is reported
-/// by [`TaskProgress`].
+/// `ProgressMode` specifies the way progress is reported by `TaskProgress`.
+// TODO: update outdated comment
 #[derive(Debug)]
 #[enum_dispatch(Progress)]
 pub enum ProgressTracker {

--- a/mirrord/protocol/Cargo.toml
+++ b/mirrord/protocol/Cargo.toml
@@ -13,6 +13,9 @@ categories.workspace = true
 publish.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 actix-codec.workspace = true
 bytes.workspace = true

--- a/mirrord/protocol/src/outgoing.rs
+++ b/mirrord/protocol/src/outgoing.rs
@@ -108,7 +108,7 @@ impl TryFrom<SocketAddress> for OsSockAddr {
     }
 }
 
-/// For error messages, e.g. [`RemoteError::ConnectTimeOut`].
+/// For error messages, e.g. `RemoteError::ConnectTimeOut`.
 impl Display for SocketAddress {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let addr = match self {

--- a/mirrord/sip/Cargo.toml
+++ b/mirrord/sip/Cargo.toml
@@ -13,6 +13,9 @@ categories.workspace = true
 publish.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 apple-codesign = { version = "0.27", default-features = false}
 memchr = "2"

--- a/sample/rust/Cargo.toml
+++ b/sample/rust/Cargo.toml
@@ -3,6 +3,9 @@ name = "sample-rust"
 version = "0.1.0"
 edition = "2021"
 
+[lints]
+workspace = true
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -3,6 +3,9 @@ name = "tests"
 version = "0.1.0"
 edition = "2021"
 
+[lints]
+workspace = true
+
 [lib]
 doctest = false
 

--- a/tests/issue1317/Cargo.toml
+++ b/tests/issue1317/Cargo.toml
@@ -13,6 +13,9 @@ categories.workspace = true
 publish.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/tests/rust-bypassed-unix-socket/Cargo.toml
+++ b/tests/rust-bypassed-unix-socket/Cargo.toml
@@ -13,6 +13,9 @@ categories.workspace = true
 publish.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/tests/rust-e2e-fileops/Cargo.toml
+++ b/tests/rust-e2e-fileops/Cargo.toml
@@ -13,6 +13,9 @@ categories.workspace = true
 publish.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/tests/rust-unix-socket-client/Cargo.toml
+++ b/tests/rust-unix-socket-client/Cargo.toml
@@ -13,6 +13,9 @@ categories.workspace = true
 publish.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/tests/rust-websockets/Cargo.toml
+++ b/tests/rust-websockets/Cargo.toml
@@ -3,6 +3,9 @@ name = "rust-websockets"
 version = "0.1.0"
 edition = "2021"
 
+[lints]
+workspace = true
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/tests/src/utils.rs
+++ b/tests/src/utils.rs
@@ -658,8 +658,9 @@ impl Drop for KubeService {
 
 /// Create a new [`KubeService`] and related Kubernetes resources. The resources will be deleted
 /// when the returned service is dropped, unless it is dropped during panic.
-/// This behavior can be changed, see [`FORCE_CLEANUP_ENV_NAME`].
+/// This behavior can be changed, see `FORCE_CLEANUP_ENV_NAME`.
 /// * `randomize_name` - whether a random suffix should be added to the end of the resource names
+// TODO: update outdated comment, FORCE_CLEANUP_ENV_NAME does not exist
 #[fixture]
 pub async fn service(
     #[default("default")] namespace: &str,
@@ -904,7 +905,7 @@ pub async fn pause_services(#[future] kube_client: Client) -> (KubeService, Kube
     (requester, logger)
 }
 
-/// Service that listens on port 80 and returns "remote: <DATA>" when getting "<DATA>" directly
+/// Service that listens on port 80 and returns `remote: <DATA>` when getting `<DATA>` directly
 /// over TCP, not HTTP.
 #[fixture]
 pub async fn tcp_echo_service(#[future] kube_client: Client) -> KubeService {
@@ -920,7 +921,7 @@ pub async fn tcp_echo_service(#[future] kube_client: Client) -> KubeService {
 }
 
 /// [Service](https://github.com/metalbear-co/test-images/blob/main/websocket/app.mjs)
-/// that listens on port 80 and returns "remote: <DATA>" when getting "<DATA>" over a websocket
+/// that listens on port 80 and returns `remote: <DATA>` when getting `<DATA>` over a websocket
 /// connection, allowing us to test HTTP upgrade requests.
 #[fixture]
 pub async fn websocket_service(#[future] kube_client: Client) -> KubeService {
@@ -948,7 +949,7 @@ pub async fn http2_service(#[future] kube_client: Client) -> KubeService {
     .await
 }
 
-/// Service that listens on port 80 and returns "remote: <DATA>" when getting "<DATA>" directly
+/// Service that listens on port 80 and returns `remote: <DATA>` when getting `<DATA>` directly
 /// over TCP, not HTTP.
 #[fixture]
 pub async fn hostname_service(#[future] kube_client: Client) -> KubeService {


### PR DESCRIPTION
Closes #1399 

- Removed some broken links to items that exist but are not in scope - if they are to be linked, the path needs to be specified manually
- Added TODOs where items appear to not exist in the codebase - possibly they refer to something that has since been renamed
- Added angle brackets around bare links in doc comments
- Fixed spellings on some links
- Added backticks to e.g. `<DATA>` that rust-doc interprets as an HTML tag
- Allowed public → private links