### PR TITLE
Add nodeSelector option to agent config

### DIFF
--- a/changelog.d/+nodeselector.added.md
+++ b/changelog.d/+nodeselector.added.md
@@ -1,0 +1,1 @@
+Add nodeSelector option to agent config

--- a/mirrord-schema.json
+++ b/mirrord-schema.json
@@ -264,6 +264,17 @@
             "type": "string"
           }
         },
+        "node_selector": {
+          "title": "agent.node_selector {#agent-node_selector}",
+          "description": "Allows setting up custom node selector for the agent Job and Pod.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
         "check_out_of_pods": {
           "title": "agent.check_out_of_pods {#agent-check_out_of_pods}",
           "description": "Determine if to check whether there is room for agent job in target node. (Not applicable when using ephemeral containers feature)\n\nCan be disabled if the check takes too long and you are sure there is enough resources on each node",

--- a/mirrord-schema.json
+++ b/mirrord-schema.json
@@ -404,7 +404,7 @@
         },
         "node_selector": {
           "title": "agent.node_selector {#agent-node_selector}",
-          "description": "Allows setting up node selector for the agent Job and Pod. ```json { \"node_selector\": { \"kubernetes.io/hostname\": \"node1\" } } ```",
+          "description": "Allows setting up custom node selector for the agent Job and Pod.\n\n```json { \"node_selector\": { \"kubernetes.io/hostname\": \"node1\" } } ```",
           "type": [
             "object",
             "null"

--- a/mirrord-schema.json
+++ b/mirrord-schema.json
@@ -404,7 +404,7 @@
         },
         "node_selector": {
           "title": "agent.node_selector {#agent-node_selector}",
-          "description": "Allows setting up custom node selector for the agent Job and Pod.\n\n```json { \"node_selector\": { \"kubernetes.io/hostname\": \"node1\" } } ```",
+          "description": "Allows setting up custom node selector for the agent Pod. Applies only to targetless runs, as targeted agent always runs on the same node as its target container.\n\n```json { \"node_selector\": { \"kubernetes.io/hostname\": \"node1\" } } ```",
           "type": [
             "object",
             "null"

--- a/mirrord-schema.json
+++ b/mirrord-schema.json
@@ -264,17 +264,6 @@
             "type": "string"
           }
         },
-        "node_selector": {
-          "title": "agent.node_selector {#agent-node_selector}",
-          "description": "Allows setting up custom node selector for the agent Job and Pod.",
-          "type": [
-            "object",
-            "null"
-          ],
-          "additionalProperties": {
-            "type": "string"
-          }
-        },
         "check_out_of_pods": {
           "title": "agent.check_out_of_pods {#agent-check_out_of_pods}",
           "description": "Determine if to check whether there is room for agent job in target node. (Not applicable when using ephemeral containers feature)\n\nCan be disabled if the check takes too long and you are sure there is enough resources on each node",
@@ -412,6 +401,17 @@
             "boolean",
             "null"
           ]
+        },
+        "node_selector": {
+          "title": "agent.node_selector {#agent-node_selector}",
+          "description": "Allows setting up node selector for the agent Job and Pod. ```json { \"node_selector\": { \"kubernetes.io/hostname\": \"node1\" } } ```",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "type": "string"
+          }
         },
         "privileged": {
           "title": "agent.privileged {#agent-privileged}",

--- a/mirrord/config/configuration.md
+++ b/mirrord/config/configuration.md
@@ -169,7 +169,8 @@ Allows setting up custom annotations for the agent Job and Pod.
 
 ### agent.node_selector {#agent-node_selector}
 
-Allows setting up custom node selector for the agent Job and Pod.
+Allows setting up custom node selector for the agent Pod. Applies only to targetless runs,
+as targeted agent always runs on the same node as its target container.
 
 ```json
 {

--- a/mirrord/config/configuration.md
+++ b/mirrord/config/configuration.md
@@ -167,6 +167,16 @@ Allows setting up custom annotations for the agent Job and Pod.
 }
 ```
 
+### agent.node_selector {#agent-node_selector}
+
+Allows setting up custom node selector for the agent Job and Pod.
+
+```json
+{
+  "node_selector": { "kubernetes.io/hostname": "node1" }
+}
+```
+
 ### agent.check_out_of_pods {#agent-check_out_of_pods}
 
 Determine if to check whether there is room for agent job in target node. (Not applicable

--- a/mirrord/config/src/agent.rs
+++ b/mirrord/config/src/agent.rs
@@ -329,7 +329,8 @@ pub struct AgentConfig {
 
     /// ### agent.node_selector {#agent-node_selector}
     ///
-    /// Allows setting up custom node selector for the agent Job and Pod.
+    /// Allows setting up custom node selector for the agent Pod. Applies only to targetless runs,
+    /// as targeted agent always runs on the same node as its target container.
     ///
     /// ```json
     /// {

--- a/mirrord/config/src/agent.rs
+++ b/mirrord/config/src/agent.rs
@@ -328,10 +328,12 @@ pub struct AgentConfig {
     pub annotations: Option<HashMap<String, String>>,
 
     /// ### agent.node_selector {#agent-node_selector}
-    /// Allows setting up node selector for the agent Job and Pod.
+    ///
+    /// Allows setting up custom node selector for the agent Job and Pod.
+    ///
     /// ```json
     /// {
-    ///  "node_selector": { "kubernetes.io/hostname": "node1" }
+    ///   "node_selector": { "kubernetes.io/hostname": "node1" }
     /// }
     /// ```
     pub node_selector: Option<HashMap<String, String>>,

--- a/mirrord/config/src/agent.rs
+++ b/mirrord/config/src/agent.rs
@@ -327,6 +327,13 @@ pub struct AgentConfig {
     /// ```
     pub annotations: Option<HashMap<String, String>>,
 
+    /// ### agent.node_selector {#agent-node_selector}
+    /// Allows setting up node selector for the agent Job and Pod.
+    /// ```json
+    /// {
+    ///  "node_selector": { "kubernetes.io/hostname": "node1" }
+    /// }
+    /// ```
     pub node_selector: Option<HashMap<String, String>>,
 
     /// <!--${internal}-->

--- a/mirrord/config/src/agent.rs
+++ b/mirrord/config/src/agent.rs
@@ -327,6 +327,8 @@ pub struct AgentConfig {
     /// ```
     pub annotations: Option<HashMap<String, String>>,
 
+    pub node_selector: Option<HashMap<String, String>>,
+
     /// <!--${internal}-->
     /// Create an agent that returns an error after accepting the first client. For testing
     /// purposes. Only supported with job agents (not with ephemeral agents).

--- a/mirrord/kube/src/api/container/job.rs
+++ b/mirrord/kube/src/api/container/job.rs
@@ -292,6 +292,7 @@ mod test {
                     "spec": {
                         "restartPolicy": "Never",
                         "imagePullSecrets": agent.image_pull_secrets,
+                        "nodeSelector": {},
                         "tolerations": *DEFAULT_TOLERATIONS,
                         "containers": [
                             {
@@ -410,6 +411,7 @@ mod test {
                             }
                         ],
                         "imagePullSecrets": agent.image_pull_secrets,
+                        "nodeSelector": {},
                         "tolerations": *DEFAULT_TOLERATIONS,
                         "containers": [
                             {

--- a/mirrord/kube/src/api/container/job.rs
+++ b/mirrord/kube/src/api/container/job.rs
@@ -165,8 +165,18 @@ where
             ("linkerd.io/inject".to_string(), "disabled".to_string()),
         ]));
 
+        let node_selector = config
+            .node_selector
+            .clone()
+            .map(BTreeMap::from_iter)
+            .unwrap_or_default();
+
         pod.labels_mut().extend(labels.clone());
         pod.annotations_mut().extend(annotations.clone());
+
+        if let Some(spec) = pod.spec.as_mut() {
+          spec.node_selector = Some(node_selector);
+        }
 
         Job {
             metadata: ObjectMeta {

--- a/mirrord/kube/src/api/container/job.rs
+++ b/mirrord/kube/src/api/container/job.rs
@@ -165,18 +165,8 @@ where
             ("linkerd.io/inject".to_string(), "disabled".to_string()),
         ]));
 
-        let node_selector = config
-            .node_selector
-            .clone()
-            .map(BTreeMap::from_iter)
-            .unwrap_or_default();
-
         pod.labels_mut().extend(labels.clone());
         pod.annotations_mut().extend(annotations.clone());
-
-        if let Some(spec) = pod.spec.as_mut() {
-            spec.node_selector = Some(node_selector);
-        }
 
         Job {
             metadata: ObjectMeta {

--- a/mirrord/kube/src/api/container/job.rs
+++ b/mirrord/kube/src/api/container/job.rs
@@ -175,7 +175,7 @@ where
         pod.annotations_mut().extend(annotations.clone());
 
         if let Some(spec) = pod.spec.as_mut() {
-          spec.node_selector = Some(node_selector);
+            spec.node_selector = Some(node_selector);
         }
 
         Job {

--- a/mirrord/kube/src/api/container/pod.rs
+++ b/mirrord/kube/src/api/container/pod.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use k8s_openapi::{
     api::core::v1::{
         Capabilities, Container, EnvVar, HostPathVolumeSource, LocalObjectReference, Pod, PodSpec,
@@ -92,6 +94,11 @@ impl ContainerVariant for PodVariant<'_> {
                 })
                 .collect()
         });
+        let node_selector = agent
+            .node_selector
+            .clone()
+            .map(BTreeMap::from_iter)
+            .unwrap_or_default();
 
         Pod {
             metadata: ObjectMeta {
@@ -118,6 +125,7 @@ impl ContainerVariant for PodVariant<'_> {
                 restart_policy: Some("Never".to_string()),
                 image_pull_secrets,
                 tolerations: Some(tolerations.clone()),
+                node_selector: Some(node_selector),
                 containers: vec![Container {
                     name: "mirrord-agent".to_string(),
                     image: Some(agent.image().to_string()),


### PR DESCRIPTION
Hello, this is my first PR so please go easy on me.
When I run `mirrord exec` I missed the option to tell the agent on which node to spawn, so I added the functionality after seeing that `labels` and `annotations` were already supported (since they're more or less the same, except node selector sits under the `spec` key).

I tested it on my own cluster using this config JSON:

```json
{
  "agent": {
    "node_selector":
      {
        "node1": "label1"
      }
  }
}
```

I was interested in adding this option in the CLI too, but this seemed like a quicker proof-of-concept. If this is something you're willing to merge, I can work on the CLI version as well.

Let me know what you think 😄 
