### PR TITLE
Remove automatic ignore of incoming/outgoing traffic for ports high ports

### DIFF
--- a/changelog.d/2597.fixed.md
+++ b/changelog.d/2597.fixed.md
@@ -1,0 +1,1 @@
+Remove automatic ignore of incoming/outgoing traffic for ports 50000-60000

--- a/mirrord/layer/src/socket.rs
+++ b/mirrord/layer/src/socket.rs
@@ -433,9 +433,7 @@ impl OutgoingFilterExt for OutgoingFilter {
 
 #[inline]
 fn is_ignored_port(addr: &SocketAddr) -> bool {
-    let (ip, port) = (addr.ip(), addr.port());
-    let ignored_ip = ip == IpAddr::V4(Ipv4Addr::LOCALHOST) || ip == IpAddr::V6(Ipv6Addr::LOCALHOST);
-    port == 0 || ignored_ip && (port > 50000 && port < 60000)
+    addr.port() == 0
 }
 
 /// Fill in the sockaddr structure for the given address.

--- a/mirrord/layer/src/socket.rs
+++ b/mirrord/layer/src/socket.rs
@@ -1,7 +1,7 @@
 //! We implement each hook function in a safe function as much as possible, having the unsafe do the
 //! absolute minimum
 use std::{
-    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, ToSocketAddrs},
+    net::{SocketAddr, ToSocketAddrs},
     os::unix::io::RawFd,
     str::FromStr,
     sync::{Arc, LazyLock},


### PR DESCRIPTION
Remove automatic ignore of incoming/outgoing traffic for ports high ports 50000-60000
This was a patch we had back in the day to handle debuggers, but since then we have other means to support it (DebuggerPorts impl)

closes #2597 