### PR TITLE
Escape paths used in regexes

### DIFF
--- a/changelog.d/+escape-regexes.fixed.md
+++ b/changelog.d/+escape-regexes.fixed.md
@@ -1,0 +1,1 @@
+Read current dir, current exe, and temp dir locally, also when they contain characters with a meaning for regexes, like e.g. paretheses.

--- a/mirrord/layer/src/file/filter/read_local_by_default.rs
+++ b/mirrord/layer/src/file/filter/read_local_by_default.rs
@@ -73,7 +73,7 @@ pub fn regex_set_builder() -> RegexSetBuilder {
         #[cfg(target_os = "macos")]
         r"^/Network",
         // Any path under the standard temp directory.
-        &format!("^{}", env::temp_dir().to_string_lossy()),
+        &format!("^{}", regex::escape(&env::temp_dir().to_string_lossy())),
         "^/$", // root
     ]
     .iter()
@@ -85,11 +85,11 @@ pub fn regex_set_builder() -> RegexSetBuilder {
             "^{}(/|$)",
             // We trim any trailing '/' and add it above, so that the regex is correct whether
             // current_dir returns a trailing '/' or not.
-            cwd.to_string_lossy().trim_end_matches('/')
+            regex::escape(cwd.to_string_lossy().trim_end_matches('/'))
         ));
     }
     if let Ok(executable) = env::current_exe() {
-        patterns.push(format!("{}$", executable.to_string_lossy()));
+        patterns.push(format!("{}$", regex::escape(&executable.to_string_lossy())));
     }
 
     RegexSetBuilder::new(patterns)


### PR DESCRIPTION
Otherwise, a path like "/my/cool/executable (1)" would be used in the regex, and that regex would not match that path (it would match "/my/cool/executable 1").