### PR TITLE
Stop mirrord ending unexpectedly when port forwarding in reverse

### DIFF
--- a/changelog.d/2962.fixed.md
+++ b/changelog.d/2962.fixed.md
@@ -1,0 +1,1 @@
+Stop mirrord ending unexpectedly when port forwarding in reverse due to unexpected connection end.


### PR DESCRIPTION
Changed the ping/pong routine of `ReversePortForwarder` to match that of `PortForwarder` - this prevents the timeout being repeatedly reset when recieving messages more frequently than every 30 seconds (causing the ping to never be sent)