### PR TITLE
Do not sort targets from mirrord ls based on string values, instead let the iterator chain handle it.

### DIFF
--- a/mirrord/cli/src/main.rs
+++ b/mirrord/cli/src/main.rs
@@ -444,10 +444,9 @@ async fn print_targets(args: &ListTargetArgs) -> Result<()> {
         remove_proxy_env();
     }
 
-    let mut targets = list_targets(&layer_config, args).await?;
-
-    targets.sort();
-
+    // The targets come sorted in the following order:
+    // `pods - deployments - rollouts - jobs - cronjobs - statefulsets`
+    let targets = list_targets(&layer_config, args).await?;
     let json_obj = json!(targets);
     println!("{json_obj}");
     Ok(())


### PR DESCRIPTION
- Issue: https://github.com/metalbear-co/mirrord-vscode/issues/147

Remove a string sort that we had in the targets, when running `mirrord ls`. We have a neat chain of iterators that sorts the targets by type, starting with `pods`, which is nicer than alphabetical ordering.