### PR TITLE
Rejecting empty composite HTTP filters

### DIFF
--- a/changelog.d/+rejecting-empty-http-filters.internal.md
+++ b/changelog.d/+rejecting-empty-http-filters.internal.md
@@ -1,0 +1,1 @@
+Rejecting empty composite HTTP filters during config validation.

--- a/mirrord-schema.json
+++ b/mirrord-schema.json
@@ -989,7 +989,7 @@
       "properties": {
         "all_of": {
           "title": "feature.network.incoming.http_filter.all_of {#feature-network-incoming-http_filter-all_of}",
-          "description": "Messages must match all of the specified filters.",
+          "description": "Messages must match all of the specified filters. Cannot be empty an empty list.",
           "type": [
             "array",
             "null"
@@ -1000,7 +1000,7 @@
         },
         "any_of": {
           "title": "feature.network.incoming.http_filter.any_of {#feature-network-incoming-http_filter-any_of}",
-          "description": "Messages must match any of the specified filters.",
+          "description": "Messages must match any of the specified filters. Cannot be empty an empty list.",
           "type": [
             "array",
             "null"

--- a/mirrord/config/configuration.md
+++ b/mirrord/config/configuration.md
@@ -1000,10 +1000,12 @@ Setting this filter will make mirrord only steal requests to URIs that do not st
 #### feature.network.incoming.http_filter.all_of {#feature-network-incoming-http_filter-all_of}
 
 Messages must match all of the specified filters.
+Cannot be empty an empty list.
 
 #### feature.network.incoming.http_filter.any_of {#feature-network-incoming-http_filter-any_of}
 
 Messages must match any of the specified filters.
+Cannot be empty an empty list.
 
 ##### feature.network.incoming.http_filter.header_filter {#feature-network-incoming-http-header-filter}
 

--- a/mirrord/config/src/feature/network/incoming/http_filter.rs
+++ b/mirrord/config/src/feature/network/incoming/http_filter.rs
@@ -84,11 +84,13 @@ pub struct HttpFilterConfig {
     /// #### feature.network.incoming.http_filter.all_of {#feature-network-incoming-http_filter-all_of}
     ///
     /// Messages must match all of the specified filters.
+    /// Cannot be empty an empty list.
     pub all_of: Option<Vec<InnerFilter>>,
 
     /// #### feature.network.incoming.http_filter.any_of {#feature-network-incoming-http_filter-any_of}
     ///
     /// Messages must match any of the specified filters.
+    /// Cannot be empty an empty list.
     pub any_of: Option<Vec<InnerFilter>>,
 
     /// ##### feature.network.incoming.http_filter.ports {#feature-network-incoming-http_filter-ports}

--- a/mirrord/config/src/lib.rs
+++ b/mirrord/config/src/lib.rs
@@ -383,6 +383,16 @@ impl LayerConfig {
             ))?
         }
 
+        if [http_filter.all_of.as_ref(), http_filter.any_of.as_ref()]
+            .into_iter()
+            .flatten()
+            .any(Vec::is_empty)
+        {
+            Err(ConfigError::Conflict(
+                "Composite HTTP filter cannot be empty".to_string(),
+            ))?;
+        }
+
         if !self.feature.network.incoming.ignore_ports.is_empty()
             && self.feature.network.incoming.ports.is_some()
         {


### PR DESCRIPTION
If we get an empty list of filters, it's probably by user's mistake and the filter doesn't do anything useful (accepts/rejects all messages)