### PR TITLE
Remove from tests host name that often can't be found

### DIFF
--- a/changelog.d/+remove-baidu.internal.md
+++ b/changelog.d/+remove-baidu.internal.md
@@ -1,0 +1,1 @@
+Remove baidu.com from E2E tests.

--- a/tests/node-e2e/outgoing/test_outgoing_traffic_many_requests.mjs
+++ b/tests/node-e2e/outgoing/test_outgoing_traffic_many_requests.mjs
@@ -8,7 +8,6 @@ const hostList = [
   "www.google.com",
   "www.bing.com",
   "www.yahoo.com",
-  "www.baidu.com",
   "www.twitter.com",
   "www.microsoft.com",
   "www.youtube.com",


### PR DESCRIPTION
See example flake here: https://github.com/metalbear-co/mirrord/actions/runs/9450763078/job/26030239466?pr=2486#step:10:252

I don't know that this is not actually an issue with mirrord, but since [we removed the last website with which the tests often flaked](https://github.com/metalbear-co/mirrord/pull/2471) I'm assuming we can just remove this one as well.