### PR TITLE
Print full request/response headers only once in intproxy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4458,7 +4458,7 @@ dependencies = [
 
 [[package]]
 name = "mirrord-protocol"
-version = "1.18.1"
+version = "1.18.2"
 dependencies = [
  "actix-codec",
  "bincode",

--- a/changelog.d/+less-trace-spam.internal.md
+++ b/changelog.d/+less-trace-spam.internal.md
@@ -1,0 +1,2 @@
+Changed `Debug` implementation for `InternalHttpRequest` and `InternalHttpResponse` not to print full headers.
+Printing full headers creates a lot of spam in the logs.

--- a/mirrord/protocol/Cargo.toml
+++ b/mirrord/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mirrord-protocol"
-version = "1.18.1"
+version = "1.18.2"
 authors.workspace = true
 description.workspace = true
 documentation.workspace = true

--- a/mirrord/protocol/src/tcp.rs
+++ b/mirrord/protocol/src/tcp.rs
@@ -286,7 +286,7 @@ pub enum ChunkedResponse {
 }
 
 /// (De-)Serializable HTTP request.
-#[derive(Serialize, Deserialize, PartialEq, Debug, Eq, Clone)]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct InternalHttpRequest<B> {
     #[serde(with = "http_serde::method")]
     pub method: Method,
@@ -343,6 +343,18 @@ impl<B> From<InternalHttpRequest<B>> for Request<B> {
         *request.headers_mut() = headers;
 
         request
+    }
+}
+
+impl<B: fmt::Debug> fmt::Debug for InternalHttpRequest<B> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("InternalHttpRequest")
+            .field("method", &self.method)
+            .field("uri", &self.uri)
+            .field("headers", &self.headers.len())
+            .field("version", &self.version)
+            .field("body", &self.body)
+            .finish()
     }
 }
 
@@ -410,7 +422,7 @@ impl<B> HttpRequest<B> {
 }
 
 /// (De-)Serializable HTTP response.
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct InternalHttpResponse<Body> {
     #[serde(with = "http_serde::status_code")]
     pub status: StatusCode,
@@ -460,6 +472,17 @@ impl<B> From<InternalHttpResponse<B>> for Response<B> {
         *response.headers_mut() = headers;
 
         response
+    }
+}
+
+impl<B: fmt::Debug> fmt::Debug for InternalHttpResponse<B> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("InternalHttpResponse")
+            .field("status", &self.status)
+            .field("version", &self.version)
+            .field("headers", &self.headers.len())
+            .field("body", &self.body)
+            .finish()
     }
 }
 


### PR DESCRIPTION
Printing full headers creates a lot of spam, especially since they're printed in parent spans. Sometimes multiple times. And `cookie` alone can be quite long.