### PR TITLE
feat: use default config path when no arg for -f is provided

### DIFF
--- a/changelog.d/1706.fixed.md
+++ b/changelog.d/1706.fixed.md
@@ -1,0 +1,1 @@
+make `-f` flag accept optional argument, defaulting to "./mirrord.json" when no argument is provided

--- a/changelog.d/1706.fixed.md
+++ b/changelog.d/1706.fixed.md
@@ -1,1 +1,1 @@
-make `-f` flag accept optional argument, defaulting to "./mirrord.json" when no argument is provided
+make `-f` flag accept optional argument, defaulting to "./.mirrord/mirrord.json" when no argument is provided

--- a/mirrord/cli/src/config.rs
+++ b/mirrord/cli/src/config.rs
@@ -204,7 +204,8 @@ pub(super) struct ExecParams {
     pub disable_version_check: bool,
 
     /// Load config from config file
-    #[arg(short = 'f', long, value_hint = ValueHint::FilePath)]
+    /// When using -f flag without a value, defaults to "./mirrord.json"
+    #[arg(short = 'f', long, value_hint = ValueHint::FilePath, default_missing_value = "./mirrord.json", num_args = 0..=1)]
     pub config_file: Option<PathBuf>,
 
     /// Kube context to use from Kubeconfig
@@ -426,7 +427,8 @@ pub(super) struct PortForwardArgs {
     pub disable_version_check: bool,
 
     /// Load config from config file
-    #[arg(short = 'f', long, value_hint = ValueHint::FilePath)]
+    /// When using -f flag without a value, defaults to "./mirrord.json"
+    #[arg(short = 'f', long, value_hint = ValueHint::FilePath, default_missing_value = "./mirrord.json", num_args = 0..=1)]
     pub config_file: Option<PathBuf>,
 
     /// Kube context to use from Kubeconfig
@@ -587,7 +589,7 @@ pub(super) enum OperatorCommand {
     /// Print operator status
     Status {
         /// Specify config file to use
-        #[arg(short = 'f', long, value_hint = ValueHint::FilePath)]
+        #[arg(short = 'f', long, value_hint = ValueHint::FilePath, default_missing_value = "./mirrord.json", num_args = 0..=1)]
         config_file: Option<PathBuf>,
     },
     /// Operator session management commands.
@@ -727,7 +729,7 @@ impl ListTargetArgs {
 #[derive(Args, Debug)]
 pub(super) struct ExtensionExecArgs {
     /// Specify config file to use
-    #[arg(short = 'f', long, value_hint = ValueHint::FilePath)]
+    #[arg(short = 'f', long, value_hint = ValueHint::FilePath, default_missing_value = "./mirrord.json", num_args = 0..=1)]
     pub config_file: Option<PathBuf>,
     /// Specify target
     #[arg(short = 't')]
@@ -766,7 +768,7 @@ pub(super) enum DiagnoseCommand {
     /// Check network connectivity and provide RTT (latency) statistics.
     Latency {
         /// Specify config file to use
-        #[arg(short = 'f', long, value_hint = ValueHint::FilePath)]
+        #[arg(short = 'f', long, value_hint = ValueHint::FilePath, default_missing_value = "./mirrord.json", num_args = 0..=1)]
         config_file: Option<PathBuf>,
     },
 }
@@ -895,7 +897,8 @@ pub(super) struct VpnArgs {
     pub namespace: Option<String>,
 
     /// Load config from config file
-    #[arg(short = 'f', long, value_hint = ValueHint::FilePath)]
+    /// When using -f flag without a value, defaults to "./mirrord.json"
+    #[arg(short = 'f', long, value_hint = ValueHint::FilePath, default_missing_value = "./mirrord.json", num_args = 0..=1)]
     pub config_file: Option<PathBuf>,
 
     #[cfg(target_os = "macos")]

--- a/mirrord/cli/src/config.rs
+++ b/mirrord/cli/src/config.rs
@@ -204,8 +204,8 @@ pub(super) struct ExecParams {
     pub disable_version_check: bool,
 
     /// Load config from config file
-    /// When using -f flag without a value, defaults to "./mirrord.json"
-    #[arg(short = 'f', long, value_hint = ValueHint::FilePath, default_missing_value = "./mirrord.json", num_args = 0..=1)]
+    /// When using -f flag without a value, defaults to "./.mirrord/mirrord.json"
+    #[arg(short = 'f', long, value_hint = ValueHint::FilePath, default_missing_value = "./.mirrord/mirrord.json", num_args = 0..=1)]
     pub config_file: Option<PathBuf>,
 
     /// Kube context to use from Kubeconfig
@@ -427,8 +427,8 @@ pub(super) struct PortForwardArgs {
     pub disable_version_check: bool,
 
     /// Load config from config file
-    /// When using -f flag without a value, defaults to "./mirrord.json"
-    #[arg(short = 'f', long, value_hint = ValueHint::FilePath, default_missing_value = "./mirrord.json", num_args = 0..=1)]
+    /// When using -f flag without a value, defaults to "./.mirrord/mirrord.json"
+    #[arg(short = 'f', long, value_hint = ValueHint::FilePath, default_missing_value = "./.mirrord/mirrord.json", num_args = 0..=1)]
     pub config_file: Option<PathBuf>,
 
     /// Kube context to use from Kubeconfig
@@ -589,7 +589,7 @@ pub(super) enum OperatorCommand {
     /// Print operator status
     Status {
         /// Specify config file to use
-        #[arg(short = 'f', long, value_hint = ValueHint::FilePath, default_missing_value = "./mirrord.json", num_args = 0..=1)]
+        #[arg(short = 'f', long, value_hint = ValueHint::FilePath, default_missing_value = "./.mirrord/mirrord.json", num_args = 0..=1)]
         config_file: Option<PathBuf>,
     },
     /// Operator session management commands.
@@ -768,7 +768,7 @@ pub(super) enum DiagnoseCommand {
     /// Check network connectivity and provide RTT (latency) statistics.
     Latency {
         /// Specify config file to use
-        #[arg(short = 'f', long, value_hint = ValueHint::FilePath, default_missing_value = "./mirrord.json", num_args = 0..=1)]
+        #[arg(short = 'f', long, value_hint = ValueHint::FilePath, default_missing_value = "./.mirrord/mirrord.json", num_args = 0..=1)]
         config_file: Option<PathBuf>,
     },
 }
@@ -897,8 +897,8 @@ pub(super) struct VpnArgs {
     pub namespace: Option<String>,
 
     /// Load config from config file
-    /// When using -f flag without a value, defaults to "./mirrord.json"
-    #[arg(short = 'f', long, value_hint = ValueHint::FilePath, default_missing_value = "./mirrord.json", num_args = 0..=1)]
+    /// When using -f flag without a value, defaults to "./.mirrord/mirrord.json"
+    #[arg(short = 'f', long, value_hint = ValueHint::FilePath, default_missing_value = "./.mirrord/mirrord.json", num_args = 0..=1)]
     pub config_file: Option<PathBuf>,
 
     #[cfg(target_os = "macos")]


### PR DESCRIPTION
part of https://github.com/metalbear-co/mirrord/issues/1706 