### PR TITLE
Add warning for unnecessary port mappings

### DIFF
--- a/changelog.d/+port-mapping-warning.added.md
+++ b/changelog.d/+port-mapping-warning.added.md
@@ -1,0 +1,1 @@
+Emit a warning when the `port_mapping` field of the configuration contains an unnecessary mapping of a port to itself.

--- a/mirrord/config/src/lib.rs
+++ b/mirrord/config/src/lib.rs
@@ -424,6 +424,23 @@ impl LayerConfig {
             }
         }
 
+        if self
+            .feature
+            .network
+            .incoming
+            .port_mapping
+            .iter()
+            .any(|(to, from)| to == from)
+        {
+            context.add_warning(
+                "The feature.network.incoming.port_mapping mirrord configuration field \
+                contains a mapping of a local port to the same remote port. \
+                A mapping is only necessary when the local application is listening on \
+                a different port than the remote one."
+                    .into(),
+            );
+        }
+
         Ok(())
     }
 }


### PR DESCRIPTION
When you search for "port_mapping" on our discord server, most of the results are configuration files that contain a port mapping that maps each port their application uses to that same identical port.

Let's help users declutter their config files and be less confused, by explaining that field if they don't understand it and nudge them to remove unnecessary mappings.