### PR TITLE
Remove invalid schema doc mentioning `podname` as a valid pod target selector.

### DIFF
--- a/changelog.d/721.fixed.md
+++ b/changelog.d/721.fixed.md
@@ -1,0 +1,1 @@
+Remove invalid schema doc mentioning podname as a valid pod target selector.

--- a/mirrord-schema.json
+++ b/mirrord-schema.json
@@ -1326,7 +1326,7 @@
       "additionalProperties": false
     },
     "Target": {
-      "description": "<!--${internal}--> ## path\n\nSpecifies the running pod (or deployment) to mirror.\n\nSupports: - `pod/{sample-pod}`; - `podname/{sample-pod}`; - `deployment/{sample-deployment}`; - `container/{sample-container}`; - `containername/{sample-container}`. - `job/{sample-job}`; - `cronjob/{sample-cronjob}`; - `statefulset/{sample-statefulset}`;",
+      "description": "<!--${internal}--> ## path\n\nSpecifies the running pod (or deployment) to mirror.\n\nSupports: - `pod/{sample-pod}`; - `deployment/{sample-deployment}`; - `container/{sample-container}`; - `containername/{sample-container}`. - `job/{sample-job}`; - `cronjob/{sample-cronjob}`; - `statefulset/{sample-statefulset}`;",
       "anyOf": [
         {
           "description": "<!--${internal}--> Mirror a deployment.",

--- a/mirrord/config/configuration.md
+++ b/mirrord/config/configuration.md
@@ -1250,7 +1250,6 @@ accepted values for the `target` option.
 The simplified configuration supports:
 
 - `pod/{sample-pod}/[container]/{sample-container}`;
-- `podname/{sample-pod}/[container]/{sample-container}`;
 - `deployment/{sample-deployment}/[container]/{sample-container}`;
 
 Shortened setup:
@@ -1289,7 +1288,6 @@ If you use it without it, it will choose a random pod replica to work with.
 
 Supports:
 - `pod/{sample-pod}`;
-- `podname/{sample-pod}`;
 - `deployment/{sample-deployment}`;
 - `container/{sample-container}`;
 - `containername/{sample-container}`.

--- a/mirrord/config/src/target.rs
+++ b/mirrord/config/src/target.rs
@@ -77,7 +77,6 @@ fn make_simple_target_custom_schema(gen: &mut SchemaGenerator) -> schemars::sche
 /// The simplified configuration supports:
 ///
 /// - `pod/{sample-pod}/[container]/{sample-container}`;
-/// - `podname/{sample-pod}/[container]/{sample-container}`;
 /// - `deployment/{sample-deployment}/[container]/{sample-container}`;
 ///
 /// Shortened setup:
@@ -113,7 +112,6 @@ pub struct TargetConfig {
     ///
     /// Supports:
     /// - `pod/{sample-pod}`;
-    /// - `podname/{sample-pod}`;
     /// - `deployment/{sample-deployment}`;
     /// - `container/{sample-container}`;
     /// - `containername/{sample-container}`.
@@ -206,7 +204,6 @@ mirrord-layer failed to parse the provided target!
 ///
 /// Supports:
 /// - `pod/{sample-pod}`;
-/// - `podname/{sample-pod}`;
 /// - `deployment/{sample-deployment}`;
 /// - `container/{sample-container}`;
 /// - `containername/{sample-container}`.


### PR DESCRIPTION
- Issue: #721 

The error reported in the issue seems to have been fixed at some point:

![error](https://user-images.githubusercontent.com/5508354/201323613-c3ec50ba-8b56-453a-b1f9-64be7a77759f.png)

Looks like vscode allows a string there now.