### PR TITLE
Add rmdir support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4503,7 +4503,7 @@ dependencies = [
 
 [[package]]
 name = "mirrord-protocol"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "actix-codec",
  "bincode",

--- a/changelog.d/2221.fixed.md
+++ b/changelog.d/2221.fixed.md
@@ -1,1 +1,1 @@
-Add mkdir support
+Add mkdir / mkdirat / rmdir support

--- a/mirrord/agent/src/file.rs
+++ b/mirrord/agent/src/file.rs
@@ -258,6 +258,9 @@ impl FileManager {
                 pathname,
                 mode,
             }) => Some(FileResponse::MakeDir(self.mkdirat(dirfd, &pathname, mode))),
+            FileRequest::RemoveDir(RemoveDirRequest { pathname }) => {
+                Some(FileResponse::RemoveDir(self.rmdir(&pathname)))
+            }
         })
     }
 
@@ -518,6 +521,14 @@ impl FileManager {
         } else {
             Err(ResponseError::NotDirectory(dirfd))
         }
+    }
+
+    pub(crate) fn rmdir(&mut self, path: &Path) -> RemoteResult<()> {
+        trace!("FileManager::rmdir -> path {:#?}", path);
+
+        let path = resolve_path(path, &self.root_path)?;
+
+        std::fs::remove_dir(&path.as_path()).map_err(ResponseError::from)
     }
 
     pub(crate) fn seek(&mut self, fd: u64, seek_from: SeekFrom) -> RemoteResult<SeekFileResponse> {

--- a/mirrord/intproxy/protocol/src/lib.rs
+++ b/mirrord/intproxy/protocol/src/lib.rs
@@ -325,6 +325,13 @@ impl_request!(
 );
 
 impl_request!(
+    req = RemoveDirRequest,
+    res = RemoteResult<()>,
+    req_path = LayerToProxyMessage::File => FileRequest::RemoveDir,
+    res_path = ProxyToLayerMessage::File => FileResponse::RemoveDir,
+);
+
+impl_request!(
     req = SeekFileRequest,
     res = RemoteResult<SeekFileResponse>,
     req_path = LayerToProxyMessage::File => FileRequest::Seek,

--- a/mirrord/layer/tests/apps/rmdir/rmdir.c
+++ b/mirrord/layer/tests/apps/rmdir/rmdir.c
@@ -1,0 +1,21 @@
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+#include <sys/fcntl.h>
+
+/// Test `rmdir`.
+///
+/// Creates a folder and then removes it.
+///
+int main()
+{
+  char *test_dir = "/test_dir";
+  int mkdir_result = mkdir(mkdir_result, 0777);
+  assert(mkdir_result == 0);
+
+  int rmdir_result = rmdir(test_dir);
+  assert(rmdir_result == 0);
+
+  return 0;
+}

--- a/mirrord/layer/tests/rmdir.rs
+++ b/mirrord/layer/tests/rmdir.rs
@@ -6,22 +6,22 @@ use rstest::rstest;
 mod common;
 pub use common::*;
 
-/// Test for the [`libc::mkdir`] function.
+/// Test for the [`libc::rmdir`] function.
 #[rstest]
 #[tokio::test]
 #[timeout(Duration::from_secs(60))]
-async fn mkdir(dylib_path: &Path) {
-    let application = Application::MakeDir;
+async fn rmdir(dylib_path: &Path) {
+    let application = Application::RemoveDir;
 
     let (mut test_process, mut intproxy) = application
         .start_process_with_layer(dylib_path, Default::default(), None)
         .await;
 
     println!("waiting for MakeDirRequest.");
-    intproxy.expect_make_dir("/mkdir_test_path", 0o777).await;
+    intproxy.expect_make_dir("/test_dir", 0o777).await;
 
-    println!("waiting for MakeDirRequest.");
-    intproxy.expect_make_dir("/mkdirat_test_path", 0o777).await;
+    println!("waiting for RemoveDirRequest.");
+    intproxy.expect_remove_dir("/test_dir").await;
 
     assert_eq!(intproxy.try_recv().await, None);
 

--- a/mirrord/protocol/Cargo.toml
+++ b/mirrord/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mirrord-protocol"
-version = "1.13.0"
+version = "1.14.0"
 authors.workspace = true
 description.workspace = true
 documentation.workspace = true

--- a/mirrord/protocol/src/codec.rs
+++ b/mirrord/protocol/src/codec.rs
@@ -85,6 +85,7 @@ pub enum FileRequest {
     ReadDirBatch(ReadDirBatchRequest),
     MakeDir(MakeDirRequest),
     MakeDirAt(MakeDirAtRequest),
+    RemoveDir(RemoveDirRequest),
 }
 
 /// Minimal mirrord-protocol version that allows `ClientMessage::ReadyForLogs` message.
@@ -130,6 +131,7 @@ pub enum FileResponse {
     ReadLink(RemoteResult<ReadLinkFileResponse>),
     ReadDirBatch(RemoteResult<ReadDirBatchResponse>),
     MakeDir(RemoteResult<()>),
+    RemoveDir(RemoteResult<()>),
 }
 
 /// `-agent` --> `-layer` messages.

--- a/mirrord/protocol/src/file.rs
+++ b/mirrord/protocol/src/file.rs
@@ -22,8 +22,13 @@ pub static READLINK_VERSION: LazyLock<VersionReq> =
 pub static READDIR_BATCH_VERSION: LazyLock<VersionReq> =
     LazyLock::new(|| ">=1.9.0".parse().expect("Bad Identifier"));
 
+/// Minimal mirrord-protocol version that allows [`MakeDirRequest`] and [`MakeDirAtRequest`].
 pub static MKDIR_VERSION: LazyLock<VersionReq> =
     LazyLock::new(|| ">=1.13.0".parse().expect("Bad Identifier"));
+
+/// Minimal mirrord-protocol version that allows [`RemoveDirRequest`].
+pub static RMDIR_VERSION: LazyLock<VersionReq> =
+    LazyLock::new(|| ">=1.14.0".parse().expect("Bad Identifier"));
 
 /// Internal version of Metadata across operating system (macOS, Linux)
 /// Only mutual attributes
@@ -280,6 +285,11 @@ pub struct MakeDirAtRequest {
     pub dirfd: u64,
     pub pathname: PathBuf,
     pub mode: u32,
+}
+
+#[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
+pub struct RemoveDirRequest {
+    pub pathname: PathBuf,
 }
 
 #[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]

--- a/tests/go-e2e-dir/main.go
+++ b/tests/go-e2e-dir/main.go
@@ -30,6 +30,12 @@ func main() {
 		os.Exit(-1)
 	}
 
+	err = os.Remove("/app/test_mkdir")
+	if err != nil {
+		fmt.Printf("Rmdir error: %s\n", err)
+		os.Exit(-1)
+	}
+
 	// let close requests be sent for test
 	time.Sleep(1 * time.Second)
 	os.Exit(0)

--- a/tests/python-e2e/ops.py
+++ b/tests/python-e2e/ops.py
@@ -87,7 +87,16 @@ class FileOpsTest(unittest.TestCase):
             os.mkdir("test_mkdir_error_already_exists", dir_fd=dir)
 
         os.close(dir)
-        
+    
+    def test_rmdir(self):
+        """
+        Creates a new directory in "/tmp" and removes it using rmdir.
+        """
+        os.mkdir("/tmp/test_rmdir")
+        self.assertTrue(os.path.isdir("/tmp/test_rmdir"))
+        os.rmdir("/tmp/test_rmdir")
+        self.assertFalse(os.path.isdir("/tmp/test_rmdir"))
+            
     def _create_new_tmp_file(self):
         """
         Creates a new file in /tmp and returns the path and name of the file.


### PR DESCRIPTION
Add support to forward the `rmdir` command to the agent

- Mentioned in a comment on: https://github.com/metalbear-co/mirrord/issues/2221
