### PR TITLE
Add operator permissions for argocd appications

### DIFF
--- a/changelog.d/+operator-setup-permissions.internal.md
+++ b/changelog.d/+operator-setup-permissions.internal.md
@@ -1,0 +1,1 @@
+Add argocd application permissions to operator setup.

--- a/mirrord/cli/src/config.rs
+++ b/mirrord/cli/src/config.rs
@@ -615,6 +615,12 @@ pub(super) struct OperatorSetupParams {
     /// a Kafka splitting component.
     #[arg(long, visible_alias = "kafka", default_value_t = false)]
     pub(super) kafka_splitting: bool,
+
+    /// Enable argocd Application auto-pause
+    /// When set the operator will temporary pause automated sync for applications whom resources
+    /// are targeted with `scale_down` feature enabled.
+    #[arg(long, default_value_t = false)]
+    pub(super) application_auto_pause: bool,
 }
 
 /// `mirrord operator session` family of commands.

--- a/mirrord/cli/src/operator.rs
+++ b/mirrord/cli/src/operator.rs
@@ -59,6 +59,7 @@ async fn operator_setup(
         aws_role_arn,
         sqs_splitting,
         kafka_splitting,
+        application_auto_pause,
     }: OperatorSetupParams,
 ) -> Result<(), OperatorSetupError> {
     if !accept_tos {
@@ -105,6 +106,7 @@ async fn operator_setup(
             aws_role_arn,
             sqs_splitting,
             kafka_splitting,
+            application_auto_pause,
         });
 
         match file {

--- a/mirrord/operator/src/setup.rs
+++ b/mirrord/operator/src/setup.rs
@@ -94,6 +94,7 @@ pub struct SetupOptions {
     pub aws_role_arn: Option<String>,
     pub sqs_splitting: bool,
     pub kafka_splitting: bool,
+    pub application_auto_pause: bool,
 }
 
 #[derive(Debug)]
@@ -122,6 +123,7 @@ impl Operator {
             aws_role_arn,
             sqs_splitting,
             kafka_splitting,
+            application_auto_pause,
         } = options;
 
         let (license_secret, license_key) = match license {
@@ -133,7 +135,7 @@ impl Operator {
 
         let service_account = OperatorServiceAccount::new(&namespace, aws_role_arn);
 
-        let role = OperatorRole::new(sqs_splitting, kafka_splitting);
+        let role = OperatorRole::new(sqs_splitting, kafka_splitting, application_auto_pause);
         let role_binding = OperatorRoleBinding::new(&role, &service_account);
         let user_cluster_role = OperatorClusterUserRole::new();
 
@@ -149,6 +151,7 @@ impl Operator {
             image,
             sqs_splitting,
             kafka_splitting,
+            application_auto_pause,
         );
 
         let service = OperatorService::new(&namespace);
@@ -264,6 +267,7 @@ impl FromStr for OperatorNamespace {
 pub struct OperatorDeployment(Deployment);
 
 impl OperatorDeployment {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         namespace: &OperatorNamespace,
         sa: &OperatorServiceAccount,
@@ -272,6 +276,7 @@ impl OperatorDeployment {
         image: String,
         sqs_splitting: bool,
         kafka_splitting: bool,
+        application_auto_pause: bool,
     ) -> Self {
         let mut envs = vec![
             EnvVar {
@@ -342,6 +347,14 @@ impl OperatorDeployment {
         if kafka_splitting {
             envs.push(EnvVar {
                 name: "OPERATOR_KAFKA_SPLITTING".into(),
+                value: Some("true".into()),
+                value_from: None,
+            });
+        }
+
+        if application_auto_pause {
+            envs.push(EnvVar {
+                name: "OPERATOR_APPLICATION_PAUSE_AUTO_SYNC".into(),
                 value: Some("true".into()),
                 value_from: None,
             });
@@ -465,7 +478,7 @@ impl OperatorServiceAccount {
 pub struct OperatorRole(ClusterRole);
 
 impl OperatorRole {
-    pub fn new(sqs_splitting: bool, kafka_splitting: bool) -> Self {
+    pub fn new(sqs_splitting: bool, kafka_splitting: bool, application_auto_pause: bool) -> Self {
         let mut rules = vec![
             PolicyRule {
                 api_groups: Some(vec![
@@ -499,12 +512,6 @@ impl OperatorRole {
                     "statefulsets/scale".to_owned(),
                 ]),
                 verbs: vec!["patch".to_owned()],
-                ..Default::default()
-            },
-            PolicyRule {
-                api_groups: Some(vec!["argoproj.io".to_owned()]),
-                resources: Some(vec!["applications".to_owned()]),
-                verbs: vec!["list".to_owned(), "get".to_owned(), "patch".to_owned()],
                 ..Default::default()
             },
             PolicyRule {
@@ -637,6 +644,15 @@ impl OperatorRole {
             ]);
         }
 
+        if application_auto_pause {
+            rules.push(PolicyRule {
+                api_groups: Some(vec!["argoproj.io".to_owned()]),
+                resources: Some(vec!["applications".to_owned()]),
+                verbs: vec!["list".to_owned(), "get".to_owned(), "patch".to_owned()],
+                ..Default::default()
+            });
+        }
+
         let role = ClusterRole {
             metadata: ObjectMeta {
                 name: Some(OPERATOR_ROLE_NAME.to_owned()),
@@ -660,7 +676,7 @@ impl OperatorRole {
 
 impl Default for OperatorRole {
     fn default() -> Self {
-        Self::new(false, false)
+        Self::new(false, false, false)
     }
 }
 

--- a/mirrord/operator/src/setup.rs
+++ b/mirrord/operator/src/setup.rs
@@ -502,6 +502,12 @@ impl OperatorRole {
                 ..Default::default()
             },
             PolicyRule {
+                api_groups: Some(vec!["argoproj.io".to_owned()]),
+                resources: Some(vec!["applications".to_owned()]),
+                verbs: vec!["list".to_owned(), "get".to_owned(), "patch".to_owned()],
+                ..Default::default()
+            },
+            PolicyRule {
                 api_groups: Some(vec!["".to_owned(), "batch".to_owned()]),
                 resources: Some(vec!["jobs".to_owned(), "pods".to_owned()]),
                 verbs: vec!["create".to_owned(), "delete".to_owned()],


### PR DESCRIPTION
add a clusterrole rule to allow applications integration
```yaml
- apiGroups:
  - argoproj.io
  resources:
  - applications
  verbs:
  - list
  - get
  - patch
  ```