### PR TITLE
Fix homebrew shasum

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -312,11 +312,12 @@ jobs:
           path: /tmp/artifacts
       - uses: actions/checkout@v4
       - name: Get release version and hashes
+        shell: bash # for -o pipefail, see https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
         run: |
           echo "version=$(grep -m 1 version Cargo.toml | cut -d' ' -f3 | tr -d '\"' | cut -d'-' -f1)" >> $GITHUB_ENV
-          echo "sha256_mac=$(cat /tmp/artifacts/shasum/universal-apple-darwin/mirrord_mac_universal.shasum256 | awk '{ print $1 }')" >> $GITHUB_ENV
-          echo "sha256_linux_aarch64=$(cat /tmp/artifacts/shasum/aarch64-unknown-linux-gnu/mirrord_linux_aarch64.shasum256 | awk '{ print $1 }')" >> $GITHUB_ENV
-          echo "sha256_linux_x86_64=$(cat /tmp/artifacts/shasum/x86_64-unknown-linux-gnu/mirrord_linux_x86_64.shasum256 | awk '{ print $1 }')" >> $GITHUB_ENV
+          echo "sha256_mac=$(cat /tmp/artifacts/universal-apple-darwin/mirrord_mac_universal.shasum256 | awk '{ print $1 }')" >> $GITHUB_ENV
+          echo "sha256_linux_aarch64=$(cat /tmp/artifacts/aarch64-unknown-linux-gnu/mirrord_linux_aarch64.shasum256 | awk '{ print $1 }')" >> $GITHUB_ENV
+          echo "sha256_linux_x86_64=$(cat /tmp/artifacts/x86_64-unknown-linux-gnu/mirrord_linux_x86_64.shasum256 | awk '{ print $1 }')" >> $GITHUB_ENV
       - name: Checkout into homebrew-mirrord
         uses: actions/checkout@v4
         with:

--- a/changelog.d/homebrew-shasum-ci.fixed.md
+++ b/changelog.d/homebrew-shasum-ci.fixed.md
@@ -1,0 +1,1 @@
+Fixed upload of mirrord binaries' shasums to homebrew repository in the release action.


### PR DESCRIPTION
https://github.com/metalbear-co/mirrord/pull/2655 changed the download artifact step to only download `shasum` artifact. This effectively changed destination path (no `shasum` parent dir, files are extracted to straight to `/tmp/artifacts`)