### PR TITLE
Don't include non-running pods in node capacity check

### DIFF
--- a/changelog.d/2582.fixed.md
+++ b/changelog.d/2582.fixed.md
@@ -1,0 +1,1 @@
+Don't include non-running pods in node capacity check

--- a/mirrord/kube/src/api/runtime.rs
+++ b/mirrord/kube/src/api/runtime.rs
@@ -184,7 +184,10 @@ impl RuntimeData {
 
         let mut pod_count = 0;
         let mut list_params = ListParams {
-            field_selector: Some(format!("spec.nodeName={}", self.node_name)),
+            field_selector: Some(format!(
+                "status.phase=Running,spec.nodeName={}",
+                self.node_name
+            )),
             ..Default::default()
         };
 


### PR DESCRIPTION
Fixes #2582 