### PR TITLE
Warn when automatically picking a container out of many

### DIFF
--- a/changelog.d/+warn-multiple-containers.added.md
+++ b/changelog.d/+warn-multiple-containers.added.md
@@ -1,0 +1,1 @@
+Warning when mirrord automatically picked one of multiple containers on the target.

--- a/mirrord/kube/src/api/container.rs
+++ b/mirrord/kube/src/api/container.rs
@@ -132,38 +132,28 @@ pub fn choose_container<'a>(
         }
     });
 
-    // How many containers does mirrord have to choose from:
-    // 0: no containers, or container was specified.
-    // 1: only one, no choice.
-    // 2: 2 or more choices (non-mesh, or only non-mesh, but multiple of them).
-    let mut possible_containers = 0u8;
+    let mut picked_from_many = false;
 
     let container = if let Some(name) = container_name {
         container_statuses
             .iter()
             .find(|&status| status.name == name)
     } else {
-        // Choose any container that isn't part of the skip list
-        let container_refs = container_statuses
+        let mut container_refs = container_statuses
             .iter()
-            .take_while(|&status| !SKIP_NAMES.contains(status.name.as_str()))
-            .inspect(|_| possible_containers += 1)
-            // Iterate up to 2 even though we're taking the first container, so that we know if
-            // there are other possible choices for target container (for the purposes of showing a
-            // warning).
-            .take(2)
-            // Collect so that counting happens before we only take the first.
-            .collect::<Vec<&ContainerStatus>>();
-        container_refs
-            .into_iter()
-            .next()
-            .or_else(|| {
-                tracing::warn!("Target has only containers with names that we would otherwise skip. Picking first one.");
-                possible_containers = 2; // So that we display the progress warning.
-                container_statuses.first()
-            })
+            .filter(|&status| !SKIP_NAMES.contains(status.name.as_str()));
+        // Choose first container that isn't part of the skip list
+        let container = container_refs.next().or_else(|| {
+            tracing::warn!(
+                "Target has only containers with names that we would otherwise skip. Picking one."
+            );
+            picked_from_many = container_statuses.len() > 1;
+            container_statuses.first()
+        });
+        picked_from_many = picked_from_many || container_refs.next().is_some();
+        container
     };
 
     // container_counter is only incremented if there is no specified container name.
-    (container, mesh, possible_containers > 1)
+    (container, mesh, picked_from_many)
 }

--- a/mirrord/kube/src/api/container.rs
+++ b/mirrord/kube/src/api/container.rs
@@ -28,6 +28,7 @@ pub static SKIP_NAMES: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
         "linkerd-init",
         "vault-agent",
         "vault-agent-init",
+        "queue-proxy", // Knative
     ])
 });
 

--- a/mirrord/kube/src/api/container/job.rs
+++ b/mirrord/kube/src/api/container/job.rs
@@ -343,6 +343,7 @@ mod test {
                 container_id: "container".to_string(),
                 container_runtime: ContainerRuntime::Docker,
                 container_name: "foo".to_string(),
+                guessed_container: false,
             },
         )
         .as_update();

--- a/mirrord/kube/src/api/kubernetes.rs
+++ b/mirrord/kube/src/api/kubernetes.rs
@@ -218,6 +218,14 @@ impl KubernetesAPI {
         P: Progress + Send + Sync,
     {
         let (params, runtime_data) = self.create_agent_params(target, tls_cert).await?;
+        if let Some(RuntimeData {
+            guessed_container: true,
+            container_name,
+            ..
+        }) = runtime_data.as_ref()
+        {
+            progress.warning(format!("Target has multiple containers, mirrord picked \"{container_name}\". To target a different one, include it in the target path.").as_str());
+        }
 
         let incoming_mode = config.map(|config| config.feature.network.incoming.mode);
         let is_mesh = runtime_data

--- a/mirrord/kube/src/api/runtime.rs
+++ b/mirrord/kube/src/api/runtime.rs
@@ -71,6 +71,9 @@ pub struct RuntimeData {
     pub container_id: String,
     pub container_runtime: ContainerRuntime,
     pub container_name: String,
+    /// True when no container was specified by the user, but there are multiple containers,
+    /// so mirrord chose one of them for the user.
+    pub guessed_container: bool,
 
     /// Used to check if we're running with a mesh/sidecar in `detect_mesh_mirror_mode`.
     pub mesh: Option<MeshVendor>,
@@ -126,6 +129,8 @@ impl RuntimeData {
             .and_then(|status| status.container_statuses.as_ref())
             .ok_or_else(|| KubeApiError::missing_field(pod, ".status.containerStatuses"))?;
 
+        let guessed_container = container_name.is_none() && container_statuses.len() > 1;
+
         let (chosen_container, mesh) =
             choose_container(container_name, container_statuses.as_ref());
 
@@ -173,6 +178,7 @@ impl RuntimeData {
             container_id,
             container_runtime,
             container_name,
+            guessed_container,
             mesh,
         })
     }


### PR DESCRIPTION
* When there are multiple containers on the target, and the user did not specify a target container, show a warning with 
 the chosen container name.
 ![Target has multiple containers, mirrord picked](https://github.com/user-attachments/assets/c243a18f-85ca-43de-bcc1-ffe38db5da39)
 Currently shows only when not connected to an operator. Adding that warning when running with the operator is a bit more complicated because we don't have the target resource (pod/deployment/etc.) at the client side. So we would need to send back a signal that a warning should be displayed. I think we should leave that to a separate PR as this PR is just a quick detour to pick low hanging fruit.

* Also, added Knative's "queue-proxy" container to the skipped list.