### PR TITLE
mirrord container docker check run

### DIFF
--- a/changelog.d/2927.fixed.md
+++ b/changelog.d/2927.fixed.md
@@ -1,0 +1,1 @@
+Manually call `docker start <sidecar_id>` if after our sidecar `run` command the container hasn't started yet and is in "created" status.

--- a/mirrord/cli/src/container.rs
+++ b/mirrord/cli/src/container.rs
@@ -431,21 +431,14 @@ pub(crate) async fn container_command(
         .status()
         .await;
 
-    let mut exit_code = None;
+    let _ = composed_config_file.close();
 
     match runtime_command_result {
         Err(err) => {
-            tracing::error!("Couldn't execute {:?}", err);
-
             analytics.set_error(AnalyticsError::BinaryExecuteFailed);
+
+            Err(err)
         }
-        Ok(status) if !status.success() => {
-            exit_code = status.code();
-        }
-        _ => {}
+        Ok(status) => Ok(status.code().unwrap_or_default()),
     }
-
-    let _ = composed_config_file.close();
-
-    Ok(exit_code.unwrap_or(0))
 }

--- a/mirrord/cli/src/container.rs
+++ b/mirrord/cli/src/container.rs
@@ -212,7 +212,7 @@ async fn create_sidecar_intproxy(
                 .unwrap_or_default();
 
         let container_status = container_inspection
-            .and_then(|inspect| inspect.get("State"))
+            .get("State")
             .and_then(|inspect| inspect.get("Status"));
 
         if container_status

--- a/mirrord/cli/src/container.rs
+++ b/mirrord/cli/src/container.rs
@@ -376,17 +376,14 @@ pub(crate) async fn container_command(
     );
 
     runtime_command.add_env(MIRRORD_CONFIG_FILE_ENV, "/tmp/mirrord-config.json");
-    runtime_command.add_volume(
-        composed_config_file.path(),
-        "/tmp/mirrord-config.json",
-        true,
-    );
+    runtime_command
+        .add_volume::<true, _, _>(composed_config_file.path(), "/tmp/mirrord-config.json");
 
     let mut load_env_and_mount_pem = |env: &str, path: &Path| {
         let container_path = format!("/tmp/{}.pem", env.to_lowercase());
 
         runtime_command.add_env(env, &container_path);
-        runtime_command.add_volume(path, container_path, true);
+        runtime_command.add_volume::<true, _, _>(path, container_path);
     };
 
     if let Some(path) = config.internal_proxy.client_tls_certificate.as_ref() {

--- a/mirrord/cli/src/container.rs
+++ b/mirrord/cli/src/container.rs
@@ -437,7 +437,7 @@ pub(crate) async fn container_command(
         Err(err) => {
             analytics.set_error(AnalyticsError::BinaryExecuteFailed);
 
-            Err(err)
+            Err(ContainerError::UnableToExecuteCommand(err).into())
         }
         Ok(status) => Ok(status.code().unwrap_or_default()),
     }

--- a/mirrord/cli/src/container.rs
+++ b/mirrord/cli/src/container.rs
@@ -256,7 +256,7 @@ pub(crate) async fn container_command(
     exec_params: ExecParams,
     watch: drain::Watch,
 ) -> CliResult<i32> {
-    let progress = ProgressTracker::from_env("mirrord container");
+    let mut progress = ProgressTracker::from_env("mirrord container");
 
     if runtime_args.command.has_publish() {
         progress.warning("mirrord container may have problems with \"-p\" directly container in command, please add to \"contanier.cli_extra_args\" in config if you are planning to publish ports");
@@ -418,6 +418,8 @@ pub(crate) async fn container_command(
         MIRRORD_CONNECT_TCP_ENV,
         sidecar_intproxy_address.to_string(),
     );
+
+    progress.success(None);
 
     let (binary, binary_args) = runtime_command
         .with_command(runtime_args.command)

--- a/mirrord/cli/src/container/command_builder.rs
+++ b/mirrord/cli/src/container/command_builder.rs
@@ -17,7 +17,7 @@ pub struct RuntimeCommandBuilder<T = Empty> {
 }
 
 impl<T> RuntimeCommandBuilder<T> {
-    pub fn runtime(&self) -> &ContainerRuntime {
+    pub(super) fn runtime(&self) -> &ContainerRuntime {
         &self.runtime
     }
 
@@ -38,7 +38,7 @@ impl RuntimeCommandBuilder {
         }
     }
 
-    pub fn add_env<K, V>(&mut self, key: K, value: V)
+    pub(super) fn add_env<K, V>(&mut self, key: K, value: V)
     where
         K: AsRef<OsStr>,
         V: AsRef<OsStr>,
@@ -50,7 +50,7 @@ impl RuntimeCommandBuilder {
         self.push_arg(format!("{key}={value}"))
     }
 
-    pub fn add_envs<I, K, V>(&mut self, iter: I)
+    pub(super) fn add_envs<I, K, V>(&mut self, iter: I)
     where
         I: IntoIterator<Item = (K, V)>,
         K: AsRef<OsStr>,
@@ -61,7 +61,7 @@ impl RuntimeCommandBuilder {
         }
     }
 
-    pub fn add_volume<H, C>(&mut self, host_path: H, container_path: C, readonly: bool)
+    pub(super) fn add_volume<const READONLY: bool, H, C>(&mut self, host_path: H, container_path: C)
     where
         H: AsRef<Path>,
         C: AsRef<Path>,
@@ -70,7 +70,7 @@ impl RuntimeCommandBuilder {
             ContainerRuntime::Podman | ContainerRuntime::Docker | ContainerRuntime::Nerdctl => {
                 self.push_arg("-v");
 
-                if readonly {
+                if READONLY {
                     self.push_arg(format!(
                         "{}:{}:ro",
                         host_path.as_ref().display(),
@@ -87,7 +87,7 @@ impl RuntimeCommandBuilder {
         }
     }
 
-    pub fn add_volumes_from<V>(&mut self, volumes_from: V)
+    pub(super) fn add_volumes_from<V>(&mut self, volumes_from: V)
     where
         V: Into<String>,
     {
@@ -99,7 +99,7 @@ impl RuntimeCommandBuilder {
         }
     }
 
-    pub fn add_network<N>(&mut self, network: N)
+    pub(super) fn add_network<N>(&mut self, network: N)
     where
         N: Into<String>,
     {
@@ -111,7 +111,10 @@ impl RuntimeCommandBuilder {
         }
     }
 
-    pub fn with_command(self, command: ContainerCommand) -> RuntimeCommandBuilder<WithCommand> {
+    pub(super) fn with_command(
+        self,
+        command: ContainerCommand,
+    ) -> RuntimeCommandBuilder<WithCommand> {
         let RuntimeCommandBuilder {
             runtime,
             extra_args,
@@ -128,7 +131,7 @@ impl RuntimeCommandBuilder {
 
 impl RuntimeCommandBuilder<WithCommand> {
     /// Return completed command command with updated arguments
-    pub fn into_command_args(self) -> (String, impl Iterator<Item = String>) {
+    pub(super) fn into_command_args(self) -> (String, impl Iterator<Item = String>) {
         let RuntimeCommandBuilder {
             runtime,
             extra_args,

--- a/mirrord/cli/src/main.rs
+++ b/mirrord/cli/src/main.rs
@@ -682,7 +682,11 @@ fn main() -> miette::Result<()> {
             Commands::Diagnose(args) => diagnose_command(*args).await?,
             Commands::Container(args) => {
                 let (runtime_args, exec_params) = args.into_parts();
-                container_command(runtime_args, exec_params, watch).await?
+                let exit_code = container_command(runtime_args, exec_params, watch).await?;
+
+                if exit_code != 0 {
+                    std::process::exit(exit_code);
+                }
             }
             Commands::ExternalProxy { port } => external_proxy::proxy(port, watch).await?,
             Commands::PortForward(args) => port_forward(&args, watch).await?,


### PR DESCRIPTION
For mirrord container command check that the sidecar container is started after it is created when running with docker runtime

relevant for #2927