### PR TITLE
update deps to not use tonic 0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1549,7 +1549,7 @@ checksum = "7782af8f90fe69a4bb41e460abe1727d493403d8b2cc43201a3a3e906b24379f"
 [[package]]
 name = "containerd-client"
 version = "0.5.0"
-source = "git+https://github.com/metalbear-co/rust-extensions.git?branch=update-tonic#af86309813b5ba0e64f7edefa390fcac1d7c0981"
+source = "git+https://github.com/containerd/rust-extensions.git#3f541b9454f2be062dcd2a5605b87633662ff300"
 dependencies = [
  "hyper-util",
  "prost",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -903,40 +903,12 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.6.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
-dependencies = [
- "async-trait",
- "axum-core 0.3.4",
- "bitflags 1.3.2",
- "bytes",
- "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.30",
- "itoa",
- "matchit",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rustversion",
- "serde",
- "sync_wrapper 0.1.2",
- "tower 0.4.13",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f43644eed690f5374f1af436ecd6aea01cd201f6fbdf0178adaf6907afb2cec"
 dependencies = [
  "async-trait",
- "axum-core 0.4.4",
+ "axum-core",
  "base64 0.21.7",
  "bytes",
  "futures-util",
@@ -964,23 +936,6 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "mime",
- "rustversion",
- "tower-layer",
- "tower-service",
 ]
 
 [[package]]
@@ -1594,10 +1549,11 @@ checksum = "7782af8f90fe69a4bb41e460abe1727d493403d8b2cc43201a3a3e906b24379f"
 [[package]]
 name = "containerd-client"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a39c07fb941da8bb545667ce3669b2a6f560d825ff957c50eda7494eeccdd88"
+source = "git+https://github.com/metalbear-co/rust-extensions.git?branch=update-tonic#af86309813b5ba0e64f7edefa390fcac1d7c0981"
 dependencies = [
+ "hyper-util",
  "prost",
+ "prost-build",
  "prost-types",
  "tokio",
  "tonic",
@@ -3098,18 +3054,6 @@ dependencies = [
 
 [[package]]
 name = "hyper-timeout"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
-dependencies = [
- "hyper 0.14.30",
- "pin-project-lite",
- "tokio",
- "tokio-io-timeout",
-]
-
-[[package]]
-name = "hyper-timeout"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3203a961e5c83b6f5498933e78b6b263e208c197b63e9c6c53cc82ffd3f63793"
@@ -3474,9 +3418,9 @@ checksum = "17ab85f84ca42c5ec520e6f3c9966ba1fd62909ce260f8837e248857d2560509"
 
 [[package]]
 name = "k8s-cri"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "311a0cbfd7f4d0a7d2b67ee8665fca40fbe59143c681f5b66e9479885df8854a"
+checksum = "7bfc95bdd8656db93c9333625f5bc8d7c30febff31dc5f8ee9f6f5a8f5a068fc"
 dependencies = [
  "prost",
  "serde",
@@ -3551,7 +3495,7 @@ dependencies = [
  "hyper-http-proxy",
  "hyper-rustls 0.27.2",
  "hyper-socks2",
- "hyper-timeout 0.5.1",
+ "hyper-timeout",
  "hyper-util",
  "jsonpath-rust",
  "k8s-openapi",
@@ -5239,9 +5183,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.12.6"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
+checksum = "7b0487d90e047de87f984913713b85c601c05609aad5b0df4b4573fbf69aa13f"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -5249,9 +5193,9 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.12.6"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
+checksum = "0c1318b19085f08681016926435853bbf7858f9c082d0999b80550ff5d9abe15"
 dependencies = [
  "bytes",
  "heck 0.5.0",
@@ -5270,9 +5214,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.12.6"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
+checksum = "e9552f850d5f0964a4e4d0bf306459ac29323ddfbae05e35a7c0d35cb0803cc5"
 dependencies = [
  "anyhow",
  "itertools",
@@ -5283,9 +5227,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.12.6"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
+checksum = "4759aa0d3a6232fb8dbdb97b61de2c20047c68aca932c7ed76da9d788508d670"
 dependencies = [
  "prost",
 ]
@@ -5751,7 +5695,7 @@ dependencies = [
 name = "rust-websockets"
 version = "0.1.0"
 dependencies = [
- "axum 0.7.6",
+ "axum",
  "tokio",
 ]
 
@@ -6822,16 +6766,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-io-timeout"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
-dependencies = [
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
 name = "tokio-macros"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6969,23 +6903,26 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.11.0"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76c4eb7a4e9ef9d4763600161f12f5070b92a578e1b634db88a6887844c91a13"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
 dependencies = [
  "async-stream",
  "async-trait",
- "axum 0.6.20",
- "base64 0.21.7",
+ "axum",
+ "base64 0.22.1",
  "bytes",
- "h2 0.3.26",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.30",
- "hyper-timeout 0.4.1",
+ "h2 0.4.6",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyper-timeout",
+ "hyper-util",
  "percent-encoding",
  "pin-project",
  "prost",
+ "socket2",
  "tokio",
  "tokio-stream",
  "tower 0.4.13",
@@ -6996,13 +6933,14 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.11.0"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4ef6dd70a610078cb4e338a0f79d06bc759ff1b22d2120c2ff02ae264ba9c2"
+checksum = "9557ce109ea773b399c9b9e5dca39294110b74f1f342cb347a80d1fce8c26a11"
 dependencies = [
  "prettyplease",
  "proc-macro2",
  "prost-build",
+ "prost-types",
  "quote",
  "syn 2.0.77",
 ]
@@ -7640,7 +7578,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,4 +122,5 @@ strip = "debuginfo"
 lto = false
 
 [patch.crates-io]
+# Don't use tonic 0.11!
 containerd-client = { git = "https://github.com/containerd/rust-extensions.git", package = "containerd-client" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,3 +120,6 @@ private_intra_doc_links = "allow"
 strip = "debuginfo"
 # Enabling LTO causes this issue https://github.com/metalbear-co/mirrord/issues/906
 lto = false
+
+[patch.crates-io]
+containerd-client = { git = "https://github.com/containerd/rust-extensions.git", package = "containerd-client" }

--- a/changelog.d/+update-tonic-deps.changed.md
+++ b/changelog.d/+update-tonic-deps.changed.md
@@ -1,0 +1,1 @@
+Dependency tree does not contain tonic 0.11.

--- a/mirrord/agent/Cargo.toml
+++ b/mirrord/agent/Cargo.toml
@@ -20,7 +20,7 @@ workspace = true
 
 [dependencies]
 # Don't use tonic 0.11!
-containerd-client = { git = "https://github.com/metalbear-co/rust-extensions.git", package = "containerd-client", branch = "update-tonic" }
+containerd-client = "0.5"
 tokio = { workspace = true, features = [
     "rt",
     "net",

--- a/mirrord/agent/Cargo.toml
+++ b/mirrord/agent/Cargo.toml
@@ -19,7 +19,8 @@ workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-containerd-client = "0.5"
+# Don't use tonic 0.11!
+containerd-client = { git = "https://github.com/metalbear-co/rust-extensions.git", package = "containerd-client", branch = "update-tonic" }
 tokio = { workspace = true, features = [
     "rt",
     "net",
@@ -61,10 +62,10 @@ fancy-regex = { workspace = true }
 dashmap = { version = "5" }
 oci-spec = "0.6.0"
 async-trait = "0.1"
-tonic = "0.11"
+tonic = "0.12"
 tower = "0.4"
 http = "1"
-k8s-cri = "0.8"
+k8s-cri = "0.9"
 semver.workspace = true
 tokio-rustls = "0.26"
 x509-parser = "0.16"

--- a/mirrord/agent/Cargo.toml
+++ b/mirrord/agent/Cargo.toml
@@ -19,7 +19,7 @@ workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-# Don't use tonic 0.11!
+# Don't use tonic 0.11! (patched in main Cargo.toml)
 containerd-client = "0.5"
 tokio = { workspace = true, features = [
     "rt",

--- a/mirrord/agent/src/runtime.rs
+++ b/mirrord/agent/src/runtime.rs
@@ -151,7 +151,9 @@ async fn connect(path: impl AsRef<std::path::Path>) -> ContainerRuntimeResult<Ch
 
     Endpoint::try_from("http://localhost")
         .map_err(ContainerRuntimeError::containerd)?
-        .connect_with_connector(service_fn(move |_: Uri| UnixStream::connect(path.clone())))
+        .connect_with_connector(service_fn(move |_: Uri| {
+            UnixStream::connect(path.clone()).map(hyper_util::rt::TokioIo::new)
+        }))
         .await
         .map_err(ContainerRuntimeError::containerd)
 }

--- a/mirrord/agent/src/runtime.rs
+++ b/mirrord/agent/src/runtime.rs
@@ -152,9 +152,11 @@ async fn connect(path: impl AsRef<std::path::Path>) -> ContainerRuntimeResult<Ch
 
     Endpoint::try_from("http://localhost")
         .map_err(ContainerRuntimeError::containerd)?
-        .connect_with_connector(hyper_util::rt::TokioIo::new(service_fn(move |_: Uri| {
-            UnixStream::connect(path.clone())
-        })))
+        .connect_with_connector(service_fn(move |_: Uri| {
+            Ok::<_, std::io::Error>(hyper_util::rt::TokioIo::new(
+                UnixStream::connect(path.clone()).await?,
+            ))
+        }))
         .await
         .map_err(ContainerRuntimeError::containerd)
 }

--- a/mirrord/agent/src/runtime.rs
+++ b/mirrord/agent/src/runtime.rs
@@ -10,6 +10,7 @@ use containerd_client::{
     with_namespace,
 };
 use enum_dispatch::enum_dispatch;
+use futures::FutureExt;
 use oci_spec::runtime::Spec;
 use tokio::net::UnixStream;
 use tonic::transport::{Endpoint, Uri};

--- a/mirrord/agent/src/runtime.rs
+++ b/mirrord/agent/src/runtime.rs
@@ -152,9 +152,9 @@ async fn connect(path: impl AsRef<std::path::Path>) -> ContainerRuntimeResult<Ch
 
     Endpoint::try_from("http://localhost")
         .map_err(ContainerRuntimeError::containerd)?
-        .connect_with_connector(service_fn(move |_: Uri| {
-            UnixStream::connect(path.clone()).map(hyper_util::rt::TokioIo::new)
-        }))
+        .connect_with_connector(hyper_util::rt::TokioIo::new(service_fn(move |_: Uri| {
+            UnixStream::connect(path.clone())
+        })))
         .await
         .map_err(ContainerRuntimeError::containerd)
 }

--- a/mirrord/agent/src/runtime/crio.rs
+++ b/mirrord/agent/src/runtime/crio.rs
@@ -1,4 +1,4 @@
-use futures::FutureExt;
+use futures::TryFutureExt;
 use k8s_cri::v1::{runtime_service_client::RuntimeServiceClient, ContainerStatusRequest};
 use serde::Deserialize;
 use tokio::net::UnixStream;
@@ -31,11 +31,9 @@ impl ContainerRuntime for CriOContainer {
     async fn get_info(&self) -> ContainerRuntimeResult<ContainerInfo> {
         let channel = Endpoint::try_from("http://localhost")
             .map_err(ContainerRuntimeError::crio)?
-            .connect_with_connector(service_fn(move |_: Uri| {
-                UnixStream::connect(CRIO_DEFAULT_SOCK_PATH)
-                    .map(hyper_util::rt::TokioIo::new)
-                    .inspect_err(|err| error!("{err:?}"))
-            }))
+            .connect_with_connector(hyper_util::rt::TokioIo::new(service_fn(move |_: Uri| {
+                UnixStream::connect(CRIO_DEFAULT_SOCK_PATH).inspect_err(|err| error!("{err:?}"))
+            })))
             .await
             .map_err(ContainerRuntimeError::crio)?;
 

--- a/mirrord/agent/src/runtime/crio.rs
+++ b/mirrord/agent/src/runtime/crio.rs
@@ -31,9 +31,12 @@ impl ContainerRuntime for CriOContainer {
     async fn get_info(&self) -> ContainerRuntimeResult<ContainerInfo> {
         let channel = Endpoint::try_from("http://localhost")
             .map_err(ContainerRuntimeError::crio)?
-            .connect_with_connector(hyper_util::rt::TokioIo::new(service_fn(move |_: Uri| {
-                UnixStream::connect(CRIO_DEFAULT_SOCK_PATH).inspect_err(|err| error!("{err:?}"))
-            })))
+            .connect_with_connector(service_fn(move |_: Uri| {
+                Ok::<_, std::io::Error>(hyper_util::rt::TokioIo::new(
+                    UnixStream::connect(CRIO_DEFAULT_SOCK_PATH).await?,
+                ))
+                .inspect_err(|err| error!("{err:?}"))
+            }))
             .await
             .map_err(ContainerRuntimeError::crio)?;
 

--- a/mirrord/agent/src/runtime/crio.rs
+++ b/mirrord/agent/src/runtime/crio.rs
@@ -1,4 +1,4 @@
-use futures::{FutureExt, TryFutureExt};
+use futures::FutureExt;
 use k8s_cri::v1::{runtime_service_client::RuntimeServiceClient, ContainerStatusRequest};
 use serde::Deserialize;
 use tokio::net::UnixStream;

--- a/mirrord/agent/src/runtime/crio.rs
+++ b/mirrord/agent/src/runtime/crio.rs
@@ -1,4 +1,3 @@
-use futures::TryFutureExt;
 use k8s_cri::v1::{runtime_service_client::RuntimeServiceClient, ContainerStatusRequest};
 use serde::Deserialize;
 use tokio::net::UnixStream;
@@ -31,11 +30,12 @@ impl ContainerRuntime for CriOContainer {
     async fn get_info(&self) -> ContainerRuntimeResult<ContainerInfo> {
         let channel = Endpoint::try_from("http://localhost")
             .map_err(ContainerRuntimeError::crio)?
-            .connect_with_connector(service_fn(move |_: Uri| {
+            .connect_with_connector(service_fn(move |_: Uri| async {
                 Ok::<_, std::io::Error>(hyper_util::rt::TokioIo::new(
-                    UnixStream::connect(CRIO_DEFAULT_SOCK_PATH).await?,
+                    UnixStream::connect(CRIO_DEFAULT_SOCK_PATH)
+                        .await
+                        .inspect_err(|err| error!("{err:?}"))?,
                 ))
-                .inspect_err(|err| error!("{err:?}"))
             }))
             .await
             .map_err(ContainerRuntimeError::crio)?;


### PR DESCRIPTION
```bash
cargo tree -i tonic
tonic v0.12.3
├── containerd-client v0.5.0 (https://github.com/metalbear-co/rust-extensions.git?branch=update-tonic#af863098)
│   └── mirrord-agent v3.118.1 (/Users/tal/Documents/projects/mirrord/mirrord/agent)
├── k8s-cri v0.9.0
│   └── mirrord-agent v3.118.1 (/Users/t4lz/projects/mirrord/mirrord/agent)
└── mirrord-agent v3.118.1 (/Users/t4lz/projects/mirrord/mirrord/agent)
```