### PR TITLE
Rename some potentially confusing names.

### DIFF
--- a/changelog.d/+better-name-for-result-and-config-param.internal.md
+++ b/changelog.d/+better-name-for-result-and-config-param.internal.md
@@ -1,0 +1,1 @@
+Changes the Result alias to CliResult, and config to layer_config (in some places).

--- a/mirrord/cli/src/connection.rs
+++ b/mirrord/cli/src/connection.rs
@@ -17,7 +17,7 @@ use mirrord_protocol::{ClientMessage, DaemonMessage};
 use tokio::sync::mpsc;
 use tracing::Level;
 
-use crate::{CliError, Result};
+use crate::{CliError, CliResult};
 
 pub const AGENT_CONNECT_INFO_ENV_KEY: &str = "MIRRORD_AGENT_CONNECT_INFO";
 
@@ -35,7 +35,7 @@ async fn try_connect_using_operator<P, R>(
     config: &LayerConfig,
     progress: &P,
     analytics: &mut R,
-) -> Result<Option<OperatorSessionConnection>>
+) -> CliResult<Option<OperatorSessionConnection>>
 where
     P: Progress,
     R: Reporter,
@@ -114,7 +114,7 @@ pub(crate) async fn create_and_connect<P, R: Reporter>(
     config: &LayerConfig,
     progress: &mut P,
     analytics: &mut R,
-) -> Result<(AgentConnectInfo, AgentConnection)>
+) -> CliResult<(AgentConnectInfo, AgentConnection)>
 where
     P: Progress + Send + Sync,
 {
@@ -208,7 +208,7 @@ fn user_persistent_random_message_select() -> bool {
         == 0
 }
 
-pub(crate) fn show_multipod_warning<P>(progress: &mut P) -> Result<(), CliError>
+pub(crate) fn show_multipod_warning<P>(progress: &mut P) -> CliResult<(), CliError>
 where
     P: Progress + Send + Sync,
 {
@@ -238,7 +238,7 @@ where
     Ok(())
 }
 
-pub(crate) fn show_http_filter_warning<P>(progress: &mut P) -> Result<(), CliError>
+pub(crate) fn show_http_filter_warning<P>(progress: &mut P) -> CliResult<(), CliError>
 where
     P: Progress + Send + Sync,
 {

--- a/mirrord/cli/src/container.rs
+++ b/mirrord/cli/src/container.rs
@@ -25,7 +25,7 @@ use crate::{
     config::{ContainerCommand, ExecParams, RuntimeArgs},
     connection::AGENT_CONNECT_INFO_ENV_KEY,
     container::command_builder::RuntimeCommandBuilder,
-    error::{ContainerError, Result},
+    error::{CliResult, ContainerError},
     execution::{
         MirrordExecution, LINUX_INJECTION_ENV_VAR, MIRRORD_CONNECT_TCP_ENV,
         MIRRORD_EXECUTION_KIND_ENV,
@@ -51,7 +51,9 @@ fn format_command(command: &Command) -> String {
 
 /// Execute a [`Command`] and read first line from stdout
 #[tracing::instrument(level = Level::TRACE, ret)]
-async fn exec_and_get_first_line(command: &mut Command) -> Result<Option<String>, ContainerError> {
+async fn exec_and_get_first_line(
+    command: &mut Command,
+) -> CliResult<Option<String>, ContainerError> {
     let mut child = command
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
@@ -110,7 +112,7 @@ async fn exec_and_get_first_line(command: &mut Command) -> Result<Option<String>
 /// Create a temp file with a json serialized [`LayerConfig`] to be loaded by container and external
 /// proxy
 #[tracing::instrument(level = Level::TRACE, ret)]
-fn create_composed_config(config: &LayerConfig) -> Result<NamedTempFile, ContainerError> {
+fn create_composed_config(config: &LayerConfig) -> CliResult<NamedTempFile, ContainerError> {
     let mut composed_config_file = tempfile::Builder::new()
         .suffix(".json")
         .tempfile()
@@ -126,7 +128,7 @@ fn create_composed_config(config: &LayerConfig) -> Result<NamedTempFile, Contain
 #[tracing::instrument(level = Level::TRACE, ret)]
 fn create_self_signed_certificate(
     subject_alt_names: Vec<String>,
-) -> Result<(NamedTempFile, NamedTempFile), ContainerError> {
+) -> CliResult<(NamedTempFile, NamedTempFile), ContainerError> {
     let geerated = rcgen::generate_simple_self_signed(subject_alt_names)
         .map_err(ContainerError::SelfSignedCertificate)?;
 
@@ -153,7 +155,7 @@ async fn create_sidecar_intproxy(
     config: &LayerConfig,
     base_command: &RuntimeCommandBuilder,
     connection_info: Vec<(&str, &str)>,
-) -> Result<(String, SocketAddr), ContainerError> {
+) -> CliResult<(String, SocketAddr), ContainerError> {
     let mut sidecar_command = base_command.clone();
 
     sidecar_command.add_env(MIRRORD_INTPROXY_CONTAINER_MODE_ENV, "true");
@@ -219,7 +221,7 @@ pub(crate) async fn container_command(
     runtime_args: RuntimeArgs,
     exec_params: ExecParams,
     watch: drain::Watch,
-) -> Result<()> {
+) -> CliResult<()> {
     let progress = ProgressTracker::from_env("mirrord container");
 
     progress.warning("mirrord container is currently an unstable feature");

--- a/mirrord/cli/src/diagnose.rs
+++ b/mirrord/cli/src/diagnose.rs
@@ -11,15 +11,15 @@ use tokio::{sync::mpsc, time::Instant};
 use tracing::Level;
 
 use crate::{
-    connection::create_and_connect, util::remove_proxy_env, CliError, DiagnoseArgs,
-    DiagnoseCommand, Result,
+    connection::create_and_connect, util::remove_proxy_env, CliError, CliResult, DiagnoseArgs,
+    DiagnoseCommand,
 };
 
 /// Sends a ping the connection and expects a pong.
 async fn ping(
     sender: &mpsc::Sender<ClientMessage>,
     receiver: &mut mpsc::Receiver<DaemonMessage>,
-) -> Result<()> {
+) -> CliResult<()> {
     sender.send(ClientMessage::Ping).await.map_err(|_| {
         CliError::PingPongFailed(
             "failed to send ping message - agent unexpectedly closed connection".to_string(),
@@ -47,7 +47,7 @@ async fn ping(
 
 /// Create a targetless session and run pings to diagnose network latency.
 #[tracing::instrument(level = Level::TRACE, ret)]
-async fn diagnose_latency(config: Option<&Path>) -> Result<()> {
+async fn diagnose_latency(config: Option<&Path>) -> CliResult<()> {
     let mut progress = ProgressTracker::from_env("mirrord network diagnosis");
 
     let mut cfg_context = ConfigContext::default();
@@ -98,7 +98,7 @@ async fn diagnose_latency(config: Option<&Path>) -> Result<()> {
 }
 
 /// Handle commands related to the operator `mirrord diagnose ...`
-pub(crate) async fn diagnose_command(args: DiagnoseArgs) -> Result<()> {
+pub(crate) async fn diagnose_command(args: DiagnoseArgs) -> CliResult<()> {
     match args.command {
         DiagnoseCommand::Latency { config_file } => diagnose_latency(config_file.as_deref()).await,
     }

--- a/mirrord/cli/src/error.rs
+++ b/mirrord/cli/src/error.rs
@@ -13,7 +13,7 @@ use thiserror::Error;
 
 use crate::port_forward::PortForwardError;
 
-pub(crate) type Result<T, E = CliError> = core::result::Result<T, E>;
+pub(crate) type CliResult<T, E = CliError> = core::result::Result<T, E>;
 
 const GENERAL_HELP: &str = r#"
 

--- a/mirrord/cli/src/execution.rs
+++ b/mirrord/cli/src/execution.rs
@@ -35,7 +35,7 @@ use crate::{
     error::CliError,
     extract::extract_library,
     util::remove_proxy_env,
-    Result,
+    CliResult,
 };
 
 /// Env variable mirrord-layer uses to connect to intproxy
@@ -171,7 +171,7 @@ impl MirrordExecution {
         #[cfg(target_os = "macos")] executable: Option<&str>,
         progress: &mut P,
         analytics: &mut AnalyticsReporter,
-    ) -> Result<Self>
+    ) -> CliResult<Self>
     where
         P: Progress + Send + Sync,
     {
@@ -325,7 +325,7 @@ impl MirrordExecution {
         })
     }
 
-    async fn get_agent_version(connection: &mut AgentConnection) -> Result<Version> {
+    async fn get_agent_version(connection: &mut AgentConnection) -> CliResult<Version> {
         let Ok(_) = connection
             .sender
             .send(ClientMessage::SwitchProtocolVersion(
@@ -354,7 +354,7 @@ impl MirrordExecution {
         config: &LayerConfig,
         progress: &mut P,
         analytics: &mut AnalyticsReporter,
-    ) -> Result<Self>
+    ) -> CliResult<Self>
     where
         P: Progress + Send + Sync,
     {
@@ -447,7 +447,7 @@ impl MirrordExecution {
     async fn fetch_env_vars(
         config: &LayerConfig,
         connection: &mut AgentConnection,
-    ) -> Result<HashMap<String, String>> {
+    ) -> CliResult<HashMap<String, String>> {
         let mut env_vars = HashMap::new();
 
         let (env_vars_exclude, env_vars_include) = match (
@@ -500,7 +500,7 @@ impl MirrordExecution {
         connection: &mut AgentConnection,
         env_vars_filter: HashSet<String>,
         env_vars_select: HashSet<String>,
-    ) -> Result<HashMap<String, String>> {
+    ) -> CliResult<HashMap<String, String>> {
         connection
             .sender
             .send(ClientMessage::GetEnvVarsRequest(GetEnvVarsRequest {
@@ -552,7 +552,7 @@ impl MirrordExecution {
     /// cleans up the process when the parent process exits, so we need the parent to stay alive
     /// while the internal proxy is running.
     /// See <https://github.com/metalbear-co/mirrord/issues/1211>
-    pub(crate) async fn wait(mut self) -> Result<()> {
+    pub(crate) async fn wait(mut self) -> CliResult<()> {
         self.child
             .wait()
             .await

--- a/mirrord/cli/src/extension.rs
+++ b/mirrord/cli/src/extension.rs
@@ -4,7 +4,7 @@ use mirrord_analytics::{AnalyticsError, AnalyticsReporter, Reporter};
 use mirrord_config::{LayerConfig, MIRRORD_CONFIG_FILE_ENV};
 use mirrord_progress::{JsonProgress, Progress, ProgressTracker};
 
-use crate::{config::ExtensionExecArgs, error::CliError, execution::MirrordExecution, Result};
+use crate::{config::ExtensionExecArgs, error::CliError, execution::MirrordExecution, CliResult};
 
 /// Actually facilitate execution after all preparations were complete
 async fn mirrord_exec<P>(
@@ -13,7 +13,7 @@ async fn mirrord_exec<P>(
     config: LayerConfig,
     mut progress: P,
     analytics: &mut AnalyticsReporter,
-) -> Result<()>
+) -> CliResult<()>
 where
     P: Progress + Send + Sync,
 {
@@ -37,7 +37,7 @@ where
 }
 
 /// Facilitate the execution of a process using mirrord by an IDE extension
-pub(crate) async fn extension_exec(args: ExtensionExecArgs, watch: drain::Watch) -> Result<()> {
+pub(crate) async fn extension_exec(args: ExtensionExecArgs, watch: drain::Watch) -> CliResult<()> {
     let progress = ProgressTracker::try_from_env("mirrord preparing to launch")
         .unwrap_or_else(|| JsonProgress::new("mirrord preparing to launch").into());
     let mut env: HashMap<String, String> = HashMap::new();

--- a/mirrord/cli/src/external_proxy.rs
+++ b/mirrord/cli/src/external_proxy.rs
@@ -45,7 +45,7 @@ use tracing_subscriber::EnvFilter;
 
 use crate::{
     connection::AGENT_CONNECT_INFO_ENV_KEY,
-    error::{ExternalProxyError, Result},
+    error::{ExternalProxyError, CliResult},
     execution::MIRRORD_EXECUTION_KIND_ENV,
     internal_proxy::connect_and_ping,
     util::{create_listen_socket, detach_io},
@@ -59,7 +59,7 @@ fn print_addr(listener: &TcpListener) -> io::Result<()> {
     Ok(())
 }
 
-pub async fn proxy(listen_port: u16, watch: drain::Watch) -> Result<()> {
+pub async fn proxy(listen_port: u16, watch: drain::Watch) -> CliResult<()> {
     let config = LayerConfig::from_env()?;
 
     tracing::info!(?config, "external_proxy starting");
@@ -185,7 +185,7 @@ pub async fn proxy(listen_port: u16, watch: drain::Watch) -> Result<()> {
 
 async fn create_external_proxy_tls_acceptor(
     config: &LayerConfig,
-) -> Result<Option<tokio_rustls::TlsAcceptor>, ExternalProxyError> {
+) -> CliResult<Option<tokio_rustls::TlsAcceptor>, ExternalProxyError> {
     if !config.external_proxy.tls_enable {
         return Ok(None);
     }
@@ -205,7 +205,7 @@ async fn create_external_proxy_tls_acceptor(
             })
             .map_err(ExternalProxyError::Tls)?,
     ))
-    .collect::<Result<Vec<_>, _>>()
+    .collect::<CliResult<Vec<_>, _>>()
     .map_err(|error| ConnectionTlsError::ParsingPem(client_tls_certificate.to_path_buf(), error))
     .map_err(ExternalProxyError::Tls)?;
 
@@ -214,7 +214,7 @@ async fn create_external_proxy_tls_acceptor(
             .map_err(|error| ConnectionTlsError::MissingPem(tls_certificate.to_path_buf(), error))
             .map_err(ExternalProxyError::Tls)?,
     ))
-    .collect::<Result<Vec<_>, _>>()
+    .collect::<CliResult<Vec<_>, _>>()
     .map_err(|error| ConnectionTlsError::ParsingPem(tls_certificate.to_path_buf(), error))
     .map_err(ExternalProxyError::Tls)?;
 

--- a/mirrord/cli/src/external_proxy.rs
+++ b/mirrord/cli/src/external_proxy.rs
@@ -45,7 +45,7 @@ use tracing_subscriber::EnvFilter;
 
 use crate::{
     connection::AGENT_CONNECT_INFO_ENV_KEY,
-    error::{ExternalProxyError, CliResult},
+    error::{CliResult, ExternalProxyError},
     execution::MIRRORD_EXECUTION_KIND_ENV,
     internal_proxy::connect_and_ping,
     util::{create_listen_socket, detach_io},

--- a/mirrord/cli/src/extract.rs
+++ b/mirrord/cli/src/extract.rs
@@ -8,7 +8,7 @@ use const_random::const_random;
 use mirrord_progress::Progress;
 use tracing::debug;
 
-use crate::{error::CliError, Result};
+use crate::{error::CliError, CliResult};
 
 /// For some reason loading dylib from $TMPDIR can get the process killed somehow..?
 #[cfg(target_os = "macos")]
@@ -35,7 +35,7 @@ pub(crate) fn extract_library<P>(
     dest_dir: Option<String>,
     progress: &P,
     prefix: bool,
-) -> Result<PathBuf>
+) -> CliResult<PathBuf>
 where
     P: Progress + Send + Sync,
 {
@@ -72,7 +72,7 @@ where
 /// If prefix is true, add a random prefix to the file name that identifies the specific build
 /// of the layer. This is useful for debug purposes usually.
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
-pub(crate) fn extract_arm64<P>(progress: &P, prefix: bool) -> Result<PathBuf>
+pub(crate) fn extract_arm64<P>(progress: &P, prefix: bool) -> CliResult<PathBuf>
 where
     P: Progress + Send + Sync,
 {

--- a/mirrord/cli/src/internal_proxy.rs
+++ b/mirrord/cli/src/internal_proxy.rs
@@ -35,7 +35,7 @@ use tracing_subscriber::EnvFilter;
 
 use crate::{
     connection::AGENT_CONNECT_INFO_ENV_KEY,
-    error::{InternalProxyError, CliResult},
+    error::{CliResult, InternalProxyError},
     execution::MIRRORD_EXECUTION_KIND_ENV,
     util::{create_listen_socket, detach_io},
 };
@@ -50,7 +50,10 @@ fn print_addr(listener: &TcpListener) -> io::Result<()> {
 
 /// Main entry point for the internal proxy.
 /// It listens for inbound layer connect and forwards to agent.
-pub(crate) async fn proxy(listen_port: u16, watch: drain::Watch) -> CliResult<(), InternalProxyError> {
+pub(crate) async fn proxy(
+    listen_port: u16,
+    watch: drain::Watch,
+) -> CliResult<(), InternalProxyError> {
     let config = LayerConfig::from_env()?;
 
     tracing::info!(?config, "internal_proxy starting");

--- a/mirrord/cli/src/internal_proxy.rs
+++ b/mirrord/cli/src/internal_proxy.rs
@@ -35,7 +35,7 @@ use tracing_subscriber::EnvFilter;
 
 use crate::{
     connection::AGENT_CONNECT_INFO_ENV_KEY,
-    error::{InternalProxyError, Result},
+    error::{InternalProxyError, CliResult},
     execution::MIRRORD_EXECUTION_KIND_ENV,
     util::{create_listen_socket, detach_io},
 };
@@ -50,7 +50,7 @@ fn print_addr(listener: &TcpListener) -> io::Result<()> {
 
 /// Main entry point for the internal proxy.
 /// It listens for inbound layer connect and forwards to agent.
-pub(crate) async fn proxy(listen_port: u16, watch: drain::Watch) -> Result<(), InternalProxyError> {
+pub(crate) async fn proxy(listen_port: u16, watch: drain::Watch) -> CliResult<(), InternalProxyError> {
     let config = LayerConfig::from_env()?;
 
     tracing::info!(?config, "internal_proxy starting");
@@ -153,7 +153,7 @@ pub(crate) async fn connect_and_ping(
     config: &LayerConfig,
     connect_info: Option<AgentConnectInfo>,
     analytics: &mut AnalyticsReporter,
-) -> Result<AgentConnection, InternalProxyError> {
+) -> CliResult<AgentConnection, InternalProxyError> {
     let mut agent_conn = AgentConnection::new(config, connect_info, analytics)
         .await
         .map_err(IntProxyError::from)?;

--- a/mirrord/cli/src/main.rs
+++ b/mirrord/cli/src/main.rs
@@ -64,7 +64,7 @@ mod util;
 mod verify_config;
 mod vpn;
 
-pub(crate) use error::{CliError, Result};
+pub(crate) use error::{CliError, CliResult};
 use verify_config::verify_config;
 
 use crate::util::remove_proxy_env;
@@ -78,7 +78,7 @@ async fn exec_process<P>(
     args: &ExecArgs,
     progress: &P,
     analytics: &mut AnalyticsReporter,
-) -> Result<()>
+) -> CliResult<()>
 where
     P: Progress + Send + Sync,
 {
@@ -138,12 +138,12 @@ where
         .clone()
         .into_iter()
         .map(CString::new)
-        .collect::<Result<Vec<_>, _>>()?;
+        .collect::<CliResult<Vec<_>, _>>()?;
     // env vars should be formatted as "varname=value" CStrings
     let env = env_vars
         .into_iter()
         .map(|(k, v)| CString::new(format!("{k}={v}")))
-        .collect::<Result<Vec<_>, _>>()?;
+        .collect::<CliResult<Vec<_>, _>>()?;
 
     // The execve hook is not yet active and does not hijack this call.
     let errno = nix::unistd::execve(&path, args.as_slice(), env.as_slice())
@@ -330,7 +330,7 @@ fn print_config<P>(
     }
 }
 
-async fn exec(args: &ExecArgs, watch: drain::Watch) -> Result<()> {
+async fn exec(args: &ExecArgs, watch: drain::Watch) -> CliResult<()> {
     let progress = ProgressTracker::from_env("mirrord exec");
     if !args.params.disable_version_check {
         prompt_outdated_version(&progress).await;
@@ -377,7 +377,7 @@ async fn exec(args: &ExecArgs, watch: drain::Watch) -> Result<()> {
 /// Lists targets based on whether or not the operator has been enabled in `layer_config`.
 /// If the operator is enabled (and we can reach it), then we list [`KubeResourceSeeker::all`]
 /// targets, otherwise we list [`KubeResourceSeeker::all_open_source`] only.
-async fn list_targets(layer_config: &LayerConfig, args: &ListTargetArgs) -> Result<Vec<String>> {
+async fn list_targets(layer_config: &LayerConfig, args: &ListTargetArgs) -> CliResult<Vec<String>> {
     let client = create_kube_config(
         layer_config.accept_invalid_certificates,
         layer_config.kubeconfig.clone(),
@@ -444,7 +444,7 @@ async fn list_targets(layer_config: &LayerConfig, args: &ListTargetArgs) -> Resu
 ///  "statefulset/nginx-statefulset/container/nginx"
 /// ]
 /// ```
-async fn print_targets(args: &ListTargetArgs) -> Result<()> {
+async fn print_targets(args: &ListTargetArgs) -> CliResult<()> {
     let mut layer_config = if let Some(config) = &args.config_file {
         let mut cfg_context = ConfigContext::default();
         LayerFileConfig::from_path(config)?.generate_config(&mut cfg_context)?
@@ -468,10 +468,10 @@ async fn print_targets(args: &ListTargetArgs) -> Result<()> {
     Ok(())
 }
 
-async fn port_forward(args: &PortForwardArgs, watch: drain::Watch) -> Result<()> {
+async fn port_forward(args: &PortForwardArgs, watch: drain::Watch) -> CliResult<()> {
     fn hash_port_mappings(
         args: &PortForwardArgs,
-    ) -> Result<HashMap<SocketAddr, (RemoteAddr, u16)>, PortForwardError> {
+    ) -> CliResult<HashMap<SocketAddr, (RemoteAddr, u16)>, PortForwardError> {
         let port_mappings = &args.port_mapping;
         let mut mappings: HashMap<SocketAddr, (RemoteAddr, u16)> =
             HashMap::with_capacity(port_mappings.len());
@@ -489,7 +489,7 @@ async fn port_forward(args: &PortForwardArgs, watch: drain::Watch) -> Result<()>
 
     fn hash_rev_port_mappings(
         args: &PortForwardArgs,
-    ) -> Result<HashMap<RemotePort, LocalPort>, PortForwardError> {
+    ) -> CliResult<HashMap<RemotePort, LocalPort>, PortForwardError> {
         let port_mappings = &args.reverse_port_mapping;
         let mut mappings: HashMap<RemotePort, LocalPort> =
             HashMap::with_capacity(port_mappings.len());
@@ -648,7 +648,7 @@ fn main() -> miette::Result<()> {
         .map(|s| s.parse().unwrap_or(false))
         .unwrap_or(false);
 
-    let res: Result<(), CliError> = rt.block_on(async move {
+    let res: CliResult<(), CliError> = rt.block_on(async move {
         if let Ok(console_addr) = std::env::var("MIRRORD_CONSOLE_ADDR") {
             mirrord_console::init_async_logger(&console_addr, watch.clone(), 124).await?;
         } else if force_log || !init_ext_error_handler(&cli.commands) {

--- a/mirrord/cli/src/operator.rs
+++ b/mirrord/cli/src/operator.rs
@@ -25,7 +25,7 @@ use crate::{
     config::{OperatorArgs, OperatorCommand},
     error::{CliError, OperatorSetupError},
     util::remove_proxy_env,
-    OperatorSetupParams, CliResult,
+    CliResult, OperatorSetupParams,
 };
 
 mod session;

--- a/mirrord/cli/src/operator/session.rs
+++ b/mirrord/cli/src/operator/session.rs
@@ -11,7 +11,7 @@ use mirrord_operator::{
 use mirrord_progress::{Progress, ProgressTracker};
 use tracing::Level;
 
-use crate::{CliError, Result, SessionCommand};
+use crate::{CliError, CliResult, SessionCommand};
 
 /// Handles the [`SessionCommand`]s that deal with session management in the operator.
 pub(super) struct SessionCommandHandler {
@@ -32,7 +32,7 @@ pub(super) struct SessionCommandHandler {
 impl SessionCommandHandler {
     /// Starts a new handler for [`SessionCommand`]s.
     #[tracing::instrument(level = Level::TRACE)]
-    pub(super) async fn new(command: SessionCommand) -> Result<Self> {
+    pub(super) async fn new(command: SessionCommand) -> CliResult<Self> {
         let mut progress = ProgressTracker::from_env("Operator session action");
 
         let config = LayerConfig::from_env().inspect_err(|error| {
@@ -66,7 +66,7 @@ impl SessionCommandHandler {
     /// Does the actual work of talking to the operator through the kube [`Api`], using
     /// the routes defined in [`SessionCrd`].
     #[tracing::instrument(level = Level::TRACE, skip(self), ret)]
-    pub(super) async fn handle(self) -> Result<()> {
+    pub(super) async fn handle(self) -> CliResult<()> {
         let Self {
             mut progress,
             mut sub_progress,

--- a/mirrord/cli/src/verify_config.rs
+++ b/mirrord/cli/src/verify_config.rs
@@ -2,7 +2,7 @@
 //! [`VerifyConfig`](crate::Commands::VerifyConfig) enum after checking the config file passed in
 //! `path`. It's used by the IDE plugins to display errors/warnings quickly, without having to start
 //! mirrord-layer.
-use error::Result;
+use error::CliResult;
 use mirrord_config::{
     config::{ConfigContext, MirrordConfig},
     feature::FeatureConfig,
@@ -201,7 +201,7 @@ enum VerifiedConfig {
 ///   "errors": ["mirrord-config: IO operation failed with `No such file or directory (os error 2)`"]
 /// }
 /// ```
-pub(super) async fn verify_config(VerifyConfigArgs { ide, path }: VerifyConfigArgs) -> Result<()> {
+pub(super) async fn verify_config(VerifyConfigArgs { ide, path }: VerifyConfigArgs) -> CliResult<()> {
     let mut config_context = ConfigContext::new(ide);
 
     let layer_config = LayerFileConfig::from_path(path)

--- a/mirrord/cli/src/verify_config.rs
+++ b/mirrord/cli/src/verify_config.rs
@@ -201,7 +201,9 @@ enum VerifiedConfig {
 ///   "errors": ["mirrord-config: IO operation failed with `No such file or directory (os error 2)`"]
 /// }
 /// ```
-pub(super) async fn verify_config(VerifyConfigArgs { ide, path }: VerifyConfigArgs) -> CliResult<()> {
+pub(super) async fn verify_config(
+    VerifyConfigArgs { ide, path }: VerifyConfigArgs,
+) -> CliResult<()> {
     let mut config_context = ConfigContext::new(ide);
 
     let layer_config = LayerFileConfig::from_path(path)

--- a/mirrord/cli/src/vpn.rs
+++ b/mirrord/cli/src/vpn.rs
@@ -9,11 +9,11 @@ use tokio::signal;
 use crate::{
     config::VpnArgs,
     connection::create_and_connect,
-    error::{CliError, Result},
+    error::{CliError, CliResult},
 };
 
 #[allow(clippy::indexing_slicing)]
-pub async fn vpn_command(args: VpnArgs) -> Result<()> {
+pub async fn vpn_command(args: VpnArgs) -> CliResult<()> {
     let mut progress = ProgressTracker::from_env("mirrord vpn");
 
     let mut analytics = NullReporter::default();


### PR DESCRIPTION
- Issue: n/a

1. Renames the `Result` type we have for `cli` to `CliResult`;
2. Renames some `config` args to `layer_config`, where it could be confused with kube config.