### PR TITLE
mirrord container port-publish warning

### DIFF
--- a/changelog.d/+mirrord-container-publish.changed.md
+++ b/changelog.d/+mirrord-container-publish.changed.md
@@ -1,1 +1,1 @@
-Update `mirrord container` command to automatically "move" `-p` arguments to sidecar command, this is to prevent incomptability with our usage of container type network mode.
+Print a warning to the user when `-p` is provided as part of `mirrord container` run command that it may cause an issue because of our usage of container type network mode.

--- a/changelog.d/+mirrord-container-publish.changed.md
+++ b/changelog.d/+mirrord-container-publish.changed.md
@@ -1,0 +1,1 @@
+Update `mirrord container` command to automatically "move" `-p` arguments to sidecar command, this is to prevent incomptability with our usage of container type network mode.

--- a/mirrord/cli/src/config.rs
+++ b/mirrord/cli/src/config.rs
@@ -802,13 +802,20 @@ impl ContainerCommand {
         let mut publish_ports = Vec::new();
 
         let ContainerCommand::Run { runtime_args } = self;
+
         let unfiltered_runtime_args = std::mem::take(runtime_args);
         let mut unfiltered_runtime_args_iter = unfiltered_runtime_args.into_iter();
 
+        let mut hit_trailing_token = false;
+
         while let Some(runtime_arg) = unfiltered_runtime_args_iter.next() {
             match runtime_arg.as_str() {
-                "-p" | "--publish" => {
+                "-p" | "--publish" if !hit_trailing_token => {
                     publish_ports.extend(unfiltered_runtime_args_iter.next());
+                }
+                "--" => {
+                    hit_trailing_token = true;
+                    runtime_args.push(runtime_arg);
                 }
                 _ => {
                     runtime_args.push(runtime_arg);

--- a/mirrord/cli/src/config.rs
+++ b/mirrord/cli/src/config.rs
@@ -797,6 +797,27 @@ impl ContainerCommand {
             runtime_args: runtime_args.into_iter().map(T::into).collect(),
         }
     }
+
+    pub fn extract_publish(&mut self) -> Vec<String> {
+        let mut publish_ports = Vec::new();
+
+        let ContainerCommand::Run { runtime_args } = self;
+        let unfiltered_runtime_args = std::mem::take(runtime_args);
+        let mut unfiltered_runtime_args_iter = unfiltered_runtime_args.into_iter();
+
+        while let Some(runtime_arg) = unfiltered_runtime_args_iter.next() {
+            match runtime_arg.as_str() {
+                "-p" | "--publish" => {
+                    publish_ports.extend(unfiltered_runtime_args_iter.next());
+                }
+                _ => {
+                    runtime_args.push(runtime_arg);
+                }
+            }
+        }
+
+        publish_ports
+    }
 }
 
 #[derive(Args, Debug)]

--- a/mirrord/cli/src/config.rs
+++ b/mirrord/cli/src/config.rs
@@ -798,32 +798,16 @@ impl ContainerCommand {
         }
     }
 
-    pub fn extract_publish(&mut self) -> Vec<String> {
-        let mut publish_ports = Vec::new();
-
+    pub fn has_publish(&self) -> bool {
         let ContainerCommand::Run { runtime_args } = self;
-
-        let unfiltered_runtime_args = std::mem::take(runtime_args);
-        let mut unfiltered_runtime_args_iter = unfiltered_runtime_args.into_iter();
 
         let mut hit_trailing_token = false;
 
-        while let Some(runtime_arg) = unfiltered_runtime_args_iter.next() {
-            match runtime_arg.as_str() {
-                "-p" | "--publish" if !hit_trailing_token => {
-                    publish_ports.extend(unfiltered_runtime_args_iter.next());
-                }
-                "--" => {
-                    hit_trailing_token = true;
-                    runtime_args.push(runtime_arg);
-                }
-                _ => {
-                    runtime_args.push(runtime_arg);
-                }
-            }
-        }
+        runtime_args.iter().any(|runtime_arg| {
+            hit_trailing_token = hit_trailing_token || runtime_arg == "--";
 
-        publish_ports
+            !hit_trailing_token && matches!(runtime_arg.as_str(), "-p" | "--publish")
+        })
     }
 }
 

--- a/mirrord/cli/src/container.rs
+++ b/mirrord/cli/src/container.rs
@@ -155,8 +155,11 @@ async fn create_sidecar_intproxy(
     config: &LayerConfig,
     base_command: &RuntimeCommandBuilder,
     connection_info: Vec<(&str, &str)>,
+    port_bindings: Vec<String>,
 ) -> CliResult<(String, SocketAddr), ContainerError> {
     let mut sidecar_command = base_command.clone();
+
+    sidecar_command.add_port_bindings(port_bindings);
 
     sidecar_command.add_env(MIRRORD_INTPROXY_CONTAINER_MODE_ENV, "true");
     sidecar_command.add_envs(connection_info);
@@ -218,7 +221,7 @@ async fn create_sidecar_intproxy(
 /// Main entry point for the `mirrord container` command.
 /// This spawns: "agent" - "external proxy" - "intproxy sidecar" - "execution container"
 pub(crate) async fn container_command(
-    runtime_args: RuntimeArgs,
+    mut runtime_args: RuntimeArgs,
     exec_params: ExecParams,
     watch: drain::Watch,
 ) -> CliResult<()> {
@@ -365,8 +368,13 @@ pub(crate) async fn container_command(
 
     runtime_command.add_envs(execution_info_env_without_connection_info);
 
-    let (sidecar_container_id, sidecar_intproxy_address) =
-        create_sidecar_intproxy(&config, &runtime_command, connection_info).await?;
+    let (sidecar_container_id, sidecar_intproxy_address) = create_sidecar_intproxy(
+        &config,
+        &runtime_command,
+        connection_info,
+        runtime_args.command.extract_publish(),
+    )
+    .await?;
 
     runtime_command.add_network(format!("container:{sidecar_container_id}"));
     runtime_command.add_volumes_from(sidecar_container_id);

--- a/mirrord/cli/src/container/command_builder.rs
+++ b/mirrord/cli/src/container/command_builder.rs
@@ -57,24 +57,6 @@ impl RuntimeCommandBuilder {
         }
     }
 
-    pub fn add_publish<P>(&mut self, value: P)
-    where
-        P: AsRef<OsStr>,
-    {
-        self.push_arg("-p");
-        self.push_arg(value.as_ref().to_str().unwrap_or_default())
-    }
-
-    pub fn add_port_bindings<I, P>(&mut self, iter: I)
-    where
-        I: IntoIterator<Item = P>,
-        P: AsRef<OsStr>,
-    {
-        for publish in iter {
-            self.add_publish(publish)
-        }
-    }
-
     pub fn add_volume<H, C>(&mut self, host_path: H, container_path: C)
     where
         H: AsRef<Path>,

--- a/mirrord/cli/src/container/command_builder.rs
+++ b/mirrord/cli/src/container/command_builder.rs
@@ -123,7 +123,7 @@ impl RuntimeCommandBuilder<WithCommand> {
         } = self;
 
         let (runtime_command, runtime_args) = match step.command {
-            ContainerCommand::Run { runtime_args, .. } => ("run".to_owned(), runtime_args),
+            ContainerCommand::Run { runtime_args } => ("run".to_owned(), runtime_args),
         };
 
         (

--- a/mirrord/cli/src/container/command_builder.rs
+++ b/mirrord/cli/src/container/command_builder.rs
@@ -57,6 +57,24 @@ impl RuntimeCommandBuilder {
         }
     }
 
+    pub fn add_publish<P>(&mut self, value: P)
+    where
+        P: AsRef<OsStr>,
+    {
+        self.push_arg("-p");
+        self.push_arg(value.as_ref().to_str().unwrap_or_default())
+    }
+
+    pub fn add_port_bindings<I, P>(&mut self, iter: I)
+    where
+        I: IntoIterator<Item = P>,
+        P: AsRef<OsStr>,
+    {
+        for publish in iter {
+            self.add_publish(publish)
+        }
+    }
+
     pub fn add_volume<H, C>(&mut self, host_path: H, container_path: C)
     where
         H: AsRef<Path>,
@@ -123,7 +141,7 @@ impl RuntimeCommandBuilder<WithCommand> {
         } = self;
 
         let (runtime_command, runtime_args) = match step.command {
-            ContainerCommand::Run { runtime_args } => ("run".to_owned(), runtime_args),
+            ContainerCommand::Run { runtime_args, .. } => ("run".to_owned(), runtime_args),
         };
 
         (


### PR DESCRIPTION
Add a warning to `mirrord container` command if `-p` is provided as part of run command.