### PR TITLE
Made idle timeout configurable for local HTTP clients

### DIFF
--- a/changelog.d/+local-http-connection-timeout.added.md
+++ b/changelog.d/+local-http-connection-timeout.added.md
@@ -1,0 +1,1 @@
+Added an option to configure timeout for idle local HTTP connections (`experimental.idle_local_http_connection_timeout`).

--- a/mirrord-schema.json
+++ b/mirrord-schema.json
@@ -823,6 +823,16 @@
             "null"
           ]
         },
+        "idle_local_http_connection_timeout": {
+          "title": "_experimental_ idle_local_http_connection_timeout {#experimental-idle_local_http_connection_timeout}",
+          "description": "Sets a timeout for idle local HTTP connections (in milliseconds).\n\nHTTP requests stolen with a filter are delivered to the local application from a HTTP connection made from the local machine. Once a request is delivered, the connection is cached for some time, so that it can be reused to deliver the next request.\n\nThis timeout determines for how long such connections are cached.\n\nSet to 0 to disable caching local HTTP connections (connections will be dropped as soon as the request is delivered).",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
+        },
         "readlink": {
           "title": "_experimental_ readlink {#experimental-readlink}",
           "description": "DEPRECATED, WILL BE REMOVED",

--- a/mirrord-schema.json
+++ b/mirrord-schema.json
@@ -825,7 +825,7 @@
         },
         "idle_local_http_connection_timeout": {
           "title": "_experimental_ idle_local_http_connection_timeout {#experimental-idle_local_http_connection_timeout}",
-          "description": "Sets a timeout for idle local HTTP connections (in milliseconds).\n\nHTTP requests stolen with a filter are delivered to the local application from a HTTP connection made from the local machine. Once a request is delivered, the connection is cached for some time, so that it can be reused to deliver the next request.\n\nThis timeout determines for how long such connections are cached.\n\nSet to 0 to disable caching local HTTP connections (connections will be dropped as soon as the request is delivered).",
+          "description": "Sets a timeout for idle local HTTP connections (in milliseconds).\n\nHTTP requests stolen with a filter are delivered to the local application from a HTTP connection made from the local machine. Once a request is delivered, the connection is cached for some time, so that it can be reused to deliver the next request.\n\nThis timeout determines for how long such connections are cached.\n\nSet to 0 to disable caching local HTTP connections (connections will be dropped as soon as the request is delivered).\n\nDefaults to 3000ms.",
           "type": [
             "integer",
             "null"

--- a/mirrord/cli/src/internal_proxy.rs
+++ b/mirrord/cli/src/internal_proxy.rs
@@ -106,6 +106,7 @@ pub(crate) async fn proxy(
         agent_conn,
         listener,
         config.experimental.readonly_file_buffer,
+        Duration::from_millis(config.experimental.idle_local_http_connection_timeout),
     )
     .run(first_connection_timeout, consecutive_connection_timeout)
     .await

--- a/mirrord/cli/src/main.rs
+++ b/mirrord/cli/src/main.rs
@@ -525,6 +525,7 @@ async fn port_forward(args: &PortForwardArgs, watch: drain::Watch) -> CliResult<
                     connection_2,
                     rev_port_mappings,
                     config.feature.network.incoming,
+                    Duration::from_millis(config.experimental.idle_local_http_connection_timeout),
                 )
                 .await?;
                 port_forward.run().await.map_err(|error| error.into())

--- a/mirrord/cli/src/port_forward.rs
+++ b/mirrord/cli/src/port_forward.rs
@@ -440,10 +440,15 @@ impl ReversePortForwarder {
         mut agent_connection: AgentConnection,
         mappings: HashMap<RemotePort, LocalPort>,
         network_config: IncomingConfig,
+        idle_local_http_connection_timeout: Duration,
     ) -> Result<Self, PortForwardError> {
         let mut background_tasks: BackgroundTasks<(), ProxyMessage, IncomingProxyError> =
             Default::default();
-        let incoming = background_tasks.register(IncomingProxy::default(), (), 512);
+        let incoming = background_tasks.register(
+            IncomingProxy::new(idle_local_http_connection_timeout),
+            (),
+            512,
+        );
 
         agent_connection
             .sender
@@ -1284,12 +1289,17 @@ mod test {
         let (mut test_connection, agent_connection) = TestAgentConnection::new();
 
         tokio::spawn(async move {
-            ReversePortForwarder::new(agent_connection, mappings, network_config)
-                .await
-                .unwrap()
-                .run()
-                .await
-                .unwrap()
+            ReversePortForwarder::new(
+                agent_connection,
+                mappings,
+                network_config,
+                Duration::from_secs(3),
+            )
+            .await
+            .unwrap()
+            .run()
+            .await
+            .unwrap()
         });
 
         // expect port subscription for remote port and send subscribe result
@@ -1352,12 +1362,17 @@ mod test {
 
         let (mut test_connection, agent_connection) = TestAgentConnection::new();
         tokio::spawn(async move {
-            ReversePortForwarder::new(agent_connection, mappings, network_config)
-                .await
-                .unwrap()
-                .run()
-                .await
-                .unwrap()
+            ReversePortForwarder::new(
+                agent_connection,
+                mappings,
+                network_config,
+                Duration::from_secs(3),
+            )
+            .await
+            .unwrap()
+            .run()
+            .await
+            .unwrap()
         });
 
         // expect port subscription for remote port and send subscribe result
@@ -1436,10 +1451,14 @@ mod test {
 
         let (mut test_connection, agent_connection) = TestAgentConnection::new();
         tokio::spawn(async move {
-            let mut port_forwarder =
-                ReversePortForwarder::new(agent_connection, mappings, network_config)
-                    .await
-                    .unwrap();
+            let mut port_forwarder = ReversePortForwarder::new(
+                agent_connection,
+                mappings,
+                network_config,
+                Duration::from_secs(3),
+            )
+            .await
+            .unwrap();
             port_forwarder.run().await.unwrap()
         });
 
@@ -1548,10 +1567,14 @@ mod test {
         let (mut test_connection, agent_connection) = TestAgentConnection::new();
 
         tokio::spawn(async move {
-            let mut port_forwarder =
-                ReversePortForwarder::new(agent_connection, mappings, network_config)
-                    .await
-                    .unwrap();
+            let mut port_forwarder = ReversePortForwarder::new(
+                agent_connection,
+                mappings,
+                network_config,
+                Duration::from_secs(3),
+            )
+            .await
+            .unwrap();
             port_forwarder.run().await.unwrap()
         });
 

--- a/mirrord/config/configuration.md
+++ b/mirrord/config/configuration.md
@@ -496,6 +496,20 @@ but the feature is not stable and may cause other issues.
 
 Enables `getifaddrs` hook that removes IPv6 interfaces from the list returned by libc.
 
+### _experimental_ idle_local_http_connection_timeout {#experimental-idle_local_http_connection_timeout}
+
+Sets a timeout for idle local HTTP connections (in milliseconds).
+
+HTTP requests stolen with a filter are delivered to the local application
+from a HTTP connection made from the local machine. Once a request is delivered,
+the connection is cached for some time, so that it can be reused to deliver
+the next request.
+
+This timeout determines for how long such connections are cached.
+
+Set to 0 to disable caching local HTTP connections (connections will be dropped as soon as
+the request is delivered).
+
 ### _experimental_ readlink {#experimental-readlink}
 
 DEPRECATED, WILL BE REMOVED

--- a/mirrord/config/configuration.md
+++ b/mirrord/config/configuration.md
@@ -510,6 +510,8 @@ This timeout determines for how long such connections are cached.
 Set to 0 to disable caching local HTTP connections (connections will be dropped as soon as
 the request is delivered).
 
+Defaults to 3000ms.
+
 ### _experimental_ readlink {#experimental-readlink}
 
 DEPRECATED, WILL BE REMOVED

--- a/mirrord/config/src/experimental.rs
+++ b/mirrord/config/src/experimental.rs
@@ -70,6 +70,22 @@ pub struct ExperimentalConfig {
     /// <https://github.com/metalbear-co/mirrord/issues/2069>
     #[config(default = 128000)]
     pub readonly_file_buffer: u64,
+
+    /// ### _experimental_ idle_local_http_connection_timeout {#experimental-idle_local_http_connection_timeout}
+    ///
+    /// Sets a timeout for idle local HTTP connections (in milliseconds).
+    ///
+    /// HTTP requests stolen with a filter are delivered to the local application
+    /// from a HTTP connection made from the local machine. Once a request is delivered,
+    /// the connection is cached for some time, so that it can be reused to deliver
+    /// the next request.
+    ///
+    /// This timeout determines for how long such connections are cached.
+    ///
+    /// Set to 0 to disable caching local HTTP connections (connections will be dropped as soon as
+    /// the request is delivered).
+    #[config(default = 3000)]
+    pub idle_local_http_connection_timeout: u64,
 }
 
 impl CollectAnalytics for &ExperimentalConfig {
@@ -81,5 +97,9 @@ impl CollectAnalytics for &ExperimentalConfig {
         analytics.add("hide_ipv6_interfaces", self.hide_ipv6_interfaces);
         analytics.add("disable_reuseaddr", self.disable_reuseaddr);
         analytics.add("readonly_file_buffer", self.readonly_file_buffer);
+        analytics.add(
+            "idle_local_http_connection_timeout",
+            self.idle_local_http_connection_timeout,
+        );
     }
 }

--- a/mirrord/config/src/experimental.rs
+++ b/mirrord/config/src/experimental.rs
@@ -84,7 +84,7 @@ pub struct ExperimentalConfig {
     ///
     /// Set to 0 to disable caching local HTTP connections (connections will be dropped as soon as
     /// the request is delivered).
-    /// 
+    ///
     /// Defaults to 3000ms.
     #[config(default = 3000)]
     pub idle_local_http_connection_timeout: u64,

--- a/mirrord/config/src/experimental.rs
+++ b/mirrord/config/src/experimental.rs
@@ -84,6 +84,8 @@ pub struct ExperimentalConfig {
     ///
     /// Set to 0 to disable caching local HTTP connections (connections will be dropped as soon as
     /// the request is delivered).
+    /// 
+    /// Defaults to 3000ms.
     #[config(default = 3000)]
     pub idle_local_http_connection_timeout: u64,
 }

--- a/mirrord/intproxy/src/lib.rs
+++ b/mirrord/intproxy/src/lib.rs
@@ -73,6 +73,7 @@ impl IntProxy {
         agent_conn: AgentConnection,
         listener: TcpListener,
         file_buffer_size: u64,
+        idle_local_http_connection_timeout: Duration,
     ) -> Self {
         let mut background_tasks: BackgroundTasks<MainTaskId, ProxyMessage, IntProxyError> =
             Default::default();
@@ -100,7 +101,7 @@ impl IntProxy {
             Self::CHANNEL_SIZE,
         );
         let incoming = background_tasks.register(
-            IncomingProxy::default(),
+            IncomingProxy::new(idle_local_http_connection_timeout),
             MainTaskId::IncomingProxy,
             Self::CHANNEL_SIZE,
         );

--- a/mirrord/intproxy/src/proxies/incoming.rs
+++ b/mirrord/intproxy/src/proxies/incoming.rs
@@ -6,7 +6,7 @@
 //!    until connection becomes readable (is TCP) or receives an http request.
 //! 2. HttpSender -
 
-use std::{collections::HashMap, io, net::SocketAddr};
+use std::{collections::HashMap, io, net::SocketAddr, time::Duration};
 
 use bound_socket::BoundTcpSocket;
 use http::{ClientStore, ResponseMode, StreamingBody};
@@ -126,7 +126,6 @@ struct HttpGatewayHandle {
 /// An HTTP request stolen with a filter can result in an HTTP upgrade.
 /// When this happens, the TCP connection is recovered and passed to a new [`TcpProxyTask`].
 /// The TCP connection is then treated as stolen without a filter.
-#[derive(Default)]
 pub struct IncomingProxy {
     /// Active port subscriptions for all layers.
     subscriptions: SubscriptionsManager,
@@ -156,6 +155,19 @@ pub struct IncomingProxy {
 impl IncomingProxy {
     /// Used when registering new tasks in the internal [`BackgroundTasks`] instance.
     const CHANNEL_SIZE: usize = 512;
+
+    pub fn new(idle_local_http_connection_timeout: Duration) -> Self {
+        Self {
+            subscriptions: Default::default(),
+            metadata_store: Default::default(),
+            response_mode: Default::default(),
+            client_store: ClientStore::new_with_timeout(idle_local_http_connection_timeout),
+            mirror_tcp_proxies: Default::default(),
+            steal_tcp_proxies: Default::default(),
+            http_gateways: Default::default(),
+            tasks: Default::default(),
+        }
+    }
 
     /// Starts a new [`HttpGatewayTask`] to handle the given request.
     ///

--- a/mirrord/intproxy/src/proxies/incoming/http/client_store.rs
+++ b/mirrord/intproxy/src/proxies/incoming/http/client_store.rs
@@ -43,15 +43,7 @@ pub struct ClientStore {
     notify: Arc<Notify>,
 }
 
-impl Default for ClientStore {
-    fn default() -> Self {
-        Self::new_with_timeout(Self::IDLE_CLIENT_DEFAULT_TIMEOUT)
-    }
-}
-
 impl ClientStore {
-    pub const IDLE_CLIENT_DEFAULT_TIMEOUT: Duration = Duration::from_secs(3);
-
     /// Creates a new store.
     ///
     /// The store will keep unused clients alive for at least the given time.

--- a/mirrord/intproxy/src/proxies/incoming/http/client_store.rs
+++ b/mirrord/intproxy/src/proxies/incoming/http/client_store.rs
@@ -32,7 +32,7 @@ impl fmt::Debug for IdleLocalClient {
 /// Cache for unused [`LocalHttpClient`]s.
 ///
 /// [`LocalHttpClient`] that have not been used for some time are dropped in the background by a
-/// dedicated [`tokio::task`]. This timeout defaults to [`Self::IDLE_CLIENT_DEFAULT_TIMEOUT`].
+/// dedicated [`tokio::task`]. This timeout is configurable.
 #[derive(Clone)]
 pub struct ClientStore {
     clients: Arc<Mutex<Vec<IdleLocalClient>>>,

--- a/mirrord/intproxy/src/proxies/incoming/http_gateway.rs
+++ b/mirrord/intproxy/src/proxies/incoming/http_gateway.rs
@@ -534,7 +534,7 @@ mod test {
             };
             let gateway = HttpGatewayTask::new(
                 request,
-                Default::default(),
+                ClientStore::new_with_timeout(Duration::from_secs(1)),
                 ResponseMode::Basic,
                 local_destination,
             );
@@ -687,7 +687,12 @@ mod test {
 
         let mut tasks: BackgroundTasks<(), InProxyTaskMessage, Infallible> = Default::default();
         let _gateway = tasks.register(
-            HttpGatewayTask::new(request, ClientStore::default(), response_mode, addr),
+            HttpGatewayTask::new(
+                request,
+                ClientStore::new_with_timeout(Duration::from_secs(1)),
+                response_mode,
+                addr,
+            ),
             (),
             8,
         );
@@ -829,7 +834,7 @@ mod test {
             .insert(header::CONTENT_LENGTH, HeaderValue::from_static("12"));
 
         let mut tasks: BackgroundTasks<(), InProxyTaskMessage, Infallible> = Default::default();
-        let client_store = ClientStore::default();
+        let client_store = ClientStore::new_with_timeout(Duration::from_secs(1));
         let _gateway = tasks.register(
             HttpGatewayTask::new(request, client_store.clone(), ResponseMode::Basic, addr),
             (),

--- a/mirrord/layer/tests/common/mod.rs
+++ b/mirrord/layer/tests/common/mod.rs
@@ -111,7 +111,8 @@ impl TestIntProxy {
             let agent_conn = AgentConnection::new_for_raw_address(fake_agent_address)
                 .await
                 .unwrap();
-            let intproxy = IntProxy::new_with_connection(agent_conn, listener, 0);
+            let intproxy =
+                IntProxy::new_with_connection(agent_conn, listener, 0, Duration::from_secs(3));
             intproxy
                 .run(Duration::from_secs(5), Duration::from_secs(5))
                 .await


### PR DESCRIPTION
Issue #3072

The situation improved when we started reusing local connections, which eliminated long-standing idle connections. My suspicion is that the user application does not handle multiple open HTTP connections very well. With this config, they'll be able to have the connections killed right after the request