### PR TITLE
rerun medschool after medschool change

### DIFF
--- a/changelog.d/+medschool-order.changed.md
+++ b/changelog.d/+medschool-order.changed.md
@@ -1,0 +1,1 @@
+Configuration documentation contents order.

--- a/mirrord/config/configuration.md
+++ b/mirrord/config/configuration.md
@@ -127,100 +127,8 @@ certificates).
 
 Defaults to `false`.
 
-## operator {#root-operator}
-
-Whether mirrord should use the operator.
-If not set, mirrord will first attempt to use the operator, but continue without it in case
-of failure.
-
-## skip_build_tools {#root-skip_build_tools}
-
-Allows mirrord to skip build tools. Useful when running command lines that build and run
-the application in a single command.
-
-Defaults to `true`.
-
-Build-Tools: `["as", "cc", "ld", "go", "air", "asm", "cc1", "cgo", "dlv", "gcc", "git",
-"link", "math", "cargo", "hpack", "rustc", "compile", "collect2", "cargo-watch",
-"debugserver"]`
-
-## telemetry {#root-telemetry}
-Controls whether or not mirrord sends telemetry data to MetalBear cloud.
-Telemetry sent doesn't contain personal identifiers or any data that
-should be considered sensitive. It is used to improve the product.
-[For more information](https://github.com/metalbear-co/mirrord/blob/main/TELEMETRY.md)
-
-## use_proxy {#root-use_proxy}
-
-When disabled, mirrord will remove `HTTP[S]_PROXY` env variables before
-doing any network requests. This is useful when the system sets a proxy
-but you don't want mirrord to use it.
-This also applies to the mirrord process (as it just removes the env).
-If the remote pod sets this env, the mirrord process will still use it.
-
-## connect_tcp {#root-connect_tpc}
-
-IP:PORT to connect to instead of using k8s api, for testing purposes.
-
-```json
-{
-  "connect_tcp": "10.10.0.100:7777"
-}
-```
-
-## kube_context {#root-kube_context}
-
-Kube context to use from the kubeconfig file.
-Will use current context if not specified.
-
-```json
-{
- "kube_context": "mycluster"
-}
-```
-
-## kubeconfig {#root-kubeconfig}
-
-Path to a kubeconfig file, if not specified, will use `KUBECONFIG`, or `~/.kube/config`, or
-the in-cluster config.
-
-```json
-{
- "kubeconfig": "~/bear/kube-config"
-}
-```
-
-## sip_binaries {#root-sip_binaries}
-
-Binaries to patch (macOS SIP).
-
-Use this when mirrord isn't loaded to protected binaries that weren't automatically
-patched.
-
-Runs `endswith` on the binary path (so `bash` would apply to any binary ending with `bash`
-while `/usr/bin/bash` would apply only for that binary).
-
-```json
-{
- "sip_binaries": "bash;python"
-}
-```
-
-## skip_processes {#root-skip_processes}
-
-Allows mirrord to skip unwanted processes.
-
-Useful when process A spawns process B, and the user wants mirrord to operate only on
-process B.
-Accepts a single value, or multiple values separated by `;`.
-
-```json
-{
- "skip_processes": "bash;node"
-}
-```
-
 ## agent {#root-agent}
+
 Configuration for the mirrord-agent pod that is spawned in the Kubernetes cluster.
 
 We provide sane defaults for this option, so you don't have to set up anything here.
@@ -244,28 +152,15 @@ We provide sane defaults for this option, so you don't have to set up anything h
 }
 ```
 
-### agent.communication_timeout {#agent-communication_timeout}
+### agent.annotations {#agent-annotations}
 
-Controls how long the agent lives when there are no connections.
+Allows setting up custom annotations for the agent Job and Pod.
 
-Each connection has its own heartbeat mechanism, so even if the local application has no
-messages, the agent stays alive until there are no more heartbeat messages.
-
-### agent.startup_timeout {#agent-startup_timeout}
-
-Controls how long to wait for the agent to finish initialization.
-
-If initialization takes longer than this value, mirrord exits.
-
-Defaults to `60`.
-
-### agent.ttl {#agent-ttl}
-
-Controls how long the agent pod persists for after the agent exits (in seconds).
-
-Can be useful for collecting logs.
-
-Defaults to `1`.
+```json
+{
+  "annotations": { "cats.io/inject": "enabled" }
+}
+```
 
 ### agent.check_out_of_pods {#agent-check_out_of_pods}
 
@@ -274,6 +169,21 @@ when using ephemeral containers feature)
 
 Can be disabled if the check takes too long and you are sure there is enough resources on
 each node
+
+### agent.communication_timeout {#agent-communication_timeout}
+
+Controls how long the agent lives when there are no connections.
+
+Each connection has its own heartbeat mechanism, so even if the local application has no
+messages, the agent stays alive until there are no more heartbeat messages.
+
+### agent.disabled_capabilities {#agent-disabled_capabilities}
+
+Disables specified Linux capabilities for the agent container.
+If nothing is disabled here, agent uses `NET_ADMIN`, `NET_RAW`, `SYS_PTRACE` and
+`SYS_ADMIN`.
+
+### agent.dns {#agent-dns}
 
 ### agent.ephemeral {#agent-ephemeral}
 
@@ -289,39 +199,29 @@ aren't stolen (due to being already established)
 
 Defaults to `true`.
 
-### agent.json_log {#agent-json_log}
+### agent.image {#agent-image}
 
-Controls whether the agent produces logs in a human-friendly format, or json.
+Name of the agent's docker image.
+
+Useful when a custom build of mirrord-agent is required, or when using an internal
+registry.
+
+Defaults to the latest stable image `"ghcr.io/metalbear-co/mirrord:latest"`.
 
 ```json
 {
-  "agent": {
-    "json_log": true
-  }
+  "image": "internal.repo/images/mirrord:latest"
 }
 ```
 
-### agent.nftables {#agent-nftables}
-
-Use iptables-nft instead of iptables-legacy.
-Defaults to `false`.
-
-Needed if your mesh uses nftables instead of iptables-legacy,
-
-### agent.privileged {#agent-privileged}
-
-Run the mirror agent as privileged container.
-Defaults to `false`.
-
-Might be needed in strict environments such as Bottlerocket.
-
-### agent.annotations {#agent-annotations}
-
-Allows setting up custom annotations for the agent Job and Pod.
+Complete setup:
 
 ```json
 {
-  "annotations": { "cats.io/inject": "enabled" }
+  "image": {
+    "registry": "internal.repo/images/mirrord",
+    "tag": "latest"
+  }
 }
 ```
 
@@ -333,6 +233,37 @@ Supports `"IfNotPresent"`, `"Always"`, `"Never"`, or any valid kubernetes
 [image pull policy](https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy)
 
 Defaults to `"IfNotPresent"`
+
+### agent.image_pull_secrets {#agent-image_pull_secrets}
+
+List of secrets the agent pod has access to.
+
+Takes an array of entries with the format `{ name: <secret-name> }`.
+
+Read more [here](https://kubernetes.io/docs/concepts/containers/images/#referring-to-an-imagepullsecrets-on-a-pod).
+
+```json
+{
+  "agent": {
+    "image_pull_secrets": [
+      { "name": "secret-key-1" },
+      { "name": "secret-key-2" }
+    ]
+  }
+}
+```
+
+### agent.json_log {#agent-json_log}
+
+Controls whether the agent produces logs in a human-friendly format, or json.
+
+```json
+{
+  "agent": {
+    "json_log": true
+  }
+}
+```
 
 ### agent.labels {#agent-labels}
 
@@ -373,72 +304,19 @@ Which network interface to use for mirroring.
 The default behavior is try to access the internet and use that interface. If that fails
 it uses `eth0`.
 
-### agent.tolerations {#agent-tolerations}
+### agent.nftables {#agent-nftables}
 
-Set pod tolerations. (not with ephemeral agents)
-Default is
-```json
-[
-  {
-    "operator": "Exists"
-  }
-]
-```
+Use iptables-nft instead of iptables-legacy.
+Defaults to `false`.
 
-Set to an empty array to have no tolerations at all
+Needed if your mesh uses nftables instead of iptables-legacy,
 
-### agent.dns {#agent-dns}
+### agent.privileged {#agent-privileged}
 
-### agent.disabled_capabilities {#agent-disabled_capabilities}
+Run the mirror agent as privileged container.
+Defaults to `false`.
 
-Disables specified Linux capabilities for the agent container.
-If nothing is disabled here, agent uses `NET_ADMIN`, `NET_RAW`, `SYS_PTRACE` and
-`SYS_ADMIN`.
-
-### agent.image_pull_secrets {#agent-image_pull_secrets}
-
-List of secrets the agent pod has access to.
-
-Takes an array of entries with the format `{ name: <secret-name> }`.
-
-Read more [here](https://kubernetes.io/docs/concepts/containers/images/#referring-to-an-imagepullsecrets-on-a-pod).
-
-```json
-{
-  "agent": {
-    "image_pull_secrets": [
-      { "name": "secret-key-1" },
-      { "name": "secret-key-2" }
-    ]
-  }
-}
-```
-
-### agent.image {#agent-image}
-
-Name of the agent's docker image.
-
-Useful when a custom build of mirrord-agent is required, or when using an internal
-registry.
-
-Defaults to the latest stable image `"ghcr.io/metalbear-co/mirrord:latest"`.
-
-```json
-{
-  "image": "internal.repo/images/mirrord:latest"
-}
-```
-
-Complete setup:
-
-```json
-{
-  "image": {
-    "registry": "internal.repo/images/mirrord",
-    "tag": "latest"
-  }
-}
-```
+Might be needed in strict environments such as Bottlerocket.
 
 ### agent.resources {#agent-resources}
 
@@ -459,59 +337,61 @@ Default is
 }
 ```
 
-## target {#root-target}
-Specifies the target and namespace to mirror, see [`path`](#target-path) for a list of
-accepted values for the `target` option.
+### agent.startup_timeout {#agent-startup_timeout}
 
-The simplified configuration supports:
+Controls how long to wait for the agent to finish initialization.
 
-- `pod/{sample-pod}/[container]/{sample-container}`;
-- `podname/{sample-pod}/[container]/{sample-container}`;
-- `deployment/{sample-deployment}/[container]/{sample-container}`;
+If initialization takes longer than this value, mirrord exits.
 
-Shortened setup:
+Defaults to `60`.
+
+### agent.tolerations {#agent-tolerations}
+
+Set pod tolerations. (not with ephemeral agents)
+Default is
+```json
+[
+  {
+    "operator": "Exists"
+  }
+]
+```
+
+Set to an empty array to have no tolerations at all
+
+### agent.ttl {#agent-ttl}
+
+Controls how long the agent pod persists for after the agent exits (in seconds).
+
+Can be useful for collecting logs.
+
+Defaults to `1`.
+
+## connect_tcp {#root-connect_tpc}
+
+IP:PORT to connect to instead of using k8s api, for testing purposes.
 
 ```json
 {
- "target": "pod/bear-pod"
+  "connect_tcp": "10.10.0.100:7777"
 }
 ```
 
-Complete setup:
+# experimental {#root-experimental}
 
-```json
-{
- "target": {
-   "path": {
-     "pod": "bear-pod"
-   },
-   "namespace": "default"
- }
-}
-```
+mirrord Experimental features.
+This shouldn't be used unless someone from MetalBear/mirrord tells you to.
 
-### target.namespace {#target-namespace}
+## _experimental_ readlink {#fexperimental-readlink}
 
-Namespace where the target lives.
+Enables the `readlink` hook.
 
-Defaults to `"default"`.
+## _experimental_ tcp_ping4_mock {#fexperimental-tcp_ping4_mock}
 
-### target.path {#target-path}
-
-Specifies the running pod (or deployment) to mirror.
-
-Note: Deployment level steal/mirroring is available only in mirrord for Teams
-If you use it without it, it will choose a random pod replica to work with.
-
-Supports:
-- `pod/{sample-pod}`;
-- `podname/{sample-pod}`;
-- `deployment/{sample-deployment}`;
-- `container/{sample-container}`;
-- `containername/{sample-container}`.
-- `job/{sample-job}` (only when [`copy_target`](#feature-copy_target) is enabled).
+<https://github.com/metalbear-co/mirrord/issues/2421#issuecomment-2093200904>
 
 # feature {#root-feature}
+
 Controls mirrord features.
 
 See the
@@ -565,11 +445,123 @@ have support for a shortened version, that you can see [here](#root-shortened).
 }
 ```
 
-## feature.hostname {#feature-hostname}
+## feature.copy_target {#feature-copy_target}
 
-Should mirrord return the hostname of the target pod when calling `gethostname`
+Creates a new copy of the target. mirrord will use this copy instead of the original target
+(e.g. intercept network traffic). This feature requires a [mirrord operator](https://mirrord.dev/docs/overview/teams/).
+
+This feature is not compatible with rollout targets and running without a target
+(`targetless` mode).
+
+Allows the user to target a pod created dynamically from the orignal [`target`](#target).
+The new pod inherits most of the original target's specification, e.g. labels.
+
+```json
+{
+  "feature": {
+    "copy_target": {
+      "scale_down": true
+    }
+  }
+}
+```
+
+```json
+{
+  "feature": {
+    "copy_target": true
+  }
+}
+```
+
+### feature.copy_target.scale_down {#feature-copy_target-scale_down}
+
+If this option is set, mirrord will scale down the target deployment to 0 for the time
+the copied pod is alive.
+
+This option is compatible only with deployment targets.
+```json
+    {
+      "scale_down": true
+    }
+```
+
+## feature.env {#feature-env}
+
+Allows the user to set or override the local process' environment variables with the ones
+from the remote pod.
+
+Which environment variables to load from the remote pod are controlled by setting either
+[`include`](#feature-env-include) or [`exclude`](#feature-env-exclude).
+
+See the environment variables [reference](https://mirrord.dev/docs/reference/env/) for more details.
+
+```json
+{
+  "feature": {
+    "env": {
+      "include": "DATABASE_USER;PUBLIC_ENV;MY_APP_*",
+      "exclude": "DATABASE_PASSWORD;SECRET_ENV",
+      "override": {
+        "DATABASE_CONNECTION": "db://localhost:7777/my-db",
+        "LOCAL_BEAR": "panda"
+      }
+    }
+  }
+}
+```
+
+### feature.env.exclude {#feature-env-exclude}
+
+Include the remote environment variables in the local process that are **NOT** specified by
+this option.
+Variable names can be matched using `*` and `?` where `?` matches exactly one occurrence of
+any character and `*` matches arbitrary many (including zero) occurrences of any character.
+
+Some of the variables that are excluded by default:
+`PATH`, `HOME`, `HOMEPATH`, `CLASSPATH`, `JAVA_EXE`, `JAVA_HOME`, `PYTHONPATH`.
+
+Can be passed as a list or as a semicolon-delimited string (e.g. `"VAR;OTHER_VAR"`).
+
+### feature.env.include {#feature-env-include}
+
+Include only these remote environment variables in the local process.
+Variable names can be matched using `*` and `?` where `?` matches exactly one occurrence of
+any character and `*` matches arbitrary many (including zero) occurrences of any character.
+
+Can be passed as a list or as a semicolon-delimited string (e.g. `"VAR;OTHER_VAR"`).
+
+Some environment variables are excluded by default (`PATH` for example), including these
+requires specifying them with `include`
+
+### feature.env.load_from_process {#feature-env-load_from_process}
+
+Allows for changing the way mirrord loads remote environment variables.
+If set, the variables are fetched after the user application is started.
+
+This setting is meant to resolve issues when using mirrord via the IntelliJ plugin on WSL
+and the remote environment contains a lot of variables.
+
+### feature.env.override {#feature-env-override}
+
+Allows setting or overriding environment variables (locally) with a custom value.
+
+For example, if the remote pod has an environment variable `REGION=1`, but this is an
+undesirable value, it's possible to use `override` to set `REGION=2` (locally) instead.
+
+### feature.env.unset {#feature-env-unset}
+
+Allows unsetting environment variables in the executed process.
+
+This is useful for when some system/user-defined environment like `AWS_PROFILE` make the
+application behave as if it's running locally, instead of using the remote settings.
+The unsetting happens from extension (if possible)/CLI and when process initializes.
+In some cases, such as Go the env might not be able to be modified from the process itself.
+This is case insensitive, meaning if you'd put `AWS_PROFILE` it'd unset both `AWS_PROFILE`
+and `Aws_Profile` and other variations.
 
 ## feature.fs {#feature-fs}
+
 Allows the user to specify the default behavior for file operations:
 
 1. `"read"` - Read from the remote file system (default)
@@ -636,6 +628,18 @@ For more information, check the file operations
 
 Specify file path patterns that if matched will be opened locally.
 
+### feature.fs.mode {#feature-fs-mode}
+
+Configuration for enabling read-only or read-write file operations.
+
+These options are overriden by user specified overrides and mirrord default overrides.
+
+If you set [`"localwithoverrides"`](#feature-fs-mode-localwithoverrides) then some files
+can be read/write remotely based on our default/user specified.
+Default option for general file configuration.
+
+The accepted values are: `"local"`, `"localwithoverrides`, `"read"`, or `"write`.
+
 ### feature.fs.not_found {#feature-fs-not_found}
 
 Specify file path patterns that if matched will be treated as non-existent.
@@ -649,91 +653,12 @@ if file matching the pattern is opened for writing or read/write it will be open
 
 Specify file path patterns that if matched will be read and written to the remote.
 
-### feature.fs.mode {#feature-fs-mode}
-Configuration for enabling read-only or read-write file operations.
+## feature.hostname {#feature-hostname}
 
-These options are overriden by user specified overrides and mirrord default overrides.
-
-If you set [`"localwithoverrides"`](#feature-fs-mode-localwithoverrides) then some files
-can be read/write remotely based on our default/user specified.
-Default option for general file configuration.
-
-The accepted values are: `"local"`, `"localwithoverrides`, `"read"`, or `"write`.
-
-## feature.env {#feature-env}
-Allows the user to set or override the local process' environment variables with the ones
-from the remote pod.
-
-Which environment variables to load from the remote pod are controlled by setting either
-[`include`](#feature-env-include) or [`exclude`](#feature-env-exclude).
-
-See the environment variables [reference](https://mirrord.dev/docs/reference/env/) for more details.
-
-```json
-{
-  "feature": {
-    "env": {
-      "include": "DATABASE_USER;PUBLIC_ENV;MY_APP_*",
-      "exclude": "DATABASE_PASSWORD;SECRET_ENV",
-      "override": {
-        "DATABASE_CONNECTION": "db://localhost:7777/my-db",
-        "LOCAL_BEAR": "panda"
-      }
-    }
-  }
-}
-```
-
-### feature.env.load_from_process {#feature-env-load_from_process}
-
-Allows for changing the way mirrord loads remote environment variables.
-If set, the variables are fetched after the user application is started.
-
-This setting is meant to resolve issues when using mirrord via the IntelliJ plugin on WSL
-and the remote environment contains a lot of variables.
-
-### feature.env.exclude {#feature-env-exclude}
-
-Include the remote environment variables in the local process that are **NOT** specified by
-this option.
-Variable names can be matched using `*` and `?` where `?` matches exactly one occurrence of
-any character and `*` matches arbitrary many (including zero) occurrences of any character.
-
-Some of the variables that are excluded by default:
-`PATH`, `HOME`, `HOMEPATH`, `CLASSPATH`, `JAVA_EXE`, `JAVA_HOME`, `PYTHONPATH`.
-
-Can be passed as a list or as a semicolon-delimited string (e.g. `"VAR;OTHER_VAR"`).
-
-### feature.env.include {#feature-env-include}
-
-Include only these remote environment variables in the local process.
-Variable names can be matched using `*` and `?` where `?` matches exactly one occurrence of
-any character and `*` matches arbitrary many (including zero) occurrences of any character.
-
-Can be passed as a list or as a semicolon-delimited string (e.g. `"VAR;OTHER_VAR"`).
-
-Some environment variables are excluded by default (`PATH` for example), including these
-requires specifying them with `include`
-
-### feature.env.override {#feature-env-override}
-
-Allows setting or overriding environment variables (locally) with a custom value.
-
-For example, if the remote pod has an environment variable `REGION=1`, but this is an
-undesirable value, it's possible to use `override` to set `REGION=2` (locally) instead.
-
-### feature.env.unset {#feature-env-unset}
-
-Allows unsetting environment variables in the executed process.
-
-This is useful for when some system/user-defined environment like `AWS_PROFILE` make the
-application behave as if it's running locally, instead of using the remote settings.
-The unsetting happens from extension (if possible)/CLI and when process initializes.
-In some cases, such as Go the env might not be able to be modified from the process itself.
-This is case insensitive, meaning if you'd put `AWS_PROFILE` it'd unset both `AWS_PROFILE`
-and `Aws_Profile` and other variations.
+Should mirrord return the hostname of the target pod when calling `gethostname`
 
 ## feature.network {#feature-network}
+
 Controls mirrord network operations.
 
 See the network traffic [reference](https://mirrord.dev/docs/reference/traffic/)
@@ -780,6 +705,7 @@ If you see an address resolution error, try enabling the [`fs`](#feature-fs) fea
 and setting `read_only: ["/etc/resolv.conf"]`.
 
 ### feature.network.incoming {#feature-network-incoming}
+
 Controls the incoming TCP traffic feature.
 
 See the incoming [reference](https://mirrord.dev/docs/reference/traffic/#incoming) for more
@@ -849,77 +775,8 @@ Steal only traffic that matches the
 }
 ```
 
-#### feature.network.incoming.ignore_ports {#feature-network-incoming-ignore_ports}
-
-Ports to ignore when mirroring/stealing traffic, these ports will remain local.
-
-Can be especially useful when
-[`feature.network.incoming.mode`](#feature-network-incoming-mode) is set to `"steal"`,
-and you want to avoid redirecting traffic from some ports (for example, traffic from
-a health probe, or other heartbeat-like traffic).
-
-Mutually exclusive with [`feature.network.incoming.ports`](#feature-network-ports).
-
-#### feature.network.incoming.listen_ports {#feature-network-incoming-listen_ports}
-
-Mapping for local ports to actually used local ports.
-When application listens on a port while steal/mirror is active
-we fallback to random ports to avoid port conflicts.
-Using this configuration will always use the specified port.
-If this configuration doesn't exist, mirrord will try to listen on the original port
-and if it fails it will assign a random port
-
-This is useful when you want to access ports exposed by your service locally
-For example, if you have a service that listens on port `80` and you want to access it,
-you probably can't listen on `80` without sudo, so you can use `[[80, 4480]]`
-then access it on `4480` while getting traffic from remote `80`.
-The value of `port_mapping` doesn't affect this.
-
-#### feature.network.incoming.port_mapping {#feature-network-incoming-port_mapping}
-
-Mapping for local ports to remote ports.
-
-This is useful when you want to mirror/steal a port to a different port on the remote
-machine. For example, your local process listens on port `9333` and the container listens
-on port `80`. You'd use `[[9333, 80]]`
-
-#### feature.network.incoming.ports {#feature-network-incoming-ports}
-
-List of ports to mirror/steal traffic from. Other ports will remain local.
-
-Mutually exclusive with
-[`feature.network.incoming.ignore_ports`](#feature-network-ignore_ports).
-
-#### feature.network.incoming.ignore_localhost {#feature-network-incoming-ignore_localhost}
-
-#### feature.network.incoming.mode {#feature-network-incoming-mode}
-Allows selecting between mirrorring or stealing traffic.
-
-Can be set to either `"mirror"` (default), `"steal"` or `"off"`.
-
-- `"mirror"`: Sniffs on TCP port, and send a copy of the data to listeners.
-- `"off"`: Disables the incoming network feature.
-- `"steal"`: Supports 2 modes of operation:
-
-1. Port traffic stealing: Steals all TCP data from a
-  port, which is selected whenever the
-user listens in a TCP socket (enabling the feature is enough to make this work, no
-additional configuration is needed);
-
-2. HTTP traffic stealing: Steals only HTTP traffic, mirrord tries to detect if the incoming
-data on a port is HTTP (in a best-effort kind of way, not guaranteed to be HTTP), and
-steals the traffic on the port if it is HTTP;
-
-#### feature.network.incoming.on_concurrent_steal {#feature-network-incoming-on_concurrent_steal}
-(Operator Only): Allows overriding port locks
-
-Can be set to either `"continue"` or `"override"`.
-
-- `"continue"`: Continue with normal execution
-- `"override"`: If port lock detected then override it with new lock and force close the
-  original locking connection.
-
 #### feature.network.incoming.http_filter {#feature-network-incoming-http-filter}
+
 Filter configuration for the HTTP traffic stealer feature.
 
 Allows the user to set a filter (regex) for the HTTP headers, so that the stealer traffic
@@ -981,7 +838,8 @@ case-insensitive.
 Supports regexes validated by the
 [`fancy-regex`](https://docs.rs/fancy-regex/latest/fancy_regex/) crate.
 
-Case-insensitive.
+Case-insensitive. Tries to find match in the path (without query) and path+query.
+If any of the two matches, the request is stolen.
 
 ##### feature.network.incoming.http_filter.ports {#feature-network-incoming-http_filter-ports}
 
@@ -992,7 +850,80 @@ Other ports will *not* be stolen, unless listed in
 
 Set to [80, 8080] by default.
 
+#### feature.network.incoming.ignore_localhost {#feature-network-incoming-ignore_localhost}
+
+#### feature.network.incoming.ignore_ports {#feature-network-incoming-ignore_ports}
+
+Ports to ignore when mirroring/stealing traffic, these ports will remain local.
+
+Can be especially useful when
+[`feature.network.incoming.mode`](#feature-network-incoming-mode) is set to `"steal"`,
+and you want to avoid redirecting traffic from some ports (for example, traffic from
+a health probe, or other heartbeat-like traffic).
+
+Mutually exclusive with [`feature.network.incoming.ports`](#feature-network-ports).
+
+#### feature.network.incoming.listen_ports {#feature-network-incoming-listen_ports}
+
+Mapping for local ports to actually used local ports.
+When application listens on a port while steal/mirror is active
+we fallback to random ports to avoid port conflicts.
+Using this configuration will always use the specified port.
+If this configuration doesn't exist, mirrord will try to listen on the original port
+and if it fails it will assign a random port
+
+This is useful when you want to access ports exposed by your service locally
+For example, if you have a service that listens on port `80` and you want to access it,
+you probably can't listen on `80` without sudo, so you can use `[[80, 4480]]`
+then access it on `4480` while getting traffic from remote `80`.
+The value of `port_mapping` doesn't affect this.
+
+#### feature.network.incoming.mode {#feature-network-incoming-mode}
+
+Allows selecting between mirrorring or stealing traffic.
+
+Can be set to either `"mirror"` (default), `"steal"` or `"off"`.
+
+- `"mirror"`: Sniffs on TCP port, and send a copy of the data to listeners.
+- `"off"`: Disables the incoming network feature.
+- `"steal"`: Supports 2 modes of operation:
+
+1. Port traffic stealing: Steals all TCP data from a
+  port, which is selected whenever the
+user listens in a TCP socket (enabling the feature is enough to make this work, no
+additional configuration is needed);
+
+2. HTTP traffic stealing: Steals only HTTP traffic, mirrord tries to detect if the incoming
+data on a port is HTTP (in a best-effort kind of way, not guaranteed to be HTTP), and
+steals the traffic on the port if it is HTTP;
+
+#### feature.network.incoming.on_concurrent_steal {#feature-network-incoming-on_concurrent_steal}
+
+(Operator Only): Allows overriding port locks
+
+Can be set to either `"continue"` or `"override"`.
+
+- `"continue"`: Continue with normal execution
+- `"override"`: If port lock detected then override it with new lock and force close the
+  original locking connection.
+
+#### feature.network.incoming.port_mapping {#feature-network-incoming-port_mapping}
+
+Mapping for local ports to remote ports.
+
+This is useful when you want to mirror/steal a port to a different port on the remote
+machine. For example, your local process listens on port `9333` and the container listens
+on port `80`. You'd use `[[9333, 80]]`
+
+#### feature.network.incoming.ports {#feature-network-incoming-ports}
+
+List of ports to mirror/steal traffic from. Other ports will remain local.
+
+Mutually exclusive with
+[`feature.network.incoming.ignore_ports`](#feature-network-ignore_ports).
+
 ### feature.network.outgoing {#feature-network-outgoing}
+
 Tunnel outgoing network operations through mirrord.
 
 See the outgoing [reference](https://mirrord.dev/docs/reference/traffic/#outgoing) for more
@@ -1018,35 +949,10 @@ The `remote` and `local` config for this feature are **mutually** exclusive.
 }
 ```
 
-#### feature.network.outgoing.ignore_localhost {#feature.network.outgoing.ignore_localhost}
-
-Defaults to `false`.
-
-#### feature.network.outgoing.tcp {#feature.network.outgoing.tcp}
-
-Defaults to `true`.
-
-#### feature.network.outgoing.udp {#feature.network.outgoing.udp}
-
-Defaults to `true`.
-
-#### feature.network.outgoing.unix_streams {#feature.network.outgoing.unix_streams}
-
-Connect to these unix streams remotely (and to all other paths locally).
-
-You can either specify a single value or an array of values.
-Each value is interpreted as a regular expression
-([Supported Syntax](https://docs.rs/regex/1.7.1/regex/index.html#syntax)).
-
-When your application connects to a unix socket, the target address will be converted to a
-string (non-utf8 bytes are replaced by a placeholder character) and matched against the set
-of regexes specified here. If there is a match, mirrord will connect your application with
-the target unix socket address on the target pod. Otherwise, it will leave the connection
-to happen locally on your machine.
-
 #### feature.network.outgoing.filter {#feature.network.outgoing.filter}
 
 Unstable: the precise syntax of this config is subject to change.
+
 List of addresses/ports/subnets that should be sent through either the remote pod or local app,
 depending how you set this up with either `remote` or `local`.
 
@@ -1090,60 +996,34 @@ will go through the remote pod.
 
 Valid values follow this pattern: `[protocol]://[name|address|subnet/mask]:[port]`.
 
-## feature.copy_target {#feature-copy_target}
+#### feature.network.outgoing.ignore_localhost {#feature.network.outgoing.ignore_localhost}
 
-Creates a new copy of the target. mirrord will use this copy instead of the original target
-(e.g. intercept network traffic). This feature requires a [mirrord operator](https://mirrord.dev/docs/overview/teams/).
+Defaults to `false`.
 
-This feature is not compatible with rollout targets and running without a target
-(`targetless` mode).
-Allows the user to target a pod created dynamically from the orignal [`target`](#target).
-The new pod inherits most of the original target's specification, e.g. labels.
+#### feature.network.outgoing.tcp {#feature.network.outgoing.tcp}
 
-```json
-{
-  "feature": {
-    "copy_target": {
-      "scale_down": true
-    }
-  }
-}
-```
+Defaults to `true`.
 
-```json
-{
-  "feature": {
-    "copy_target": true
-  }
-}
-```
+#### feature.network.outgoing.udp {#feature.network.outgoing.udp}
 
+Defaults to `true`.
 
-### feature.copy_target.scale_down {#feature-copy_target-scale_down}
+#### feature.network.outgoing.unix_streams {#feature.network.outgoing.unix_streams}
 
-If this option is set, mirrord will scale down the target deployment to 0 for the time
-the copied pod is alive.
+Connect to these unix streams remotely (and to all other paths locally).
 
-This option is compatible only with deployment targets.
-```json
-    {
-      "scale_down": true
-    }
-```
+You can either specify a single value or an array of values.
+Each value is interpreted as a regular expression
+([Supported Syntax](https://docs.rs/regex/1.7.1/regex/index.html#syntax)).
 
-# experimental {#root-experimental}
-mirrord Experimental features.
-This shouldn't be used unless someone from MetalBear/mirrord tells you to.
-
-## _experimental_ readlink {#fexperimental-readlink}
-
-Enables the `readlink` hook.
-
-## _experimental_ tcp_ping4_mock {#fexperimental-tcp_ping4_mock}
-
-<https://github.com/metalbear-co/mirrord/issues/2421#issuecomment-2093200904>
+When your application connects to a unix socket, the target address will be converted to a
+string (non-utf8 bytes are replaced by a placeholder character) and matched against the set
+of regexes specified here. If there is a match, mirrord will connect your application with
+the target unix socket address on the target pod. Otherwise, it will leave the connection
+to happen locally on your machine.
 
 # internal_proxy {#root-internal_proxy}
+
 Configuration for the internal proxy mirrord spawns for each local mirrord session
 that local layers use to connect to the remote agent
 
@@ -1174,6 +1054,14 @@ and don't connect to the proxy.
 }
 ```
 
+### internal_proxy.log_destination {#internal_proxy-log_destination}
+Set the log file destination for the internal proxy.
+
+### internal_proxy.log_level {#internal_proxy-log_level}
+Set the log level for the internal proxy.
+RUST_LOG convention (i.e `mirrord=trace`)
+will only be used if log_destination is set
+
 ### internal_proxy.start_idle_timeout {#internal_proxy-start_idle_timeout}
 
 How much time to wait for the first connection to the proxy in seconds.
@@ -1189,11 +1077,139 @@ on process execution, delaying the layer startup and connection to proxy.
 }
 ```
 
-### internal_proxy.log_destination {#internal_proxy-log_destination}
-Set the log file destination for the internal proxy.
+## kube_context {#root-kube_context}
 
-### internal_proxy.log_level {#internal_proxy-log_level}
-Set the log level for the internal proxy.
-RUST_LOG convention (i.e `mirrord=trace`)
-will only be used if log_destination is set
+Kube context to use from the kubeconfig file.
+Will use current context if not specified.
+
+```json
+{
+ "kube_context": "mycluster"
+}
+```
+
+## kubeconfig {#root-kubeconfig}
+
+Path to a kubeconfig file, if not specified, will use `KUBECONFIG`, or `~/.kube/config`, or
+the in-cluster config.
+
+```json
+{
+ "kubeconfig": "~/bear/kube-config"
+}
+```
+
+## operator {#root-operator}
+
+Whether mirrord should use the operator.
+If not set, mirrord will first attempt to use the operator, but continue without it in case
+of failure.
+
+## sip_binaries {#root-sip_binaries}
+
+Binaries to patch (macOS SIP).
+
+Use this when mirrord isn't loaded to protected binaries that weren't automatically
+patched.
+
+Runs `endswith` on the binary path (so `bash` would apply to any binary ending with `bash`
+while `/usr/bin/bash` would apply only for that binary).
+
+```json
+{
+ "sip_binaries": "bash;python"
+}
+```
+
+## skip_build_tools {#root-skip_build_tools}
+
+Allows mirrord to skip build tools. Useful when running command lines that build and run
+the application in a single command.
+
+Defaults to `true`.
+
+Build-Tools: `["as", "cc", "ld", "go", "air", "asm", "cc1", "cgo", "dlv", "gcc", "git",
+"link", "math", "cargo", "hpack", "rustc", "compile", "collect2", "cargo-watch",
+"debugserver"]`
+
+## skip_processes {#root-skip_processes}
+
+Allows mirrord to skip unwanted processes.
+
+Useful when process A spawns process B, and the user wants mirrord to operate only on
+process B.
+Accepts a single value, or multiple values separated by `;`.
+
+```json
+{
+ "skip_processes": "bash;node"
+}
+```
+
+## target {#root-target}
+
+Specifies the target and namespace to mirror, see [`path`](#target-path) for a list of
+accepted values for the `target` option.
+
+The simplified configuration supports:
+
+- `pod/{sample-pod}/[container]/{sample-container}`;
+- `podname/{sample-pod}/[container]/{sample-container}`;
+- `deployment/{sample-deployment}/[container]/{sample-container}`;
+
+Shortened setup:
+
+```json
+{
+ "target": "pod/bear-pod"
+}
+```
+
+Complete setup:
+
+```json
+{
+ "target": {
+   "path": {
+     "pod": "bear-pod"
+   },
+   "namespace": "default"
+ }
+}
+```
+
+### target.namespace {#target-namespace}
+
+Namespace where the target lives.
+
+Defaults to `"default"`.
+
+### target.path {#target-path}
+
+Specifies the running pod (or deployment) to mirror.
+
+Note: Deployment level steal/mirroring is available only in mirrord for Teams
+If you use it without it, it will choose a random pod replica to work with.
+
+Supports:
+- `pod/{sample-pod}`;
+- `podname/{sample-pod}`;
+- `deployment/{sample-deployment}`;
+- `container/{sample-container}`;
+- `containername/{sample-container}`.
+- `job/{sample-job}` (only when [`copy_target`](#feature-copy_target) is enabled).
+
+## telemetry {#root-telemetry}
+Controls whether or not mirrord sends telemetry data to MetalBear cloud.
+Telemetry sent doesn't contain personal identifiers or any data that
+should be considered sensitive. It is used to improve the product.
+[For more information](https://github.com/metalbear-co/mirrord/blob/main/TELEMETRY.md)
+
+## use_proxy {#root-use_proxy}
+
+When disabled, mirrord will remove `HTTP[S]_PROXY` env variables before
+doing any network requests. This is useful when the system sets a proxy
+but you don't want mirrord to use it.
+This also applies to the mirrord process (as it just removes the env).
+If the remote pod sets this env, the mirrord process will still use it.
 


### PR DESCRIPTION
After #2424 medschool produces a documentation markdown file with a different content order than before.
In order to separate this change from any other change to the configuration docs, I want to merge the new `configuration.md`.

Running medschool when changing the config docs and pushing the changed file, on every PR that changes the docs is important because it helps the PR sender and reviewer check that the new docs will be added to the markdown file correctly (were added in the right place of the source code, etc).

I did not check myself that the new file contains everything it should. I hope `medschool` was not broken and the output is valid. The length of the file changed, but there could have been PRs that made changes to the docs without rerunning `medschool`, idk. But I guess making sure medschool still works fine is part of the PR that changed it, not of a PR that uses it.  