### PR TITLE
Don't override kubeconfig `insecure-skip-tls-verify` option when `accept_invalid_certificates` is not set

### DIFF
--- a/changelog.d/2825.fixed.md
+++ b/changelog.d/2825.fixed.md
@@ -1,0 +1,1 @@
+mirrord now respects `insecure-skip-tls-verify` option set in the kubeconfig when `accept_invalid_certificates` is not provided in the mirrord config.

--- a/mirrord-schema.json
+++ b/mirrord-schema.json
@@ -6,7 +6,7 @@
   "properties": {
     "accept_invalid_certificates": {
       "title": "accept_invalid_certificates {#root-accept_invalid_certificates}",
-      "description": "Controls whether or not mirrord accepts invalid TLS certificates (e.g. self-signed certificates).\n\nDefaults to `false`.",
+      "description": "Controls whether or not mirrord accepts invalid TLS certificates (e.g. self-signed certificates).\n\nIf not provided, mirrord will use value from the kubeconfig.",
       "type": [
         "boolean",
         "null"

--- a/mirrord/cli/src/config.rs
+++ b/mirrord/cli/src/config.rs
@@ -162,8 +162,8 @@ pub(super) struct ExecParams {
     pub agent_startup_timeout: Option<u16>,
 
     /// Accept/reject invalid certificates.
-    #[arg(short = 'c', long)]
-    pub accept_invalid_certificates: bool,
+    #[arg(short = 'c', long, default_missing_value="true", num_args=0..=1, require_equals=true)]
+    pub accept_invalid_certificates: Option<bool>,
 
     /// Use an Ephemeral Container to mirror traffic.
     #[arg(short, long)]
@@ -266,9 +266,15 @@ impl ExecParams {
             envs.insert("MIRRORD_REMOTE_DNS".into(), "false".into());
         }
 
-        if self.accept_invalid_certificates {
-            envs.insert("MIRRORD_ACCEPT_INVALID_CERTIFICATES".into(), "true".into());
-            tracing::warn!("Accepting invalid certificates");
+        if let Some(accept_invalid_certificates) = self.accept_invalid_certificates {
+            let value = if accept_invalid_certificates {
+                tracing::warn!("Accepting invalid certificates");
+                "true"
+            } else {
+                "false"
+            };
+
+            envs.insert("MIRRORD_ACCEPT_INVALID_CERTIFICATES".into(), value.into());
         }
 
         if self.ephemeral_container {
@@ -374,8 +380,8 @@ pub(super) struct PortForwardArgs {
     pub agent_startup_timeout: Option<u16>,
 
     /// Accept/reject invalid certificates
-    #[arg(short = 'c', long)]
-    pub accept_invalid_certificates: bool,
+    #[arg(short = 'c', long, default_missing_value="true", num_args=0..=1, require_equals=true)]
+    pub accept_invalid_certificates: Option<bool>,
 
     /// Use an Ephemeral Container to mirror traffic
     #[arg(short, long)]

--- a/mirrord/cli/src/main.rs
+++ b/mirrord/cli/src/main.rs
@@ -754,3 +754,39 @@ async fn prompt_outdated_version(progress: &ProgressTracker) {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+    use rstest::rstest;
+
+    use crate::{Cli, Commands};
+
+    /// Verifies that
+    /// [`ExecParams::accept_invalid_certificates`](crate::config::ExecParams::accept_invalid_certificates)
+    /// and [`PortForwardArgs::accept_invalid_certificates`](crate::config::PortForwardArgs::accept_invalid_certificates)
+    /// correctly parse from command line arguments.
+    #[rstest]
+    #[case(&["mirrord", "exec", "-c", "--", "echo", "hello"], Some(true))]
+    #[case(&["mirrord", "exec", "-c=true", "--", "echo", "hello"], Some(true))]
+    #[case(&["mirrord", "exec", "-c=false", "--", "echo", "hello"], Some(false))]
+    #[case(&["mirrord", "exec", "--", "echo", "hello"], None)]
+    #[case(&["mirrord", "port-forward", "-c", "-L", "8080:py-serv:80"], Some(true))]
+    #[case(&["mirrord", "port-forward", "-c=true", "-L", "8080:py-serv:80"], Some(true))]
+    #[case(&["mirrord", "port-forward", "-c=false", "-L", "8080:py-serv:80"], Some(false))]
+    #[case(&["mirrord", "port-forward", "-L", "8080:py-serv:80"], None)]
+    fn parse_accept_invalid_certificates(
+        #[case] args: &[&str],
+        #[case] expected_value: Option<bool>,
+    ) {
+        match Cli::parse_from(args).commands {
+            Commands::Exec(params) if args[1] == "exec" => {
+                assert_eq!(params.params.accept_invalid_certificates, expected_value)
+            }
+            Commands::PortForward(params) if args[1] == "port-forward" => {
+                assert_eq!(params.accept_invalid_certificates, expected_value)
+            }
+            other => panic!("unexpected args parsed: {other:?}"),
+        }
+    }
+}

--- a/mirrord/cli/src/main.rs
+++ b/mirrord/cli/src/main.rs
@@ -335,6 +335,7 @@ fn print_config<P>(
 
 async fn exec(args: &ExecArgs, watch: drain::Watch) -> Result<()> {
     let progress = ProgressTracker::from_env("mirrord exec");
+    progress.warning(&format!("{:?}", args.params.accept_invalid_certificates));
     if !args.params.disable_version_check {
         prompt_outdated_version(&progress).await;
     }
@@ -551,9 +552,15 @@ async fn port_forward(args: &PortForwardArgs, watch: drain::Watch) -> Result<()>
         );
     }
 
-    if args.accept_invalid_certificates {
-        std::env::set_var("MIRRORD_ACCEPT_INVALID_CERTIFICATES", "true");
-        warn!("Accepting invalid certificates");
+    if let Some(accept_invalid_certificates) = args.accept_invalid_certificates {
+        let value = if accept_invalid_certificates {
+            warn!("Accepting invalid certificates");
+            "true"
+        } else {
+            "false"
+        };
+
+        std::env::set_var("MIRRORD_ACCEPT_INVALID_CERTIFICATES", value);
     }
 
     if args.ephemeral_container {

--- a/mirrord/config/configuration.md
+++ b/mirrord/config/configuration.md
@@ -130,7 +130,7 @@ configuration file containing all fields.
 Controls whether or not mirrord accepts invalid TLS certificates (e.g. self-signed
 certificates).
 
-Defaults to `false`.
+If not provided, mirrord will use value from the kubeconfig.
 
 ## agent {#root-agent}
 
@@ -164,17 +164,6 @@ Allows setting up custom annotations for the agent Job and Pod.
 ```json
 {
   "annotations": { "cats.io/inject": "enabled" }
-}
-```
-
-### agent.node_selector {#agent-node_selector}
-
-Allows setting up custom node selector for the agent Pod. Applies only to targetless runs,
-as targeted agent always runs on the same node as its target container.
-
-```json
-{
-  "node_selector": { "kubernetes.io/hostname": "node1" }
 }
 ```
 
@@ -326,6 +315,17 @@ Use iptables-nft instead of iptables-legacy.
 Defaults to `false`.
 
 Needed if your mesh uses nftables instead of iptables-legacy,
+
+### agent.node_selector {#agent-node_selector}
+
+Allows setting up custom node selector for the agent Pod. Applies only to targetless runs,
+as targeted agent always runs on the same node as its target container.
+
+```json
+{
+  "node_selector": { "kubernetes.io/hostname": "node1" }
+}
+```
 
 ### agent.privileged {#agent-privileged}
 
@@ -692,7 +692,7 @@ Case insensitive.
 2. `"read_only"` - List of patterns that should be read only remotely.
 3. `"local"` - List of patterns that should be read locally.
 4. `"not_found"` - List of patters that should never be read nor written. These files should be
-treated as non-existent.
+   treated as non-existent.
 4. `"mapping"` - Map of patterns and their corresponding replacers. The replacement happens before any specific behavior as defined above or mode (uses [`Regex::replace`](https://docs.rs/regex/latest/regex/struct.Regex.html#method.replace))
 
 The logic for choosing the behavior is as follows:
@@ -700,9 +700,9 @@ The logic for choosing the behavior is as follows:
 
 1. Check agains "mapping" if path needs to be replaced, if matched then continue to next step
    with new path after replacements otherwise continue as usual.
-2. Check if one of the patterns match the file path, do the corresponding action. There's
-no specified order if two lists match the same path, we will use the first one (and we
-do not guarantee what is first).
+2. Check if one of the patterns match the file path, do the corresponding action. There's no
+   specified order if two lists match the same path, we will use the first one (and we do not
+   guarantee what is first).
 
     **Warning**: Specifying the same path in two lists is unsupported and can lead to undefined
     behaviour.
@@ -838,11 +838,11 @@ Resolve DNS via the remote pod.
 Defaults to `true`.
 
 Mind that:
-- DNS resolving can be done in multiple ways. Some frameworks use
-`getaddrinfo`/`gethostbyname` functions, while others communicate directly with the DNS server
-at port `53` and perform a sort of manual resolution. Just enabling the `dns` feature in mirrord
-might not be enough. If you see an address resolution error, try enabling the
-[`fs`](#feature-fs) feature, and setting `read_only: ["/etc/resolv.conf"]`.
+- DNS resolving can be done in multiple ways. Some frameworks use `getaddrinfo`/`gethostbyname`
+  functions, while others communicate directly with the DNS server at port `53` and perform a
+  sort of manual resolution. Just enabling the `dns` feature in mirrord might not be enough. If
+  you see an address resolution error, try enabling the [`fs`](#feature-fs) feature, and setting
+  `read_only: ["/etc/resolv.conf"]`.
 - DNS filter currently works only with frameworks that use `getaddrinfo`/`gethostbyname`
   functions.
 
@@ -876,8 +876,8 @@ Takes a list of values, such as:
 }
 ```
 
-- Only queries for hostname `google.com` with service port `1337` or `7331`
-will go through the remote pod.
+- Only queries for hostname `google.com` with service port `1337` or `7331` will go through the
+  remote pod.
 
 ```json
 {
@@ -913,7 +913,7 @@ details.
 Incoming traffic supports 3 [modes](#feature-network-incoming-mode) of operation:
 
 1. Mirror (**default**): Sniffs the TCP data from a port, and forwards a copy to the interested
-listeners;
+   listeners;
 
 2. Steal: Captures the TCP data from a port, and forwards it to the local process.
 
@@ -1097,14 +1097,13 @@ Can be set to either `"mirror"` (default), `"steal"` or `"off"`.
 - `"off"`: Disables the incoming network feature.
 - `"steal"`: Supports 2 modes of operation:
 
-1. Port traffic stealing: Steals all TCP data from a
-  port, which is selected whenever the
-user listens in a TCP socket (enabling the feature is enough to make this work, no
-additional configuration is needed);
+1. Port traffic stealing: Steals all TCP data from a port, which is selected whenever the user
+   listens in a TCP socket (enabling the feature is enough to make this work, no additional
+   configuration is needed);
 
-2. HTTP traffic stealing: Steals only HTTP traffic, mirrord tries to detect if the incoming
-data on a port is HTTP (in a best-effort kind of way, not guaranteed to be HTTP), and
-steals the traffic on the port if it is HTTP;
+2. HTTP traffic stealing: Steals only HTTP traffic, mirrord tries to detect if the incoming data
+   on a port is HTTP (in a best-effort kind of way, not guaranteed to be HTTP), and steals the
+   traffic on the port if it is HTTP;
 
 #### feature.network.incoming.on_concurrent_steal {#feature-network-incoming-on_concurrent_steal}
 
@@ -1179,8 +1178,8 @@ Takes a list of values, such as:
 }
 ```
 
-- Only UDP and TCP traffic on resolved address of `google.com` on port `1337` and `7331`
-will go through the remote pod.
+- Only UDP and TCP traffic on resolved address of `google.com` on port `1337` and `7331` will go
+  through the remote pod.
 ```json
 {
   "remote": ["google.com:1337", "google.com:7331"]

--- a/mirrord/config/src/lib.rs
+++ b/mirrord/config/src/lib.rs
@@ -173,9 +173,9 @@ pub struct LayerConfig {
     /// Controls whether or not mirrord accepts invalid TLS certificates (e.g. self-signed
     /// certificates).
     ///
-    /// Defaults to `false`.
-    #[config(env = "MIRRORD_ACCEPT_INVALID_CERTIFICATES", default = false)]
-    pub accept_invalid_certificates: bool,
+    /// If not provided, mirrord will use value from the kubeconfig.
+    #[config(env = "MIRRORD_ACCEPT_INVALID_CERTIFICATES")]
+    pub accept_invalid_certificates: Option<bool>,
 
     /// ## skip_processes {#root-skip_processes}
     ///
@@ -538,10 +538,9 @@ impl LayerConfig {
 
 impl CollectAnalytics for &LayerConfig {
     fn collect_analytics(&self, analytics: &mut mirrord_analytics::Analytics) {
-        analytics.add(
-            "accept_invalid_certificates",
-            self.accept_invalid_certificates,
-        );
+        if let Some(value) = self.accept_invalid_certificates {
+            analytics.add("accept_invalid_certificates", value);
+        };
         analytics.add("use_kubeconfig", self.kubeconfig.is_some());
         (&self.target).collect_analytics(analytics);
         (&self.agent).collect_analytics(analytics);

--- a/mirrord/kube/src/api/kubernetes.rs
+++ b/mirrord/kube/src/api/kubernetes.rs
@@ -293,7 +293,7 @@ pub struct AgentKubernetesConnectInfo {
 }
 
 pub async fn create_kube_config<P>(
-    accept_invalid_certificates: bool,
+    accept_invalid_certificates: Option<bool>,
     kubeconfig: Option<P>,
     kube_context: Option<String>,
 ) -> Result<Config>
@@ -318,7 +318,10 @@ where
         // kube or incluster configuration.
         Config::infer().await?
     };
-    config.accept_invalid_certs = accept_invalid_certificates;
+
+    if let Some(accept_invalid_certificates) = accept_invalid_certificates {
+        config.accept_invalid_certs = accept_invalid_certificates;
+    }
 
     Ok(config)
 }


### PR DESCRIPTION
Issue #2825 