### PR TITLE
Some mirrord-kube improvements

### DIFF
--- a/changelog.d/+mirrord-kube-improvements.internal.md
+++ b/changelog.d/+mirrord-kube-improvements.internal.md
@@ -1,0 +1,1 @@
+Made some minor improvements to `mirrord-kube`s typesystem.

--- a/mirrord/kube/src/api.rs
+++ b/mirrord/kube/src/api.rs
@@ -12,7 +12,7 @@ const CONNECTION_CHANNEL_SIZE: usize = 1000;
 
 /// Spawns a background [`tokio::task`] that sends and receives [`mirrord_protocol`] messages
 /// over the given IO stream.
-/// 
+///
 /// The task handles the encoding/decoding of the [`mirrord_protocol`].
 pub fn wrap_raw_connection<IO>(
     stream: IO,

--- a/mirrord/kube/src/api.rs
+++ b/mirrord/kube/src/api.rs
@@ -2,7 +2,7 @@ use actix_codec::{AsyncRead, AsyncWrite};
 use futures::{SinkExt, StreamExt};
 use mirrord_protocol::{ClientCodec, ClientMessage, DaemonMessage};
 use tokio::sync::mpsc;
-use tracing::Instrument;
+use tracing::Level;
 
 pub mod container;
 pub mod kubernetes;
@@ -10,59 +10,63 @@ pub mod runtime;
 
 const CONNECTION_CHANNEL_SIZE: usize = 1000;
 
-/// Creates the task that handles the messaging between layer/agent.
-/// It does the encoding/decoding of protocol.
-#[tracing::instrument(level = "trace", skip_all)]
-pub fn wrap_raw_connection(
-    stream: impl AsyncRead + AsyncWrite + Unpin + Send + 'static,
-) -> (mpsc::Sender<ClientMessage>, mpsc::Receiver<DaemonMessage>) {
+/// Spawns a background [`tokio::task`] that sends and receives [`mirrord_protocol`] messages
+/// over the given IO stream.
+/// 
+/// The task handles the encoding/decoding of the [`mirrord_protocol`].
+pub fn wrap_raw_connection<IO>(
+    stream: IO,
+) -> (mpsc::Sender<ClientMessage>, mpsc::Receiver<DaemonMessage>)
+where
+    IO: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+{
     let mut codec = actix_codec::Framed::new(stream, ClientCodec::default());
 
     let (in_tx, mut in_rx) = mpsc::channel(CONNECTION_CHANNEL_SIZE);
     let (out_tx, out_rx) = mpsc::channel(CONNECTION_CHANNEL_SIZE);
 
-    tokio::spawn(
-        async move {
-            // Generally, this loop should not be exited early with any `return` statement.
-            // We want the `close` below to happen.
-            loop {
-                tokio::select! {
-                    msg = in_rx.recv() => match msg {
-                        Some(msg) => {
-                            if let Err(error) = codec.send(msg).await {
-                                tracing::error!(?error, "Failed to send client message");
-                                break;
-                            }
-                        }
-                        None => {
-                            tracing::trace!("No more client messages, disconnecting");
-                            break;
-                        }
-                    },
+    tokio::spawn(async move {
+        let span = tracing::span!(Level::TRACE, "mirrord_protocol_connection_wrapper_task");
+        let _entered = span.enter();
 
-                    msg = codec.next() => match msg {
-                        Some(Ok(msg)) => {
-                            if let Err(error) = out_tx.send(msg).await {
-                                tracing::error!(?error, "Failed to send agent message");
-                                break;
-                            }
-                        }
-                        Some(Err(error)) => {
-                            tracing::error!(?error, "Failed to receive agent message");
+        // Generally, this loop should not be exited early with any `return` statement.
+        // We want the `close` below to happen.
+        loop {
+            tokio::select! {
+                msg = in_rx.recv() => match msg {
+                    Some(msg) => {
+                        if let Err(error) = codec.send(msg).await {
+                            tracing::error!(%error, "Failed to send a client message");
                             break;
                         }
-                        None => {
-                            tracing::trace!("No more agent messages, disconnecting");
+                    }
+                    None => {
+                        tracing::trace!("No more client messages, disconnecting");
+                        break;
+                    }
+                },
+
+                msg = codec.next() => match msg {
+                    Some(Ok(msg)) => {
+                        if let Err(error) = out_tx.send(msg).await {
+                            tracing::error!(%error, "Failed to send an agent message");
                             break;
                         }
-                    },
-                }
+                    }
+                    Some(Err(error)) => {
+                        tracing::error!(%error, "Failed to receive an agent message");
+                        break;
+                    }
+                    None => {
+                        tracing::trace!("No more agent messages, disconnecting");
+                        break;
+                    }
+                },
             }
-
-            let _ = codec.close().await;
         }
-        .in_current_span(),
-    );
+
+        let _ = codec.close().await;
+    });
 
     (in_tx, out_rx)
 }

--- a/mirrord/kube/src/api/container/job.rs
+++ b/mirrord/kube/src/api/container/job.rs
@@ -368,7 +368,6 @@ mod test {
         let expected: Job = serde_json::from_value(serde_json::json!({
             "metadata": {
                 "name": "foobar",
-                "namespace": "default",
                 "labels": {
                     "kuma.io/sidecar-injection": "disabled",
                     "app": "mirrord"

--- a/mirrord/kube/src/api/kubernetes/portforwarder.rs
+++ b/mirrord/kube/src/api/kubernetes/portforwarder.rs
@@ -14,7 +14,7 @@ use tokio_retry::{
 };
 
 use crate::{
-    api::kubernetes::{get_k8s_resource_api, AgentKubernetesConnectInfo, UnpinStream},
+    api::kubernetes::{AgentKubernetesConnectInfo, UnpinStream},
     error::{KubeApiError, Result},
 };
 
@@ -131,7 +131,7 @@ impl SinglePortForwarder {
     ) -> Result<Self> {
         let mut retry_strategy = Box::new(ExponentialBackoff::from_millis(10).map(jitter).take(5));
 
-        let pod_api: Api<Pod> = get_k8s_resource_api(client, connect_info.namespace.as_deref());
+        let pod_api: Api<Pod> = Api::namespaced(client.clone(), &connect_info.pod_namespace);
 
         let (stream, error_future) =
             create_portforward_streams(&pod_api, &connect_info, &mut retry_strategy).await?;

--- a/mirrord/kube/src/api/runtime.rs
+++ b/mirrord/kube/src/api/runtime.rs
@@ -76,7 +76,7 @@ impl Display for ContainerRuntime {
 pub struct RuntimeData {
     pub pod_name: String,
     pub pod_ips: Vec<IpAddr>,
-    pub pod_namespace: Option<String>,
+    pub pod_namespace: String,
     pub node_name: String,
     pub container_id: String,
     pub container_runtime: ContainerRuntime,
@@ -103,6 +103,12 @@ impl RuntimeData {
             .name
             .as_ref()
             .ok_or_else(|| KubeApiError::missing_field(pod, ".metadata.name"))?
+            .to_owned();
+        let pod_namespace = pod
+            .metadata
+            .namespace
+            .as_ref()
+            .ok_or_else(|| KubeApiError::missing_field(pod, ".metadata.namespace"))?
             .to_owned();
 
         let phase = pod
@@ -203,7 +209,7 @@ impl RuntimeData {
         Ok(RuntimeData {
             pod_ips,
             pod_name,
-            pod_namespace: pod.metadata.namespace.clone(),
+            pod_namespace,
             node_name,
             container_id,
             container_runtime,


### PR DESCRIPTION
* Improved logging in `wrap_raw_connection`
* Namespaces of the agent pod and the target pod are now non-optional (they were always `Some` anyway)
* Removed unnecessary "agent_version" field - has not been used for a long time
* Incluster version of `KubernetesAPI::create_connection` now takes connect info via reference