### PR TITLE
Replaced `dotenv` dependency with `dotenvy`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2081,10 +2081,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
-name = "dotenv"
-version = "0.15.0"
+name = "dotenvy"
+version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "downcast"
@@ -4133,7 +4133,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "const-random",
- "dotenv",
+ "dotenvy",
  "drain",
  "futures",
  "http-body-util",
@@ -4405,7 +4405,7 @@ dependencies = [
  "bincode",
  "bytemuck",
  "ctor",
- "dotenv",
+ "dotenvy",
  "errno 0.3.10",
  "exec",
  "frida-gum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,7 @@ streammap-ext = "0.1"
 regex = { version = "1", features = ["unicode-case"] }
 fancy-regex = { version = "0.14" }
 enum_dispatch = "0.3"
-dotenv = "0.15"
+dotenvy = "0.15.7"
 
 # If you update `hyper`, check that `h2` version is compatible in `intproxy/Cargo.toml`.
 # There is a test for this: `cargo test -p mirrord-intproxy hyper_and_h2_versions_in_sync`

--- a/mirrord/cli/Cargo.toml
+++ b/mirrord/cli/Cargo.toml
@@ -35,7 +35,7 @@ mirrord-vpn = { path = "../vpn" }
 
 actix-codec.workspace = true
 clap.workspace = true
-dotenv.workspace = true
+dotenvy.workspace = true
 tracing.workspace = true
 serde_json.workspace = true
 serde.workspace = true

--- a/mirrord/cli/src/config.rs
+++ b/mirrord/cli/src/config.rs
@@ -331,7 +331,7 @@ impl ExecParams {
             // Set canonicalized path to env file, in case forks/children are in different
             // working directories.
             let full_path = std::fs::canonicalize(env_file).map_err(|e| {
-                CliError::EnvFileAccessError(env_file.clone(), dotenv::Error::Io(e))
+                CliError::EnvFileAccessError(env_file.clone(), dotenvy::Error::Io(e))
             })?;
             envs.insert(
                 MIRRORD_OVERRIDE_ENV_FILE_ENV.into(),

--- a/mirrord/cli/src/error.rs
+++ b/mirrord/cli/src/error.rs
@@ -250,7 +250,7 @@ pub(crate) enum CliError {
 
     #[error("Failed to access env file at `{0}`: {1}")]
     #[diagnostic(help("Please check that the path is correct and that you have permissions to read it.{GENERAL_HELP}"))]
-    EnvFileAccessError(PathBuf, dotenv::Error),
+    EnvFileAccessError(PathBuf, dotenvy::Error),
 
     #[cfg(target_os = "macos")]
     #[error("SIP Error: `{0:#?}`")]

--- a/mirrord/cli/src/execution.rs
+++ b/mirrord/cli/src/execution.rs
@@ -498,8 +498,7 @@ impl MirrordExecution {
         };
 
         if let Some(file) = &config.feature.env.env_file {
-            #[allow(deprecated)]
-            let envs_from_file = dotenv::from_path_iter(file)
+            let envs_from_file = dotenvy::from_path_iter(file)
                 .and_then(|iter| iter.collect::<Result<Vec<_>, _>>())
                 .map_err(|error| CliError::EnvFileAccessError(file.clone(), error))?;
 

--- a/mirrord/layer/Cargo.toml
+++ b/mirrord/layer/Cargo.toml
@@ -31,7 +31,7 @@ base64.workspace = true
 bincode.workspace = true
 bytemuck = "1"
 ctor = "0.2"
-dotenv.workspace = true
+dotenvy.workspace = true
 errno = "0.3"
 frida-gum = { version = "0.15", features = ["auto-download"] }
 hashbrown = "0.15"

--- a/mirrord/layer/src/lib.rs
+++ b/mirrord/layer/src/lib.rs
@@ -460,8 +460,7 @@ fn fetch_env_vars() -> HashMap<String, String> {
         .unwrap_or_default();
 
     if let Some(file) = &setup().env_config().env_file {
-        #[allow(deprecated)]
-        let envs_from_file = dotenv::from_path_iter(file)
+        let envs_from_file = dotenvy::from_path_iter(file)
             .and_then(|iter| iter.collect::<Result<Vec<_>, _>>())
             .expect("failed to access the env file");
 


### PR DESCRIPTION
[`dotenv` is no longer maintained](https://rustsec.org/advisories/RUSTSEC-2021-0141.html), rustsec proposes `dotenvy` (maintained fork) instead