### PR TITLE
Agent housekeeping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4023,7 +4023,7 @@ dependencies = [
 
 [[package]]
 name = "mirrord-protocol"
-version = "1.8.2"
+version = "1.8.3"
 dependencies = [
  "actix-codec",
  "bincode",

--- a/changelog.d/+agent-improvements.internal.md
+++ b/changelog.d/+agent-improvements.internal.md
@@ -1,0 +1,1 @@
+Some agent code housekeeping, including improved tracing and errors and removal of index allocator.

--- a/mirrord/agent/src/entrypoint.rs
+++ b/mirrord/agent/src/entrypoint.rs
@@ -87,8 +87,7 @@ impl State {
                 container_runtime,
                 ..
             } => {
-                let container =
-                    get_container(container_id.clone(), Some(container_runtime)).await?;
+                let container = get_container(container_id.clone(), container_runtime).await?;
 
                 let container_handle = ContainerHandle::new(container).await?;
                 let pid = container_handle.pid().to_string();
@@ -438,7 +437,7 @@ impl ClientConnectionHandler {
                     sniffer_api.handle_client_message(message).await?
                 } else {
                     warn!("received tcp sniffer request while not available");
-                    Err(AgentError::SnifferApiError)?
+                    Err(AgentError::SnifferNotRunning)?
                 }
             }
             ClientMessage::TcpSteal(message) => {
@@ -446,7 +445,7 @@ impl ClientConnectionHandler {
                     tcp_stealer_api.handle_client_message(message).await?
                 } else {
                     warn!("received tcp steal request while not available");
-                    Err(AgentError::SnifferApiError)?
+                    Err(AgentError::StealerNotRunning)?
                 }
             }
             ClientMessage::Close => {
@@ -610,9 +609,9 @@ async fn start_agent(args: Args) -> Result<()> {
             Err(error)?
         }
 
-        Err(error) => {
+        Err(..) => {
             error!("start_agent -> Failed to accept first connection: timeout");
-            Err(error)?
+            Err(AgentError::FirstConnectionTimeout)?
         }
     }
 

--- a/mirrord/agent/src/entrypoint.rs
+++ b/mirrord/agent/src/entrypoint.rs
@@ -361,7 +361,7 @@ impl ClientConnectionHandler {
                     Ok(message) => self.respond(DaemonMessage::TcpSteal(message)).await?,
                     Err(e) => break e,
                 },
-                message = self.tcp_outgoing_api.daemon_message() => match message {
+                message = self.tcp_outgoing_api.recv_from_task() => match message {
                     Ok(message) => self.respond(DaemonMessage::TcpOutgoing(message)).await?,
                     Err(e) => break e,
                 },
@@ -409,7 +409,7 @@ impl ClientConnectionHandler {
                 }
             }
             ClientMessage::TcpOutgoing(layer_message) => {
-                self.tcp_outgoing_api.layer_message(layer_message).await?
+                self.tcp_outgoing_api.send_to_task(layer_message).await?
             }
             ClientMessage::UdpOutgoing(layer_message) => {
                 self.udp_outgoing_api.layer_message(layer_message).await?

--- a/mirrord/agent/src/error.rs
+++ b/mirrord/agent/src/error.rs
@@ -1,80 +1,36 @@
 use std::process::ExitStatus;
 
-use mirrord_protocol::{
-    outgoing::{
-        tcp::LayerTcpOutgoing,
-        udp::{DaemonUdpOutgoing, LayerUdpOutgoing},
-        LayerConnect,
-    },
-    tcp::DaemonTcp,
-    FileRequest, FileResponse,
-};
+use mirrord_protocol::outgoing::udp::DaemonUdpOutgoing;
 use thiserror::Error;
-use tokio::sync::mpsc;
+use tokio::sync::mpsc::{self, error::SendError};
 
 use crate::{
-    client_connection::TlsSetupError, namespace::NamespaceError, sniffer::messages::SnifferCommand,
-    steal::StealerCommand,
+    client_connection::TlsSetupError, namespace::NamespaceError, runtime,
+    sniffer::messages::SnifferCommand, steal::StealerCommand,
 };
 
 #[derive(Debug, Error)]
 pub(crate) enum AgentError {
-    #[error("Agent failed with `{0:?}`")]
+    #[error("io error: {0}")]
     IO(#[from] std::io::Error),
 
     #[error("SnifferCommand sender failed with `{0}`")]
-    SendSnifferCommand(#[from] tokio::sync::mpsc::error::SendError<SnifferCommand>),
+    SendSnifferCommand(#[from] SendError<SnifferCommand>),
 
     #[error("TCP stealer task is dead")]
     TcpStealerTaskDead,
 
-    #[error("FileRequest sender failed with `{0}`")]
-    SendFileRequest(#[from] tokio::sync::mpsc::error::SendError<(u32, FileRequest)>),
-
-    #[error("FileResponse sender failed with `{0}`")]
-    SendFileResponse(#[from] tokio::sync::mpsc::error::SendError<(u32, FileResponse)>),
-
-    #[error("DaemonTcp sender failed with `{0}`")]
-    SendDaemonTcp(#[from] tokio::sync::mpsc::error::SendError<DaemonTcp>),
-
-    #[error("ConnectRequest sender failed with `{0}`")]
-    SendConnectRequest(#[from] tokio::sync::mpsc::error::SendError<LayerConnect>),
-
-    #[error("OutgoingTrafficRequest sender failed with `{0}`")]
-    SendOutgoingTrafficRequest(#[from] tokio::sync::mpsc::error::SendError<LayerTcpOutgoing>),
-
-    #[error("UdpOutgoingTrafficRequest sender failed with `{0}`")]
-    SendUdpOutgoingTrafficRequest(#[from] tokio::sync::mpsc::error::SendError<LayerUdpOutgoing>),
-
     #[error("UdpConnectRequest sender failed with `{0}`")]
-    SendUdpOutgoingTrafficResponse(#[from] tokio::sync::mpsc::error::SendError<DaemonUdpOutgoing>),
+    SendUdpOutgoingTrafficResponse(#[from] SendError<DaemonUdpOutgoing>),
 
     #[error("task::Join failed with `{0}`")]
     Join(#[from] tokio::task::JoinError),
 
-    #[error("time::Elapsed failed with `{0}`")]
-    Elapsed(#[from] tokio::time::error::Elapsed),
-
-    #[error("tonic::Transport failed with `{0}`")]
-    Transport(#[from] containerd_client::tonic::transport::Error),
-
-    #[error("tonic::Status failed with `{0}`")]
-    Status(#[from] containerd_client::tonic::Status),
-
-    #[error("NotFound failed with `{0}`")]
-    NotFound(String),
-
-    #[error("Serde failed with `{0}`")]
-    SerdeJson(#[from] serde_json::Error),
-
-    #[error("Errno failed with `{0}`")]
-    Errno(#[from] nix::errno::Errno),
+    #[error("Container runtime error: {0}")]
+    ContainerRuntimeError(#[from] runtime::ContainerRuntimeError),
 
     #[error("Path failed with `{0}`")]
     StripPrefixError(#[from] std::path::StripPrefixError),
-
-    #[error("Bollard failed with `{0}`")]
-    Bollard(#[from] bollard::errors::Error),
 
     #[error("IPTables failed with `{0}`")]
     IPTablesError(String),
@@ -83,37 +39,24 @@ pub(crate) enum AgentError {
     JoinTask,
 
     #[error("DNS request send failed with `{0}`")]
-    DnsRequestSendError(#[from] tokio::sync::mpsc::error::SendError<crate::dns::DnsCommand>),
+    DnsRequestSendError(#[from] SendError<crate::dns::DnsCommand>),
 
     #[error("DNS response receive failed with `{0}`")]
     DnsResponseReceiveError(#[from] tokio::sync::oneshot::error::RecvError),
 
-    #[error("Failed to fetch container info with `{0}`")]
-    MissingContainerInfo(String),
-
     #[error(r#"Failed to set socket flag PACKET_IGNORE_OUTGOING, this might be due to kernel version before 4.20.
     Original error `{0}`"#)]
     PacketIgnoreOutgoing(#[source] std::io::Error),
-
-    #[error("Reading request body failed with `{0}`")]
-    HttpRequestSerializationError(#[from] hyper::Error),
-
-    #[error("Failed to encode a an HTTP response with error: `{0}`")]
-    HttpEncoding(#[from] hyper::http::Error),
 
     #[error(
         r#"Couldn't send message to sniffer (mirror) api, sniffer probably not running. 
         Possible reason can be node kernel version before 4.20
         Check agent logs for errors and please report a bug if kernel version >=4.20"#
     )]
-    SnifferApiError,
+    SnifferNotRunning,
 
-    #[error(
-        r#"Couldn't find containerd socket to use, please open a bug report
-           providing information on how you installed k8s and if you know where
-           the containerd socket is"#
-    )]
-    ContainerdSocketNotFound,
+    #[error("Couldn't send message to stealer (steal) api, stealer probably not running.")]
+    StealerNotRunning,
 
     #[error("Background task `{task}` failed with `{cause}`")]
     BackgroundTaskFailed { task: &'static str, cause: String },
@@ -133,6 +76,9 @@ pub(crate) enum AgentError {
 
     #[error("Exhausted possible identifiers for incoming connections.")]
     ExhaustedConnectionId,
+
+    #[error("Timeout on accepting first client connection")]
+    FirstConnectionTimeout,
 }
 
 impl From<mpsc::error::SendError<StealerCommand>> for AgentError {

--- a/mirrord/agent/src/error.rs
+++ b/mirrord/agent/src/error.rs
@@ -2,7 +2,7 @@ use std::process::ExitStatus;
 
 use mirrord_protocol::{
     outgoing::{
-        tcp::{DaemonTcpOutgoing, LayerTcpOutgoing},
+        tcp::LayerTcpOutgoing,
         udp::{DaemonUdpOutgoing, LayerUdpOutgoing},
         LayerConnect,
     },
@@ -45,9 +45,6 @@ pub(crate) enum AgentError {
 
     #[error("UdpOutgoingTrafficRequest sender failed with `{0}`")]
     SendUdpOutgoingTrafficRequest(#[from] tokio::sync::mpsc::error::SendError<LayerUdpOutgoing>),
-
-    #[error("ConnectRequest sender failed with `{0}`")]
-    SendOutgoingTrafficResponse(#[from] tokio::sync::mpsc::error::SendError<DaemonTcpOutgoing>),
 
     #[error("UdpConnectRequest sender failed with `{0}`")]
     SendUdpOutgoingTrafficResponse(#[from] tokio::sync::mpsc::error::SendError<DaemonUdpOutgoing>),

--- a/mirrord/agent/src/file.rs
+++ b/mirrord/agent/src/file.rs
@@ -261,7 +261,7 @@ impl FileManager {
         let fd = self
             .fds_iter
             .next()
-            .ok_or_else(|| ResponseError::AllocationFailure("FileManager::open".to_string()))?;
+            .ok_or_else(|| ResponseError::IdsExhausted("open".to_string()))?;
 
         let metadata = file.metadata()?;
 
@@ -294,7 +294,7 @@ impl FileManager {
             let file = OpenOptions::from(open_options).open(&path)?;
 
             let fd = self.fds_iter.next().ok_or_else(|| {
-                ResponseError::AllocationFailure("FileManager::open_relative".to_string())
+                ResponseError::IdsExhausted("FileManager::open_relative".to_string())
             })?;
 
             let metadata = file.metadata()?;
@@ -637,9 +637,10 @@ impl FileManager {
             _ => Err(ResponseError::NotDirectory(fd)),
         }?;
 
-        let fd = self.fds_iter.next().ok_or_else(|| {
-            ResponseError::AllocationFailure("FileManager::fdopen_dir".to_string())
-        })?;
+        let fd = self
+            .fds_iter
+            .next()
+            .ok_or_else(|| ResponseError::IdsExhausted("fdopen_dir".to_string()))?;
 
         let dir_stream = path.read_dir()?.enumerate();
         self.dir_streams.insert(fd, dir_stream);

--- a/mirrord/agent/src/file.rs
+++ b/mirrord/agent/src/file.rs
@@ -4,6 +4,7 @@ use std::{
     fs::{read_link, DirEntry, File, OpenOptions, ReadDir},
     io::{self, prelude::*, BufReader, SeekFrom},
     iter::{Enumerate, Map, Peekable},
+    ops::RangeInclusive,
     os::unix::{fs::MetadataExt, prelude::FileExt},
     path::{Path, PathBuf},
     vec::IntoIter,
@@ -25,7 +26,7 @@ use mirrord_protocol::{
 };
 use tracing::{error, trace};
 
-use crate::{error::Result, util::IndexAllocator};
+use crate::error::Result;
 
 #[derive(Debug)]
 pub enum RemoteFile {
@@ -52,13 +53,25 @@ type GetDEnts64Stream = Peekable<
     >,
 >;
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub(crate) struct FileManager {
     root_path: PathBuf,
     open_files: HashMap<u64, RemoteFile>,
     dir_streams: HashMap<u64, Enumerate<ReadDir>>,
     getdents_streams: HashMap<u64, GetDEnts64Stream>,
-    index_allocator: IndexAllocator<u64, 100>,
+    fds_iter: RangeInclusive<u64>,
+}
+
+impl Default for FileManager {
+    fn default() -> Self {
+        Self {
+            root_path: Default::default(),
+            open_files: Default::default(),
+            dir_streams: Default::default(),
+            getdents_streams: Default::default(),
+            fds_iter: (0..=u64::MAX),
+        }
+    }
 }
 
 pub fn get_root_path_from_optional_pid(pid: Option<u64>) -> PathBuf {
@@ -246,8 +259,8 @@ impl FileManager {
         let file = OpenOptions::from(open_options).open(&path)?;
 
         let fd = self
-            .index_allocator
-            .next_index()
+            .fds_iter
+            .next()
             .ok_or_else(|| ResponseError::AllocationFailure("FileManager::open".to_string()))?;
 
         let metadata = file.metadata()?;
@@ -280,7 +293,7 @@ impl FileManager {
 
             let file = OpenOptions::from(open_options).open(&path)?;
 
-            let fd = self.index_allocator.next_index().ok_or_else(|| {
+            let fd = self.fds_iter.next().ok_or_else(|| {
                 ResponseError::AllocationFailure("FileManager::open_relative".to_string())
             })?;
 
@@ -501,8 +514,6 @@ impl FileManager {
 
         if self.open_files.remove(&fd).is_none() {
             error!("FileManager::close -> fd {:#?} not found", fd);
-        } else {
-            self.index_allocator.free_index(fd);
         }
     }
 
@@ -511,8 +522,6 @@ impl FileManager {
 
         if self.dir_streams.remove(&fd).is_none() && self.getdents_streams.remove(&fd).is_none() {
             error!("FileManager::close_dir -> fd {:#?} not found", fd);
-        } else {
-            self.index_allocator.free_index(fd);
         }
     }
 
@@ -628,7 +637,7 @@ impl FileManager {
             _ => Err(ResponseError::NotDirectory(fd)),
         }?;
 
-        let fd = self.index_allocator.next_index().ok_or_else(|| {
+        let fd = self.fds_iter.next().ok_or_else(|| {
             ResponseError::AllocationFailure("FileManager::fdopen_dir".to_string())
         })?;
 

--- a/mirrord/agent/src/outgoing.rs
+++ b/mirrord/agent/src/outgoing.rs
@@ -90,6 +90,7 @@ impl TcpOutgoingApi {
     }
 
     /// Receives a [`DaemonTcpOutgoing`] message from the background task.
+    #[tracing::instrument(level = Level::TRACE, skip(self), err)]
     pub(crate) async fn recv_from_task(&mut self) -> Result<DaemonTcpOutgoing> {
         match self.daemon_rx.recv().await {
             Some(msg) => Ok(msg),

--- a/mirrord/agent/src/outgoing/udp.rs
+++ b/mirrord/agent/src/outgoing/udp.rs
@@ -133,7 +133,7 @@ impl UdpOutgoingApi {
                                     .and_then(|mirror_socket| {
                                         let connection_id = connection_ids
                                             .next()
-                                            .ok_or_else(|| ResponseError::AllocationFailure("UdpOutgoing::connect".into()))?;
+                                            .ok_or_else(|| ResponseError::IdsExhausted("connect".into()))?;
 
                                         debug!("interceptor_task -> mirror_socket {:#?}", mirror_socket);
                                         let peer_address = mirror_socket.peer_addr()?;

--- a/mirrord/agent/src/runtime/crio.rs
+++ b/mirrord/agent/src/runtime/crio.rs
@@ -7,7 +7,7 @@ use tower::service_fn;
 use tracing::error;
 
 use super::ContainerRuntimeError;
-use crate::runtime::{error::Result, ContainerInfo, ContainerRuntime};
+use crate::runtime::{error::ContainerRuntimeResult, ContainerInfo, ContainerRuntime};
 
 static CRIO_DEFAULT_SOCK_PATH: &str = "/host/run/crio/crio.sock";
 
@@ -28,7 +28,7 @@ impl CriOContainer {
 }
 
 impl ContainerRuntime for CriOContainer {
-    async fn get_info(&self) -> Result<ContainerInfo> {
+    async fn get_info(&self) -> ContainerRuntimeResult<ContainerInfo> {
         let channel = Endpoint::try_from("http://localhost")
             .map_err(ContainerRuntimeError::crio)?
             .connect_with_connector(service_fn(move |_: Uri| {

--- a/mirrord/agent/src/runtime/crio.rs
+++ b/mirrord/agent/src/runtime/crio.rs
@@ -6,10 +6,8 @@ use tonic::transport::{Endpoint, Uri};
 use tower::service_fn;
 use tracing::error;
 
-use crate::{
-    error::{AgentError, Result},
-    runtime::{ContainerInfo, ContainerRuntime},
-};
+use super::ContainerRuntimeError;
+use crate::runtime::{error::Result, ContainerInfo, ContainerRuntime};
 
 static CRIO_DEFAULT_SOCK_PATH: &str = "/host/run/crio/crio.sock";
 
@@ -31,11 +29,13 @@ impl CriOContainer {
 
 impl ContainerRuntime for CriOContainer {
     async fn get_info(&self) -> Result<ContainerInfo> {
-        let channel = Endpoint::try_from("http://localhost")?
+        let channel = Endpoint::try_from("http://localhost")
+            .map_err(ContainerRuntimeError::crio)?
             .connect_with_connector(service_fn(move |_: Uri| {
                 UnixStream::connect(CRIO_DEFAULT_SOCK_PATH).inspect_err(|err| error!("{err:?}"))
             }))
-            .await?;
+            .await
+            .map_err(ContainerRuntimeError::crio)?;
 
         let mut client = RuntimeServiceClient::new(channel);
 
@@ -44,23 +44,23 @@ impl ContainerRuntime for CriOContainer {
                 container_id: self.container_id.clone(),
                 verbose: true,
             })
-            .await?
+            .await
+            .map_err(ContainerRuntimeError::crio)?
             .into_inner();
 
         // Not sure if the `.get("pid")` logic works as on OpenShift
         // we observed that the `pid` exists in the `info` field which is JSON encoded.
         // for now we're adding a fallback
         let pid: u64 = match status.info.get("pid") {
-            Some(val) => val.parse().map_err(|err| {
-                AgentError::MissingContainerInfo(format!("Failed to parse pid: {err:?}"))
+            Some(val) => val.parse().map_err(|_| {
+                ContainerRuntimeError::crio("failed to parse pid from the runtime response")
             })?,
             None => {
                 let info_json = status.info.get("info").ok_or_else(|| {
-                    AgentError::MissingContainerInfo("no info found in status".into())
+                    ContainerRuntimeError::crio("info not found in the runtime response status")
                 })?;
-                let info: ContainerStatus = serde_json::from_str(info_json).map_err(|err| {
-                    AgentError::MissingContainerInfo(format!("Failed to parse pid: {err:?}"))
-                })?;
+                let info: ContainerStatus =
+                    serde_json::from_str(info_json).map_err(ContainerRuntimeError::crio)?;
                 info.pid
             }
         };

--- a/mirrord/agent/src/runtime/error.rs
+++ b/mirrord/agent/src/runtime/error.rs
@@ -36,4 +36,4 @@ impl ContainerRuntimeError {
     }
 }
 
-pub(crate) type Result<T, E = ContainerRuntimeError> = core::result::Result<T, E>;
+pub(crate) type ContainerRuntimeResult<T, E = ContainerRuntimeError> = core::result::Result<T, E>;

--- a/mirrord/agent/src/runtime/error.rs
+++ b/mirrord/agent/src/runtime/error.rs
@@ -1,0 +1,39 @@
+use thiserror::Error;
+
+/// Errors that can occur when fetching target container info.
+#[derive(Error, Debug)]
+pub(crate) enum ContainerRuntimeError {
+    #[error("failed to get target container info: {} [{}]", .error, .runtime)]
+    GetInfoError { runtime: String, error: String },
+    #[error("unknown container runtime `{0}`")]
+    UnknownRuntimeName(String),
+}
+
+impl ContainerRuntimeError {
+    pub(crate) fn crio<E: ToString>(error: E) -> Self {
+        Self::GetInfoError {
+            runtime: "cri-o".into(),
+            error: error.to_string(),
+        }
+    }
+
+    pub(crate) fn docker<E: ToString>(error: E) -> Self {
+        Self::GetInfoError {
+            runtime: "docker".into(),
+            error: error.to_string(),
+        }
+    }
+
+    pub(crate) fn containerd<E: ToString>(error: E) -> Self {
+        Self::GetInfoError {
+            runtime: "containerd".into(),
+            error: error.to_string(),
+        }
+    }
+
+    pub(crate) fn unknown_runtime<N: ToString>(name: N) -> Self {
+        Self::UnknownRuntimeName(name.to_string())
+    }
+}
+
+pub(crate) type Result<T, E = ContainerRuntimeError> = core::result::Result<T, E>;

--- a/mirrord/agent/src/steal.rs
+++ b/mirrord/agent/src/steal.rs
@@ -37,11 +37,6 @@ enum Command {
     /// The agent stops stealing traffic from this [`Port`].
     PortUnsubscribe(Port),
 
-    /// Part of the [`Drop`] implementation of [`TcpStealerApi`].
-    ///
-    /// Closes a layer connection, and unsubscribes its ports.
-    ClientClose,
-
     /// Unsubscribes the layer from the connection.
     ///
     /// The agent stops sending incoming traffic.

--- a/mirrord/layer/src/error.rs
+++ b/mirrord/layer/src/error.rs
@@ -242,7 +242,7 @@ impl From<HookError> for i64 {
             HookError::LockError => libc::EINVAL,
             HookError::BincodeEncode(_) => libc::EINVAL,
             HookError::ResponseError(response_fail) => match response_fail {
-                ResponseError::AllocationFailure(_) => libc::ENOMEM,
+                ResponseError::IdsExhausted(_) => libc::ENOMEM,
                 ResponseError::NotFound(_) => libc::ENOENT,
                 ResponseError::NotDirectory(_) => libc::ENOTDIR,
                 ResponseError::NotFile(_) => libc::EISDIR,

--- a/mirrord/protocol/Cargo.toml
+++ b/mirrord/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mirrord-protocol"
-version = "1.8.2"
+version = "1.8.3"
 authors.workspace = true
 description.workspace = true
 documentation.workspace = true

--- a/mirrord/protocol/src/error.rs
+++ b/mirrord/protocol/src/error.rs
@@ -29,8 +29,8 @@ pub struct MeshVendorParseError(pub String);
 
 #[derive(Encode, Decode, Debug, PartialEq, Clone, Eq, Error)]
 pub enum ResponseError {
-    #[error("Index allocator is full, operation `{0}` failed!")]
-    AllocationFailure(String),
+    #[error("File/connection ids exhausted, operation `{0}` failed!")]
+    IdsExhausted(String),
 
     #[error("Failed to find resource `{0}`!")]
     NotFound(u64),


### PR DESCRIPTION
Some minor improvements to agent code:
1. `TcpStealerApi` no longer need to hold a shared channel permit to close session with the background task
2. Removed last uses `IndexAllocator`
3. Added some more logs to outgoing task
4. Improved agent errors