### PR TITLE
Removed all operator-managed resources from mirrord ls output

### DIFF
--- a/changelog.d/+mirrord-ls.fixed.md
+++ b/changelog.d/+mirrord-ls.fixed.md
@@ -1,0 +1,1 @@
+Fixed a bug where `mirrord ls` output would include a list of copied pods (mfT) in case of connectivity issues with the operator.

--- a/mirrord/cli/src/kube_resource.rs
+++ b/mirrord/cli/src/kube_resource.rs
@@ -103,7 +103,7 @@ impl KubeResourceSeeker<'_> {
         // Set up filters on the K8s resources returned - in this case, excluding the agent
         // resources and then applying any provided field-based filter conditions.
         let params = ListParams {
-            label_selector: Some("app!=mirrord".to_string()),
+            label_selector: Some("app!=mirrord,!operator.metalbear.co/type".to_string()),
             field_selector: field_selector.map(ToString::to_string),
             ..Default::default()
         };


### PR DESCRIPTION
Relevant for https://github.com/metalbear-co/operator/issues/635

Regardless of the linked operator issue, nice to have due to following scenario:
1. Operator is installed in the cluster
2. User runs `mirrord ls` without explicitly enabling the operator
3. For some reason we fail to list targets using the operator
4. We fall back to manual listing
5. We end up showing copied pods