### PR TITLE
Forward build script args to cargo build

### DIFF
--- a/changelog.d/+build-mac-args.internal.md
+++ b/changelog.d/+build-mac-args.internal.md
@@ -1,0 +1,1 @@
+build script forwards args to cargo build.

--- a/scripts/build_fat_mac.sh
+++ b/scripts/build_fat_mac.sh
@@ -1,14 +1,15 @@
 #!/bin/sh
 # This script builds a fat binary for Mac OS X.
 # Output will be in target/universal-apple-darwin/debug/mirrord
+# Any arguments provided to this script are passed to `cargo build`.
 # If compilation fails, try running:
 # rustup target add --toolchain nightly x86_64-apple-darwin
 
 set -e
 
 # build layer
-cargo build -p mirrord-layer --target=x86_64-apple-darwin
-cargo build -p mirrord-layer --target=aarch64-apple-darwin
+cargo build "$@" -p mirrord-layer --target=x86_64-apple-darwin
+cargo build "$@" -p mirrord-layer --target=aarch64-apple-darwin
 
 # sign layer dylibs
 codesign -f -s - target/aarch64-apple-darwin/debug/libmirrord_layer.dylib
@@ -26,8 +27,8 @@ lipo -create -output target/universal-apple-darwin/debug/libmirrord_layer.dylib 
 codesign -f -s - target/universal-apple-darwin/debug/libmirrord_layer.dylib
 
 # build mirrord package - aarch64-apple-darwin target requires MIRRORD_LAYER_FILE_MACOS_ARM64 var
-MIRRORD_LAYER_FILE_MACOS_ARM64=../../../target/aarch64-apple-darwin/debug/libmirrord_layer.dylib MIRRORD_LAYER_FILE=../../../target/universal-apple-darwin/debug/libmirrord_layer.dylib cargo build -p mirrord --target=aarch64-apple-darwin
-MIRRORD_LAYER_FILE=../../../target/universal-apple-darwin/debug/libmirrord_layer.dylib cargo build -p mirrord --target=x86_64-apple-darwin
+MIRRORD_LAYER_FILE_MACOS_ARM64=../../../target/aarch64-apple-darwin/debug/libmirrord_layer.dylib MIRRORD_LAYER_FILE=../../../target/universal-apple-darwin/debug/libmirrord_layer.dylib cargo build "$@" -p mirrord --target=aarch64-apple-darwin
+MIRRORD_LAYER_FILE=../../../target/universal-apple-darwin/debug/libmirrord_layer.dylib cargo build "$@" -p mirrord --target=x86_64-apple-darwin
 
 # create universal binary for mirrord and sign
 lipo -create -output target/universal-apple-darwin/debug/mirrord target/aarch64-apple-darwin/debug/mirrord target/x86_64-apple-darwin/debug/mirrord


### PR DESCRIPTION
My main motivation was cargo's `--offline`.