### PR TITLE
Fix mirrord-operator compilation with only `crd` feature enabled

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -147,6 +147,8 @@ jobs:
       - run: cargo-zigbuild clippy --lib --bins --all-features --target x86_64-unknown-linux-gnu -- -Wclippy::indexing_slicing -D warnings
       # Check that compiles for the supported linux targets (aarch64)
       - run: cargo-zigbuild clippy --lib --bins --all-features --target aarch64-unknown-linux-gnu -- -Wclippy::indexing_slicing -D warnings
+      # Check whether `mirrord-operator` crate compiles the way it's used in the operator
+      - run: cargo-zigbuild check -p mirrord-operator --features crd --target x86_64-unknown-linux-gnu
 
   # if the branch is named is `x.x.x`, x ∈ [0, 9], then it's a release branch
   # the output of this test is a boolean indicating if it's a release branch

--- a/changelog.d/+mirrord-operator-crate.internal.md
+++ b/changelog.d/+mirrord-operator-crate.internal.md
@@ -1,0 +1,1 @@
+Fixed compilation errors in `mirrord-operator` crate with only `crd` feature enabled.

--- a/mirrord/cli/src/error.rs
+++ b/mirrord/cli/src/error.rs
@@ -244,12 +244,9 @@ pub(crate) enum CliError {
     ))]
     OperatorNotInstalled,
 
-    #[error("Failed targeting resource with: {0}")]
-    #[diagnostic(help(
-        "The target might be known by the mirrord operator, but your current version of mirrord doesn't support it.
-        Consider updating mirrord to have access to this resource type.{GENERAL_HELP}"
-    ))]
-    UnknownTarget(String),
+    #[error("mirrord returned a target resource of unknown type: {0}")]
+    #[diagnostic(help("{GENERAL_BUG}"))]
+    OperatorReturnedUnknownTargetType(String),
 }
 
 impl From<OperatorApiError> for CliError {
@@ -288,7 +285,9 @@ impl From<OperatorApiError> for CliError {
             }
             OperatorApiError::NoLicense => Self::OperatorLicenseExpired,
             OperatorApiError::ClientCertError(error) => Self::OperatorClientCertError(error),
-            OperatorApiError::UnknownTarget(error) => Self::UnknownTarget(error),
+            OperatorApiError::FetchedUnknownTargetType(error) => {
+                Self::OperatorReturnedUnknownTargetType(error.0)
+            }
         }
     }
 }

--- a/mirrord/cli/src/main.rs
+++ b/mirrord/cli/src/main.rs
@@ -582,7 +582,7 @@ async fn print_targets(args: &ListTargetArgs) -> Result<()> {
                 .await?
                 .iter()
                 .filter_map(|target_crd| {
-                    let target = target_crd.spec.target.known()?;
+                    let target = target_crd.spec.target.as_known().ok()?;
                     if let Some(container) = target.container() {
                         if SKIP_NAMES.contains(container.as_str()) {
                             return None;

--- a/mirrord/operator/src/client.rs
+++ b/mirrord/operator/src/client.rs
@@ -170,7 +170,7 @@ impl OperatorSessionTarget {
     ) -> Result<String, OperatorApiError> {
         Ok(match (use_proxy, self) {
             (true, OperatorSessionTarget::Raw(crd)) => {
-                let name = TargetCrd::urlfied_name(crd.spec.target.as_ref().try_into()?);
+                let name = TargetCrd::urlfied_name(crd.spec.target.as_known()?);
                 let namespace = crd
                     .meta()
                     .namespace
@@ -183,7 +183,7 @@ impl OperatorSessionTarget {
             }
 
             (false, OperatorSessionTarget::Raw(crd)) => {
-                let name = TargetCrd::urlfied_name(crd.spec.target.as_ref().try_into()?);
+                let name = TargetCrd::urlfied_name(crd.spec.target.as_known()?);
                 let namespace = crd
                     .meta()
                     .namespace

--- a/mirrord/operator/src/client/error.rs
+++ b/mirrord/operator/src/client/error.rs
@@ -4,6 +4,8 @@ pub use http::Error as HttpError;
 use mirrord_kube::error::KubeApiError;
 use thiserror::Error;
 
+use crate::crd::kube_target::UnknownTargetType;
+
 /// Operations performed on the operator via [`kube`] API.
 #[derive(Debug)]
 pub enum OperatorOperation {
@@ -64,8 +66,8 @@ pub enum OperatorApiError {
     #[error("failed to prepare client certificate: {0}")]
     ClientCertError(String),
 
-    #[error("Trying to target unknown kubernetes resource: {0}")]
-    UnknownTarget(String),
+    #[error("mirrord operator returned a target of unknown type: {}", .0 .0)]
+    FetchedUnknownTargetType(#[from] UnknownTargetType),
 }
 
 pub type OperatorApiResult<T, E = OperatorApiError> = Result<T, E>;

--- a/mirrord/operator/src/crd.rs
+++ b/mirrord/operator/src/crd.rs
@@ -1,11 +1,11 @@
 use kube::CustomResource;
-use kube_target::KubeTarget;
+use kube_target::{KubeTarget, UnknownTargetType};
 use mirrord_config::target::{Target, TargetConfig};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use self::label_selector::LabelSelector;
-use crate::{client::error::OperatorApiError, types::LicenseInfoOwned};
+use crate::types::LicenseInfoOwned;
 
 pub mod kube_target;
 pub mod label_selector;
@@ -63,20 +63,14 @@ impl TargetCrd {
 }
 
 impl TryFrom<TargetCrd> for TargetConfig {
-    type Error = OperatorApiError;
+    type Error = UnknownTargetType;
 
     fn try_from(crd: TargetCrd) -> Result<Self, Self::Error> {
         Ok(TargetConfig {
-            path: Some(Target::try_from(crd.spec.target)?.clone()),
+            path: Some(Target::try_from(crd.spec.target)?),
             namespace: crd.metadata.namespace,
         })
     }
-}
-
-#[derive(Clone, Debug, Default, Deserialize, Serialize, JsonSchema)]
-pub struct TargetPortLock {
-    pub target_hash: String,
-    pub port: u16,
 }
 
 pub static OPERATOR_STATUS_NAME: &str = "operator";


### PR DESCRIPTION
I found myself fixing the same thing again, so I added an extra CI check for this