### PR TITLE
Add exclusion for DOTNET_EnableDiagnostics 

### DIFF
--- a/changelog.d/+dotnet-debug-env.fixed.md
+++ b/changelog.d/+dotnet-debug-env.fixed.md
@@ -1,0 +1,1 @@
+Add exclusion for DOTNET_EnableDiagnostics to make DotNet debugging work by default

--- a/mirrord/agent/src/env.rs
+++ b/mirrord/agent/src/env.rs
@@ -60,6 +60,7 @@ impl EnvFilter {
                 WildMatch::new("RUBYOPT"),
                 WildMatch::new("RUST_LOG"),
                 WildMatch::new("_JAVA_OPTIONS"),
+                WildMatch::new("DOTNET_EnableDiagnostics"),
             ];
 
             for selector in &filter_env_vars {


### PR DESCRIPTION
Add exclusion for DOTNET_EnableDiagnostics  to make DotNet debugging work by default
