### PR TITLE
Extend operator headers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3409,8 +3409,7 @@ dependencies = [
 [[package]]
 name = "kube"
 version = "0.92.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12dc4487eda98835dcaa7ac92a14165446db29dbd67a743c79fe9f41bf38ee72"
+source = "git+https://github.com/kube-rs/kube?rev=f9902f1439b3c0baafc2ece1680644c2bfade742#f9902f1439b3c0baafc2ece1680644c2bfade742"
 dependencies = [
  "k8s-openapi",
  "kube-client",
@@ -3422,8 +3421,7 @@ dependencies = [
 [[package]]
 name = "kube-client"
 version = "0.92.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "408f35eab36927d3b883e4ad54c3080ea8c49f899ac84a7856e7182e4ee3b392"
+source = "git+https://github.com/kube-rs/kube?rev=f9902f1439b3c0baafc2ece1680644c2bfade742#f9902f1439b3c0baafc2ece1680644c2bfade742"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -3464,8 +3462,7 @@ dependencies = [
 [[package]]
 name = "kube-core"
 version = "0.92.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f776624097c1e09e72eb1e9e0c2bb5d17d97c27a6a87734390a9fba246a8f67f"
+source = "git+https://github.com/kube-rs/kube?rev=f9902f1439b3c0baafc2ece1680644c2bfade742#f9902f1439b3c0baafc2ece1680644c2bfade742"
 dependencies = [
  "chrono",
  "form_urlencoded",
@@ -3481,8 +3478,7 @@ dependencies = [
 [[package]]
 name = "kube-derive"
 version = "0.92.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae07adfd7d21b7fa582789206391243f98e155b46c806eb494839569853bcfd"
+source = "git+https://github.com/kube-rs/kube?rev=f9902f1439b3c0baafc2ece1680644c2bfade742#f9902f1439b3c0baafc2ece1680644c2bfade742"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -3494,8 +3490,7 @@ dependencies = [
 [[package]]
 name = "kube-runtime"
 version = "0.92.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12e5933f2d429f3a05d4cb67f935b25c94a133b0baeb558ab3917c270a11f6ef"
+source = "git+https://github.com/kube-rs/kube?rev=f9902f1439b3c0baafc2ece1680644c2bfade742#f9902f1439b3c0baafc2ece1680644c2bfade742"
 dependencies = [
  "ahash",
  "async-broadcast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ reqwest = { version = "0.12", default-features = false, features = [
     "socks",
     "http2",
 ] }
-kube = { version = "0.92", default-features = false, features = [
+kube = { git = "https://github.com/kube-rs/kube", rev = "f9902f1439b3c0baafc2ece1680644c2bfade742", default-features = false, features = [
     "runtime",
     "derive",
     "client",
@@ -83,7 +83,7 @@ kube = { version = "0.92", default-features = false, features = [
     "oidc",
     "socks5",
     "http-proxy",
-]}
+] }
 hickory-resolver = { version = "0.24", features = [
     "serde-config",
     "tokio-runtime",

--- a/changelog.d/2466.internal.md
+++ b/changelog.d/2466.internal.md
@@ -1,0 +1,1 @@
+CLI now sends additional headers with each request to the mirrord operator.

--- a/mirrord/cli/src/connection.rs
+++ b/mirrord/cli/src/connection.rs
@@ -37,7 +37,7 @@ where
 {
     let mut operator_subtask = progress.subtask("checking operator");
 
-    let Some(mut api) = OperatorApi::try_new(config, analytics, &operator_subtask).await? else {
+    let Some(api) = OperatorApi::try_new(config, analytics, &operator_subtask).await? else {
         operator_subtask.success(Some("proceeding without operator"));
         return Ok(None);
     };
@@ -66,7 +66,7 @@ where
     }
 
     let mut user_cert_subtask = operator_subtask.subtask("preparing user credentials");
-    api.prepare_client_cert(analytics).await?;
+    let api = api.prepare_client_cert(analytics).await.into_certified()?;
     user_cert_subtask.success(Some("user credentials prepared"));
 
     let mut session_subtask = operator_subtask.subtask("starting session");

--- a/mirrord/cli/src/connection.rs
+++ b/mirrord/cli/src/connection.rs
@@ -61,14 +61,14 @@ where
     let mut version_cmp_subtask = operator_subtask.subtask("checking version compatibility");
     let compatible = api.check_operator_version(&version_cmp_subtask);
     if compatible {
-        version_cmp_subtask.success(None);
+        version_cmp_subtask.success(Some("operator version compatible"));
     } else {
-        version_cmp_subtask.failure(None);
+        version_cmp_subtask.failure(Some("operator version may not be compatible"));
     }
 
     let mut license_subtask = operator_subtask.subtask("checking license");
     match api.check_license_validity(&license_subtask) {
-        Ok(()) => license_subtask.success(None),
+        Ok(()) => license_subtask.success(Some("operator license valid")),
         Err(error) => {
             license_subtask.failure(Some("operator license expired"));
 
@@ -83,11 +83,13 @@ where
 
     let mut user_cert_subtask = operator_subtask.subtask("preparing user credentials");
     api.prepare_client_cert(analytics).await?;
-    user_cert_subtask.success(None);
+    user_cert_subtask.success(Some("user credentials prepared"));
 
     let mut session_subtask = operator_subtask.subtask("starting session");
     let connection = api.connect_in_new_session(config, &session_subtask).await?;
-    session_subtask.success(None);
+    session_subtask.success(Some("session started"));
+
+    operator_subtask.success(Some("using operator"));
 
     Ok(Some(connection))
 }

--- a/mirrord/cli/src/connection.rs
+++ b/mirrord/cli/src/connection.rs
@@ -36,9 +36,13 @@ where
     R: Reporter,
 {
     let mut operator_subtask = progress.subtask("checking operator");
+    if config.operator == Some(false) {
+        operator_subtask.success(Some("operator disabled"));
+        return Ok(None);
+    }
 
-    let Some(api) = OperatorApi::try_new(config, analytics, &operator_subtask).await? else {
-        operator_subtask.success(Some("proceeding without operator"));
+    let Some(api) = OperatorApi::try_new(config, analytics).await? else {
+        operator_subtask.success(Some("operator not found"));
         return Ok(None);
     };
 

--- a/mirrord/cli/src/connection.rs
+++ b/mirrord/cli/src/connection.rs
@@ -7,30 +7,97 @@ use mirrord_kube::{
     api::{kubernetes::KubernetesAPI, wrap_raw_connection},
     error::KubeApiError,
 };
-use mirrord_operator::client::{
-    OperatorApi, OperatorApiError, OperatorOperation, OperatorSessionInformation,
-};
+use mirrord_operator::client::{OperatorApi, OperatorSessionConnection};
 use mirrord_progress::{
     messages::MULTIPOD_WARNING, IdeAction, IdeMessage, NotificationLevel, Progress,
 };
 use mirrord_protocol::{ClientMessage, DaemonMessage};
 use tokio::sync::mpsc;
 
-use crate::{operator, CliError, Result};
+use crate::{CliError, Result};
 
 pub(crate) struct AgentConnection {
     pub sender: mpsc::Sender<ClientMessage>,
     pub receiver: mpsc::Receiver<DaemonMessage>,
 }
 
-/// Creates an agent if needed then connects to it.
-///
-/// First it checks if we have an `operator` in the [`config`](LayerConfig), which we do if the
-/// user has installed the mirrord-operator in their cluster, even without a valid license. And
-/// then we create a session with the operator with [`OperatorApi::create_session`].
-///
-/// If there is no operator, or the license is not good enough for starting an operator session,
-/// then we create the mirrord-agent and run mirrord by itself, without the operator.
+/// 1. If mirrord-operator is explicitly enabled in the given [`LayerConfig`], makes a connection
+///    with the target using the mirrord-operator.
+/// 2. If mirrord-operator is explicitly disabled in the given [`LayerConfig`], returns [`None`].
+/// 3. Otherwise, attempts to use the mirrord-operator and returns [`None`] in case mirrord-operator
+///    is not found or its license is invalid.
+async fn try_connect_using_operator<P, R>(
+    config: &LayerConfig,
+    progress: &P,
+    analytics: &mut R,
+) -> Result<Option<OperatorSessionConnection>>
+where
+    P: Progress,
+    R: Reporter,
+{
+    let operator_required = match config.operator {
+        Some(true) => true,
+        Some(false) => return Ok(None),
+        None => false,
+    };
+
+    let mut operator_subtask = progress.subtask("checking operator");
+
+    let mut find_operator_subtask = operator_subtask.subtask("detecting operator");
+
+    let api = if operator_required {
+        OperatorApi::new(config, analytics).await?.into()
+    } else {
+        OperatorApi::try_new(config, analytics).await?
+    };
+    let Some(mut api) = api else {
+        find_operator_subtask.success(Some("operator not found"));
+        operator_subtask.success(Some("proceeding without operator"));
+        return Ok(None);
+    };
+
+    find_operator_subtask.success(Some("operator found"));
+
+    let mut version_cmp_subtask = operator_subtask.subtask("checking version compatibility");
+    let compatible = api.check_operator_version(&version_cmp_subtask);
+    if compatible {
+        version_cmp_subtask.success(None);
+    } else {
+        version_cmp_subtask.failure(None);
+    }
+
+    let mut license_subtask = operator_subtask.subtask("checking license");
+    match api.check_license_validity(&license_subtask) {
+        Ok(()) => license_subtask.success(None),
+        Err(error) => {
+            license_subtask.failure(Some("operator license expired"));
+
+            if operator_required {
+                return Err(error.into());
+            } else {
+                operator_subtask.failure(Some("proceeding without operator"));
+                return Ok(None);
+            }
+        }
+    }
+
+    let mut user_cert_subtask = operator_subtask.subtask("preparing user credentials");
+    api.prepare_client_cert(analytics).await?;
+    user_cert_subtask.success(None);
+
+    let mut session_subtask = operator_subtask.subtask("starting session");
+    let connection = api.connect_in_new_session(config, &session_subtask).await?;
+    session_subtask.success(None);
+
+    Ok(Some(connection))
+}
+
+/// 1. If mirrord-operator is explicitly enabled in the given [`LayerConfig`], makes a connection
+///    with the target using the mirrord-operator.
+/// 2. If mirrord-operator is explicitly disabled in the given [`LayerConfig`], creates a
+///    mirrord-agent and runs session without the mirrord-operator.
+/// 3. Otherwise, attempts to use the mirrord-operator and falls back to OSS flow in case
+///    mirrord-operator is not found or its license is invalid.
 ///
 /// Here is where we start interactions with the kubernetes API.
 #[tracing::instrument(level = "trace", skip_all)]
@@ -42,54 +109,14 @@ pub(crate) async fn create_and_connect<P, R: Reporter>(
 where
     P: Progress + Send + Sync,
 {
-    if config.operator != Some(false) {
-        let mut subtask = progress.subtask("checking operator");
-
-        let result = try {
-            let api = OperatorApi::new(config, &subtask, analytics).await?;
-            let target = api.get_target(config, &subtask).await?;
-            let connection = api
-                .connect_target(&target, config.feature.network.incoming.on_concurrent_steal)
-                .await?;
-            let session_info = OperatorSessionInformation {
-                target,
-                metadata: api.session_metadata().clone(),
-            };
-            (connection, session_info)
-        };
-
-        match result {
-            Ok((connection, session)) => {
-                subtask.success(Some("connected to the operator"));
-
-                return Ok((
-                    AgentConnectInfo::Operator(session),
-                    AgentConnection {
-                        sender: connection.tx,
-                        receiver: connection.rx,
-                    },
-                ));
-            }
-
-            Err(OperatorApiError::NoLicense) if config.operator.is_none() => {
-                tracing::trace!("operator license expired");
-                subtask.success(Some("operator license expired"));
-            }
-
-            Err(
-                e @ OperatorApiError::KubeError {
-                    operation: OperatorOperation::FindingOperator,
-                    ..
-                },
-            ) if config.operator.is_none() => {
-                // We need to check if the operator is really installed or not.
-                if operator::check_if_operator_resource_exists(config).await? {
-                    return Err(e.into());
-                }
-            }
-
-            Err(e) => return Err(e.into()),
-        }
+    if let Some(connection) = try_connect_using_operator(config, progress, analytics).await? {
+        return Ok((
+            AgentConnectInfo::Operator(connection.session),
+            AgentConnection {
+                sender: connection.tx,
+                receiver: connection.rx,
+            },
+        ));
     }
 
     if config.feature.copy_target.enabled {

--- a/mirrord/cli/src/error.rs
+++ b/mirrord/cli/src/error.rs
@@ -233,9 +233,9 @@ pub(crate) enum CliError {
     ))]
     PingPongFailed(String),
 
-    #[error("Failed to prepare mirrord operator user certificate: {0}")]
+    #[error("Failed to prepare mirrord operator client certificate: {0}")]
     #[diagnostic(help("{GENERAL_BUG}"))]
-    OperatorUserCertError(String),
+    OperatorClientCertError(String),
 }
 
 impl From<OperatorApiError> for CliError {
@@ -273,7 +273,7 @@ impl From<OperatorApiError> for CliError {
                 Self::OperatorApiFailed(operation, error)
             }
             OperatorApiError::NoLicense => Self::OperatorLicenseExpired,
-            OperatorApiError::ClientCertError(error) => Self::OperatorUserCertError(error),
+            OperatorApiError::ClientCertError(error) => Self::OperatorClientCertError(error),
         }
     }
 }

--- a/mirrord/cli/src/error.rs
+++ b/mirrord/cli/src/error.rs
@@ -242,6 +242,10 @@ pub(crate) enum CliError {
     Please remember that some features are supported only when using mirrord operator (https://mirrord.dev/docs/overview/teams/#supported-features).{GENERAL_HELP}"
     ))]
     OperatorInstallationCheckError(KubeApiError),
+
+    #[error("Failed to prepare mirrord operator user certificate: {0}")]
+    #[diagnostic(help("{GENERAL_BUG}"))]
+    OperatorUserCertError(String),
 }
 
 impl From<OperatorApiError> for CliError {
@@ -254,7 +258,7 @@ impl From<OperatorApiError> for CliError {
                 feature,
                 operator_version,
             },
-            OperatorApiError::CreateApiError(e) => Self::CreateKubeApiFailed(e),
+            OperatorApiError::CreateKubeClient(e) => Self::CreateKubeApiFailed(e),
             OperatorApiError::ConnectRequestBuildError(e) => Self::ConnectRequestBuildError(e),
             OperatorApiError::KubeError {
                 error: kube::Error::Api(ErrorResponse { message, code, .. }),
@@ -279,6 +283,7 @@ impl From<OperatorApiError> for CliError {
                 Self::OperatorApiFailed(operation, error)
             }
             OperatorApiError::NoLicense => Self::OperatorLicenseExpired,
+            OperatorApiError::UserCertError(error) => Self::OperatorUserCertError(error),
         }
     }
 }

--- a/mirrord/cli/src/error.rs
+++ b/mirrord/cli/src/error.rs
@@ -6,7 +6,7 @@ use mirrord_config::config::ConfigError;
 use mirrord_console::error::ConsoleError;
 use mirrord_intproxy::error::IntProxyError;
 use mirrord_kube::error::KubeApiError;
-use mirrord_operator::client::{HttpError, OperatorApiError, OperatorOperation};
+use mirrord_operator::client::error::{HttpError, OperatorApiError, OperatorOperation};
 use reqwest::StatusCode;
 use thiserror::Error;
 
@@ -233,16 +233,6 @@ pub(crate) enum CliError {
     ))]
     PingPongFailed(String),
 
-    #[error("Failed to check whether mirrord operator is installed in the cluster: {0}")]
-    #[diagnostic(help(
-    "Please check that Kubernetes is configured correctly and test your connection with `kubectl get pods`.
-
-    If you want to run without the operator, please set `\"operator\": false` in the mirrord configuration file.
-
-    Please remember that some features are supported only when using mirrord operator (https://mirrord.dev/docs/overview/teams/#supported-features).{GENERAL_HELP}"
-    ))]
-    OperatorInstallationCheckError(KubeApiError),
-
     #[error("Failed to prepare mirrord operator user certificate: {0}")]
     #[diagnostic(help("{GENERAL_BUG}"))]
     OperatorUserCertError(String),
@@ -283,7 +273,7 @@ impl From<OperatorApiError> for CliError {
                 Self::OperatorApiFailed(operation, error)
             }
             OperatorApiError::NoLicense => Self::OperatorLicenseExpired,
-            OperatorApiError::UserCertError(error) => Self::OperatorUserCertError(error),
+            OperatorApiError::ClientCertError(error) => Self::OperatorUserCertError(error),
         }
     }
 }

--- a/mirrord/cli/src/main.rs
+++ b/mirrord/cli/src/main.rs
@@ -577,8 +577,7 @@ async fn print_targets(args: &ListTargetArgs) -> Result<()> {
             };
 
             match api {
-                Some(api) => {
-                    api
+                Some(api) => api
                     .list_targets(layer_config.target.namespace.as_deref())
                     .await?
                     .iter()
@@ -591,8 +590,7 @@ async fn print_targets(args: &ListTargetArgs) -> Result<()> {
                         }
                         Some(format!("{target}"))
                     })
-                    .collect()
-                },
+                    .collect(),
                 None => list_pods(&layer_config, args).await?,
             }
         }

--- a/mirrord/cli/src/main.rs
+++ b/mirrord/cli/src/main.rs
@@ -33,7 +33,7 @@ use mirrord_kube::api::{
     kubernetes::{create_kube_config, get_k8s_resource_api, rollout::Rollout},
 };
 use mirrord_operator::client::OperatorApi;
-use mirrord_progress::{NullProgress, Progress, ProgressTracker};
+use mirrord_progress::{Progress, ProgressTracker};
 use operator::operator_command;
 use semver::Version;
 use serde::de::DeserializeOwned;
@@ -566,12 +566,7 @@ async fn print_targets(args: &ListTargetArgs) -> Result<()> {
     }
 
     // Try operator first if relevant
-    let operator_api = OperatorApi::try_new(
-        &layer_config,
-        &mut NullReporter::default(),
-        &NullProgress {},
-    )
-    .await?;
+    let operator_api = OperatorApi::try_new(&layer_config, &mut NullReporter::default()).await?;
     let mut targets = match operator_api {
         Some(api) => {
             let api = api.prepare_client_cert(&mut NullReporter::default()).await;

--- a/mirrord/cli/src/main.rs
+++ b/mirrord/cli/src/main.rs
@@ -705,9 +705,9 @@ async fn prompt_outdated_version(progress: &ProgressTracker) {
                         let command = if is_homebrew { "brew upgrade metalbear-co/mirrord/mirrord" } else { "curl -fsSL https://raw.githubusercontent.com/metalbear-co/mirrord/main/scripts/install.sh | bash" };
                         progress.print(&format!("New mirrord version available: {}. To update, run: `{:?}`.", latest_version, command));
                         progress.print("To disable version checks, set env variable MIRRORD_CHECK_VERSION to 'false'.");
-                        progress.success(Some(&format!("Update to {latest_version} available")));
+                        progress.success(Some(&format!("update to {latest_version} available")));
                     } else {
-                        progress.success(Some(&format!("Running on latest ({CURRENT_VERSION})!")));
+                        progress.success(Some(&format!("running on latest ({CURRENT_VERSION})!")));
                     }
                 }
             }

--- a/mirrord/cli/src/main.rs
+++ b/mirrord/cli/src/main.rs
@@ -573,14 +573,11 @@ async fn print_targets(args: &ListTargetArgs) -> Result<()> {
     )
     .await?;
     let mut targets = match operator_api {
-        Some(mut api) => {
-            api.prepare_client_cert(&mut NullReporter::default())
-                .await
-                .inspect_err(
-                    |error| tracing::error!(%error, "failed to prepare client certificate"),
-                )
-                .ok();
-
+        Some(api) => {
+            let api = api.prepare_client_cert(&mut NullReporter::default()).await;
+            api.inspect_cert_error(
+                |error| tracing::error!(%error, "failed to prepare client certificate"),
+            );
             api.list_targets(layer_config.target.namespace.as_deref())
                 .await?
                 .iter()

--- a/mirrord/kube/src/api/kubernetes.rs
+++ b/mirrord/kube/src/api/kubernetes.rs
@@ -42,12 +42,13 @@ pub struct KubernetesAPI {
 
 impl KubernetesAPI {
     pub async fn create(config: &LayerConfig) -> Result<Self> {
-        let client = create_kube_api(
+        let client = create_kube_config(
             config.accept_invalid_certificates,
             config.kubeconfig.clone(),
             config.kube_context.clone(),
         )
-        .await?;
+        .await?
+        .try_into()?;
 
         Ok(KubernetesAPI::new(client, config.agent.clone()))
     }
@@ -285,11 +286,11 @@ pub struct AgentKubernetesConnectInfo {
     pub agent_version: Option<String>,
 }
 
-pub async fn create_kube_api<P>(
+pub async fn create_kube_config<P>(
     accept_invalid_certificates: bool,
     kubeconfig: Option<P>,
     kube_context: Option<String>,
-) -> Result<Client>
+) -> Result<Config>
 where
     P: AsRef<str>,
 {
@@ -312,7 +313,8 @@ where
         Config::infer().await?
     };
     config.accept_invalid_certs = accept_invalid_certificates;
-    Client::try_from(config).map_err(KubeApiError::from)
+
+    Ok(config)
 }
 
 #[tracing::instrument(level = "debug", skip(client))]

--- a/mirrord/operator/src/client.rs
+++ b/mirrord/operator/src/client.rs
@@ -393,7 +393,7 @@ impl OperatorApi {
             let namespace = self.target_namespace(config);
             let copied = self.copy_target(target, scale_down, namespace).await?;
 
-            copy_subtask.success(None);
+            copy_subtask.success(Some("target copied"));
 
             OperatorSessionTarget::Copied(copied)
         } else {
@@ -409,7 +409,7 @@ impl OperatorApi {
                     operation: OperatorOperation::FindingTarget,
                 })?;
 
-            fetch_subtask.success(None);
+            fetch_subtask.success(Some("target fetched"));
 
             OperatorSessionTarget::Raw(raw_target)
         };
@@ -438,9 +438,9 @@ impl OperatorApi {
                 .and_then(|version| version.parse().ok()),
         };
 
-        let mut connection_subtask = progress.subtask("connecting with the target");
+        let mut connection_subtask = progress.subtask("connecting to the target");
         let (tx, rx) = Self::connect_target(&self.client, &session).await?;
-        connection_subtask.success(None);
+        connection_subtask.success(Some("connected to the target"));
 
         Ok(OperatorSessionConnection { session, tx, rx })
     }

--- a/mirrord/operator/src/client.rs
+++ b/mirrord/operator/src/client.rs
@@ -382,7 +382,7 @@ impl OperatorApi {
     where
         P: Progress,
     {
-        self.check_feature_support(config)?;
+        self.check_copy_target_feature_support(config)?;
 
         let target = if config.feature.copy_target.enabled {
             let mut copy_subtask = progress.subtask("copying target");
@@ -633,9 +633,9 @@ impl OperatorApi {
         Ok(client_config)
     }
 
-    /// Checks features specified in the given [`LayerConfig`] against what is supported by the
-    /// detected operator installation.
-    fn check_feature_support(&self, config: &LayerConfig) -> OperatorApiResult<()> {
+    /// If `copy_target` feature is enabled in the given [`LayerConfig`], checks that the operator
+    /// supports it.
+    fn check_copy_target_feature_support(&self, config: &LayerConfig) -> OperatorApiResult<()> {
         let client_wants_copy = config.feature.copy_target.enabled;
         let operator_supports_copy = self.operator.spec.copy_target_enabled.unwrap_or(false);
         if client_wants_copy && !operator_supports_copy {

--- a/mirrord/operator/src/client.rs
+++ b/mirrord/operator/src/client.rs
@@ -451,7 +451,11 @@ impl OperatorApi {
 
     /// Returns a CRD for the target specified in the given [`LayerConfig`].
     /// If `copy_target` feature is enabled, this required creating [`CopyTargetCrd`] first.
-    #[tracing::instrument(level = "trace", skip(self, progress))]
+    #[tracing::instrument(
+        level = "trace",
+        fields(target_config = ?config.target, copy_target_config = ?config.feature.copy_target)
+        skip_all,
+    )]
     pub async fn get_target<P>(
         &self,
         config: &LayerConfig,
@@ -608,7 +612,11 @@ impl OperatorApi {
     ///
     /// `copy_target` feature is not available for all target types.
     /// Target type compatibility is checked by the operator.
-    #[tracing::instrument(level = "trace", skip(self))]
+    #[tracing::instrument(
+        level = "trace",
+        fields(target_config = ?config.target, copy_target_config = ?config.feature.copy_target)
+        skip_all,
+    )]
     async fn copy_target(&self, config: &LayerConfig) -> Result<CopyTargetCrd> {
         let target = config.target.path.clone().unwrap_or(Target::Targetless);
         let name = TargetCrd::target_name(&target);

--- a/mirrord/operator/src/client/conn_wrapper.rs
+++ b/mirrord/operator/src/client/conn_wrapper.rs
@@ -1,0 +1,126 @@
+use futures::{Sink, SinkExt, Stream, StreamExt};
+use mirrord_protocol::{ClientMessage, DaemonMessage};
+use thiserror::Error;
+use tokio::sync::mpsc::{self, Receiver, Sender};
+use tokio_tungstenite::tungstenite::{self, Message};
+
+#[derive(Error, Debug)]
+enum ConnectionWrapperError {
+    #[error(transparent)]
+    DecodeError(#[from] bincode::error::DecodeError),
+    #[error(transparent)]
+    EncodeError(#[from] bincode::error::EncodeError),
+    #[error(transparent)]
+    WsError(#[from] tungstenite::Error),
+    #[error("invalid message: {0:?}")]
+    InvalidMessage(Message),
+    #[error("message channel is closed")]
+    ChannelClosed,
+}
+
+pub struct ConnectionWrapper<T> {
+    connection: T,
+    client_rx: Receiver<ClientMessage>,
+    daemon_tx: Sender<DaemonMessage>,
+    protocol_version: Option<semver::Version>,
+}
+
+impl<T> ConnectionWrapper<T>
+where
+    for<'stream> T: Stream<Item = Result<Message, tungstenite::Error>>
+        + Sink<Message, Error = tungstenite::Error>
+        + Send
+        + Unpin
+        + 'stream,
+{
+    const CONNECTION_CHANNEL_SIZE: usize = 1000;
+
+    pub fn wrap(
+        connection: T,
+        protocol_version: Option<semver::Version>,
+    ) -> (Sender<ClientMessage>, Receiver<DaemonMessage>) {
+        let (client_tx, client_rx) = mpsc::channel(Self::CONNECTION_CHANNEL_SIZE);
+        let (daemon_tx, daemon_rx) = mpsc::channel(Self::CONNECTION_CHANNEL_SIZE);
+
+        let connection_wrapper = ConnectionWrapper {
+            protocol_version,
+            connection,
+            client_rx,
+            daemon_tx,
+        };
+
+        tokio::spawn(async move {
+            match connection_wrapper.start().await {
+                Ok(()) | Err(ConnectionWrapperError::ChannelClosed) => {}
+                Err(error) => tracing::error!(%error, "Operator connection failed"),
+            }
+        });
+
+        (client_tx, daemon_rx)
+    }
+
+    async fn handle_client_message(
+        &mut self,
+        client_message: ClientMessage,
+    ) -> Result<(), ConnectionWrapperError> {
+        let payload = bincode::encode_to_vec(client_message, bincode::config::standard())?;
+
+        self.connection.send(payload.into()).await?;
+
+        Ok(())
+    }
+
+    async fn handle_daemon_message(
+        &mut self,
+        daemon_message: Result<Message, tungstenite::Error>,
+    ) -> Result<(), ConnectionWrapperError> {
+        match daemon_message? {
+            Message::Binary(payload) => {
+                let (daemon_message, _) = bincode::decode_from_slice::<DaemonMessage, _>(
+                    &payload,
+                    bincode::config::standard(),
+                )?;
+
+                self.daemon_tx
+                    .send(daemon_message)
+                    .await
+                    .map_err(|_| ConnectionWrapperError::ChannelClosed)
+            }
+            message => Err(ConnectionWrapperError::InvalidMessage(message)),
+        }
+    }
+
+    async fn start(mut self) -> Result<(), ConnectionWrapperError> {
+        loop {
+            tokio::select! {
+                client_message = self.client_rx.recv() => {
+                    match client_message {
+                        Some(ClientMessage::SwitchProtocolVersion(version)) => {
+                            if let Some(operator_protocol_version) = self.protocol_version.as_ref() {
+                                self.handle_client_message(ClientMessage::SwitchProtocolVersion(operator_protocol_version.min(&version).clone())).await?;
+                            } else {
+                                self.daemon_tx
+                                    .send(DaemonMessage::SwitchProtocolVersionResponse(
+                                        "1.2.1".parse().expect("Bad static version"),
+                                    ))
+                                    .await
+                                    .map_err(|_| ConnectionWrapperError::ChannelClosed)?;
+                            }
+                        }
+                        Some(client_message) => self.handle_client_message(client_message).await?,
+                        None => break,
+                    }
+                }
+
+                daemon_message = self.connection.next() => match daemon_message {
+                    Some(daemon_message) => self.handle_daemon_message(daemon_message).await?,
+                    None => break,
+                },
+            }
+        }
+
+        let _ = self.connection.send(Message::Close(None)).await;
+
+        Ok(())
+    }
+}

--- a/mirrord/operator/src/client/discovery.rs
+++ b/mirrord/operator/src/client/discovery.rs
@@ -1,0 +1,18 @@
+use kube::{api::GroupVersionKind, discovery, Client, Resource};
+
+use crate::crd::MirrordOperatorCrd;
+
+#[tracing::instrument(level = "trace", skip_all, ret, err)]
+pub async fn operator_installed(client: &Client) -> kube::Result<bool> {
+    let gvk = GroupVersionKind {
+        group: MirrordOperatorCrd::group(&()).into_owned(),
+        version: MirrordOperatorCrd::version(&()).into_owned(),
+        kind: MirrordOperatorCrd::kind(&()).into_owned(),
+    };
+
+    match discovery::oneshot::pinned_kind(client, &gvk).await {
+        Ok(..) => Ok(true),
+        Err(kube::Error::Api(response)) if response.code == 404 => Ok(false),
+        Err(error) => Err(error),
+    }
+}

--- a/mirrord/operator/src/client/error.rs
+++ b/mirrord/operator/src/client/error.rs
@@ -1,0 +1,68 @@
+use std::fmt;
+
+pub use http::Error as HttpError;
+use mirrord_kube::error::KubeApiError;
+use thiserror::Error;
+
+/// Operations performed on the operator via [`kube`] API.
+#[derive(Debug)]
+pub enum OperatorOperation {
+    FindingOperator,
+    FindingTarget,
+    WebsocketConnection,
+    CopyingTarget,
+    GettingStatus,
+    SessionManagement,
+    ListingTargets,
+}
+
+impl fmt::Display for OperatorOperation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let as_str = match self {
+            Self::FindingOperator => "finding operator",
+            Self::FindingTarget => "finding target",
+            Self::WebsocketConnection => "creating a websocket connection",
+            Self::CopyingTarget => "copying target",
+            Self::GettingStatus => "getting status",
+            Self::SessionManagement => "session management",
+            Self::ListingTargets => "listing targets",
+        };
+
+        f.write_str(as_str)
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum OperatorApiError {
+    #[error("failed to build a websocket connect request: {0}")]
+    ConnectRequestBuildError(HttpError),
+
+    #[error("failed to create Kubernetes client: {0}")]
+    CreateKubeClient(KubeApiError),
+
+    #[error("{operation} failed: {error}")]
+    KubeError {
+        error: kube::Error,
+        operation: OperatorOperation,
+    },
+
+    #[error("mirrord operator {operator_version} does not support feature {feature}")]
+    UnsupportedFeature {
+        feature: String,
+        operator_version: String,
+    },
+
+    #[error("{operation} failed with code {}: {}", status.code, status.reason)]
+    StatusFailure {
+        operation: OperatorOperation,
+        status: Box<kube::core::Status>,
+    },
+
+    #[error("mirrord operator license expired")]
+    NoLicense,
+
+    #[error("failed to prepare client certificate: {0}")]
+    ClientCertError(String),
+}
+
+pub type OperatorApiResult<T, E = OperatorApiError> = Result<T, E>;

--- a/mirrord/operator/src/client/upgrade.rs
+++ b/mirrord/operator/src/client/upgrade.rs
@@ -1,0 +1,150 @@
+//! Code copied from [`kube::client`] and adjusted.
+//!
+//! Just like original [`Client::connect`] function, [`connect_ws`] creates a
+//! WebSockets connection. However, original function swallows
+//! [`ErrorResponse`] sent by the operator and returns flat
+//! [`UpgradeConnectionError`]. [`connect_ws`] attempts to
+//! recover the [`ErrorResponse`] - if operator response code is not
+//! [`StatusCode::SWITCHING_PROTOCOLS`], it tries to read
+//! response body and deserialize it.
+
+use base64::Engine;
+use http::{HeaderValue, Request, Response, StatusCode};
+use http_body_util::BodyExt;
+use hyper_util::rt::TokioIo;
+use kube::{
+    client::{Body, UpgradeConnectionError},
+    core::ErrorResponse,
+    Client, Error, Result,
+};
+use tokio_tungstenite::{tungstenite::protocol::Role, WebSocketStream};
+
+const WS_PROTOCOL: &str = "v4.channel.k8s.io";
+
+// Verify upgrade response according to RFC6455.
+// Based on `tungstenite` and added subprotocol verification.
+async fn verify_response(res: Response<Body>, key: &HeaderValue) -> Result<Response<Body>> {
+    let status = res.status();
+
+    if status != StatusCode::SWITCHING_PROTOCOLS {
+        if status.is_client_error() || status.is_server_error() {
+            let error_response = res
+                .into_body()
+                .collect()
+                .await
+                .ok()
+                .map(|body| body.to_bytes())
+                .and_then(|body_bytes| serde_json::from_slice::<ErrorResponse>(&body_bytes).ok());
+
+            if let Some(error_response) = error_response {
+                return Err(Error::Api(error_response));
+            }
+        }
+
+        return Err(Error::UpgradeConnection(
+            UpgradeConnectionError::ProtocolSwitch(status),
+        ));
+    }
+
+    let headers = res.headers();
+    if !headers
+        .get(http::header::UPGRADE)
+        .and_then(|h| h.to_str().ok())
+        .map(|h| h.eq_ignore_ascii_case("websocket"))
+        .unwrap_or(false)
+    {
+        return Err(Error::UpgradeConnection(
+            UpgradeConnectionError::MissingUpgradeWebSocketHeader,
+        ));
+    }
+
+    if !headers
+        .get(http::header::CONNECTION)
+        .and_then(|h| h.to_str().ok())
+        .map(|h| h.eq_ignore_ascii_case("Upgrade"))
+        .unwrap_or(false)
+    {
+        return Err(Error::UpgradeConnection(
+            UpgradeConnectionError::MissingConnectionUpgradeHeader,
+        ));
+    }
+
+    let accept_key = tokio_tungstenite::tungstenite::handshake::derive_accept_key(key.as_ref());
+    if !headers
+        .get(http::header::SEC_WEBSOCKET_ACCEPT)
+        .map(|h| h == &accept_key)
+        .unwrap_or(false)
+    {
+        return Err(Error::UpgradeConnection(
+            UpgradeConnectionError::SecWebSocketAcceptKeyMismatch,
+        ));
+    }
+
+    // Make sure that the server returned the correct subprotocol.
+    if !headers
+        .get(http::header::SEC_WEBSOCKET_PROTOCOL)
+        .map(|h| h == WS_PROTOCOL)
+        .unwrap_or(false)
+    {
+        return Err(Error::UpgradeConnection(
+            UpgradeConnectionError::SecWebSocketProtocolMismatch,
+        ));
+    }
+
+    Ok(res)
+}
+
+/// Generate a random key for the `Sec-WebSocket-Key` header.
+/// This must be nonce consisting of a randomly selected 16-byte value in base64.
+fn sec_websocket_key() -> HeaderValue {
+    let random: [u8; 16] = rand::random();
+    base64::engine::general_purpose::STANDARD
+        .encode(random)
+        .parse()
+        .expect("should be valid")
+}
+
+pub async fn connect_ws(
+    client: &Client,
+    request: Request<Vec<u8>>,
+) -> kube::Result<WebSocketStream<TokioIo<hyper::upgrade::Upgraded>>> {
+    let (mut parts, body) = request.into_parts();
+    parts.headers.insert(
+        http::header::CONNECTION,
+        HeaderValue::from_static("Upgrade"),
+    );
+    parts
+        .headers
+        .insert(http::header::UPGRADE, HeaderValue::from_static("websocket"));
+    parts.headers.insert(
+        http::header::SEC_WEBSOCKET_VERSION,
+        HeaderValue::from_static("13"),
+    );
+    let key = sec_websocket_key();
+    parts
+        .headers
+        .insert(http::header::SEC_WEBSOCKET_KEY, key.clone());
+    // Use the binary subprotocol v4, to get JSON `Status` object in `error` channel (3).
+    // There's no official documentation about this protocol, but it's described in
+    // [`k8s.io/apiserver/pkg/util/wsstream/conn.go`](https://git.io/JLQED).
+    // There's a comment about v4 and `Status` object in
+    // [`kublet/cri/streaming/remotecommand/httpstream.go`](https://git.io/JLQEh).
+    parts.headers.insert(
+        http::header::SEC_WEBSOCKET_PROTOCOL,
+        HeaderValue::from_static(WS_PROTOCOL),
+    );
+
+    let res = client
+        .send(Request::from_parts(parts, Body::from(body)))
+        .await?;
+    let res = verify_response(res, &key).await?;
+    match hyper::upgrade::on(res).await {
+        Ok(upgraded) => {
+            Ok(WebSocketStream::from_raw_socket(TokioIo::new(upgraded), Role::Client, None).await)
+        }
+
+        Err(e) => Err(Error::UpgradeConnection(
+            UpgradeConnectionError::GetPendingUpgrade(e),
+        )),
+    }
+}

--- a/mirrord/operator/src/lib.rs
+++ b/mirrord/operator/src/lib.rs
@@ -1,5 +1,6 @@
 #![feature(let_chains)]
 #![feature(lazy_cell)]
+#![feature(try_blocks)]
 #![warn(clippy::indexing_slicing)]
 
 #[cfg(feature = "client")]

--- a/mirrord/operator/src/types.rs
+++ b/mirrord/operator/src/types.rs
@@ -1,4 +1,5 @@
 use chrono::NaiveDate;
+use http::HeaderName;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -13,12 +14,25 @@ pub struct LicenseInfoOwned {
     pub subscription_id: Option<String>,
 }
 
-/// Name of the HTTP header containing CLI version.
+/// HTTP header containing CLI version.
 /// Sent with each request to the mirrord operator.
-pub const MIRRORD_CLI_VERSION_HEADER_NAME: &str = "x-mirrord-cli-version";
+pub static MIRRORD_CLI_VERSION_HEADER: HeaderName =
+    HeaderName::from_static("x-mirrord-cli-version");
 
-/// Name of the HTTP header containing client certificate.
-/// Send with each request to the mirrord operator except:
+/// HTTP header containing client certificate.
+/// Sent with each request to the mirrord operator except:
 /// 1. Initial GET on the operator resource
 /// 2. User certificate request
-pub const CLIENT_CERT_HEADER_NAME: &str = "x-client-der";
+pub static CLIENT_CERT_HEADER: HeaderName = HeaderName::from_static("x-client-der");
+
+/// HTTP header containing client hostname.
+/// Sent with each request to the mirrord operator (if available).
+pub static CLIENT_HOSTNAME_HEADER: HeaderName = HeaderName::from_static("x-client-hostname");
+
+/// HTTP header containing client name.
+/// Sent with each request to the mirrord operator (if available).
+pub static CLIENT_NAME_HEADER: HeaderName = HeaderName::from_static("x-client-name");
+
+/// HTTP header containing operator session id.
+/// Sent with target connection request.
+pub static SESSION_ID_HEADER: HeaderName = HeaderName::from_static("x-session-id");

--- a/mirrord/operator/src/types.rs
+++ b/mirrord/operator/src/types.rs
@@ -20,9 +20,10 @@ pub static MIRRORD_CLI_VERSION_HEADER: HeaderName =
     HeaderName::from_static("x-mirrord-cli-version");
 
 /// HTTP header containing client certificate.
-/// Sent with each request to the mirrord operator except:
+/// Sent with each request to the mirrord operator (if available) except:
 /// 1. Initial GET on the operator resource
 /// 2. User certificate request
+/// Required for making the target connection request.
 pub static CLIENT_CERT_HEADER: HeaderName = HeaderName::from_static("x-client-der");
 
 /// HTTP header containing client hostname.

--- a/mirrord/operator/src/types.rs
+++ b/mirrord/operator/src/types.rs
@@ -12,3 +12,13 @@ pub struct LicenseInfoOwned {
     /// Subscription id encoded in the operator license extension.
     pub subscription_id: Option<String>,
 }
+
+/// Name of the HTTP header containing CLI version.
+/// Sent with each request to the mirrord operator.
+pub const MIRRORD_CLI_VERSION_HEADER_NAME: &str = "x-mirrord-cli-version";
+
+/// Name of the HTTP header containing client certificate.
+/// Send with each request to the mirrord operator except:
+/// 1. Initial GET on the operator resource
+/// 2. User certificate request
+pub const CLIENT_CERT_HEADER_NAME: &str = "x-client-der";


### PR DESCRIPTION
Closes #2466 

CLI version and user name/hostname headers are sent with all operator requests.
Client certificate header:
1. `mirrord operator status`: we don't know operator license fingerprint before getting the resource, so header is not sent.
2. `mirrord exec`: as soon as we get the operator resource, we prepare the client cert header. If we fail, command aborts.
3. `mirrord ls` / `mirrord operator session`: as soon as we get the operator resource, we try to prepare the client cert header. If we fail, we continue without it

I kind of went full aggro on the operator client code and made more changes than necessary :V
1. Copied to `mirrord ls` the extra discovery step present in `mirrord exec` (https://github.com/metalbear-co/mirrord/issues/2487)
2. Moved some parts of operator client code to new separate submodules (errors, http upgrade request logic, connection wrapper, operator discovery)
3. Unified format of progress messages
