### PR TITLE
Add serviceAccount option to agent config

### DIFF
--- a/changelog.d/2876.added.md
+++ b/changelog.d/2876.added.md
@@ -1,0 +1,1 @@
+Added serviceAccount option to agent config

--- a/mirrord-schema.json
+++ b/mirrord-schema.json
@@ -413,14 +413,6 @@
             "type": "string"
           }
         },
-        "service_account": {
-          "title": "agent.service_account {#agent-service_account}",
-          "description": "Allows setting up custom Service Account for the agent Job and Pod.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
         "privileged": {
           "title": "agent.privileged {#agent-privileged}",
           "description": "Run the mirror agent as privileged container. Defaults to `false`.\n\nMight be needed in strict environments such as Bottlerocket.",
@@ -439,6 +431,14 @@
             {
               "type": "null"
             }
+          ]
+        },
+        "service_account": {
+          "title": "agent.service_account {#agent-service_account}",
+          "description": "Allows setting up custom Service Account for the agent Job and Pod.\\\n\n```json { \"service_account\": \"my-service-account\" } ```",
+          "type": [
+            "string",
+            "null"
           ]
         },
         "startup_timeout": {

--- a/mirrord-schema.json
+++ b/mirrord-schema.json
@@ -413,6 +413,14 @@
             "type": "string"
           }
         },
+        "service_account": {
+          "title": "agent.service_account {#agent-service_account}",
+          "description": "Allows setting up custom Service Account for the agent Job and Pod.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "privileged": {
           "title": "agent.privileged {#agent-privileged}",
           "description": "Run the mirror agent as privileged container. Defaults to `false`.\n\nMight be needed in strict environments such as Bottlerocket.",

--- a/mirrord/config/configuration.md
+++ b/mirrord/config/configuration.md
@@ -327,6 +327,10 @@ as targeted agent always runs on the same node as its target container.
 }
 ```
 
+### agent.service_account {#agent-service_account}
+
+Allows setting up custom Service Account for the agent Job and Pod.
+
 ### agent.privileged {#agent-privileged}
 
 Run the mirror agent as privileged container.

--- a/mirrord/config/src/agent.rs
+++ b/mirrord/config/src/agent.rs
@@ -339,6 +339,11 @@ pub struct AgentConfig {
     /// ```
     pub node_selector: Option<HashMap<String, String>>,
 
+    /// ### agent.service_account {#agent-service_account}
+    ///
+    /// Allows setting up custom Service Account for the agent Job and Pod.
+    pub service_account: Option<String>,
+
     /// <!--${internal}-->
     /// Create an agent that returns an error after accepting the first client. For testing
     /// purposes. Only supported with job agents (not with ephemeral agents).

--- a/mirrord/config/src/agent.rs
+++ b/mirrord/config/src/agent.rs
@@ -341,7 +341,13 @@ pub struct AgentConfig {
 
     /// ### agent.service_account {#agent-service_account}
     ///
-    /// Allows setting up custom Service Account for the agent Job and Pod.
+    /// Allows setting up custom Service Account for the agent Job and Pod.\
+    /// 
+    /// ```json
+    /// {
+    ///   "service_account": "my-service-account"
+    /// }
+    /// ```
     pub service_account: Option<String>,
 
     /// <!--${internal}-->

--- a/mirrord/config/src/agent.rs
+++ b/mirrord/config/src/agent.rs
@@ -342,7 +342,7 @@ pub struct AgentConfig {
     /// ### agent.service_account {#agent-service_account}
     ///
     /// Allows setting up custom Service Account for the agent Job and Pod.\
-    /// 
+    ///
     /// ```json
     /// {
     ///   "service_account": "my-service-account"

--- a/mirrord/kube/src/api/container/job.rs
+++ b/mirrord/kube/src/api/container/job.rs
@@ -284,6 +284,7 @@ mod test {
                         "imagePullSecrets": agent.image_pull_secrets,
                         "nodeSelector": {},
                         "tolerations": *DEFAULT_TOLERATIONS,
+                        "serviceAccountName": agent.service_account,
                         "containers": [
                             {
                                 "name": "mirrord-agent",
@@ -403,6 +404,7 @@ mod test {
                         "imagePullSecrets": agent.image_pull_secrets,
                         "nodeSelector": {},
                         "tolerations": *DEFAULT_TOLERATIONS,
+                        "serviceAccountName": agent.service_account,
                         "containers": [
                             {
                                 "name": "mirrord-agent",

--- a/mirrord/kube/src/api/container/pod.rs
+++ b/mirrord/kube/src/api/container/pod.rs
@@ -126,6 +126,7 @@ impl ContainerVariant for PodVariant<'_> {
                 image_pull_secrets,
                 tolerations: Some(tolerations.clone()),
                 node_selector: Some(node_selector),
+                service_account_name: agent.service_account.clone(),
                 containers: vec![Container {
                     name: "mirrord-agent".to_string(),
                     image: Some(agent.image().to_string()),


### PR DESCRIPTION
Added the option to specify a serviceAccount in the config file as mentioned [here](https://github.com/metalbear-co/mirrord/issues/2876).