### PR TITLE
Tweak mirrord container command

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -345,6 +345,8 @@ jobs:
         run: cargo test --target x86_64-unknown-linux-gnu -p mirrord-auth
       - name: mirrord operator UT
         run: cargo test --target x86_64-unknown-linux-gnu -p mirrord-operator --features "crd, client"
+      - name: mirrord cli UT
+        run: cargo test --target x86_64-unknown-linux-gnu -p mirrord
 
   macos_tests:
     runs-on: macos-13

--- a/changelog.d/+tweak-container-command.internal.md
+++ b/changelog.d/+tweak-container-command.internal.md
@@ -1,0 +1,12 @@
+Update the location of `--` in container command
+```
+mirrord container [options] <docker/podman/nerdctl> run -- ...
+```
+Now will be
+```
+mirrord container [options] -- <docker/podman/nerdctl> run ...
+```
+or simply
+```
+mirrord container [options] <docker/podman/nerdctl> run ...
+```

--- a/mirrord/cli/src/config.rs
+++ b/mirrord/cli/src/config.rs
@@ -486,6 +486,13 @@ pub(super) struct ContainerArgs {
     /// Parameters to be passed to mirrord.
     pub params: ExecParams,
 
+    /// Container command to be executed
+    #[arg(trailing_var_arg = true)]
+    pub exec: Vec<String>,
+}
+
+#[derive(Parser, Debug)]
+pub struct RuntimeArgs {
     /// Which kind of container runtime to use.
     #[arg(value_enum)]
     pub runtime: ContainerRuntime,
@@ -495,13 +502,13 @@ pub(super) struct ContainerArgs {
     pub command: ContainerCommand,
 }
 
-/// Commands for using mirrord with container runtimes.
+/// Supported command for using mirrord with container runtimes.
 #[derive(Subcommand, Debug, Clone)]
 pub(super) enum ContainerCommand {
     /// Execute a `<RUNTIME> run` command with mirrord loaded.
     Run {
         /// Arguments that will be propogated to underlying `<RUNTIME> run` command.
-        #[arg(raw = true)]
+        #[arg(allow_hyphen_values = true, trailing_var_arg = true)]
         runtime_args: Vec<String>,
     },
 }

--- a/mirrord/cli/src/container.rs
+++ b/mirrord/cli/src/container.rs
@@ -157,12 +157,12 @@ async fn create_sidecar_intproxy(
 /// This spawns: "agent" - "external proxy" - "intproxy sidecar" - "execution container"
 pub(crate) async fn container_command(
     runtime_args: RuntimeArgs,
-    params: ExecParams,
+    exec_params: ExecParams,
     watch: drain::Watch,
 ) -> Result<()> {
     let progress = ProgressTracker::from_env("mirrord container");
 
-    for (name, value) in params.as_env_vars()? {
+    for (name, value) in exec_params.as_env_vars()? {
         std::env::set_var(name, value);
     }
 

--- a/mirrord/cli/src/container.rs
+++ b/mirrord/cli/src/container.rs
@@ -23,7 +23,7 @@ use tokio::process::Command;
 use tracing::Level;
 
 use crate::{
-    config::{ContainerArgs, ContainerCommand},
+    config::{ContainerCommand, ExecParams, RuntimeArgs},
     connection::AGENT_CONNECT_INFO_ENV_KEY,
     container::command_builder::RuntimeCommandBuilder,
     error::{ContainerError, Result},
@@ -155,10 +155,14 @@ async fn create_sidecar_intproxy(
 
 /// Main entry point for the `mirrord container` command.
 /// This spawns: "agent" - "external proxy" - "intproxy sidecar" - "execution container"
-pub(crate) async fn container_command(args: ContainerArgs, watch: drain::Watch) -> Result<()> {
+pub(crate) async fn container_command(
+    runtime_args: RuntimeArgs,
+    params: ExecParams,
+    watch: drain::Watch,
+) -> Result<()> {
     let progress = ProgressTracker::from_env("mirrord container");
 
-    for (name, value) in args.params.as_env_vars()? {
+    for (name, value) in params.as_env_vars()? {
         std::env::set_var(name, value);
     }
 
@@ -244,7 +248,7 @@ pub(crate) async fn container_command(args: ContainerArgs, watch: drain::Watch) 
 
     sub_progress.success(None);
 
-    let mut runtime_command = RuntimeCommandBuilder::new(args.runtime);
+    let mut runtime_command = RuntimeCommandBuilder::new(runtime_args.runtime);
 
     if let Ok(console_addr) = std::env::var(MIRRORD_CONSOLE_ADDR_ENV) {
         if console_addr
@@ -308,7 +312,7 @@ pub(crate) async fn container_command(args: ContainerArgs, watch: drain::Watch) 
     );
 
     let (binary, binary_args) = runtime_command
-        .with_command(args.command)
+        .with_command(runtime_args.command)
         .into_execvp_args();
 
     let err = execvp(binary, binary_args);

--- a/mirrord/cli/src/main.rs
+++ b/mirrord/cli/src/main.rs
@@ -501,7 +501,13 @@ fn main() -> miette::Result<()> {
             }
             Commands::Teams => teams::navigate_to_intro().await,
             Commands::Diagnose(args) => diagnose_command(*args).await?,
-            Commands::Container(args) => container_command(*args, watch).await?,
+            Commands::Container(args) => {
+                let runtime_args = RuntimeArgs::parse_from(
+                    std::iter::once("mirrord container --".into()).chain(args.exec),
+                );
+
+                container_command(runtime_args, args.params, watch).await?
+            }
             Commands::ExternalProxy => external_proxy::proxy(watch).await?,
         };
 

--- a/mirrord/cli/src/main.rs
+++ b/mirrord/cli/src/main.rs
@@ -502,11 +502,8 @@ fn main() -> miette::Result<()> {
             Commands::Teams => teams::navigate_to_intro().await,
             Commands::Diagnose(args) => diagnose_command(*args).await?,
             Commands::Container(args) => {
-                let runtime_args = RuntimeArgs::parse_from(
-                    std::iter::once("mirrord container --".into()).chain(args.exec),
-                );
-
-                container_command(runtime_args, args.params, watch).await?
+                let (runtime_args, exec_params) = args.into_parts();
+                container_command(runtime_args, exec_params, watch).await?
             }
             Commands::ExternalProxy => external_proxy::proxy(watch).await?,
         };


### PR DESCRIPTION
Do some manual parsing to allow the following syntax
```
mirrord container -t deploy/my-target -- podman run ...
```