### PR TITLE
Port lock check removed from CLI

### DIFF
--- a/changelog.d/+concurrent-steal.fixed.md
+++ b/changelog.d/+concurrent-steal.fixed.md
@@ -1,0 +1,1 @@
+Fixed a bug where two mirrord sessions could not target the same pod while stealing from different ports.

--- a/mirrord/operator/src/crd.rs
+++ b/mirrord/operator/src/crd.rs
@@ -21,6 +21,7 @@ pub const TARGETLESS_TARGET_NAME: &str = "targetless";
 pub struct TargetSpec {
     /// None when targetless.
     pub target: Option<Target>,
+    #[deprecated = "port locks are enforced only in the operator, new operator versions always return an empty list"]
     pub port_locks: Option<Vec<TargetPortLock>>,
 }
 


### PR DESCRIPTION
Port locks are already enforced in the operator + this check was buggy