### PR TITLE
internal proxy now explicitly logs exit errors

### DIFF
--- a/changelog.d/+add-exit-error.added.md
+++ b/changelog.d/+add-exit-error.added.md
@@ -1,0 +1,1 @@
+internal proxy now logs exit error explicitly

--- a/mirrord/cli/src/internal_proxy.rs
+++ b/mirrord/cli/src/internal_proxy.rs
@@ -145,6 +145,9 @@ pub(crate) async fn proxy(watch: drain::Watch) -> Result<(), InternalProxyError>
         .run(first_connection_timeout, consecutive_connection_timeout)
         .await
         .map_err(InternalProxyError::from)
+        .inspect_err(|e| {
+            tracing::error!("internal proxy exiting: {e:?}");
+        })
 }
 
 /// Creates a connection with the agent and handles one round of ping pong.

--- a/mirrord/cli/src/internal_proxy.rs
+++ b/mirrord/cli/src/internal_proxy.rs
@@ -145,8 +145,8 @@ pub(crate) async fn proxy(watch: drain::Watch) -> Result<(), InternalProxyError>
         .run(first_connection_timeout, consecutive_connection_timeout)
         .await
         .map_err(InternalProxyError::from)
-        .inspect_err(|e| {
-            tracing::error!("internal proxy exiting: {e:?}");
+        .inspect_err(|error| {
+            tracing::error!(%error, "Internal proxy encountered an error, exiting");
         })
 }
 


### PR DESCRIPTION
This error https://github.com/metalbear-co/mirrord/issues/2788
could've been diagnosed easily given it was marked as an error, and logged by default by the new settings.