### PR TITLE
Add `getifaddrs` hook that removes ipv6 addresses

### DIFF
--- a/changelog.d/2807.fixed.md
+++ b/changelog.d/2807.fixed.md
@@ -1,0 +1,1 @@
+Fixed an issue where `mirrord exec ... -- npm run serve` in a Vue project was failing with `EAFNOSUPPORT: address family not supported ::1:80`. Added new `.experimental.hide_ipv6_interfaces` configuration entry that allows for hiding local IPv6 interface addresses from the user application.

--- a/mirrord/config/src/experimental.rs
+++ b/mirrord/config/src/experimental.rs
@@ -37,11 +37,11 @@ pub struct ExperimentalConfig {
     #[config(default = true)]
     pub enable_exec_hooks_linux: bool,
 
-    /// ### _experimental_ remove_ipv6_interfaces {#experimental-remove_ipv6_interfaces}
+    /// ### _experimental_ hide_ipv6_interfaces {#experimental-hide_ipv6_interfaces}
     ///
     /// Enables `getifaddrs` hook that removes IPv6 interfaces from the list returned by libc.
     #[config(default = false)]
-    pub remove_ipv6_interfaces: bool,
+    pub hide_ipv6_interfaces: bool,
 }
 
 impl CollectAnalytics for &ExperimentalConfig {
@@ -50,6 +50,6 @@ impl CollectAnalytics for &ExperimentalConfig {
         analytics.add("readlink", self.readlink);
         analytics.add("trust_any_certificate", self.trust_any_certificate);
         analytics.add("enable_exec_hooks_linux", self.enable_exec_hooks_linux);
-        analytics.add("remove_ipv6_interfaces", self.remove_ipv6_interfaces);
+        analytics.add("hide_ipv6_interfaces", self.hide_ipv6_interfaces);
     }
 }

--- a/mirrord/config/src/experimental.rs
+++ b/mirrord/config/src/experimental.rs
@@ -36,6 +36,12 @@ pub struct ExperimentalConfig {
     /// but the feature is not stable and may cause other issues.
     #[config(default = true)]
     pub enable_exec_hooks_linux: bool,
+
+    /// ### _experimental_ remove_ipv6_interfaces {#experimental-remove_ipv6_interfaces}
+    ///
+    /// Enables `getifaddrs` hook that removes IPv6 interfaces from the list returned by libc.
+    #[config(default = false)]
+    pub remove_ipv6_interfaces: bool,
 }
 
 impl CollectAnalytics for &ExperimentalConfig {
@@ -44,5 +50,6 @@ impl CollectAnalytics for &ExperimentalConfig {
         analytics.add("readlink", self.readlink);
         analytics.add("trust_any_certificate", self.trust_any_certificate);
         analytics.add("enable_exec_hooks_linux", self.enable_exec_hooks_linux);
+        analytics.add("remove_ipv6_interfaces", self.remove_ipv6_interfaces);
     }
 }

--- a/mirrord/layer/src/lib.rs
+++ b/mirrord/layer/src/lib.rs
@@ -535,7 +535,13 @@ fn enable_hooks(state: &LayerSetup) {
         replace!(&mut hook_manager, "fork", fork_detour, FnFork, FN_FORK);
     };
 
-    unsafe { socket::hooks::enable_socket_hooks(&mut hook_manager, enabled_remote_dns) };
+    unsafe {
+        socket::hooks::enable_socket_hooks(
+            &mut hook_manager,
+            enabled_remote_dns,
+            state.experimental(),
+        )
+    };
 
     if cfg!(target_os = "macos") || state.experimental().enable_exec_hooks_linux {
         unsafe { exec_hooks::hooks::enable_exec_hooks(&mut hook_manager) };

--- a/mirrord/layer/src/socket/hooks.rs
+++ b/mirrord/layer/src/socket/hooks.rs
@@ -642,7 +642,7 @@ pub(crate) unsafe fn enable_socket_hooks(
             );
         }
 
-        if experimental.remove_ipv6_interfaces {
+        if experimental.hide_ipv6_interfaces {
             replace!(
                 hook_manager,
                 "getifaddrs",

--- a/mirrord/layer/src/socket/ops.rs
+++ b/mirrord/layer/src/socket/ops.rs
@@ -1615,6 +1615,7 @@ pub(super) fn getifaddrs() -> HookResult<*mut libc::ifaddrs> {
     // I don't see any reason why we could not do this,
     // I also did not find anything suspicious in glibc [implementation](https://github.com/lattera/glibc/blob/master/sysdeps/gnu/ifaddrs.c).
     if !ipv6_head.is_null() {
+        // Safety: we constructed a valid `libc::ifaddrs` list using pointers received from libc.
         unsafe { libc::freeifaddrs(ipv6_head) };
     }
 


### PR DESCRIPTION
Issue #2807 