### PR TITLE
Make readlink stable (enabled by default) now, with the protocol part gated on version support.

### DIFF
--- a/changelog.d/2518.changed.md
+++ b/changelog.d/2518.changed.md
@@ -1,0 +1,1 @@
+Enable readlink hook by default.

--- a/mirrord/agent/src/file.rs
+++ b/mirrord/agent/src/file.rs
@@ -412,7 +412,7 @@ impl FileManager {
     }
 
     /// Handles our `readlink_detour` with [`std::fs::read_link`].
-    #[tracing::instrument(level = "trace", skip_all)]
+    #[tracing::instrument(level = Level::TRACE, skip_all, err(level = Level::ERROR))]
     pub(crate) fn read_link(&mut self, path: PathBuf) -> RemoteResult<ReadLinkFileResponse> {
         let path = path
             .strip_prefix("/")

--- a/mirrord/agent/src/file.rs
+++ b/mirrord/agent/src/file.rs
@@ -412,7 +412,7 @@ impl FileManager {
     }
 
     /// Handles our `readlink_detour` with [`std::fs::read_link`].
-    #[tracing::instrument(level = Level::TRACE, skip_all, err(level = Level::ERROR))]
+    #[tracing::instrument(level = Level::TRACE, skip_all)]
     pub(crate) fn read_link(&mut self, path: PathBuf) -> RemoteResult<ReadLinkFileResponse> {
         let path = path
             .strip_prefix("/")

--- a/mirrord/config/src/lib.rs
+++ b/mirrord/config/src/lib.rs
@@ -526,7 +526,7 @@ impl LayerConfig {
 
         if self.experimental.readlink {
             context.add_warning(
-                "experimenta.readlink config has been deprecated, and `readlink` is now\
+                "experimental.readlink config has been deprecated, and `readlink` is now\
                     enabled by default! You may remove it from your config."
                     .into(),
             );

--- a/mirrord/config/src/lib.rs
+++ b/mirrord/config/src/lib.rs
@@ -524,6 +524,14 @@ impl LayerConfig {
         self.feature.network.dns.verify(context)?;
         self.feature.network.outgoing.verify(context)?;
 
+        if self.experimental.readlink {
+            context.add_warning(
+                "experimenta.readlink config has been deprecated, and `readlink` is now\
+                    enabled by default! You may remove it from your config."
+                    .into(),
+            );
+        }
+
         Ok(())
     }
 }

--- a/mirrord/layer/src/detour.rs
+++ b/mirrord/layer/src/detour.rs
@@ -209,6 +209,12 @@ pub(crate) enum Bypass {
 
     /// DNS query should be done locally.
     LocalDns,
+
+    /// Operation is not implemented, but it should not be a hard error.
+    ///
+    /// Useful for operations that are version gated, and we want to bypass when the protocol
+    /// doesn't support them.
+    NotImplemented,
 }
 
 impl Bypass {

--- a/mirrord/layer/tests/common/mod.rs
+++ b/mirrord/layer/tests/common/mod.rs
@@ -741,7 +741,6 @@ pub enum Application {
     RustRecvFrom,
     RustListenPorts,
     Fork,
-    /// `mirrord/layer/tests/apps/readlink/readlink.c`
     ReadLink,
     OpenFile,
     CIssue2055,

--- a/mirrord/layer/tests/common/mod.rs
+++ b/mirrord/layer/tests/common/mod.rs
@@ -741,6 +741,7 @@ pub enum Application {
     RustRecvFrom,
     RustListenPorts,
     Fork,
+    /// `mirrord/layer/tests/apps/readlink/readlink.c`
     ReadLink,
     OpenFile,
     CIssue2055,

--- a/mirrord/layer/tests/configs/readlink.json
+++ b/mirrord/layer/tests/configs/readlink.json
@@ -1,5 +1,0 @@
-{
-    "experimental": {
-        "readlink": true
-    }
-}

--- a/mirrord/layer/tests/readlink.rs
+++ b/mirrord/layer/tests/readlink.rs
@@ -10,22 +10,11 @@ pub use common::*;
 #[rstest]
 #[tokio::test]
 #[timeout(Duration::from_secs(60))]
-async fn readlink(
-    #[values(Some("readlink.json"))] with_config: Option<&str>,
-    dylib_path: &Path,
-    config_dir: &Path,
-) {
+async fn readlink(dylib_path: &Path) {
     let application = Application::ReadLink;
 
-    let config = with_config.map(|config| {
-        let mut config_path = config_dir.to_path_buf();
-        config_path.push(config);
-        config_path
-    });
-    let config = config.as_ref().map(|path_buf| path_buf.to_str().unwrap());
-
     let (mut test_process, mut intproxy) = application
-        .start_process_with_layer(dylib_path, Default::default(), config)
+        .start_process_with_layer(dylib_path, Default::default(), None)
         .await;
 
     println!("waiting for file request.");


### PR DESCRIPTION
- Issue: #2518