### PR TITLE
No arm64e in fat layer binary

### DIFF
--- a/.github/workflows/arch_dylib_sign.json
+++ b/.github/workflows/arch_dylib_sign.json
@@ -1,15 +1,14 @@
 {
-    "source": [
-        "target/aarch64-apple-darwin/release/libmirrord_layer.dylib",
-        "target/aarch64-apple-darwin/release/libmirrord_layer_arm64e.dylib",
-        "target/x86_64-apple-darwin/release/libmirrord_layer.dylib"
-    ],
-    "bundle_id": "com.metalbear.mirrord",
-    "apple_id": {
-        "username": "@env:AC_USERNAME",
-        "password": "@env:AC_PASSWORD"
-    },
-    "sign": {
-        "application_identity": "Developer ID Application: METALBEAR TECH LTD (8W42TQ6PFA)"
-    }
+  "source": [
+    "target/aarch64-apple-darwin/release/libmirrord_layer.dylib",
+    "target/x86_64-apple-darwin/release/libmirrord_layer.dylib"
+  ],
+  "bundle_id": "com.metalbear.mirrord",
+  "apple_id": {
+    "username": "@env:AC_USERNAME",
+    "password": "@env:AC_PASSWORD"
+  },
+  "sign": {
+    "application_identity": "Developer ID Application: METALBEAR TECH LTD (8W42TQ6PFA)"
+  }
 }

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -74,17 +74,9 @@ jobs:
           brew install mitchellh/gon/gon
       - name: build mirrord-layer x86-64
         run: cargo +nightly-2024-09-12 build --release -p mirrord-layer --target=x86_64-apple-darwin
-      - name: build mirrord-layer macOS arm/arm64e
-        # Editing the arm64 binary, since arm64e can be loaded into both arm64 & arm64e
-        # >> target/debug/libmirrord_layer.dylib: Mach-O 64-bit dynamically linked shared library arm64
-        # >> magic bits: 0000000 facf feed 000c 0100 0000 0000 0006 0000
-        # >> After editing using dd -
-        # >> magic bits: 0000000 facf feed 000c 0100 0002 0000 0006 0000
-        # >> target/debug/libmirrord_layer.dylib: Mach-O 64-bit dynamically linked shared library arm64e
+      - name: build mirrord-layer macOS arm64
         run: |
           cargo +nightly-2024-09-12 build --release -p mirrord-layer --target=aarch64-apple-darwin
-          cp target/aarch64-apple-darwin/release/libmirrord_layer.dylib target/aarch64-apple-darwin/release/libmirrord_layer_arm64e.dylib
-          printf '\x02' | dd of=target/aarch64-apple-darwin/release/libmirrord_layer_arm64e.dylib bs=1 seek=8 count=1 conv=notrunc
       - name: Sign layer binaries
         env:
           AC_USERNAME: ${{ secrets.APPLE_DEVELOPER }}
@@ -93,7 +85,7 @@ jobs:
       - name: create universal target dir
         run: mkdir -p /tmp/target/universal-apple-darwin/release
       - name: create universal dylib
-        run: lipo -create -output /tmp/target/universal-apple-darwin/release/libmirrord_layer.dylib target/aarch64-apple-darwin/release/libmirrord_layer.dylib target/x86_64-apple-darwin/release/libmirrord_layer.dylib target/aarch64-apple-darwin/release/libmirrord_layer_arm64e.dylib
+        run: lipo -create -output /tmp/target/universal-apple-darwin/release/libmirrord_layer.dylib target/aarch64-apple-darwin/release/libmirrord_layer.dylib target/x86_64-apple-darwin/release/libmirrord_layer.dylib
       - name: Sign layer universal
         env:
           AC_USERNAME: ${{ secrets.APPLE_DEVELOPER }}

--- a/changelog.d/2846.changed.md
+++ b/changelog.d/2846.changed.md
@@ -1,0 +1,1 @@
+The dymaic library injected by mirrord ("the layer") no longer inlcludes an arm64e binary in its fat binary on macos.

--- a/scripts/build_fat_mac.sh
+++ b/scripts/build_fat_mac.sh
@@ -7,12 +7,10 @@
 set -e
 cargo build -p mirrord-layer --target=x86_64-apple-darwin
 cargo build -p mirrord-layer --target=aarch64-apple-darwin
-cp target/aarch64-apple-darwin/debug/libmirrord_layer.dylib target/aarch64-apple-darwin/debug/libmirrord_layer_arm64e.dylib
-printf '\x02' | dd of=target/aarch64-apple-darwin/debug/libmirrord_layer_arm64e.dylib bs=1 seek=8 count=1 conv=notrunc
-codesign -f -s - target/aarch64-apple-darwin/debug/libmirrord_layer_arm64e.dylib
+codesign -f -s - target/aarch64-apple-darwin/debug/libmirrord_layer.dylib
 codesign -f -s - target/x86_64-apple-darwin/debug/libmirrord_layer.dylib
 mkdir -p target/universal-apple-darwin/debug
-lipo -create -output target/universal-apple-darwin/debug/libmirrord_layer.dylib target/aarch64-apple-darwin/debug/libmirrord_layer.dylib target/x86_64-apple-darwin/debug/libmirrord_layer.dylib target/aarch64-apple-darwin/debug/libmirrord_layer_arm64e.dylib
+lipo -create -output target/universal-apple-darwin/debug/libmirrord_layer.dylib target/aarch64-apple-darwin/debug/libmirrord_layer.dylib target/x86_64-apple-darwin/debug/libmirrord_layer.dylib
 codesign -f -s - target/universal-apple-darwin/debug/libmirrord_layer.dylib
 MIRRORD_LAYER_FILE=../../../target/universal-apple-darwin/debug/libmirrord_layer.dylib cargo build -p mirrord --target=aarch64-apple-darwin
 MIRRORD_LAYER_FILE=../../../target/universal-apple-darwin/debug/libmirrord_layer.dylib cargo build -p mirrord --target=x86_64-apple-darwin


### PR DESCRIPTION
Closes #2846 (but instead of using a proper arm64e, we're not using any arm64e binary at all).