### PR TITLE
Fixed `mirrord-intproxy` lingering when executing a non-existent binary

### DIFF
--- a/changelog.d/2869.fixed.md
+++ b/changelog.d/2869.fixed.md
@@ -1,0 +1,1 @@
+`mirrord-intproxy` no longer lingers forever when the user tries to execute a non-existent binary.

--- a/mirrord/cli/src/container.rs
+++ b/mirrord/cli/src/container.rs
@@ -384,8 +384,5 @@ pub(crate) async fn container_command(
 
     analytics.set_error(AnalyticsError::BinaryExecuteFailed);
 
-    // Kills the intproxy, freeing the agent.
-    execution_info.stop().await;
-
     Ok(())
 }

--- a/mirrord/cli/src/execution.rs
+++ b/mirrord/cli/src/execution.rs
@@ -154,7 +154,7 @@ impl MirrordExecution {
     /// # Internal proxy
     ///
     /// The internal proxy will be killed as soon as this struct is dropped.
-    /// It **does not** hapen when you `exec` into user binary, because Rust destructors are not
+    /// It **does not** happen when you `exec` into user binary, because Rust destructors are not
     /// run. The whole process is instantly replaced by the OS.
     ///
     /// Therefore, everything should work fine when you create [`MirrordExecution`] with this

--- a/mirrord/cli/src/main.rs
+++ b/mirrord/cli/src/main.rs
@@ -151,9 +151,6 @@ where
     error!("Couldn't execute {:?}", errno);
     analytics.set_error(AnalyticsError::BinaryExecuteFailed);
 
-    // Kills the intproxy, freeing the agent.
-    execution_info.stop().await;
-
     #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
     if errno == Errno::from_raw(86) {
         // "Bad CPU type in executable"


### PR DESCRIPTION
Issue #2869 