### PR TITLE
Added experimental.trust_any_certificate

### DIFF
--- a/changelog.d/2576.added.md
+++ b/changelog.d/2576.added.md
@@ -1,0 +1,1 @@
+Added experimental.trust_any_certificate to enable making app trust any certificate on macOS

--- a/mirrord-schema.json
+++ b/mirrord-schema.json
@@ -617,7 +617,7 @@
       "type": "object",
       "properties": {
         "readlink": {
-          "title": "_experimental_ readlink {#fexperimental-readlink}",
+          "title": "_experimental_ readlink {#experimental-readlink}",
           "description": "Enables the `readlink` hook.",
           "type": [
             "boolean",
@@ -625,8 +625,16 @@
           ]
         },
         "tcp_ping4_mock": {
-          "title": "_experimental_ tcp_ping4_mock {#fexperimental-tcp_ping4_mock}",
+          "title": "_experimental_ tcp_ping4_mock {#experimental-tcp_ping4_mock}",
           "description": "<https://github.com/metalbear-co/mirrord/issues/2421#issuecomment-2093200904>",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "trust_any_certificate": {
+          "title": "_experimental_ trust_any_certificate {#experimental-trust_any_certificate}",
+          "description": "Enables trusting any certificate on macOS, useful for https://github.com/golang/go/issues/51991#issuecomment-2059588252",
           "type": [
             "boolean",
             "null"

--- a/mirrord-schema.json
+++ b/mirrord-schema.json
@@ -634,7 +634,7 @@
         },
         "trust_any_certificate": {
           "title": "_experimental_ trust_any_certificate {#experimental-trust_any_certificate}",
-          "description": "Enables trusting any certificate on macOS, useful for https://github.com/golang/go/issues/51991#issuecomment-2059588252",
+          "description": "Enables trusting any certificate on macOS, useful for <https://github.com/golang/go/issues/51991#issuecomment-2059588252>",
           "type": [
             "boolean",
             "null"

--- a/mirrord/config/src/experimental.rs
+++ b/mirrord/config/src/experimental.rs
@@ -10,22 +10,29 @@ use crate::config::source::MirrordConfigSource;
 #[config(map_to = "ExperimentalFileConfig", derive = "JsonSchema")]
 #[cfg_attr(test, config(derive = "PartialEq, Eq"))]
 pub struct ExperimentalConfig {
-    /// ## _experimental_ tcp_ping4_mock {#fexperimental-tcp_ping4_mock}
+    /// ## _experimental_ tcp_ping4_mock {#experimental-tcp_ping4_mock}
     ///
     /// <https://github.com/metalbear-co/mirrord/issues/2421#issuecomment-2093200904>
     #[config(default = true)]
     pub tcp_ping4_mock: bool,
 
-    /// ## _experimental_ readlink {#fexperimental-readlink}
+    /// ## _experimental_ readlink {#experimental-readlink}
     ///
     /// Enables the `readlink` hook.
     #[config(default = false)]
     pub readlink: bool,
+
+    /// # _experimental_ trust_any_certificate {#experimental-trust_any_certificate}
+    ///
+    /// Enables trusting any certificate on macOS, useful for https://github.com/golang/go/issues/51991#issuecomment-2059588252
+    #[config(default = false)]
+    pub trust_any_certificate: bool,
 }
 
 impl CollectAnalytics for &ExperimentalConfig {
     fn collect_analytics(&self, analytics: &mut mirrord_analytics::Analytics) {
         analytics.add("tcp_ping4_mock", self.tcp_ping4_mock);
         analytics.add("readlink", self.readlink);
+        analytics.add("trust_any_certificate", self.trust_any_certificate);
     }
 }

--- a/mirrord/config/src/experimental.rs
+++ b/mirrord/config/src/experimental.rs
@@ -24,7 +24,7 @@ pub struct ExperimentalConfig {
 
     /// # _experimental_ trust_any_certificate {#experimental-trust_any_certificate}
     ///
-    /// Enables trusting any certificate on macOS, useful for https://github.com/golang/go/issues/51991#issuecomment-2059588252
+    /// Enables trusting any certificate on macOS, useful for <https://github.com/golang/go/issues/51991#issuecomment-2059588252>
     #[config(default = false)]
     pub trust_any_certificate: bool,
 }

--- a/mirrord/layer/src/lib.rs
+++ b/mirrord/layer/src/lib.rs
@@ -476,6 +476,7 @@ fn sip_only_layer_start(mut config: LayerConfig, patch_binaries: Vec<String>) {
 fn enable_hooks(state: &LayerSetup) {
     let enabled_file_ops = state.fs_config().is_active();
     let enabled_remote_dns = state.remote_dns_enabled();
+    #[cfg(target_os = "macos")]
     let patch_binaries = state.sip_binaries();
 
     let mut hook_manager = HookManager::default();

--- a/mirrord/layer/src/setup.rs
+++ b/mirrord/layer/src/setup.rs
@@ -119,6 +119,7 @@ impl LayerSetup {
             .unwrap_or(true)
     }
 
+    #[cfg(target_os = "macos")]
     pub fn sip_binaries(&self) -> Vec<String> {
         self.config
             .sip_binaries

--- a/mirrord/layer/src/tls.rs
+++ b/mirrord/layer/src/tls.rs
@@ -1,0 +1,24 @@
+use libc::c_void;
+use mirrord_layer_macro::hook_guard_fn;
+
+use crate::{hooks::HookManager, replace};
+
+// https://developer.apple.com/documentation/security/2980705-sectrustevaluatewitherror
+#[hook_guard_fn]
+pub(crate) unsafe extern "C" fn sec_trust_evaluate_with_error_detour(
+    trust: *const c_void,
+    error: *const c_void,
+) -> bool {
+    tracing::trace!("sec_trust_evaluate_with_error_detour called");
+    true
+}
+
+pub(crate) unsafe fn enable_tls_hooks(hook_manager: &mut HookManager) {
+    replace!(
+        hook_manager,
+        "SecTrustEvaluateWithError",
+        sec_trust_evaluate_with_error_detour,
+        FnSec_trust_evaluate_with_error,
+        FN_SEC_TRUST_EVALUATE_WITH_ERROR
+    );
+}


### PR DESCRIPTION
Added experimental.trust_any_certificate to enable making app trust any certificate on macOS. Closes #2576
Supersedes #2576 