### PR TITLE
Fix race in CI e2e waiting for wrong job - 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -519,14 +519,14 @@ jobs:
   # which checks if the branch is a release branch
   intellij_e2e_on_release_branch:
     # requires test_agent to have image to download
-    needs: [build_mirrord_on_release_branch, test_agent]
+    needs: [build_mirrord_on_release_branch, test_agent_image]
     uses: metalbear-co/mirrord-intellij/.github/workflows/reusable_e2e.yaml@main
     with:
       mirrord_release_branch: true
 
   vscode_e2e_on_release_branch:
     # requires test_agent to have image to download
-    needs: [build_mirrord_on_release_branch, test_agent]
+    needs: [build_mirrord_on_release_branch, test_agent_image]
     uses: metalbear-co/mirrord-vscode/.github/workflows/reusable_e2e.yaml@main
     with:
       mirrord_release_branch: true

--- a/changelog.d/+fix-ci-race.internal.md
+++ b/changelog.d/+fix-ci-race.internal.md
@@ -1,0 +1,1 @@
+Fix race in CI e2e waiting for wrong job - test_agent instead of test_agent_image


### PR DESCRIPTION
Fix race in CI e2e waiting for wrong job -  test_agent instead of test_agent_image