### PR TITLE
Fixed `all_of` and `any_of` HTTP filters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4217,6 +4217,7 @@ dependencies = [
  "serde_json",
  "socket2",
  "syscalls",
+ "tempfile",
  "test-cdylib",
  "tests",
  "thiserror",

--- a/changelog.d/2817.fixed.md
+++ b/changelog.d/2817.fixed.md
@@ -1,0 +1,1 @@
+Fixed a bug where `all_of` and `any_of` HTTP filters were stealing all HTTP traffic.

--- a/mirrord/cli/src/port_forward.rs
+++ b/mirrord/cli/src/port_forward.rs
@@ -870,7 +870,7 @@ enum IncomingMode {
 }
 
 impl IncomingMode {
-    /// Creates a new instance from the given [`LayerConfig`].
+    /// Creates a new instance from the given [`IncomingConfig`].
     fn new(config: &IncomingConfig) -> Self {
         if !config.is_steal() {
             return Self::Mirror;

--- a/mirrord/cli/src/port_forward.rs
+++ b/mirrord/cli/src/port_forward.rs
@@ -5,7 +5,10 @@ use std::{
 };
 
 use futures::StreamExt;
-use mirrord_config::feature::network::incoming::IncomingConfig;
+use mirrord_config::feature::network::incoming::{
+    http_filter::{HttpFilterConfig, InnerFilter},
+    IncomingConfig,
+};
 use mirrord_intproxy::{
     background_tasks::{BackgroundTasks, TaskError, TaskSender, TaskUpdate},
     error::IntProxyError,
@@ -867,7 +870,7 @@ enum IncomingMode {
 }
 
 impl IncomingMode {
-    /// Creates a new instance from the given [`IncomingConfig`].
+    /// Creates a new instance from the given [`LayerConfig`].
     fn new(config: &IncomingConfig) -> Self {
         if !config.is_steal() {
             return Self::Mirror;
@@ -877,21 +880,72 @@ impl IncomingMode {
 
         let ports = { http_filter_config.ports.iter().copied().collect() };
 
-        let filter = match (
-            &http_filter_config.path_filter,
-            &http_filter_config.header_filter,
-        ) {
-            (Some(path), None) => StealHttpFilter::Filter(HttpFilter::Path(
+        // Matching all fields to make this check future-proof.
+        let filter = match http_filter_config {
+            HttpFilterConfig {
+                path_filter: Some(path),
+                header_filter: None,
+                all_of: None,
+                any_of: None,
+                ports: _ports,
+            } => StealHttpFilter::Filter(HttpFilter::Path(
                 Filter::new(path.into()).expect("invalid filter expression"),
             )),
-            (None, Some(header)) => StealHttpFilter::Filter(HttpFilter::Header(
+
+            HttpFilterConfig {
+                path_filter: None,
+                header_filter: Some(header),
+                all_of: None,
+                any_of: None,
+                ports: _ports,
+            } => StealHttpFilter::Filter(HttpFilter::Header(
                 Filter::new(header.into()).expect("invalid filter expression"),
             )),
-            (None, None) => StealHttpFilter::None,
-            _ => panic!("multiple HTTP filters specified"),
+
+            HttpFilterConfig {
+                path_filter: None,
+                header_filter: None,
+                all_of: Some(filters),
+                any_of: None,
+                ports: _ports,
+            } => StealHttpFilter::Filter(Self::make_composite_filter(true, filters)),
+
+            HttpFilterConfig {
+                path_filter: None,
+                header_filter: None,
+                all_of: None,
+                any_of: Some(filters),
+                ports: _ports,
+            } => StealHttpFilter::Filter(Self::make_composite_filter(false, filters)),
+
+            HttpFilterConfig {
+                path_filter: None,
+                header_filter: None,
+                all_of: None,
+                any_of: None,
+                ports: _ports,
+            } => StealHttpFilter::None,
+
+            _ => panic!("multiple HTTP filters specified, this is a bug"),
         };
 
         Self::Steal(StealHttpSettings { filter, ports })
+    }
+
+    fn make_composite_filter(all: bool, filters: &[InnerFilter]) -> HttpFilter {
+        let filters = filters
+            .iter()
+            .map(|filter| match filter {
+                InnerFilter::Path { path } => {
+                    HttpFilter::Path(Filter::new(path.clone()).expect("invalid filter expression"))
+                }
+                InnerFilter::Header { header } => HttpFilter::Header(
+                    Filter::new(header.clone()).expect("invalid filter expression"),
+                ),
+            })
+            .collect();
+
+        HttpFilter::Composite { all, filters }
     }
 
     /// Returns [`PortSubscription`] request to be used for the given port.

--- a/mirrord/layer/Cargo.toml
+++ b/mirrord/layer/Cargo.toml
@@ -61,6 +61,7 @@ chrono = { version = "0.4", features = ["clock"] }
 http-body = { workspace = true }
 hyper = { workspace = true }
 rstest = "*"
+tempfile = "3"
 test-cdylib = "*"
 tower = "0.4"
 tokio = { version = "1", features = ["rt", "net", "macros"] }

--- a/mirrord/layer/src/setup.rs
+++ b/mirrord/layer/src/setup.rs
@@ -217,7 +217,7 @@ pub enum IncomingMode {
 }
 
 impl IncomingMode {
-    /// Creates a new instance from the given [`LayerConfig`].
+    /// Creates a new instance from the given [`IncomingConfig`].
     fn new(config: &IncomingConfig) -> Self {
         if !config.is_steal() {
             return Self::Mirror;

--- a/mirrord/layer/src/setup.rs
+++ b/mirrord/layer/src/setup.rs
@@ -5,7 +5,13 @@ use mirrord_config::{
     feature::{
         env::EnvConfig,
         fs::FsConfig,
-        network::{incoming::IncomingConfig, outgoing::OutgoingConfig},
+        network::{
+            incoming::{
+                http_filter::{HttpFilterConfig, InnerFilter},
+                IncomingConfig,
+            },
+            outgoing::OutgoingConfig,
+        },
     },
     target::Target,
     LayerConfig,
@@ -221,21 +227,72 @@ impl IncomingMode {
 
         let ports = { http_filter_config.ports.iter().copied().collect() };
 
-        let filter = match (
-            &http_filter_config.path_filter,
-            &http_filter_config.header_filter,
-        ) {
-            (Some(path), None) => StealHttpFilter::Filter(HttpFilter::Path(
+        // Matching all fields to make this check future-proof.
+        let filter = match http_filter_config {
+            HttpFilterConfig {
+                path_filter: Some(path),
+                header_filter: None,
+                all_of: None,
+                any_of: None,
+                ports: _ports,
+            } => StealHttpFilter::Filter(HttpFilter::Path(
                 Filter::new(path.into()).expect("invalid filter expression"),
             )),
-            (None, Some(header)) => StealHttpFilter::Filter(HttpFilter::Header(
+
+            HttpFilterConfig {
+                path_filter: None,
+                header_filter: Some(header),
+                all_of: None,
+                any_of: None,
+                ports: _ports,
+            } => StealHttpFilter::Filter(HttpFilter::Header(
                 Filter::new(header.into()).expect("invalid filter expression"),
             )),
-            (None, None) => StealHttpFilter::None,
-            _ => panic!("multiple HTTP filters specified"),
+
+            HttpFilterConfig {
+                path_filter: None,
+                header_filter: None,
+                all_of: Some(filters),
+                any_of: None,
+                ports: _ports,
+            } => StealHttpFilter::Filter(Self::make_composite_filter(true, filters)),
+
+            HttpFilterConfig {
+                path_filter: None,
+                header_filter: None,
+                all_of: None,
+                any_of: Some(filters),
+                ports: _ports,
+            } => StealHttpFilter::Filter(Self::make_composite_filter(false, filters)),
+
+            HttpFilterConfig {
+                path_filter: None,
+                header_filter: None,
+                all_of: None,
+                any_of: None,
+                ports: _ports,
+            } => StealHttpFilter::None,
+
+            _ => panic!("multiple HTTP filters specified, this is a bug"),
         };
 
         Self::Steal(StealHttpSettings { filter, ports })
+    }
+
+    fn make_composite_filter(all: bool, filters: &[InnerFilter]) -> HttpFilter {
+        let filters = filters
+            .iter()
+            .map(|filter| match filter {
+                InnerFilter::Path { path } => {
+                    HttpFilter::Path(Filter::new(path.clone()).expect("invalid filter expression"))
+                }
+                InnerFilter::Header { header } => HttpFilter::Header(
+                    Filter::new(header.clone()).expect("invalid filter expression"),
+                ),
+            })
+            .collect();
+
+        HttpFilter::Composite { all, filters }
     }
 
     /// Returns [`PortSubscription`] request to be used for the given port.

--- a/mirrord/layer/tests/issue2817.rs
+++ b/mirrord/layer/tests/issue2817.rs
@@ -1,0 +1,141 @@
+#![feature(assert_matches)]
+#![warn(clippy::indexing_slicing)]
+
+use std::{path::Path, time::Duration};
+
+use mirrord_protocol::{
+    tcp::{Filter, HttpFilter, LayerTcpSteal, StealType},
+    ClientMessage,
+};
+use rand::Rng;
+use rstest::rstest;
+
+mod common;
+
+pub use common::*;
+
+#[derive(Clone, Copy, Debug)]
+enum TestedStealVariant {
+    Unfiltered,
+    Header,
+    Path,
+    AllOf,
+    AnyOf,
+}
+
+impl TestedStealVariant {
+    fn as_json_config(self) -> serde_json::Value {
+        serde_json::json!({
+            "path_filter": matches!(self, Self::Path).then(|| "/some/path"),
+            "header_filter": matches!(self, Self::Header).then(|| "some: header"),
+            "all_of": matches!(self, Self::AllOf).then(|| serde_json::json!([
+                { "path": "/some/path" },
+                { "header": "some: header" },
+            ])),
+            "any_of": matches!(self, Self::AnyOf).then(|| serde_json::json!([
+                { "path": "/some/path" },
+                { "header": "some: header" },
+            ]))
+        })
+    }
+
+    fn assert_matches(self, steal_type: StealType) {
+        match (self, steal_type) {
+            (Self::Unfiltered, StealType::All(80)) => {}
+            (Self::Header, StealType::FilteredHttpEx(80, HttpFilter::Header(filter))) => {
+                assert_eq!(filter, Filter::new("some: header".into()).unwrap())
+            }
+            (Self::Path, StealType::FilteredHttpEx(80, HttpFilter::Path(filter))) => {
+                assert_eq!(filter, Filter::new("/some/path".into()).unwrap())
+            }
+            (
+                Self::AllOf,
+                StealType::FilteredHttpEx(80, HttpFilter::Composite { all: true, filters }),
+            ) => {
+                assert_eq!(
+                    filters,
+                    vec![
+                        HttpFilter::Path(Filter::new("/some/path".into()).unwrap()),
+                        HttpFilter::Header(Filter::new("some: header".into()).unwrap()),
+                    ],
+                )
+            }
+            (
+                Self::AnyOf,
+                StealType::FilteredHttpEx(
+                    80,
+                    HttpFilter::Composite {
+                        all: false,
+                        filters,
+                    },
+                ),
+            ) => {
+                assert_eq!(
+                    filters,
+                    vec![
+                        HttpFilter::Path(Filter::new("/some/path".into()).unwrap()),
+                        HttpFilter::Header(Filter::new("some: header".into()).unwrap()),
+                    ],
+                )
+            }
+            (.., steal_type) => panic!("received unexpected steal type: {steal_type:?}"),
+        }
+    }
+}
+
+/// Verify that the layer requests correct subscription type based on HTTP filter config.
+#[rstest]
+#[tokio::test]
+#[timeout(Duration::from_secs(60))]
+async fn test_issue2817(
+    #[values(Application::NodeHTTP)] application: Application,
+    dylib_path: &Path,
+    #[values(
+        TestedStealVariant::Unfiltered,
+        TestedStealVariant::Header,
+        TestedStealVariant::Path,
+        TestedStealVariant::AllOf,
+        TestedStealVariant::AnyOf
+    )]
+    config_variant: TestedStealVariant,
+) {
+    let dir = tempfile::tempdir().unwrap();
+    let file_id = rand::thread_rng().gen::<u64>();
+    let config_path = dir.path().join(format!("{file_id:X}.json"));
+
+    let config = serde_json::json!({
+        "feature": {
+            "network": {
+                "incoming": {
+                    "mode": "steal",
+                    "http_filter": config_variant.as_json_config(),
+                }
+            }
+        }
+    });
+
+    tokio::fs::write(&config_path, serde_json::to_string_pretty(&config).unwrap())
+        .await
+        .expect("failed to saving layer config to tmp file");
+
+    let (mut test_process, mut intproxy) = application
+        .start_process_with_layer(
+            dylib_path,
+            Default::default(),
+            Some(config_path.to_str().unwrap()),
+        )
+        .await;
+
+    let message = intproxy.recv().await;
+    let steal_type = match message {
+        ClientMessage::TcpSteal(LayerTcpSteal::PortSubscribe(steal_type)) => steal_type,
+        other => panic!("unexpected message received from the app: {other:?}"),
+    };
+    config_variant.assert_matches(steal_type);
+
+    test_process
+        .child
+        .kill()
+        .await
+        .expect("failed to kill the app");
+}


### PR DESCRIPTION
Issue #2817