### PR TITLE
Add .log as a file type for the default intproxy logs.

### DIFF
--- a/changelog.d/2750.changed.md
+++ b/changelog.d/2750.changed.md
@@ -1,0 +1,1 @@
+Adds .log as a file type for intproxy default log file.

--- a/mirrord/cli/src/internal_proxy.rs
+++ b/mirrord/cli/src/internal_proxy.rs
@@ -69,7 +69,9 @@ pub(crate) async fn proxy(watch: drain::Watch) -> Result<(), InternalProxyError>
                 .collect();
             let timestamp = SystemTime::UNIX_EPOCH.elapsed().unwrap().as_secs();
 
-            PathBuf::from(format!("/tmp/mirrord-intproxy-{timestamp}-{random_name}"))
+            PathBuf::from(format!(
+                "/tmp/mirrord-intproxy-{timestamp}-{random_name}.log"
+            ))
         });
 
     let output_file = OpenOptions::new()


### PR DESCRIPTION
- Issue: #2750 

Without a file type, it's very annoying to upload it :sweat: 