### PR TITLE
Change Strings in SIP crate to OsStrings

### DIFF
--- a/changelog.d/2198.internal.md
+++ b/changelog.d/2198.internal.md
@@ -1,0 +1,1 @@
+Remove Strings from SIP crate where types should be OsString or PathBuf.

--- a/mirrord/cli/src/execution.rs
+++ b/mirrord/cli/src/execution.rs
@@ -1,6 +1,7 @@
+#[cfg(target_os = "macos")]
+use std::path::Path;
 use std::{
     collections::{HashMap, HashSet},
-    path::Path,
     sync::Arc,
     time::Duration,
 };
@@ -227,11 +228,12 @@ impl MirrordExecution {
             .and_then(|exe| {
                 sip_patch(
                     Path::new(exe),
-                    &config
+                    config
                         .sip_binaries
                         .clone()
-                        .map(|x| x.to_vec().iter().map(|y| y.into()).collect())
-                        .unwrap_or_default(),
+                        .map(|x| x.to_vec().iter().map(|y| y.into()).collect::<Vec<_>>())
+                        .unwrap_or_default()
+                        .as_ref(),
                 )
                 .transpose() // We transpose twice to propagate a possible error out of this
                              // closure.

--- a/mirrord/cli/src/execution.rs
+++ b/mirrord/cli/src/execution.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::{HashMap, HashSet},
+    path::Path,
     sync::Arc,
     time::Duration,
 };
@@ -225,17 +226,18 @@ impl MirrordExecution {
         let patched_path = executable
             .and_then(|exe| {
                 sip_patch(
-                    exe,
+                    Path::new(exe),
                     &config
                         .sip_binaries
                         .clone()
-                        .map(|x| x.to_vec())
+                        .map(|x| x.to_vec().iter().map(|y| y.into()).collect())
                         .unwrap_or_default(),
                 )
                 .transpose() // We transpose twice to propagate a possible error out of this
                              // closure.
             })
-            .transpose()?;
+            .transpose()?
+            .map(|x| x.to_string_lossy().to_string());
 
         #[cfg(not(target_os = "macos"))]
         let patched_path = None;

--- a/mirrord/layer/src/common.rs
+++ b/mirrord/layer/src/common.rs
@@ -103,7 +103,8 @@ impl CheckedInto<PathBuf> for *const c_char {
         let str_det = CheckedInto::<&str>::checked_into(self);
         #[cfg(target_os = "macos")]
         let str_det = str_det.and_then(|path_str| {
-            let optional_stripped_path = strip_mirrord_path(Path::new(path_str));
+            let optional_stripped_path =
+                strip_mirrord_path(Path::new(path_str)).map(|x| Path::new("/").join(x));
             if let Some(stripped_path) = optional_stripped_path {
                 // actually stripped, so bypass and provide a pointer to after the temp dir.
                 // `stripped_path` is a reference to a later character in the same string as

--- a/mirrord/layer/src/common.rs
+++ b/mirrord/layer/src/common.rs
@@ -1,9 +1,7 @@
 //! Shared place for a few types and functions that are used everywhere by the layer.
-use std::{
-    ffi::CStr,
-    fmt::Debug,
-    path::{Path, PathBuf},
-};
+#[cfg(target_os = "macos")]
+use std::path::Path;
+use std::{ffi::CStr, fmt::Debug, path::PathBuf};
 
 use libc::c_char;
 use mirrord_intproxy_protocol::{IsLayerRequest, IsLayerRequestWithResponse, MessageId};
@@ -105,7 +103,7 @@ impl CheckedInto<PathBuf> for *const c_char {
         let str_det = CheckedInto::<&str>::checked_into(self);
         #[cfg(target_os = "macos")]
         let str_det = str_det.and_then(|path_str| {
-            let optional_stripped_path = strip_mirrord_path(&Path::new(path_str));
+            let optional_stripped_path = strip_mirrord_path(Path::new(path_str));
             if let Some(stripped_path) = optional_stripped_path {
                 // actually stripped, so bypass and provide a pointer to after the temp dir.
                 // `stripped_path` is a reference to a later character in the same string as

--- a/mirrord/layer/src/common.rs
+++ b/mirrord/layer/src/common.rs
@@ -1,11 +1,15 @@
 //! Shared place for a few types and functions that are used everywhere by the layer.
-use std::{ffi::CStr, fmt::Debug, path::PathBuf};
+use std::{
+    ffi::CStr,
+    fmt::Debug,
+    path::{Path, PathBuf},
+};
 
 use libc::c_char;
 use mirrord_intproxy_protocol::{IsLayerRequest, IsLayerRequestWithResponse, MessageId};
 use mirrord_protocol::file::OpenOptionsInternal;
 #[cfg(target_os = "macos")]
-use mirrord_sip::{MIRRORD_TEMP_BIN_DIR_CANONIC_STRING, MIRRORD_TEMP_BIN_DIR_STRING};
+use mirrord_sip::{MIRRORD_TEMP_BIN_DIR_CANONIC_PATHBUF, MIRRORD_TEMP_BIN_DIR_PATH_BUF};
 use tracing::warn;
 
 use crate::{
@@ -83,10 +87,15 @@ impl CheckedInto<String> for *const c_char {
 }
 
 #[cfg(target_os = "macos")]
-pub fn strip_mirrord_path(path_str: &str) -> Option<&str> {
+pub fn strip_mirrord_path(path_str: &Path) -> Option<&Path> {
     path_str
-        .strip_prefix(MIRRORD_TEMP_BIN_DIR_STRING.as_str())
-        .or_else(|| path_str.strip_prefix(MIRRORD_TEMP_BIN_DIR_CANONIC_STRING.as_str()))
+        .strip_prefix(MIRRORD_TEMP_BIN_DIR_PATH_BUF.to_owned())
+        .ok()
+        .or_else(|| {
+            path_str
+                .strip_prefix(MIRRORD_TEMP_BIN_DIR_CANONIC_PATHBUF.to_owned())
+                .ok()
+        })
 }
 
 impl CheckedInto<PathBuf> for *const c_char {
@@ -96,14 +105,14 @@ impl CheckedInto<PathBuf> for *const c_char {
         let str_det = CheckedInto::<&str>::checked_into(self);
         #[cfg(target_os = "macos")]
         let str_det = str_det.and_then(|path_str| {
-            let optional_stripped_path = strip_mirrord_path(path_str);
+            let optional_stripped_path = strip_mirrord_path(&Path::new(path_str));
             if let Some(stripped_path) = optional_stripped_path {
                 // actually stripped, so bypass and provide a pointer to after the temp dir.
                 // `stripped_path` is a reference to a later character in the same string as
                 // `path_str`, `stripped_path.as_ptr()` returns a pointer to a later index
                 // in the same string owned by the caller (the hooked program).
                 Detour::Bypass(Bypass::FileOperationInMirrordBinTempDir(
-                    stripped_path.as_ptr() as _,
+                    stripped_path.to_string_lossy().as_ptr() as _,
                 ))
             } else {
                 Detour::Success(path_str) // strip is None, path not in temp dir.

--- a/mirrord/layer/src/exec_utils.rs
+++ b/mirrord/layer/src/exec_utils.rs
@@ -66,13 +66,13 @@ pub(crate) unsafe fn enable_execve_hook(
 /// Check if the file that is to be executed has SIP and patch it if it does.
 #[mirrord_layer_macro::instrument(level = "trace")]
 pub(super) fn patch_if_sip(path: &str) -> Detour<String> {
-    let patch_binaries = PATCH_BINARIES
+    let patch_binaries: Vec<_> = PATCH_BINARIES
         .get()
         .expect("patch binaries not set")
         .iter()
         .map(|y| y.into())
         .collect();
-    match sip_patch(Path::new(path), &patch_binaries) {
+    match sip_patch(Path::new(path), patch_binaries.as_ref()) {
         Ok(None) => Bypass(NoSipDetected(path.to_string())),
         Ok(Some(new_path)) => Success(new_path.to_string_lossy().to_string()),
         Err(SipError::FileNotFound(non_existing_bin)) => {

--- a/mirrord/layer/src/lib.rs
+++ b/mirrord/layer/src/lib.rs
@@ -68,8 +68,10 @@ extern crate core;
 use std::{
     cmp::Ordering,
     collections::{HashMap, HashSet},
+    ffi::OsString,
     net::SocketAddr,
     panic,
+    path::Path,
     sync::OnceLock,
     time::Duration,
 };
@@ -170,10 +172,10 @@ fn layer_pre_initialization() -> Result<(), LayerError> {
     let config = LayerConfig::from_env()?;
 
     #[cfg(target_os = "macos")]
-    let patch_binaries = config
+    let patch_binaries: Vec<OsString> = config
         .sip_binaries
         .clone()
-        .map(|x| x.to_vec())
+        .map(|x| x.to_vec().iter().map(|y| y.into()).collect())
         .unwrap_or_default();
 
     // SIP Patch the process' binary then re-execute it. Needed
@@ -183,7 +185,7 @@ fn layer_pre_initialization() -> Result<(), LayerError> {
         let path = EXECUTABLE_PATH
             .get()
             .expect("EXECUTABLE_PATH needs to be set!");
-        if let Ok(Some(binary)) = mirrord_sip::sip_patch(path, &patch_binaries) {
+        if let Ok(Some(binary)) = mirrord_sip::sip_patch(Path::new(path), &patch_binaries) {
             let err = exec::execvp(
                 binary,
                 EXECUTABLE_ARGS
@@ -200,7 +202,13 @@ fn layer_pre_initialization() -> Result<(), LayerError> {
     match given_process.load_type(&config) {
         LoadType::Full => layer_start(config),
         #[cfg(target_os = "macos")]
-        LoadType::SIPOnly => sip_only_layer_start(config, patch_binaries),
+        LoadType::SIPOnly => sip_only_layer_start(
+            config,
+            patch_binaries
+                .iter()
+                .map(|x| x.to_string_lossy().to_string())
+                .collect(),
+        ),
         LoadType::Skip => load_only_layer_start(&config),
     }
 

--- a/mirrord/layer/src/lib.rs
+++ b/mirrord/layer/src/lib.rs
@@ -68,13 +68,13 @@ extern crate core;
 use std::{
     cmp::Ordering,
     collections::{HashMap, HashSet},
-    ffi::OsString,
     net::SocketAddr,
     panic,
-    path::Path,
     sync::OnceLock,
     time::Duration,
 };
+#[cfg(target_os = "macos")]
+use std::{ffi::OsString, path::Path};
 
 use ctor::ctor;
 use error::{LayerError, Result};

--- a/mirrord/layer/tests/bash.rs
+++ b/mirrord/layer/tests/bash.rs
@@ -33,8 +33,8 @@ async fn bash_script(dylib_path: &Path, config_dir: &PathBuf) {
     // to ignore those paths.
     config_path.push("bash_script.json");
     let application = Application::EnvBashCat;
-    let executable = application.get_executable().await; // Own it.
-    println!("Using executable: {}", &executable);
+    let executable = PathBuf::from(application.get_executable().await.to_owned()); // Own it.
+    println!("Using executable: {:?}", &executable);
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap().to_string();
     println!("Listening for messages from the layer on {addr}");
@@ -46,7 +46,12 @@ async fn bash_script(dylib_path: &Path, config_dir: &PathBuf) {
     );
     #[cfg(target_os = "macos")]
     let executable = sip_patch(&executable, &Vec::new()).unwrap().unwrap();
-    let test_process = TestProcess::start_process(executable, application.get_args(), env).await;
+    let test_process = TestProcess::start_process(
+        executable.to_string_lossy().to_string(),
+        application.get_args(),
+        env,
+    )
+    .await;
 
     let mut intproxy = TestIntProxy::new(listener).await;
 

--- a/mirrord/layer/tests/fileops.rs
+++ b/mirrord/layer/tests/fileops.rs
@@ -70,10 +70,10 @@ async fn read_from_mirrord_bin(dylib_path: &PathBuf) {
     let executable = sip_patch(Path::new("cat"), &Vec::new()).unwrap().unwrap();
 
     // <TMPDIR>/mirrord-bin/cat <TMPDIR>/mirrord-bin/<TMPDIR>/mirrord-test-read-from-mirrord-bin
-    let application = Application::DynamicApp(
+    let application = dbg!(Application::DynamicApp(
         executable.to_string_lossy().to_string(),
         vec![path_in_mirrord_bin.to_string_lossy().to_string()],
-    );
+    ));
 
     let (mut test_process, _intproxy) = application
         .start_process_with_layer(dylib_path, vec![], None)

--- a/mirrord/layer/tests/fileops.rs
+++ b/mirrord/layer/tests/fileops.rs
@@ -67,11 +67,11 @@ async fn read_from_mirrord_bin(dylib_path: &PathBuf) {
     // Make sure we write and read from different paths (this is "meta check").
     assert_ne!(file_path, path_in_mirrord_bin);
 
-    let executable = sip_patch("cat", &Vec::new()).unwrap().unwrap();
+    let executable = sip_patch(Path::new("cat"), &Vec::new()).unwrap().unwrap();
 
     // <TMPDIR>/mirrord-bin/cat <TMPDIR>/mirrord-bin/<TMPDIR>/mirrord-test-read-from-mirrord-bin
     let application = Application::DynamicApp(
-        executable,
+        executable.to_string_lossy().to_string(),
         vec![path_in_mirrord_bin.to_string_lossy().to_string()],
     );
 

--- a/mirrord/layer/tests/fileops.rs
+++ b/mirrord/layer/tests/fileops.rs
@@ -4,7 +4,7 @@
 #[cfg(target_os = "linux")]
 use std::assert_matches::assert_matches;
 #[cfg(target_os = "macos")]
-use std::{env, fs};
+use std::{env, fs, path::Path};
 use std::{env::temp_dir, path::PathBuf, time::Duration};
 
 use libc::{pid_t, O_RDWR};

--- a/mirrord/layer/tests/sip.rs
+++ b/mirrord/layer/tests/sip.rs
@@ -23,14 +23,20 @@ use mirrord_sip::sip_patch;
 async fn tmp_dir_read_locally(dylib_path: &Path) {
     let application = Application::BashShebang;
     let executable = application.get_executable().await;
-    let executable = sip_patch(&executable, &Vec::new()).unwrap().unwrap();
-    println!("Using executable: {}", &executable);
+    let executable = sip_patch(Path::new(&executable), &Vec::new())
+        .unwrap()
+        .unwrap();
+    println!("Using executable: {:?}", &executable);
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap().to_string();
     println!("Listening for messages from the layer on {addr}");
     let env = get_env(dylib_path.to_str().unwrap(), &addr, vec![], None);
-    let mut test_process =
-        TestProcess::start_process(executable, application.get_args(), env).await;
+    let mut test_process = TestProcess::start_process(
+        executable.to_string_lossy().to_string(),
+        application.get_args(),
+        env,
+    )
+    .await;
 
     // Accept the connection from the layer and verify initial messages.
     let mut intproxy = TestIntProxy::new(listener).await;

--- a/mirrord/sip/src/codesign.rs
+++ b/mirrord/sip/src/codesign.rs
@@ -1,4 +1,9 @@
-use std::{os::unix::process::ExitStatusExt, path::Path, process::Command};
+use std::{
+    ffi::OsStr,
+    os::unix::{ffi::OsStrExt, process::ExitStatusExt},
+    path::Path,
+    process::Command,
+};
 
 use crate::error::{Result, SipError};
 
@@ -16,9 +21,7 @@ pub(crate) fn sign<P: AsRef<Path>>(path: P) -> Result<()> {
         Ok(())
     } else {
         let code = output.status.into_raw(); // Returns wait status if there's no exit status.
-        Err(SipError::Sign(
-            code,
-            String::from_utf8_lossy(&output.stderr).to_string(),
-        ))
+        let output_stderr = OsStr::from_bytes(&output.stderr).to_os_string();
+        Err(SipError::Sign(code, output_stderr))
     }
 }

--- a/mirrord/sip/src/error.rs
+++ b/mirrord/sip/src/error.rs
@@ -1,3 +1,5 @@
+use std::{ffi::OsString, path::PathBuf};
+
 use thiserror::Error;
 
 pub type Result<T> = std::result::Result<T, SipError>;
@@ -7,11 +9,11 @@ pub enum SipError {
     #[error("IO failed with `{0}`")]
     IO(#[from] std::io::Error),
 
-    #[error("Signing failed statuscode: `{0}`, output: `{1}`")]
-    Sign(i32, String),
+    #[error("Signing failed statuscode: `{0}`, output: `{1:?}`")]
+    Sign(i32, OsString),
 
-    #[error("Adding Rpaths failed with statuscode: `{0}`, output: `{1}`")]
-    AddingRpathsFailed(i32, String),
+    #[error("Adding Rpaths failed with statuscode: `{0}`, output: `{1:?}`")]
+    AddingRpathsFailed(i32, OsString),
 
     #[error("Can't patch file format `{0}`")]
     UnsupportedFileFormat(String),
@@ -30,8 +32,8 @@ pub enum SipError {
     #[error("Unlikely error happened `{0}`")]
     UnlikelyError(String),
 
-    #[error("Can't perform SIP check - executable file not found at `{0}`")]
-    FileNotFound(String),
+    #[error("Can't perform SIP check - executable file not found at `{}`", .0.display())]
+    FileNotFound(PathBuf),
 
     #[error("Got invalid string.")]
     NonUtf8Str(#[from] std::str::Utf8Error),

--- a/mirrord/sip/src/lib.rs
+++ b/mirrord/sip/src/lib.rs
@@ -44,31 +44,13 @@ mod main {
     pub static MIRRORD_TEMP_BIN_DIR_PATH_BUF: Lazy<PathBuf> =
         Lazy::new(|| env::temp_dir().join(MIRRORD_PATCH_DIR));
 
-    /// Get the `PathBuf` of the `mirrord-bin` dir, and return a `String` prefix to remove, without
-    /// a trailing `/`, so that the stripped path starts with a `/`
-    // fn get_temp_bin_str_prefix(path: &Path) -> String {
-    //     // lossy: we assume our temp dir path does not contain non-unicode chars.
-    //     path.to_string_lossy()
-    //         .to_string()
-    //         .trim_end_matches('/')
-    //         .to_string()
-    // }
-
-    /// The string path of mirrord's internal temp binary dir, where we put SIP-patched binaries and
-    /// scripts, without a trailing `/`.
-    // pub static MIRRORD_TEMP_BIN_DIR_STRING: Lazy<String> =
-    //     Lazy::new(|| get_temp_bin_str_prefix(&MIRRORD_TEMP_BIN_DIR_PATH_BUF));
-
     /// Canonicalized version of `MIRRORD_TEMP_BIN_DIR`.
-    // pub static MIRRORD_TEMP_BIN_DIR_CANONIC_STRING: Lazy<String> = Lazy::new(|| {
-    //     MIRRORD_TEMP_BIN_DIR_PATH_BUF
-    //         // Resolve symbolic links! (specifically /var -> private/var).
-    //         .canonicalize()
-    //         .as_deref()
-    //         .map(get_temp_bin_str_prefix)
-    //         // If canonicalization fails, we use the uncanonicalized path string.
-    //         .unwrap_or(MIRRORD_TEMP_BIN_DIR_STRING.to_string())
-    // });
+    pub static MIRRORD_TEMP_BIN_DIR_CANONIC_PATHBUF: Lazy<PathBuf> = Lazy::new(|| {
+        MIRRORD_TEMP_BIN_DIR_PATH_BUF
+            // Resolve symbolic links (specifically /var -> private/var).
+            .canonicalize()
+            .unwrap_or(MIRRORD_TEMP_BIN_DIR_PATH_BUF.to_path_buf())
+    });
 
     /// Check if a cpu subtype (already parsed with the correct endianness) is arm64e, given its
     /// main cpu type is arm64. We only consider the lowest byte in the check.
@@ -562,7 +544,10 @@ mod main {
     /// If it is, create a non-protected version of the file and return `Ok(Some(patched_path)`.
     /// If it is not, `Ok(None)`.
     /// Propagate errors.
-    pub fn sip_patch(binary_path: &Path, patch_binaries: &[OsString]) -> Result<Option<OsString>> {
+    pub fn sip_patch(
+        binary_path: &Path,
+        patch_binaries: &Vec<OsString>,
+    ) -> Result<Option<OsString>> {
         match get_sip_status(binary_path, patch_binaries) {
             Ok(SipScript { path, shebang }) => {
                 let patched_interpreter = patch_binary(&shebang.interpreter_path)?;

--- a/mirrord/sip/src/lib.rs
+++ b/mirrord/sip/src/lib.rs
@@ -544,10 +544,7 @@ mod main {
     /// If it is, create a non-protected version of the file and return `Ok(Some(patched_path)`.
     /// If it is not, `Ok(None)`.
     /// Propagate errors.
-    pub fn sip_patch(
-        binary_path: &Path,
-        patch_binaries: &Vec<OsString>,
-    ) -> Result<Option<OsString>> {
+    pub fn sip_patch(binary_path: &Path, patch_binaries: &[OsString]) -> Result<Option<OsString>> {
         match get_sip_status(binary_path, patch_binaries) {
             Ok(SipScript { path, shebang }) => {
                 let patched_interpreter = patch_binary(&shebang.interpreter_path)?;

--- a/mirrord/sip/src/lib.rs
+++ b/mirrord/sip/src/lib.rs
@@ -634,7 +634,7 @@ mod main {
             let path = Path::new("/usr/bin/file");
             let patched_path_buf = patch_binary(path).unwrap();
             assert!(matches!(
-                get_sip_status(path, &vec![]).unwrap(),
+                get_sip_status(&&patched_path_buf, &vec![]).unwrap(),
                 SipStatus::NoSip
             ));
             // Check DYLD_* features work on it:

--- a/mirrord/sip/src/rpath.rs
+++ b/mirrord/sip/src/rpath.rs
@@ -1,23 +1,27 @@
-use std::{iter, os::unix::process::ExitStatusExt, path::Path, process::Command};
+use std::{
+    ffi::{OsStr, OsString},
+    iter,
+    os::unix::{ffi::OsStrExt, process::ExitStatusExt},
+    path::Path,
+    process::Command,
+};
 
 use crate::error::{Result, SipError};
 
 /// Run `install_name_tool` in a child process to add a loader command for each given rpath entry
 /// to the binary in `path`.
-pub(crate) fn add_rpaths<P: AsRef<Path>>(path: P, rpath_entries: Vec<String>) -> Result<()> {
+pub(crate) fn add_rpaths<P: AsRef<Path>>(path: P, rpath_entries: Vec<OsString>) -> Result<()>
+where
+    OsString: From<P>,
+{
     if rpath_entries.is_empty() {
         return Ok(());
     }
-    let path_str = path.as_ref().to_string_lossy().to_string();
 
     // args are `-add_rpath RPATH` for each rpath entry, and the binary's path at the end.
-    let args = iter::once(String::from("-add_rpath"))
-        .chain(
-            rpath_entries
-                .into_iter()
-                .intersperse(String::from("-add_rpath")),
-        )
-        .chain(iter::once(path_str));
+    let args = iter::once("-add_rpath".into())
+        .chain(rpath_entries.into_iter().intersperse("-add_rpath".into()))
+        .chain(iter::once(path.into()));
 
     let output = Command::new("install_name_tool") // most forgettable tool name ever.
         .args(args)
@@ -27,9 +31,7 @@ pub(crate) fn add_rpaths<P: AsRef<Path>>(path: P, rpath_entries: Vec<String>) ->
         Ok(())
     } else {
         let code = output.status.into_raw();
-        Err(SipError::AddingRpathsFailed(
-            code,
-            String::from_utf8_lossy(&output.stderr).to_string(),
-        ))
+        let output_stderr = OsStr::from_bytes(&output.stderr).to_os_string();
+        Err(SipError::AddingRpathsFailed(code, output_stderr))
     }
 }


### PR DESCRIPTION
Closes #2198

This results in some lossy conversions where the SIP code is called from other crates which could be eliminated if all the Strings in the whole codebase were evaluated - there are plenty that would make more sense as OsStrings or Paths - but that would be a much larger issue. Eventually I think we could probably eliminate all the `to_string_lossy()` calls and avoid conversion to String altogether.