### PR TITLE
Add env vars remapper, allowing the user to change multiple env vars values based on a regex matched against env var keys.

### DIFF
--- a/mirrord/cli/src/execution.rs
+++ b/mirrord/cli/src/execution.rs
@@ -6,7 +6,8 @@ use std::{
 
 use mirrord_analytics::{AnalyticsError, AnalyticsReporter, Reporter};
 use mirrord_config::{
-    config::ConfigError, internal_proxy::MIRRORD_INTPROXY_CONNECT_TCP_ENV, LayerConfig,
+    config::ConfigError, feature::env::mapper::EnvVarsRemapper,
+    internal_proxy::MIRRORD_INTPROXY_CONNECT_TCP_ENV, LayerConfig,
 };
 use mirrord_intproxy::agent_conn::AgentConnectInfo;
 use mirrord_operator::client::OperatorSession;
@@ -504,8 +505,8 @@ impl MirrordExecution {
             env_vars.extend(envs_from_file);
         }
 
-        if let Some(overrides) = &config.feature.env.r#override {
-            env_vars.extend(overrides.iter().map(|(k, v)| (k.clone(), v.clone())));
+        if let Some(mapping) = config.feature.env.mapping.clone() {
+            env_vars = EnvVarsRemapper::new(mapping, env_vars).remapped();
         }
 
         Ok(env_vars)

--- a/mirrord/config/src/feature/env/mapper.rs
+++ b/mirrord/config/src/feature/env/mapper.rs
@@ -1,0 +1,101 @@
+use std::collections::HashMap;
+
+use fancy_regex::Regex;
+use tracing::Level;
+
+#[derive(Debug)]
+pub struct EnvVarsRemapper {
+    mapping: Vec<(Regex, String)>,
+    env_vars: HashMap<String, String>,
+}
+
+impl EnvVarsRemapper {
+    #[tracing::instrument(level = Level::TRACE, ret)]
+    pub fn new(mapping: HashMap<String, String>, env_vars: HashMap<String, String>) -> Self {
+        let mapping = mapping
+            .into_iter()
+            .map(|(pattern, value)| {
+                (
+                    Regex::new(&pattern).expect("Building env vars mapping regex failed"),
+                    value,
+                )
+            })
+            .collect();
+
+        EnvVarsRemapper { mapping, env_vars }
+    }
+
+    #[tracing::instrument(level = Level::TRACE, ret)]
+    pub fn remapped(self) -> HashMap<String, String> {
+        let Self { mapping, env_vars } = self;
+
+        env_vars
+            .into_iter()
+            .fold(HashMap::with_capacity(32), |mut acc, (key, value)| {
+                match mapping
+                    .iter()
+                    .find(|(k, _)| k.is_match(&key).ok().is_some_and(|matched| matched))
+                    .map(|(_, to_value)| to_value.clone())
+                {
+                    Some(to_value) => acc.insert(key, to_value),
+                    None => acc.insert(key, value),
+                };
+
+                acc
+            })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::*;
+
+    fn env_vars() -> HashMap<String, String> {
+        [
+            ("Lech".to_string(), "Legendary".to_string()),
+            ("Krakus_I".to_string(), "Legendary".to_string()),
+            ("Leszko_I".to_string(), "Legendary".to_string()),
+            ("Popiel_II".to_string(), "Legendary".to_string()),
+        ]
+        .into()
+    }
+
+    fn mappings() -> HashMap<String, String> {
+        [
+            (
+                "Lec.+".to_string(),
+                "Legendary founder of the great Polish nation".to_string(),
+            ),
+            (
+                "Krak.+".to_string(),
+                "Legendary founder of Krakow".to_string(),
+            ),
+            (".+zko_I".to_string(), "Defeated the Hungarians".to_string()),
+        ]
+        .into()
+    }
+
+    #[rstest]
+    fn simple_mapping() {
+        let mut remapper = EnvVarsRemapper::new(mappings(), env_vars()).remapped();
+
+        assert_eq!(
+            Some("Legendary founder of the great Polish nation".to_string()),
+            remapper.remove("Lech")
+        );
+
+        assert_eq!(
+            Some("Legendary founder of Krakow".to_string()),
+            remapper.remove("Krakus_I")
+        );
+
+        assert_eq!(
+            Some("Defeated the Hungarians".to_string()),
+            remapper.remove("Leszko_I")
+        );
+
+        assert_eq!(Some("Legendary".to_string()), remapper.remove("Popiel_II"));
+    }
+}

--- a/mirrord/layer/src/lib.rs
+++ b/mirrord/layer/src/lib.rs
@@ -84,7 +84,7 @@ use load::ExecuteArgs;
 #[cfg(target_os = "macos")]
 use mirrord_config::feature::fs::FsConfig;
 use mirrord_config::{
-    feature::{fs::FsModeConfig, network::incoming::IncomingMode},
+    feature::{env::mapper::EnvVarsRemapper, fs::FsModeConfig, network::incoming::IncomingMode},
     LayerConfig,
 };
 use mirrord_intproxy_protocol::NewSessionRequest;
@@ -453,6 +453,10 @@ fn fetch_env_vars() -> HashMap<String, String> {
 
     if let Some(overrides) = setup().env_config().r#override.as_ref() {
         env_vars.extend(overrides.iter().map(|(k, v)| (k.clone(), v.clone())));
+    }
+
+    if let Some(mapping) = setup().env_config().mapping.clone() {
+        env_vars = EnvVarsRemapper::new(mapping, env_vars).remapped();
     }
 
     env_vars


### PR DESCRIPTION
- Issue: #2920 