### PR TITLE
Rename CRD fields to camelCase

### DIFF
--- a/changelog.d/+sqs-crd-case.changed.md
+++ b/changelog.d/+sqs-crd-case.changed.md
@@ -1,0 +1,1 @@
+SQS CRD field names changed to camelCase.

--- a/mirrord/operator/src/crd.rs
+++ b/mirrord/operator/src/crd.rs
@@ -381,6 +381,7 @@ pub enum SplitQueue {
 
 /// A workload that is a consumer of a queue that is being split.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")] // workload_type -> workloadType
 pub struct QueueConsumer {
     pub name: String,
     /// If a container is not specified, the workload queue registry will apply to every run that
@@ -440,6 +441,7 @@ impl Display for QueueConsumer {
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")] // original_name -> originalName
 pub struct QueueNameUpdate {
     pub original_name: String,
     pub output_name: String,
@@ -452,6 +454,7 @@ pub struct QueueNameUpdate {
 // controller's code a bit simpler.
 // Some information is present in the spec, but it is organized differently.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")] // workload_type -> workloadType
 pub struct ActiveSqsSplits {
     /// For each queue_id, the actual queue name as retrieved from the target's pod spec or config
     /// map, together with the name of its temporary output queue.
@@ -474,7 +477,7 @@ impl ActiveSqsSplits {
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, JsonSchema)]
-#[serde(rename_all = "camelCase")] // active_filters -> activeFilters
+#[serde(rename_all = "camelCase")] // sqs_details -> sqsDetails
 pub struct WorkloadQueueRegistryStatus {
     /// Optional even though it's currently the only field, because in the future there will be
     /// fields for other queue types.


### PR DESCRIPTION
I missed some CRD fields and forgot to `serde(rename)` them.
Everything works as is, but these field names are not in the correct case according to k8s conventions.
One of those fields is user-facing - `spec.consumer.workload_type` in `MirrordWorkloadQueueRegistry` should be `workloadType`.
This change is breaking, but I think almost nobody installed those CRDs yet, also, the feature is marked unstable. We would need to make the same change in the helm chart too, and release an operator.

Since this is a matter of conventions, we could also avoid breaking compatibility and leave everything as is, but I would rather fix it.