### PR TITLE
Improve `mirrord-kube` errors

### DIFF
--- a/changelog.d/+mirrord-kube-errors.fixed.md
+++ b/changelog.d/+mirrord-kube-errors.fixed.md
@@ -1,0 +1,1 @@
+Fixed confusing errors produced when creating an agent.

--- a/mirrord-schema.json
+++ b/mirrord-schema.json
@@ -305,16 +305,13 @@
         },
         "image_pull_secrets": {
           "title": "agent.image_pull_secrets {#agent-image_pull_secrets}",
-          "description": "List of secrets the agent pod has access to.\n\nTakes an array of hash with the format `{ name: <secret-name> }`.\n\nRead more [here](https://kubernetes.io/docs/concepts/containers/images/).\n\n```json { \"agent\": { \"image_pull_secrets\": [ { \"very-secret\": \"secret-key\" }, { \"very-secret\": \"keep-your-secrets\" } ] } } ```",
+          "description": "List of secrets the agent pod has access to.\n\nTakes an array of entries with the format `{ name: <secret-name> }`.\n\nRead more [here](https://kubernetes.io/docs/concepts/containers/images/#referring-to-an-imagepullsecrets-on-a-pod).\n\n```json { \"agent\": { \"image_pull_secrets\": [ { \"name\": \"secret-key-1\" }, { \"name\": \"secret-key-2\" } ] } } ```",
           "type": [
             "array",
             "null"
           ],
           "items": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
+            "$ref": "#/definitions/AgentPullSecret"
           }
         },
         "log_level": {
@@ -433,6 +430,19 @@
           "additionalProperties": false
         }
       ]
+    },
+    "AgentPullSecret": {
+      "description": "<!--${internal}--> Specifies a secret reference for the agent pod.",
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "description": "Name of the secret.",
+          "type": "string"
+        }
+      }
     },
     "ConcurrentSteal": {
       "description": "(Operator Only): Allows overriding port locks\n\nCan be set to either `\"continue\"` or `\"override\"`.\n\n- `\"continue\"`: Continue with normal execution - `\"override\"`: If port lock detected then override it with new lock and force close the original locking connection.",

--- a/mirrord/config/src/lib.rs
+++ b/mirrord/config/src/lib.rs
@@ -497,7 +497,6 @@ impl LayerFileConfig {
 mod tests {
 
     use std::{
-        collections::HashMap,
         fs::{File, OpenOptions},
         io::{Read, Write},
     };
@@ -671,7 +670,7 @@ mod tests {
     fn full(
         #[values(ConfigType::Json, ConfigType::Toml, ConfigType::Yaml)] config_type: ConfigType,
     ) {
-        use crate::agent::AgentImageFileConfig;
+        use crate::agent::{AgentImageFileConfig, AgentPullSecret};
 
         let input = config_type.full();
 
@@ -697,10 +696,9 @@ mod tests {
                 namespace: Some("default".to_owned()),
                 image: Some(AgentImageFileConfig::Simple(Some("".to_owned()))),
                 image_pull_policy: Some("".to_owned()),
-                image_pull_secrets: Some(vec![HashMap::from([(
-                    "name".to_owned(),
-                    "testsecret".to_owned(),
-                )])]),
+                image_pull_secrets: Some(vec![AgentPullSecret {
+                    name: "testsecret".to_owned(),
+                }]),
                 ttl: Some(60),
                 ephemeral: Some(false),
                 communication_timeout: None,

--- a/mirrord/kube/src/api/container.rs
+++ b/mirrord/kube/src/api/container.rs
@@ -116,7 +116,7 @@ where
 /// We also check if we're in a mesh based on `MESH_LIST`, returning whether we are or not.
 #[tracing::instrument(level = "trace", ret)]
 pub fn choose_container<'a>(
-    container_name: &Option<String>,
+    container_name: Option<&str>,
     container_statuses: &'a [ContainerStatus],
 ) -> (Option<&'a ContainerStatus>, Option<MeshVendor>) {
     const ISTIO: [&str; 2] = ["istio-proxy", "istio-init"];
@@ -138,7 +138,7 @@ pub fn choose_container<'a>(
     let container = if let Some(name) = container_name {
         container_statuses
             .iter()
-            .find(|&status| &status.name == name)
+            .find(|&status| status.name == name)
     } else {
         // Choose any container that isn't part of the skip list
         container_statuses

--- a/mirrord/kube/src/api/container.rs
+++ b/mirrord/kube/src/api/container.rs
@@ -75,7 +75,7 @@ pub trait ContainerVariant {
 
     fn params(&self) -> &ContainerParams;
 
-    fn as_update(&self) -> Result<Self::Update>;
+    fn as_update(&self) -> Self::Update;
 }
 
 impl<T> ContainerVariant for Box<T>
@@ -92,7 +92,7 @@ where
         T::params(self)
     }
 
-    fn as_update(&self) -> Result<Self::Update> {
+    fn as_update(&self) -> Self::Update {
         T::as_update(self)
     }
 }

--- a/mirrord/kube/src/api/container/ephemeral.rs
+++ b/mirrord/kube/src/api/container/ephemeral.rs
@@ -1,5 +1,7 @@
 use futures::StreamExt;
-use k8s_openapi::api::core::v1::{EphemeralContainer as KubeEphemeralContainer, Pod};
+use k8s_openapi::api::core::v1::{
+    Capabilities, EphemeralContainer as KubeEphemeralContainer, Pod, SecurityContext,
+};
 use kube::{
     api::PostParams,
     runtime::{watcher, WatchStreamExt},
@@ -7,7 +9,6 @@ use kube::{
 };
 use mirrord_config::agent::AgentConfig;
 use mirrord_progress::Progress;
-use serde_json::json;
 use tokio::pin;
 use tracing::debug;
 
@@ -56,7 +57,7 @@ where
     // Ephemeral should never be targetless, so there should be runtime data.
     let mut container_progress = progress.subtask("creating ephemeral container...");
 
-    let mut ephemeral_container: KubeEphemeralContainer = variant.as_update()?;
+    let mut ephemeral_container: KubeEphemeralContainer = variant.as_update();
     debug!("Requesting ephemeral_containers_subresource");
 
     let pod_api = get_k8s_resource_api(client, runtime_data.pod_namespace.as_deref());
@@ -104,7 +105,8 @@ where
             "ephemeralcontainers",
             &runtime_data.pod_name,
             &PostParams::default(),
-            serde_json::to_vec(&ephemeral_containers_subresource).map_err(KubeApiError::from)?,
+            serde_json::to_vec(&ephemeral_containers_subresource)
+                .expect("serialization to vector never fails"),
         )
         .await
         .map_err(KubeApiError::KubeError)?;
@@ -193,7 +195,7 @@ impl ContainerVariant for EphemeralTargetedVariant<'_> {
         self.params
     }
 
-    fn as_update(&self) -> Result<KubeEphemeralContainer> {
+    fn as_update(&self) -> KubeEphemeralContainer {
         let EphemeralTargetedVariant {
             agent,
             params,
@@ -202,23 +204,30 @@ impl ContainerVariant for EphemeralTargetedVariant<'_> {
         } = self;
         let env = agent_env(agent, params);
 
-        serde_json::from_value(json!({
-            "name": params.name,
-            "image": agent.image(),
-            "securityContext": {
-                "runAsGroup": params.gid,
-                "capabilities": {
-                    "add": get_capabilities(agent),
-                },
-                "privileged": agent.privileged,
-                "runAsNonRoot": agent.privileged.then_some(false),
-                "runAsUser": agent.privileged.then_some(0),
-            },
-            "imagePullPolicy": agent.image_pull_policy,
-            "targetContainerName": runtime_data.container_name,
-            "env": env,
-            "command": command_line,
-        }))
-        .map_err(KubeApiError::from)
+        KubeEphemeralContainer {
+            name: params.name.clone(),
+            image: Some(agent.image().to_string()),
+            security_context: Some(SecurityContext {
+                run_as_group: Some(params.gid.into()),
+                capabilities: Some(Capabilities {
+                    add: Some(
+                        get_capabilities(agent)
+                            .iter()
+                            .map(ToString::to_string)
+                            .collect(),
+                    ),
+                    ..Default::default()
+                }),
+                privileged: Some(agent.privileged),
+                run_as_non_root: agent.privileged.then_some(false),
+                run_as_user: agent.privileged.then_some(0),
+                ..Default::default()
+            }),
+            image_pull_policy: Some(agent.image_pull_policy.clone()),
+            target_container_name: Some(runtime_data.container_name.clone()),
+            env: Some(env),
+            command: Some(command_line.clone()),
+            ..Default::default()
+        }
     }
 }

--- a/mirrord/kube/src/api/container/targeted.rs
+++ b/mirrord/kube/src/api/container/targeted.rs
@@ -48,10 +48,13 @@ impl<'c> ContainerApi<JobTargetedVariant<'c>> for Targeted<'c, JobTargetedVarian
                 NodeCheck::Error(err) => {
                     debug!("unable to check if node is allocatable, {err}");
                 }
-                NodeCheck::Failed(node_name, pods) => {
+                NodeCheck::Failed(node, pods) => {
                     progress.failure(Some("node is not allocatable"));
 
-                    return Err(KubeApiError::NodePodLimitExceeded(node_name, pods));
+                    return Err(KubeApiError::invalid_state(
+                        &node,
+                        format_args!("too full with {pods} pods"),
+                    ));
                 }
             }
         }

--- a/mirrord/kube/src/api/runtime.rs
+++ b/mirrord/kube/src/api/runtime.rs
@@ -1,8 +1,9 @@
 use std::{
     collections::BTreeMap,
     convert::Infallible,
-    fmt::{Display, Formatter},
+    fmt::{self, Display, Formatter},
     ops::FromResidual,
+    str::FromStr,
 };
 
 use k8s_openapi::{
@@ -10,11 +11,13 @@ use k8s_openapi::{
         apps::v1::Deployment,
         core::v1::{Node, Pod},
     },
-    apimachinery::pkg::api::resource::Quantity,
+    NamespaceResourceScope,
 };
-use kube::{api::ListParams, Api, Client};
+use kube::{api::ListParams, Api, Client, Resource};
 use mirrord_config::target::{DeploymentTarget, PodTarget, RolloutTarget, Target};
 use mirrord_protocol::MeshVendor;
+use serde::de::DeserializeOwned;
+use thiserror::Error;
 
 use crate::{
     api::{
@@ -29,6 +32,23 @@ pub enum ContainerRuntime {
     Docker,
     Containerd,
     CriO,
+}
+
+#[derive(Error, Debug)]
+#[error("invalid container runtime name: {0}")]
+pub struct ContainerRuntimeParseError(String);
+
+impl FromStr for ContainerRuntime {
+    type Err = ContainerRuntimeParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "docker" => Ok(Self::Docker),
+            "containerd" => Ok(Self::Containerd),
+            "cri-o" => Ok(Self::CriO),
+            _ => Err(ContainerRuntimeParseError(s.to_string())),
+        }
+    }
 }
 
 impl Display for ContainerRuntime {
@@ -55,61 +75,55 @@ pub struct RuntimeData {
 }
 
 impl RuntimeData {
-    fn from_pod(pod: &Pod, container_name: &Option<String>) -> Result<Self> {
+    pub fn from_pod(pod: &Pod, container_name: Option<&str>) -> Result<Self> {
         let pod_name = pod
             .metadata
             .name
             .as_ref()
-            .ok_or(KubeApiError::PodNameNotFound)?
+            .ok_or_else(|| KubeApiError::missing_field(pod, ".metadata.name"))?
             .to_owned();
         let node_name = pod
             .spec
             .as_ref()
-            .ok_or(KubeApiError::PodSpecNotFound)?
-            .node_name
-            .as_ref()
-            .ok_or(KubeApiError::NodeNotFound)?
+            .and_then(|spec| spec.node_name.as_ref())
+            .ok_or_else(|| KubeApiError::missing_field(pod, ".spec.nodeName"))?
             .to_owned();
         let container_statuses = pod
             .status
             .as_ref()
-            .ok_or(KubeApiError::PodStatusNotFound)?
-            .container_statuses
-            .clone()
-            .ok_or(KubeApiError::ContainerStatusNotFound)?;
+            .and_then(|status| status.container_statuses.as_ref())
+            .ok_or_else(|| KubeApiError::missing_field(pod, ".status.containerStatuses"))?;
         let (chosen_container, mesh) =
             choose_container(container_name, container_statuses.as_ref());
 
-        let chosen_status = chosen_container.ok_or_else(|| {
-            KubeApiError::ContainerNotFound(
-                container_name.clone().unwrap_or_else(|| "None".to_string()),
-            )
+        let chosen_status = chosen_container.ok_or_else(|| match container_name {
+            Some(name) => KubeApiError::invalid_state(
+                pod,
+                format_args!("target container `{name}` not found"),
+            ),
+            None => KubeApiError::invalid_state(pod, "no viable target container found"),
         })?;
 
         let container_name = chosen_status.name.clone();
-        let container_id_full = chosen_status
-            .container_id
-            .as_ref()
-            .ok_or(KubeApiError::ContainerIdNotFound)?
-            .to_owned();
+        let container_id_full = chosen_status.container_id.as_ref().ok_or_else(|| {
+            KubeApiError::missing_field(pod, ".status.containerStatuses.[].containerID")
+        })?;
 
         let mut split = container_id_full.split("://");
 
-        let container_runtime = match split.next() {
-            Some("docker") => ContainerRuntime::Docker,
-            Some("containerd") => ContainerRuntime::Containerd,
-            Some("cri-o") => ContainerRuntime::CriO,
+        let (container_runtime, container_id) = match (
+            split.next().map(ContainerRuntime::from_str),
+            split.next(),
+        ) {
+            (Some(Ok(runtime)), Some(id)) => (runtime, id.to_string()),
             _ => {
-                return Err(KubeApiError::ContainerRuntimeParseError(
-                    container_id_full.to_string(),
-                ))
+                return Err(KubeApiError::invalid_value(
+                    pod,
+                    ".status.containerStatuses.[].containerID",
+                    format_args!("failed to extract container runtime for `{container_name}`: `{container_id_full}`"),
+                ));
             }
         };
-
-        let container_id = split
-            .next()
-            .ok_or_else(|| KubeApiError::ContainerRuntimeParseError(container_id_full.to_string()))?
-            .to_owned();
 
         Ok(RuntimeData {
             pod_name,
@@ -129,15 +143,15 @@ impl RuntimeData {
 
         let node = node_api.get(&self.node_name).await?;
 
-        let allocatable = node
+        let allowed = node
             .status
-            .and_then(|status| status.allocatable)
-            .ok_or_else(|| KubeApiError::NodeBadAllocatable(self.node_name.clone()))?;
-
-        let allowed: usize = allocatable
-            .get("pods")
-            .and_then(|Quantity(quantity)| quantity.parse().ok())
-            .ok_or_else(|| KubeApiError::NodeBadAllocatable(self.node_name.clone()))?;
+            .as_ref()
+            .and_then(|status| status.allocatable.as_ref())
+            .and_then(|allocatable| allocatable.get("pods"))
+            .ok_or_else(|| KubeApiError::missing_field(&node, ".status.allocatable.pods"))?
+            .0
+            .parse::<usize>()
+            .map_err(|e| KubeApiError::invalid_value(&node, ".status.allocatable.pods", e))?;
 
         let mut pod_count = 0;
         let mut list_params = ListParams {
@@ -159,7 +173,7 @@ impl RuntimeData {
         }
 
         if allowed <= pod_count {
-            NodeCheck::Failed(self.node_name.clone(), pod_count)
+            NodeCheck::Failed(node, pod_count)
         } else {
             NodeCheck::Success
         }
@@ -169,7 +183,7 @@ impl RuntimeData {
 #[derive(Debug)]
 pub enum NodeCheck {
     Success,
-    Failed(String, usize),
+    Failed(Node, usize),
     Error(KubeApiError),
 }
 
@@ -180,12 +194,7 @@ where
     fn from_residual(error: Result<Infallible, E>) -> Self {
         match error {
             Ok(_) => unreachable!(),
-            Err(err) => match err.into() {
-                KubeApiError::NodePodLimitExceeded(node_name, pods) => {
-                    NodeCheck::Failed(node_name, pods)
-                }
-                err => NodeCheck::Error(err),
-            },
+            Err(err) => NodeCheck::Error(err.into()),
         }
     }
 }
@@ -195,27 +204,30 @@ pub trait RuntimeDataProvider {
     async fn runtime_data(&self, client: &Client, namespace: Option<&str>) -> Result<RuntimeData>;
 }
 
-pub trait RuntimeTarget {
-    fn target(&self) -> &str;
-
-    fn container(&self) -> &Option<String>;
-}
-
 pub trait RuntimeDataFromLabels {
+    type Resource: Resource<DynamicType = (), Scope = NamespaceResourceScope>
+        + Clone
+        + DeserializeOwned
+        + fmt::Debug;
+
     #[allow(async_fn_in_trait)]
-    async fn get_labels(
-        &self,
-        client: &Client,
-        namespace: Option<&str>,
-    ) -> Result<BTreeMap<String, String>>;
+    async fn get_labels(resource: &Self::Resource) -> Result<BTreeMap<String, String>>;
+
+    fn name(&self) -> &str;
+
+    fn container(&self) -> Option<&str>;
 }
 
 impl<T> RuntimeDataProvider for T
 where
-    T: RuntimeTarget + RuntimeDataFromLabels,
+    T: RuntimeDataFromLabels,
 {
     async fn runtime_data(&self, client: &Client, namespace: Option<&str>) -> Result<RuntimeData> {
-        let labels = self.get_labels(client, namespace).await?;
+        let api: Api<<Self as RuntimeDataFromLabels>::Resource> =
+            get_k8s_resource_api(client, namespace);
+        let resource = api.get(self.name()).await?;
+
+        let labels = Self::get_labels(&resource).await?;
 
         // convert to key value pair
         let formatted_deployments_labels = labels
@@ -227,14 +239,10 @@ where
         let pod_api: Api<Pod> = get_k8s_resource_api(client, namespace);
         let pods = pod_api
             .list(&ListParams::default().labels(&formatted_deployments_labels))
-            .await
-            .map_err(KubeApiError::KubeError)?;
+            .await?;
 
         let first_pod = pods.items.first().ok_or_else(|| {
-            KubeApiError::DeploymentNotFound(format!(
-                "Failed to fetch the default(first pod) from ObjectList<Pod> for {}",
-                self.target()
-            ))
+            KubeApiError::invalid_state(&resource, "no pods matching labels found")
         })?;
 
         RuntimeData::from_pod(first_pod, self.container())
@@ -247,75 +255,46 @@ impl RuntimeDataProvider for Target {
             Target::Deployment(deployment) => deployment.runtime_data(client, namespace).await,
             Target::Pod(pod) => pod.runtime_data(client, namespace).await,
             Target::Rollout(rollout) => rollout.runtime_data(client, namespace).await,
-            Target::Targetless => {
-                unreachable!("runtime_data can't be called on Targetless")
-            }
+            Target::Targetless => Err(KubeApiError::MissingRuntimeData),
         }
     }
 }
 
-impl RuntimeTarget for DeploymentTarget {
-    fn target(&self) -> &str {
+impl RuntimeDataFromLabels for DeploymentTarget {
+    type Resource = Deployment;
+
+    fn name(&self) -> &str {
         &self.deployment
     }
 
-    fn container(&self) -> &Option<String> {
-        &self.container
+    fn container(&self) -> Option<&str> {
+        self.container.as_deref()
     }
-}
 
-impl RuntimeDataFromLabels for DeploymentTarget {
-    async fn get_labels(
-        &self,
-        client: &Client,
-        namespace: Option<&str>,
-    ) -> Result<BTreeMap<String, String>> {
-        let deployment_api: Api<Deployment> = get_k8s_resource_api(client, namespace);
-        let deployment = deployment_api
-            .get(&self.deployment)
-            .await
-            .map_err(KubeApiError::KubeError)?;
-
-        deployment
+    async fn get_labels(resource: &Self::Resource) -> Result<BTreeMap<String, String>> {
+        resource
             .spec
-            .and_then(|spec| spec.selector.match_labels)
-            .ok_or_else(|| {
-                KubeApiError::DeploymentNotFound(format!(
-                    "Label for deployment: {}, not found!",
-                    self.deployment.clone()
-                ))
-            })
-    }
-}
-
-impl RuntimeTarget for RolloutTarget {
-    fn target(&self) -> &str {
-        &self.rollout
-    }
-
-    fn container(&self) -> &Option<String> {
-        &self.container
+            .as_ref()
+            .and_then(|spec| spec.selector.match_labels.clone())
+            .ok_or_else(|| KubeApiError::missing_field(resource, ".spec.selector.matchExpressions"))
     }
 }
 
 impl RuntimeDataFromLabels for RolloutTarget {
-    async fn get_labels(
-        &self,
-        client: &Client,
-        namespace: Option<&str>,
-    ) -> Result<BTreeMap<String, String>> {
-        let rollout_api: Api<Rollout> = get_k8s_resource_api(client, namespace);
-        let rollout = rollout_api
-            .get(&self.rollout)
-            .await
-            .map_err(KubeApiError::KubeError)?;
+    type Resource = Rollout;
 
-        rollout.match_labels().ok_or_else(|| {
-            KubeApiError::DeploymentNotFound(format!(
-                "Label for rollout: {}, not found!",
-                self.rollout.clone()
-            ))
-        })
+    fn name(&self) -> &str {
+        &self.rollout
+    }
+
+    fn container(&self) -> Option<&str> {
+        self.container.as_deref()
+    }
+
+    async fn get_labels(resource: &Self::Resource) -> Result<BTreeMap<String, String>> {
+        resource
+            .match_labels()
+            .ok_or_else(|| KubeApiError::missing_field(resource, ".spec.selector.matchLabels"))
     }
 }
 
@@ -324,7 +303,7 @@ impl RuntimeDataProvider for PodTarget {
         let pod_api: Api<Pod> = get_k8s_resource_api(client, namespace);
         let pod = pod_api.get(&self.pod).await?;
 
-        RuntimeData::from_pod(&pod, &self.container)
+        RuntimeData::from_pod(&pod, self.container.as_deref())
     }
 }
 

--- a/mirrord/kube/src/api/runtime.rs
+++ b/mirrord/kube/src/api/runtime.rs
@@ -276,7 +276,7 @@ impl RuntimeDataFromLabels for DeploymentTarget {
             .spec
             .as_ref()
             .and_then(|spec| spec.selector.match_labels.clone())
-            .ok_or_else(|| KubeApiError::missing_field(resource, ".spec.selector.matchExpressions"))
+            .ok_or_else(|| KubeApiError::missing_field(resource, ".spec.selector.matchLabels"))
     }
 }
 

--- a/mirrord/kube/src/error.rs
+++ b/mirrord/kube/src/error.rs
@@ -6,55 +6,52 @@ pub type Result<T, E = KubeApiError> = std::result::Result<T, E>;
 
 #[derive(Debug, Error)]
 pub enum KubeApiError {
-    #[error("mirrord-layer: Kube failed with error `{0}`!")]
+    #[error("Kube failed: {0}")]
     KubeError(#[from] kube::Error),
 
-    #[error("mirrord-layer: Connection to agent failed `{0}`!")]
+    #[error("Connection to agent failed: {0}")]
     KubeConnectionError(#[from] std::io::Error),
 
-    #[error("mirrord-layer: Failed to get `KubeConfig`!")]
-    KubeConfigError(#[from] kube::config::InferConfigError),
+    #[error("Failed to infer Kube config: {0}")]
+    InferKubeConfigError(#[from] kube::config::InferConfigError),
 
-    #[error("mirrord-layer: Failed to get the custom path for `KubeConfig`!")]
+    #[error("Failed to load Kube config: {0}")]
     KubeConfigPathError(#[from] kube::config::KubeconfigError),
 
-    #[error("mirrord-layer: JSON convert error")]
-    JSONConvertError(#[from] serde_json::Error),
-
-    #[error("mirrord-layer: Invalid target provided `{0}`!")]
+    #[error("Invalid target provided: {0}")]
     InvalidTarget(String),
 
-    #[error("mirrord-layer: Failed to get `Spec` for Pod!")]
+    #[error("Failed to get `Spec` for Pod!")]
     PodSpecNotFound,
 
-    #[error("mirrord-layer: Deployment: `{0} not found!`")]
+    #[error("Deployment `{0}` not found")]
     DeploymentNotFound(String),
 
-    #[error("mirrord-layer: Failed to get Container runtime data for `{0}`!")]
+    #[error("Failed to extract container runtime from container id `{0}`")]
     ContainerRuntimeParseError(String),
 
-    #[error("mirrord-layer: Container ID not found in response from kube API")]
+    #[error("Container ID not found in response from kube API")]
     ContainerIdNotFound,
 
-    #[error("mirrord-layer: Failed to get Pod for Job `{0}`!")]
+    #[error("Failed to get Pod for Job `{0}`!")]
     JobPodNotFound(String),
 
-    #[error("mirrord-layer: Pod name not found in response from kube API")]
+    #[error("Pod name not found in response from kube API")]
     PodNameNotFound,
 
-    #[error("mirrord-layer: Node name wasn't found in pod spec")]
+    #[error("Node name wasn't found in pod spec")]
     NodeNotFound,
 
-    #[error("mirrord-layer: Pod status not found in response from kube API")]
+    #[error("Pod status not found in response from kube API")]
     PodStatusNotFound,
 
-    #[error("mirrord-layer: Container status not found in response from kube API")]
+    #[error("Container status not found in response from kube API")]
     ContainerStatusNotFound,
 
-    #[error("mirrord-layer: Container not found: `{0}`")]
+    #[error("Container not found: `{0}`")]
     ContainerNotFound(String),
 
-    #[error("mirrord-layer: Timeout waiting for agent to be ready")]
+    #[error("Timeout waiting for agent to be ready")]
     AgentReadyTimeout,
 
     #[error("Port not found in port forward")]
@@ -64,16 +61,16 @@ pub enum KubeApiError {
     InvalidAddress(#[from] AddrParseError),
 
     /// This error should never happen, but has to exist if we don't want to unwrap.
-    #[error("mirrord-layer: None runtime data for non-targetless agent. This is a bug.")]
+    #[error("None runtime data for non-targetless agent. This is a bug.")]
     MissingRuntimeData,
 
-    #[error("Kube incluster error `{0}`!")]
+    #[error("Failed to load incluster Kube config: {0}")]
     KubeInclusterError(#[from] kube::config::InClusterError),
 
-    #[error("Unable to fetch node limits for {0:?}")]
+    #[error("Unable to fetch node limits for node `{0}`")]
     NodeBadAllocatable(String),
 
-    #[error("Node {0:?} is too full with {1} pods")]
+    #[error("Node `{0}` is too full with {1} pods")]
     NodePodLimitExceeded(String, usize),
 
     #[error("Path expansion for kubeconfig failed: {0}")]

--- a/mirrord/kube/src/error.rs
+++ b/mirrord/kube/src/error.rs
@@ -1,5 +1,6 @@
-use std::net::AddrParseError;
+use std::fmt;
 
+use kube::Resource;
 use thiserror::Error;
 
 pub type Result<T, E = KubeApiError> = std::result::Result<T, E>;
@@ -18,47 +19,13 @@ pub enum KubeApiError {
     #[error("Failed to load Kube config: {0}")]
     KubeConfigPathError(#[from] kube::config::KubeconfigError),
 
-    #[error("Invalid target provided: {0}")]
-    InvalidTarget(String),
-
-    #[error("Failed to get `Spec` for Pod!")]
-    PodSpecNotFound,
-
-    #[error("Deployment `{0}` not found")]
-    DeploymentNotFound(String),
-
-    #[error("Failed to extract container runtime from container id `{0}`")]
-    ContainerRuntimeParseError(String),
-
-    #[error("Container ID not found in response from kube API")]
-    ContainerIdNotFound,
-
-    #[error("Failed to get Pod for Job `{0}`!")]
-    JobPodNotFound(String),
-
-    #[error("Pod name not found in response from kube API")]
-    PodNameNotFound,
-
-    #[error("Node name wasn't found in pod spec")]
-    NodeNotFound,
-
-    #[error("Pod status not found in response from kube API")]
-    PodStatusNotFound,
-
-    #[error("Container status not found in response from kube API")]
-    ContainerStatusNotFound,
-
-    #[error("Container not found: `{0}`")]
-    ContainerNotFound(String),
-
+    // #[error("Failed to extract container runtime from container `{}` (`id {}`)", .name, .id)]
+    // ContainerRuntimeParseError { name: String, id: String },
     #[error("Timeout waiting for agent to be ready")]
     AgentReadyTimeout,
 
     #[error("Port not found in port forward")]
     PortForwardFailed,
-
-    #[error("Invaild Address Conversion: {0}")]
-    InvalidAddress(#[from] AddrParseError),
 
     /// This error should never happen, but has to exist if we don't want to unwrap.
     #[error("None runtime data for non-targetless agent. This is a bug.")]
@@ -67,12 +34,72 @@ pub enum KubeApiError {
     #[error("Failed to load incluster Kube config: {0}")]
     KubeInclusterError(#[from] kube::config::InClusterError),
 
-    #[error("Unable to fetch node limits for node `{0}`")]
-    NodeBadAllocatable(String),
-
-    #[error("Node `{0}` is too full with {1} pods")]
-    NodePodLimitExceeded(String, usize),
-
     #[error("Path expansion for kubeconfig failed: {0}")]
     ConfigPathExpansionError(String),
+
+    /// We fetched a malformed resource using [`kube`] (should not happen).
+    /// Construct with [`Self::missing_field`] or [`Self::invalid_value`] for consistent error
+    /// messages.
+    #[error("Kube API returned a malformed resource: {0}")]
+    MalformedResource(String),
+
+    /// Resource fetched using [`kube`] is in invalid state.
+    /// Construct with [`Self::invalid_state`] for consistent error messages.
+    #[error("Resource fetched from Kube API is invalid: {0}")]
+    InvalidResourceState(String),
+
+    #[error("Agent Job was created, but Pod is not running")]
+    AgentPodNotRunning,
+}
+
+impl KubeApiError {
+    pub fn missing_field<R: Resource<DynamicType = ()>>(resource: &R, field_name: &str) -> Self {
+        let kind = R::kind(&());
+        let name = resource.meta().name.as_ref();
+        let namespace = resource.meta().namespace.as_deref().unwrap_or("default");
+
+        let message = match name {
+            Some(name) => format!("{kind} `{namespace}/{name}` is missing field `{field_name}`"),
+            None => format!("{kind} is missing field `{field_name}`"),
+        };
+
+        Self::MalformedResource(message)
+    }
+
+    pub fn invalid_value<R: Resource<DynamicType = ()>, T: fmt::Display>(
+        resource: &R,
+        field_name: &str,
+        info: T,
+    ) -> Self {
+        let kind = R::kind(&());
+        let name = resource.meta().name.as_ref();
+        let namespace = resource.meta().namespace.as_deref().unwrap_or("default");
+
+        let message = match name {
+            Some(name) => {
+                format!("field `{field_name}` in {kind} `{namespace}/{name}` is invalid: {info}")
+            }
+            None => format!("field `{field_name}` in a {kind} is invalid: {info}"),
+        };
+
+        Self::MalformedResource(message)
+    }
+
+    pub fn invalid_state<R: Resource<DynamicType = ()>, T: fmt::Display>(
+        resource: &R,
+        info: T,
+    ) -> Self {
+        let kind = R::kind(&());
+        let name = resource.meta().name.as_ref();
+        let namespace = resource.meta().namespace.as_deref().unwrap_or("default");
+
+        let message = match name {
+            Some(name) => {
+                format!("{kind} `{namespace}/{name}` is in invalid state: {info}")
+            }
+            None => format!("{kind} is in invalid state: {info}"),
+        };
+
+        Self::MalformedResource(message)
+    }
 }


### PR DESCRIPTION
1. Made `RuntimeData::from_pod` public to avoid refetching multiple objects in the operator (no need to do n queries for deployment/rollout targets, consistent view of target state)
2. Improved `KubeApiError`. Error messages were starting with `mirrord-layer: `, which was confusing. Some errors produced really weird messages, like ```"mirrord-layer: Deployment: `Label for rollout: my-rollout, not found! not found!`"```
3. Payloads to kube POST requests are no longer constructed with `json!` macro and then parsed :skull: 
4. Changed `AgentConfig::image_pull_secrets` a bit to catch malformed secrets before attempting to create the agent and be more user friendly