### PR TITLE
Add `MirrordPolicy` that blocks traffic mirroring

### DIFF
--- a/changelog.d/+block-mirroring-policy.added.md
+++ b/changelog.d/+block-mirroring-policy.added.md
@@ -1,0 +1,1 @@
+`MirrordPolicy` can now block traffic mirroring (requires operator support).

--- a/mirrord/operator/src/crd.rs
+++ b/mirrord/operator/src/crd.rs
@@ -359,9 +359,19 @@ pub struct CopyTargetStatus {
 pub enum BlockedFeature {
     /// Blocks stealing traffic in any way (without or without filter).
     Steal,
+
     /// Blocks stealing traffic without specifying (any) filter. Client can still specify a
     /// filter that matches anything.
     StealWithoutFilter,
+
+    /// Blocks mirroring traffic.
+    Mirror,
+
+    /// So that the operator is able to list all policies with [`kube::Api`],
+    /// even if it doesn't recognize blocked features used in some of them.
+    #[schemars(skip)]
+    #[serde(other, skip_serializing)]
+    Unknown,
 }
 
 /// Custom resource for policies that limit what mirrord features users can use.


### PR DESCRIPTION
I tried versioning `MirrordPolicy`, but to no success. In a scenario when the cluster has the new policy and the operator does not recognize it, there are only two options:
1. Operator will fail to deserialize this policy
2. Operator will silently ignore the new blocked feature

This is because `kube::Api` fetches and attempts to deserialize all resources of the given kind, regardless of their version

Since option 1 is less scary, we can as well just add another enum variant, without introducing the versioning boilerplate.
I also added a catch-all variant to prevent this problem in the future.