### PR TITLE
Verify target state before creating the agent

### DIFF
--- a/changelog.d/462.fixed.md
+++ b/changelog.d/462.fixed.md
@@ -1,1 +1,1 @@
-mirrord now prints an informative error when the targeted pod is not in correct state (e.g. is not `Running` or some of its containers are not `ready`). When picking a pod from target deployment/rollout, mirrord filters out pods that are not in correct state.
+mirrord now prints an informative error when the targeted pod is not in correct state (e.g. is not `Running` or the target container is not `ready`). When picking a pod from target deployment/rollout, mirrord filters out pods that are not in correct state.

--- a/changelog.d/462.fixed.md
+++ b/changelog.d/462.fixed.md
@@ -1,1 +1,1 @@
-mirrord know prints a informative errors when the targeted pod is not in correct state (e.g. is not `Running` or some of its containers are not `ready`). When picking a pod from target deployment/rollout, mirrord filters out pods that are not in correct state.
+mirrord now prints a informative errors when the targeted pod is not in correct state (e.g. is not `Running` or some of its containers are not `ready`). When picking a pod from target deployment/rollout, mirrord filters out pods that are not in correct state.

--- a/changelog.d/462.fixed.md
+++ b/changelog.d/462.fixed.md
@@ -1,1 +1,1 @@
-mirrord now prints a informative errors when the targeted pod is not in correct state (e.g. is not `Running` or some of its containers are not `ready`). When picking a pod from target deployment/rollout, mirrord filters out pods that are not in correct state.
+mirrord now prints an informative error when the targeted pod is not in correct state (e.g. is not `Running` or some of its containers are not `ready`). When picking a pod from target deployment/rollout, mirrord filters out pods that are not in correct state.

--- a/changelog.d/462.fixed.md
+++ b/changelog.d/462.fixed.md
@@ -1,0 +1,1 @@
+mirrord know prints a informative errors when the targeted pod is not in correct state (e.g. is not `Running` or some of its containers are not `ready`). When picking a pod from target deployment/rollout, mirrord filters out pods that are not in correct state.

--- a/mirrord/kube/src/error.rs
+++ b/mirrord/kube/src/error.rs
@@ -111,6 +111,6 @@ impl KubeApiError {
             None => format!("{kind} is in invalid state: {info}"),
         };
 
-        Self::MalformedResource(message)
+        Self::InvalidResourceState(message)
     }
 }


### PR DESCRIPTION
Closes #462 

Added some extra checks on the targeted pod (described in `RuntimeData::from_pod` doc). Example output when targeting a pod in deletion:
![Screenshot from 2024-05-24 13-47-21](https://github.com/metalbear-co/mirrord/assets/34063647/adb9e298-1ac1-4646-abcd-96d7b5436a4b)

Additionaly, when targeting multi-pod deployments/rollouts, mirrord scans the list of matching pod and picks the first one that passes status check (instead of always using the first one on the list)