### PR TITLE
Prevent unintended stdout print

### DIFF
--- a/changelog.d/+no-stdout-sidecar-start.internal.md
+++ b/changelog.d/+no-stdout-sidecar-start.internal.md
@@ -1,0 +1,1 @@
+use `Stdio::piped()` for "sidecar start" patch added in [#2933](https://github.com/metalbear-co/mirrord/pull/2933).

--- a/mirrord/cli/src/container.rs
+++ b/mirrord/cli/src/container.rs
@@ -224,8 +224,8 @@ async fn create_sidecar_intproxy(
             container_start_command
                 .args(["start", &sidecar_container_id])
                 .stdin(Stdio::null())
-                .stdout(Stdio::piped())
-                .stderr(Stdio::piped());
+                .stdout(Stdio::null())
+                .stderr(Stdio::null());
 
             let _ = container_start_command.status().await.map_err(|err| {
                 ContainerError::UnsuccesfulCommandOutput(

--- a/mirrord/cli/src/container.rs
+++ b/mirrord/cli/src/container.rs
@@ -221,7 +221,11 @@ async fn create_sidecar_intproxy(
         {
             let mut container_start_command = Command::new(&runtime_binary);
 
-            container_start_command.args(["start", &sidecar_container_id]);
+            container_start_command
+                .args(["start", &sidecar_container_id])
+                .stdin(Stdio::null())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped());
 
             let _ = container_start_command.status().await.map_err(|err| {
                 ContainerError::UnsuccesfulCommandOutput(


### PR DESCRIPTION
#2933 added a start patch but unintentionally added a small print that is piped from the underlying command, this removes the print.
