### PR TITLE
Improve mirroring for high stress

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6783,6 +6783,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ actix-codec = "0.5"
 bincode = { version = "2.0.0-rc.2", features = ["serde"] }
 bytes = "1"
 tokio = { version = "1" }
-tokio-stream = "0.1"
+tokio-stream = { version = "0.1", features = ["sync"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 anyhow = "1"

--- a/changelog.d/2529.fixed.md
+++ b/changelog.d/2529.fixed.md
@@ -1,0 +1,1 @@
+Improved agent performance when mirroring is under high load. 

--- a/mirrord/agent/src/entrypoint.rs
+++ b/mirrord/agent/src/entrypoint.rs
@@ -13,6 +13,7 @@ use client_connection::AgentTlsConnector;
 use dns::{DnsCommand, DnsWorker};
 use futures::TryFutureExt;
 use mirrord_protocol::{ClientMessage, DaemonMessage, GetEnvVarsRequest, LogMessage};
+use sniffer::tcp_capture::RawSocketTcpCapture;
 use tokio::{
     net::{TcpListener, TcpStream},
     process::Command,
@@ -508,7 +509,7 @@ async fn start_agent(args: Args) -> Result<()> {
         let mesh = args.mode.mesh();
 
         let watched_task = WatchedTask::new(
-            TcpConnectionSniffer::TASK_NAME,
+            TcpConnectionSniffer::<RawSocketTcpCapture>::TASK_NAME,
             TcpConnectionSniffer::new(sniffer_command_rx, args.network_interface, mesh).and_then(
                 |sniffer| async move {
                     let res = sniffer.start(cancellation_token).await;
@@ -522,7 +523,7 @@ async fn start_agent(args: Args) -> Result<()> {
         let status = watched_task.status();
         let task = run_thread_in_namespace(
             watched_task.start(),
-            TcpConnectionSniffer::TASK_NAME.to_string(),
+            TcpConnectionSniffer::<RawSocketTcpCapture>::TASK_NAME.to_string(),
             state.container_pid(),
             "net",
         );

--- a/mirrord/agent/src/entrypoint.rs
+++ b/mirrord/agent/src/entrypoint.rs
@@ -35,7 +35,7 @@ use crate::{
     file::FileManager,
     outgoing::{TcpOutgoingApi, UdpOutgoingApi},
     runtime::get_container,
-    sniffer::{SnifferCommand, TcpConnectionSniffer, TcpSnifferApi},
+    sniffer::{api::TcpSnifferApi, messages::SnifferCommand, TcpConnectionSniffer},
     steal::{
         ip_tables::{
             new_iptables, IPTablesWrapper, SafeIpTables, IPTABLE_MESH, IPTABLE_MESH_ENV,
@@ -48,8 +48,7 @@ use crate::{
     *,
 };
 
-/// Size of [`mpsc`] channels connecting [`TcpStealerApi`] and [`TcpSnifferApi`] with their
-/// background tasks.
+/// Size of [`mpsc`] channels connecting [`TcpStealerApi`] with the background task.
 const CHANNEL_SIZE: usize = 1024;
 
 /// Keeps track of next client id.
@@ -201,6 +200,8 @@ struct ClientConnectionHandler {
     udp_outgoing_api: UdpOutgoingApi,
     dns_api: DnsApi,
     state: State,
+    /// Whether the client has sent us [`ClientMessage::ReadyForLogs`].
+    ready_for_logs: bool,
 }
 
 impl ClientConnectionHandler {
@@ -233,6 +234,7 @@ impl ClientConnectionHandler {
             udp_outgoing_api,
             dns_api,
             state,
+            ready_for_logs: false,
         };
 
         Ok(client_handler)
@@ -244,7 +246,7 @@ impl ClientConnectionHandler {
         connection: &mut ClientConnection,
     ) -> Option<TcpSnifferApi> {
         if let BackgroundTask::Running(sniffer_status, sniffer_sender) = task {
-            match TcpSnifferApi::new(id, sniffer_sender, sniffer_status, CHANNEL_SIZE).await {
+            match TcpSnifferApi::new(id, sniffer_sender, sniffer_status).await {
                 Ok(api) => Some(api),
                 Err(e) => {
                     let message = format!(
@@ -338,7 +340,13 @@ impl ClientConnectionHandler {
                         unreachable!()
                     }
                 }, if self.tcp_sniffer_api.is_some() => match message {
-                    Ok(message) => self.respond(DaemonMessage::Tcp(message)).await?,
+                    Ok((message, Some(log))) if self.ready_for_logs => {
+                        self.respond(DaemonMessage::LogMessage(log)).await?;
+                        self.respond(DaemonMessage::Tcp(message)).await?;
+                    }
+                    Ok((message, _)) => {
+                        self.respond(DaemonMessage::Tcp(message)).await?;
+                    },
                     Err(e) => break e,
                 },
                 message = async {
@@ -461,7 +469,9 @@ impl ClientConnectionHandler {
                 ))
                 .await?;
             }
-            ClientMessage::ReadyForLogs => {}
+            ClientMessage::ReadyForLogs => {
+                self.ready_for_logs = true;
+            }
         }
 
         Ok(true)

--- a/mirrord/agent/src/error.rs
+++ b/mirrord/agent/src/error.rs
@@ -12,7 +12,7 @@ use mirrord_protocol::{
 use thiserror::Error;
 
 use crate::{
-    client_connection::TlsSetupError, namespace::NamespaceError, sniffer::SnifferCommand,
+    client_connection::TlsSetupError, namespace::NamespaceError, sniffer::messages::SnifferCommand,
     steal::StealerCommand,
 };
 
@@ -135,6 +135,9 @@ pub(crate) enum AgentError {
     /// Child agent process spawned in `main` failed.
     #[error("Agent child process failed: {0}")]
     AgentFailed(ExitStatus),
+
+    #[error("Exhausted possible identifiers for incoming connections.")]
+    ExhaustedConnectionId,
 }
 
 pub(crate) type Result<T, E = AgentError> = std::result::Result<T, E>;

--- a/mirrord/agent/src/main.rs
+++ b/mirrord/agent/src/main.rs
@@ -1,6 +1,7 @@
 #![feature(hash_extract_if)]
 #![feature(let_chains)]
 #![feature(type_alias_impl_trait)]
+#![feature(entry_insert)]
 #![cfg_attr(target_os = "linux", feature(tcp_quickack))]
 #![feature(lazy_cell)]
 #![warn(clippy::indexing_slicing)]

--- a/mirrord/agent/src/sniffer.rs
+++ b/mirrord/agent/src/sniffer.rs
@@ -499,12 +499,10 @@ impl TcpConnectionSniffer {
 
         tracing::trace!("Resolved data broadcast channel");
 
-        if !tcp_packet.bytes.is_empty() {
-            if data_tx.get().send(tcp_packet.bytes).is_err() {
-                tracing::trace!("All data receivers are dead, dropping data broadcast sender");
-                data_tx.remove();
-                return Ok(());
-            }
+        if !tcp_packet.bytes.is_empty() && data_tx.get().send(tcp_packet.bytes).is_err() {
+            tracing::trace!("All data receivers are dead, dropping data broadcast sender");
+            data_tx.remove();
+            return Ok(());
         }
 
         if is_closed_connection(tcp_packet.flags) {

--- a/mirrord/agent/src/sniffer.rs
+++ b/mirrord/agent/src/sniffer.rs
@@ -245,7 +245,7 @@ fn get_tcp_packet(eth_packet: Vec<u8>) -> Option<(TcpSessionIdentifier, TcpPacke
 /// Because this struct does not talk directly with the remote peers, we can't apply any back
 /// pressure on the incoming connections. There is no reliable mechanism to ensure that all
 /// subscribed clients receive all of the traffic. If we wait too long when distributing data
-/// between the clients, raw socket's recv buffer will overflow and we'll loose packets.
+/// between the clients, raw socket's recv buffer will overflow and we'll lose packets.
 ///
 /// Having this in mind, this struct distributes incoming data using [`broadcast`] channels. If the
 /// clients are not fast enough to pick up TCP packets, they will loose them

--- a/mirrord/agent/src/sniffer.rs
+++ b/mirrord/agent/src/sniffer.rs
@@ -248,7 +248,7 @@ fn get_tcp_packet(eth_packet: Vec<u8>) -> Option<(TcpSessionIdentifier, TcpPacke
 /// between the clients, raw socket's recv buffer will overflow and we'll lose packets.
 ///
 /// Having this in mind, this struct distributes incoming data using [`broadcast`] channels. If the
-/// clients are not fast enough to pick up TCP packets, they will loose them
+/// clients are not fast enough to pick up TCP packets, they will lose them
 /// ([`broadcast::error::RecvError::Lagged`]).
 ///
 /// At the same time, notifying clients about new connections (and distributing

--- a/mirrord/agent/src/sniffer.rs
+++ b/mirrord/agent/src/sniffer.rs
@@ -38,8 +38,8 @@ use crate::{
     util::{ClientId, Subscriptions},
 };
 
-pub mod api;
-pub mod messages;
+pub(crate) mod api;
+pub(crate) mod messages;
 
 /// [`Future`] that resolves to [`ClientId`] when the [`TcpConnectionSniffer`] client drops their
 /// [`TcpSnifferApi`](api::TcpSnifferApi).

--- a/mirrord/agent/src/sniffer.rs
+++ b/mirrord/agent/src/sniffer.rs
@@ -135,7 +135,7 @@ pub(crate) struct TcpPacketData {
 }
 
 /// Main struct implementing incoming traffic mirroring feature.
-/// Utilizes [`RawCapture`] socket for sniffing on incoming Ethernet packets. Transforms them into
+/// Utilizes [`TcpCapture`] for sniffing on incoming TCP packets. Transforms them into
 /// incoming TCP data streams and sends copy of the traffic to all subscribed clients.
 ///
 /// Can be easily used via [`api::TcpSnifferApi`].
@@ -270,7 +270,7 @@ where
         Ok(())
     }
 
-    /// Updates BPF filter used by [`Self::raw_capture`] to match state of
+    /// Updates BPF filter used by [`Self::tcp_capture`] to match state of
     /// [`Self::port_subscriptions`].
     #[tracing::instrument(level = Level::TRACE, err)]
     fn update_packet_filter(&mut self) -> Result<(), AgentError> {
@@ -339,7 +339,7 @@ where
             )
     }
 
-    /// Handles Ethernet packet sniffed by [`Self::raw_capture`].
+    /// Handles TCP packet sniffed by [`Self::tcp_capture`].
     #[tracing::instrument(
         level = Level::TRACE,
         ret,

--- a/mirrord/agent/src/sniffer.rs
+++ b/mirrord/agent/src/sniffer.rs
@@ -65,14 +65,14 @@ impl Future for ClientClosed {
 }
 
 #[derive(Debug, Eq, Copy, Clone)]
-pub struct TcpSessionIdentifier {
+pub(crate) struct TcpSessionIdentifier {
     /// The remote address that is sending a packet to the impersonated pod.
     ///
     /// ## Details
     ///
     /// If you were to `curl {impersonated_pod_ip}:{port}`, this would be the address of whoever
     /// is making the request.
-    pub source_addr: Ipv4Addr,
+    pub(crate) source_addr: Ipv4Addr,
 
     /// Local address of the impersonated pod.
     ///
@@ -85,9 +85,9 @@ pub struct TcpSessionIdentifier {
     /// NAME        READY   STATUS    IP
     /// happy-pod   1/1     Running   1.2.3.4   
     /// ```
-    pub dest_addr: Ipv4Addr,
-    pub source_port: u16,
-    pub dest_port: u16,
+    pub(crate) dest_addr: Ipv4Addr,
+    pub(crate) source_port: u16,
+    pub(crate) dest_port: u16,
 }
 
 impl PartialEq for TcpSessionIdentifier {

--- a/mirrord/agent/src/sniffer.rs
+++ b/mirrord/agent/src/sniffer.rs
@@ -431,12 +431,9 @@ impl TcpConnectionSniffer {
     /// Handles Ethernet packet sniffed by [`Self::raw_capture`].
     #[tracing::instrument(level = Level::TRACE, ret, skip(self, eth_packet), fields(bytes = %eth_packet.len()))]
     fn handle_packet(&mut self, eth_packet: Vec<u8>) -> Result<(), AgentError> {
-        let (identifier, tcp_packet) = match get_tcp_packet(eth_packet) {
-            Some(res) => res,
-            None => {
-                // Not a TCP packet, so not interesting at all.
-                return Ok(());
-            }
+        let Some((identifier, tcp_packet)) = get_tcp_packet(eth_packet) else {
+            // Not a TCP packet, so not interesting at all.
+            return Ok(());
         };
 
         tracing::trace!(

--- a/mirrord/agent/src/sniffer/api.rs
+++ b/mirrord/agent/src/sniffer/api.rs
@@ -1,0 +1,172 @@
+use futures::StreamExt;
+use mirrord_protocol::{
+    tcp::{DaemonTcp, LayerTcp, NewTcpConnection, TcpClose, TcpData},
+    ConnectionId, LogMessage,
+};
+use tokio::sync::{
+    mpsc::{self, Receiver, Sender},
+    oneshot,
+};
+use tokio_stream::{
+    wrappers::{errors::BroadcastStreamRecvError, BroadcastStream},
+    StreamMap, StreamNotifyClose,
+};
+
+use super::messages::{SniffedConnection, SnifferCommand, SnifferCommandInner};
+use crate::{error::AgentError, util::ClientId, watched_task::TaskStatus};
+
+/// Interface used by clients to interact with the
+/// [`TcpConnectionSniffer`](super::TcpConnectionSniffer). Multiple instances of this struct operate
+/// on a single sniffer instance.
+pub(crate) struct TcpSnifferApi {
+    /// Id of the client using this struct.
+    client_id: ClientId,
+    /// Channel used to send commands to the [`TcpConnectionSniffer`](super::TcpConnectionSniffer).
+    sender: Sender<SnifferCommand>,
+    /// Channel used to receive messages from the
+    /// [`TcpConnectionSniffer`](super::TcpConnectionSniffer).
+    receiver: Receiver<SniffedConnection>,
+    /// View on the sniffer task's status.
+    task_status: TaskStatus,
+    /// Currently sniffed connections.
+    connections: StreamMap<ConnectionId, StreamNotifyClose<BroadcastStream<Vec<u8>>>>,
+    /// Id for the next sniffed connection.
+    next_connection_id: Option<ConnectionId>,
+}
+
+impl TcpSnifferApi {
+    const CONNECTION_CHANNEL_SIZE: usize = 128;
+
+    /// Create a new instance of this struct and connect it to a
+    /// [`TcpConnectionSniffer`](super::TcpConnectionSniffer) instance.
+    /// * `client_id` - id of the client using this struct
+    /// * `sniffer_sender` - channel used to send commands to the
+    ///   [`TcpConnectionSniffer`](super::TcpConnectionSniffer)
+    /// * `task_status` - handle to the [`TcpConnectionSniffer`](super::TcpConnectionSniffer) exit
+    ///   status
+    pub async fn new(
+        client_id: ClientId,
+        sniffer_sender: Sender<SnifferCommand>,
+        mut task_status: TaskStatus,
+    ) -> Result<Self, AgentError> {
+        let (sender, receiver) = mpsc::channel(Self::CONNECTION_CHANNEL_SIZE);
+
+        let command = SnifferCommand {
+            client_id,
+            command: SnifferCommandInner::NewClient(sender),
+        };
+        if sniffer_sender.send(command).await.is_err() {
+            return Err(task_status.unwrap_err().await);
+        }
+
+        Ok(Self {
+            client_id,
+            sender: sniffer_sender,
+            receiver,
+            task_status,
+            connections: Default::default(),
+            next_connection_id: Some(0),
+        })
+    }
+
+    /// Send the given command to the connected
+    /// [`TcpConnectionSniffer`](super::TcpConnectionSniffer).
+    async fn send_command(&mut self, command: SnifferCommandInner) -> Result<(), AgentError> {
+        let command = SnifferCommand {
+            client_id: self.client_id,
+            command,
+        };
+
+        if self.sender.send(command).await.is_ok() {
+            Ok(())
+        } else {
+            Err(self.task_status.unwrap_err().await)
+        }
+    }
+
+    /// Return the next message from the connected [`TcpConnectionSniffer`].
+    pub async fn recv(&mut self) -> Result<(DaemonTcp, Option<LogMessage>), AgentError> {
+        tokio::select! {
+            conn = self.receiver.recv() => match conn {
+                Some(conn) => {
+                    let id = self.next_connection_id.ok_or(AgentError::ExhaustedConnectionId)?;
+                    self.next_connection_id = id.checked_add(1);
+
+                    self.connections.insert(id, StreamNotifyClose::new(BroadcastStream::new(conn.data)));
+
+                    Ok((
+                        DaemonTcp::NewConnection(NewTcpConnection {
+                            connection_id: id,
+                            remote_address: conn.session_id.source_addr.into(),
+                            local_address: conn.session_id.dest_addr.into(),
+                            source_port: conn.session_id.source_port,
+                            destination_port: conn.session_id.dest_port,
+                        }),
+                        None,
+                    ))
+                },
+
+                None => {
+                    Err(self.task_status.unwrap_err().await)
+                },
+            },
+
+            Some((connection_id, bytes)) = self.connections.next() => match bytes {
+                Some(Ok(bytes)) => {
+                    Ok((
+                        DaemonTcp::Data(TcpData {
+                            connection_id,
+                            bytes,
+                        }),
+                        None,
+                    ))
+                }
+
+                Some(Err(BroadcastStreamRecvError::Lagged(missed_packets))) => {
+                    let log = LogMessage::error(format!(
+                        "failed to process on time {missed_packets} packet(s) from mirrored connection {connection_id}, closing connection"
+                    ));
+
+                    Ok((
+                        DaemonTcp::Close(TcpClose { connection_id }),
+                        Some(log),
+                    ))
+                }
+
+                None => {
+                    Ok((
+                        DaemonTcp::Close(TcpClose { connection_id }),
+                        None
+                    ))
+                }
+            },
+        }
+    }
+
+    /// Tansform the given message into a [`SnifferCommand`] and pass it to the connected
+    /// [`TcpConnectionSniffer`](super::TcpConnectionSniffer).
+    pub async fn handle_client_message(&mut self, message: LayerTcp) -> Result<(), AgentError> {
+        match message {
+            LayerTcp::PortSubscribe(port) => {
+                let (tx, rx) = oneshot::channel();
+                self.send_command(SnifferCommandInner::Subscribe(port, tx))
+                    .await?;
+
+                if rx.await.is_ok() {
+                    Ok(())
+                } else {
+                    Err(self.task_status.unwrap_err().await)
+                }
+            }
+            LayerTcp::PortUnsubscribe(port) => {
+                self.send_command(SnifferCommandInner::UnsubscribePort(port))
+                    .await
+            }
+            LayerTcp::ConnectionUnsubscribe(connection_id) => {
+                self.connections.remove(&connection_id);
+
+                Ok(())
+            }
+        }
+    }
+}

--- a/mirrord/agent/src/sniffer/api.rs
+++ b/mirrord/agent/src/sniffer/api.rs
@@ -35,6 +35,9 @@ pub(crate) struct TcpSnifferApi {
 }
 
 impl TcpSnifferApi {
+    /// Capacity for channel that will be used by
+    /// [`TcpConnectionSniffer`](super::TcpConnectionSniffer) to notify this struct about new
+    /// connections.
     const CONNECTION_CHANNEL_SIZE: usize = 128;
 
     /// Create a new instance of this struct and connect it to a
@@ -84,7 +87,8 @@ impl TcpSnifferApi {
         }
     }
 
-    /// Return the next message from the connected [`TcpConnectionSniffer`].
+    /// Return the next message from the connected
+    /// [`TcpConnectionSniffer`](super::TcpConnectionSniffer).
     pub async fn recv(&mut self) -> Result<(DaemonTcp, Option<LogMessage>), AgentError> {
         tokio::select! {
             conn = self.receiver.recv() => match conn {

--- a/mirrord/agent/src/sniffer/messages.rs
+++ b/mirrord/agent/src/sniffer/messages.rs
@@ -19,7 +19,7 @@ pub(crate) enum SnifferCommandInner {
         // Channel to notify with `()` when the subscription is done.
         oneshot::Sender<()>,
     ),
-    /// Client no longer wats to receive connections incoming to a specific port.
+    /// Client no longer wants to receive connections incoming to a specific port.
     UnsubscribePort(Port),
 }
 

--- a/mirrord/agent/src/sniffer/messages.rs
+++ b/mirrord/agent/src/sniffer/messages.rs
@@ -16,15 +16,13 @@ pub(crate) enum SnifferCommandInner {
     Subscribe(
         /// Number of port to subscribe.
         Port,
-        /// Channel to notify with `()` when the operation is done.
-        oneshot::Sender<()>,
+        /// Channel to notify with the same port number when the operation is done.
+        oneshot::Sender<Port>,
     ),
     /// Client no longer wants to receive connections incoming to a specific port.
     UnsubscribePort(
         /// Number of port to unsubscribe.
         Port,
-        /// Channel to notify with `()` when the operation is done.
-        oneshot::Sender<()>,
     ),
 }
 

--- a/mirrord/agent/src/sniffer/messages.rs
+++ b/mirrord/agent/src/sniffer/messages.rs
@@ -4,25 +4,39 @@ use tokio::sync::{broadcast, mpsc::Sender, oneshot};
 use super::TcpSessionIdentifier;
 use crate::util::ClientId;
 
+/// Commmand for [`TcpConnectionSniffer`](super::TcpConnectionSniffer).
 #[derive(Debug)]
-pub enum SnifferCommandInner {
-    NewClient(Sender<SniffedConnection>),
+pub(crate) enum SnifferCommandInner {
+    /// New client wants to use the sniffer.
+    NewClient(
+        /// For notyfing the client about new incoming connections.
+        Sender<SniffedConnection>,
+    ),
+    /// Client wants to start receiving connections incoming to a specific port.
     Subscribe(
         // Number of port to subscribe.
         Port,
         // Channel to notify with `()` when the subscription is done.
         oneshot::Sender<()>,
     ),
+    /// Client no longer wats to receive connections incoming to a specific port.
     UnsubscribePort(Port),
 }
 
+/// Client's command for [`TcpConnectionSniffer`](super::TcpConnectionSniffer).
 #[derive(Debug)]
-pub struct SnifferCommand {
+pub(crate) struct SnifferCommand {
+    /// Id of the client.
     pub client_id: ClientId,
+    /// Actual command.
     pub command: SnifferCommandInner,
 }
 
-pub struct SniffedConnection {
+/// New TCP connection picked up by [`TcpConnectionSniffer`](super::TcpConnectionSniffer).
+pub(crate) struct SniffedConnection {
+    /// Parameters of this connection's TCP session.
+    /// Can be used to create [`NewTcpConnection`](mirrord_protocol::tcp::NewTcpConnection).
     pub session_id: TcpSessionIdentifier,
+    /// For receiving data from this connection.
     pub data: broadcast::Receiver<Vec<u8>>,
 }

--- a/mirrord/agent/src/sniffer/messages.rs
+++ b/mirrord/agent/src/sniffer/messages.rs
@@ -1,0 +1,28 @@
+use mirrord_protocol::Port;
+use tokio::sync::{broadcast, mpsc::Sender, oneshot};
+
+use super::TcpSessionIdentifier;
+use crate::util::ClientId;
+
+#[derive(Debug)]
+pub enum SnifferCommandInner {
+    NewClient(Sender<SniffedConnection>),
+    Subscribe(
+        // Number of port to subscribe.
+        Port,
+        // Channel to notify with `()` when the subscription is done.
+        oneshot::Sender<()>,
+    ),
+    UnsubscribePort(Port),
+}
+
+#[derive(Debug)]
+pub struct SnifferCommand {
+    pub client_id: ClientId,
+    pub command: SnifferCommandInner,
+}
+
+pub struct SniffedConnection {
+    pub session_id: TcpSessionIdentifier,
+    pub data: broadcast::Receiver<Vec<u8>>,
+}

--- a/mirrord/agent/src/sniffer/messages.rs
+++ b/mirrord/agent/src/sniffer/messages.rs
@@ -14,13 +14,18 @@ pub(crate) enum SnifferCommandInner {
     ),
     /// Client wants to start receiving connections incoming to a specific port.
     Subscribe(
-        // Number of port to subscribe.
+        /// Number of port to subscribe.
         Port,
-        // Channel to notify with `()` when the subscription is done.
+        /// Channel to notify with `()` when the operation is done.
         oneshot::Sender<()>,
     ),
     /// Client no longer wants to receive connections incoming to a specific port.
-    UnsubscribePort(Port),
+    UnsubscribePort(
+        /// Number of port to unsubscribe.
+        Port,
+        /// Channel to notify with `()` when the operation is done.
+        oneshot::Sender<()>,
+    ),
 }
 
 /// Client's command for [`TcpConnectionSniffer`](super::TcpConnectionSniffer).

--- a/mirrord/agent/src/sniffer/tcp_capture.rs
+++ b/mirrord/agent/src/sniffer/tcp_capture.rs
@@ -1,0 +1,173 @@
+use std::{io, net::SocketAddr};
+
+use mirrord_protocol::MeshVendor;
+use nix::sys::socket::SockaddrStorage;
+use pnet::packet::{
+    ethernet::{EtherTypes, EthernetPacket},
+    ip::IpNextHeaderProtocols,
+    ipv4::Ipv4Packet,
+    tcp::TcpPacket,
+    Packet,
+};
+use rawsocket::{filter::SocketFilterProgram, RawCapture};
+use tokio::net::UdpSocket;
+use tracing::Level;
+
+use super::{TcpPacketData, TcpSessionIdentifier};
+use crate::error::AgentError;
+
+/// Trait for structs that are able to sniff incoming Ethernet packets and filter TCP packets.
+pub trait TcpCapture {
+    /// Sets a filter for incoming Ethernet packets.
+    fn set_filter(&mut self, filter: SocketFilterProgram) -> io::Result<()>;
+
+    /// Returns the next sniffed TCP packet.
+    async fn next(&mut self) -> io::Result<(TcpSessionIdentifier, TcpPacketData)>;
+}
+
+/// Implementor of [`TcpCapture`] that uses a raw OS socket and a BPF filter.
+pub struct RawSocketTcpCapture {
+    /// Raw OS socket.
+    inner: RawCapture,
+}
+
+impl RawSocketTcpCapture {
+    /// Creates a new instance. `network_interface` and `mesh` will be used to determine correct
+    /// network interface for the raw OS socket.
+    ///
+    /// Returned instance initially uses a BPF filter that drops every packet.
+    #[tracing::instrument(level = Level::DEBUG, err)]
+    pub async fn new(
+        network_interface: Option<String>,
+        mesh: Option<MeshVendor>,
+    ) -> Result<Self, AgentError> {
+        // Priority is whatever the user set as an option to mirrord, then we check if we're in a
+        // mesh to use `lo` interface, otherwise we try to get the appropriate interface.
+        let interface = match network_interface.or_else(|| mesh.map(|_| "lo".to_string())) {
+            Some(interface) => interface,
+            None => Self::resolve_interface()
+                .await?
+                .unwrap_or_else(|| "eth0".to_string()),
+        };
+
+        tracing::debug!(
+            resolved_interface = interface,
+            "Resolved raw capture interface"
+        );
+
+        let capture = RawCapture::from_interface_name(&interface)?;
+        capture.set_filter(rawsocket::filter::build_drop_always())?;
+        capture
+            .ignore_outgoing()
+            .map_err(AgentError::PacketIgnoreOutgoing)?;
+        Ok(Self { inner: capture })
+    }
+
+    /// Connects to a remote address (`8.8.8.8:53`) so we can find which network interface to use.
+    ///
+    /// Used when no `user_interface` is specified in [`Self::new`] to prevent mirrord from
+    /// defaulting to the wrong network interface (`eth0`), as sometimes the user's machine doesn't
+    /// have it available (i.e. their default network is `enp2s0`).
+    #[tracing::instrument(level = Level::DEBUG, err)]
+    async fn resolve_interface() -> io::Result<Option<String>> {
+        // Connect to a remote address so we can later get the default network interface.
+        let temporary_socket = UdpSocket::bind("0.0.0.0:0").await?;
+        temporary_socket.connect("8.8.8.8:53").await?;
+
+        // Create comparison address here with `port: 0`, to match the network interface's address
+        // of `sin_port: 0`.
+        let local_address = SocketAddr::new(temporary_socket.local_addr()?.ip(), 0);
+        let raw_local_address = SockaddrStorage::from(local_address);
+
+        // Try to find an interface that matches the local ip we have.
+        let usable_interface_name: Option<String> = nix::ifaddrs::getifaddrs()?.find_map(|iface| {
+            (raw_local_address == iface.address?).then_some(iface.interface_name)
+        });
+
+        Ok(usable_interface_name)
+    }
+
+    /// Extracts TCP packet from the raw Ethernet packet given as bytes.
+    /// If the given Ethernet packet is not TCP, returns [`None`].
+    #[tracing::instrument(skip(eth_packet), level = Level::TRACE, fields(bytes = %eth_packet.len()))]
+    fn get_tcp_packet(eth_packet: Vec<u8>) -> Option<(TcpSessionIdentifier, TcpPacketData)> {
+        let eth_packet = EthernetPacket::new(&eth_packet[..])?;
+        let ip_packet = match eth_packet.get_ethertype() {
+            EtherTypes::Ipv4 => Ipv4Packet::new(eth_packet.payload())?,
+            _ => return None,
+        };
+
+        let tcp_packet = match ip_packet.get_next_level_protocol() {
+            IpNextHeaderProtocols::Tcp => TcpPacket::new(ip_packet.payload())?,
+            _ => return None,
+        };
+
+        let dest_port = tcp_packet.get_destination();
+        let source_port = tcp_packet.get_source();
+
+        let identifier = TcpSessionIdentifier {
+            source_addr: ip_packet.get_source(),
+            dest_addr: ip_packet.get_destination(),
+            source_port,
+            dest_port,
+        };
+
+        tracing::trace!(session_identifier = ?identifier, "Got TCP packet");
+
+        Some((
+            identifier,
+            TcpPacketData {
+                flags: tcp_packet.get_flags(),
+                bytes: tcp_packet.payload().to_vec(),
+            },
+        ))
+    }
+}
+
+impl TcpCapture for RawSocketTcpCapture {
+    fn set_filter(&mut self, filter: SocketFilterProgram) -> io::Result<()> {
+        self.inner.set_filter(filter)
+    }
+
+    async fn next(&mut self) -> io::Result<(TcpSessionIdentifier, TcpPacketData)> {
+        loop {
+            let raw = self.inner.next().await?;
+
+            if let Some(tcp) = Self::get_tcp_packet(raw) {
+                break Ok(tcp);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+pub mod test {
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
+
+    use tokio::sync::mpsc::Receiver;
+
+    use super::*;
+
+    /// Implementor of [`TcpCapture`] that returns packets received from an
+    /// [`mpsc`](tokio::sync::mpsc) channel.
+    pub struct TcpPacketsChannel {
+        pub times_filter_changed: Arc<AtomicUsize>,
+        pub receiver: Receiver<(TcpSessionIdentifier, TcpPacketData)>,
+    }
+
+    impl TcpCapture for TcpPacketsChannel {
+        /// Filter is ignored, we don't want to execute BPF programs in tests.
+        fn set_filter(&mut self, _filter: SocketFilterProgram) -> io::Result<()> {
+            self.times_filter_changed.fetch_add(1, Ordering::Relaxed);
+
+            Ok(())
+        }
+
+        async fn next(&mut self) -> io::Result<(TcpSessionIdentifier, TcpPacketData)> {
+            Ok(self.receiver.recv().await.expect("channel closed"))
+        }
+    }
+}

--- a/mirrord/agent/src/util.rs
+++ b/mirrord/agent/src/util.rs
@@ -19,7 +19,7 @@ use crate::{
 /// When a topic has no subscribers, it is removed.
 #[derive(Debug, Default)]
 pub struct Subscriptions<T, C> {
-    _inner: HashMap<T, HashSet<C>>,
+    inner: HashMap<T, HashSet<C>>,
 }
 
 /// Id of an agent's client. Each new client connection is assigned with a unique id.
@@ -33,7 +33,7 @@ where
     /// Add a new subscription to a topic for a given client.
     /// Returns whether this resulted in adding a new topic to this mapping.
     pub fn subscribe(&mut self, client: C, topic: T) -> bool {
-        match self._inner.entry(topic) {
+        match self.inner.entry(topic) {
             Entry::Occupied(mut e) => {
                 e.get_mut().insert(client);
                 false
@@ -49,7 +49,7 @@ where
     /// Topic is removed if no subscribers left.
     /// Return whether the topic was removed.
     pub fn unsubscribe(&mut self, client: C, topic: T) -> bool {
-        match self._inner.entry(topic) {
+        match self.inner.entry(topic) {
             Entry::Occupied(mut e) => {
                 e.get_mut().remove(&client);
                 if e.get().is_empty() {
@@ -65,32 +65,32 @@ where
 
     /// Get a vector of clients subscribed to a specific topic
     pub fn get_topic_subscribers(&self, topic: T) -> Option<&HashSet<C>> {
-        self._inner.get(&topic)
+        self.inner.get(&topic)
     }
 
     /// Get subscribed topics
     pub fn get_subscribed_topics(&self) -> Vec<T> {
-        self._inner.keys().cloned().collect()
+        self.inner.keys().cloned().collect()
     }
 
     /// Remove all subscriptions of a client.
     /// Topics are removed if no subscribers left.
     /// Returns whether any topic was removed.
     pub fn remove_client(&mut self, client: C) -> bool {
-        let prev_length = self._inner.len();
+        let prev_length = self.inner.len();
 
-        self._inner.retain(|_, client_set| {
+        self.inner.retain(|_, client_set| {
             client_set.remove(&client);
             !client_set.is_empty()
         });
 
-        self._inner.len() != prev_length
+        self.inner.len() != prev_length
     }
 
     /// Removes a topic and all of it's clients
     #[allow(dead_code)] // we might want it later on
     pub fn remove_topic(&mut self, topic: T) {
-        self._inner.remove(&topic);
+        self.inner.remove(&topic);
     }
 }
 
@@ -228,7 +228,7 @@ mod subscription_tests {
         /// Get topics subscribed by a client
         fn get_client_topics(&self, client: C) -> Vec<T> {
             let mut result = Vec::new();
-            for (topic, client_set) in self._inner.iter() {
+            for (topic, client_set) in self.inner.iter() {
                 if client_set.contains(&client) {
                     result.push(*topic)
                 }

--- a/mirrord/agent/src/util.rs
+++ b/mirrord/agent/src/util.rs
@@ -39,7 +39,7 @@ where
                 false
             }
             Entry::Vacant(e) => {
-                e.insert([client].into_iter().collect());
+                e.insert([client].into());
                 true
             }
         }


### PR DESCRIPTION
Closes #2529 

1. `TcpConnectionSniffer` uses `broadcast` channels (capacity - 512 TCP packets) to send incoming data in a non-blocking way.
2. `TcpSnifferApi` notifies the client about closed connection (and sends an error log) when it's `broadcast::Receiver` is lagging.
3. `TcpConnectionSniffer` notifies `TcpSnifferApi`s about new connections via `mpsc` channels (capacity - 128 new sniffed connections). When a new connection is sniffed, the sniffer attempts to notify each client without blocking. If the client already has 128 queued new connections, client is not notified. There's some space for improvement here - instead of dropping new connection, we could be dropping the oldest one in the queue. However, `mpsc::Sender`'s api does not allow for it and we would need to implement some async circular FIFO
4. BPF filter used by the raw socket is now updated only when needed - `PortSubscribe`/`PortUnsubscribe` from a user actually changed the set of subscribed ports
5. Also some minor performance optimizations like using `hash_map::Entry` instead of `get() -> remove()`