### PR TITLE
Ignore operator discovery errors

### DIFF
--- a/changelog.d/+fallible-operator-detection.changed.md
+++ b/changelog.d/+fallible-operator-detection.changed.md
@@ -1,0 +1,1 @@
+Errors that occur when using discovery API to detect mirrord operator are no longer fatal. When such error is encountered, mirrord command falls back to using the OSS version.

--- a/mirrord/cli/src/connection.rs
+++ b/mirrord/cli/src/connection.rs
@@ -110,7 +110,7 @@ where
                     // prompt a warning and fallback to OSS
                     Err(error) => {
                         let message = "failed to check if operator is installed";
-                        tracing::trace!(%error, message);
+                        tracing::debug!(%error, message);
                         subtask.warning(message);
                         subtask.success(Some("operator not found"));
                     }

--- a/mirrord/cli/src/connection.rs
+++ b/mirrord/cli/src/connection.rs
@@ -29,14 +29,13 @@ pub(crate) struct AgentConnection {
 }
 
 #[tracing::instrument(level = "trace", skip(config), ret, err)]
-async fn check_if_operator_resource_exists(config: &LayerConfig) -> Result<bool> {
+async fn check_if_operator_resource_exists(config: &LayerConfig) -> Result<bool, KubeApiError> {
     let client = create_kube_api(
         config.accept_invalid_certificates,
         config.kubeconfig.clone(),
         config.kube_context.clone(),
     )
-    .await
-    .map_err(CliError::OperatorInstallationCheckError)?;
+    .await?;
 
     let gvk = GroupVersionKind {
         group: MirrordOperatorCrd::group(&()).into_owned(),
@@ -47,13 +46,7 @@ async fn check_if_operator_resource_exists(config: &LayerConfig) -> Result<bool>
     match discovery::oneshot::pinned_kind(&client, &gvk).await {
         Ok(..) => Ok(true),
         Err(kube::Error::Api(response)) if response.code == 404 => Ok(false),
-        Err(error) => {
-            tracing::trace!(
-                ?error,
-                "Failed to check if operator is installed in the cluster"
-            );
-            Err(CliError::OperatorInstallationCheckError(error.into()))
-        }
+        Err(error) => Err(error.into()),
     }
 }
 
@@ -104,8 +97,23 @@ where
                 },
             ) if config.operator.is_none() => {
                 // We need to check if the operator is really installed or not.
-                if check_if_operator_resource_exists(config).await? {
-                    return Err(e.into());
+                match check_if_operator_resource_exists(config).await {
+                    // Operator is installed yet we failed to use it, abort
+                    Ok(true) => {
+                        return Err(e.into());
+                    }
+                    // Operator is not installed, fallback to OSS
+                    Ok(false) => {
+                        subtask.success(Some("operator not found"));
+                    }
+                    // We don't know if operator is installed or not,
+                    // prompt a warning and fallback to OSS
+                    Err(error) => {
+                        let message = "failed to check if operator is installed";
+                        tracing::trace!(%error, message);
+                        subtask.warning(message);
+                        subtask.success(Some("operator not found"));
+                    }
                 }
             }
 

--- a/mirrord/cli/src/error.rs
+++ b/mirrord/cli/src/error.rs
@@ -232,16 +232,6 @@ pub(crate) enum CliError {
         "This usually means that connectivity was lost while pinging.{GENERAL_HELP}"
     ))]
     PingPongFailed(String),
-
-    #[error("Failed to check whether mirrord operator is installed in the cluster: {0}")]
-    #[diagnostic(help(
-    "Please check that Kubernetes is configured correctly and test your connection with `kubectl get pods`.
-
-    If you want to run without the operator, please set `\"operator\": false` in the mirrord configuration file.
-
-    Please remember that some features are supported only when using mirrord operator (https://mirrord.dev/docs/overview/teams/#supported-features).{GENERAL_HELP}"
-    ))]
-    OperatorInstallationCheckError(KubeApiError),
 }
 
 impl From<OperatorApiError> for CliError {


### PR DESCRIPTION
The clients encountered some `503`s from discovery api and had to explicitly disable the operator. A warning and fallback to OSS should be more user friendly