### PR TITLE
Warn clients of matching HTTP requests that went to another client (#3120)

### DIFF
--- a/changelog.d/3120.changed.md
+++ b/changelog.d/3120.changed.md
@@ -1,0 +1,6 @@
+Warn clients of matching HTTP requests that went to another client
+* Steal API now sends type StealerMessage to the agent, which can contain
+  either DaemonTcp or LogMessage.
+* If an HTTP request matches more than one filter, the request is forwarded to
+  the first matching client, while the other matching clients recevive a
+  warning via LogMessage.

--- a/changelog.d/3120.changed.md
+++ b/changelog.d/3120.changed.md
@@ -1,6 +1,2 @@
-Warn clients of matching HTTP requests that went to another client
-* Steal API now sends type StealerMessage to the agent, which can contain
-  either DaemonTcp or LogMessage.
-* If an HTTP request matches more than one filter, the request is forwarded to
-  the first matching client, while the other matching clients recevive a
-  warning via LogMessage.
+If a stolen HTTP request matches filters of multiple users,
+the users who don't get the request are now notified with a log message.

--- a/mirrord/agent/src/entrypoint.rs
+++ b/mirrord/agent/src/entrypoint.rs
@@ -17,6 +17,7 @@ use metrics::{start_metrics, CLIENT_COUNT};
 use mirrord_agent_env::envs;
 use mirrord_protocol::{ClientMessage, DaemonMessage, GetEnvVarsRequest, LogMessage};
 use sniffer::tcp_capture::RawSocketTcpCapture;
+use steal::StealerMessage;
 use tokio::{
     net::{TcpListener, TcpStream},
     process::Command,
@@ -367,7 +368,8 @@ impl ClientConnectionHandler {
                         unreachable!()
                     }
                 }, if self.tcp_stealer_api.is_some() => match message {
-                    Ok(message) => self.respond(DaemonMessage::TcpSteal(message)).await?,
+                    Ok(StealerMessage::TcpSteal(message)) => self.respond(DaemonMessage::TcpSteal(message)).await?,
+                    Ok(StealerMessage::LogMessage(log)) => self.respond(DaemonMessage::LogMessage(log)).await?,
                     Err(e) => break e,
                 },
                 message = self.tcp_outgoing_api.recv_from_task() => match message {

--- a/mirrord/agent/src/steal.rs
+++ b/mirrord/agent/src/steal.rs
@@ -1,5 +1,5 @@
 use mirrord_protocol::{
-    tcp::{DaemonTcp, StealType, TcpData},
+    tcp::{StealType, TcpData},
     ConnectionId, Port,
 };
 use tokio::sync::mpsc::Sender;
@@ -15,7 +15,7 @@ mod orig_dst;
 mod subscriptions;
 mod tls;
 
-pub(crate) use api::TcpStealerApi;
+pub(crate) use api::{StealerMessage, TcpStealerApi};
 pub(crate) use connection::TcpConnectionStealer;
 pub(crate) use tls::StealTlsHandlerStore;
 
@@ -29,7 +29,7 @@ use self::http::HttpResponseFallback;
 enum Command {
     /// Contains the channel that's used by the stealer worker to respond back to the agent
     /// (stealer -> agent -> layer).
-    NewClient(Sender<DaemonTcp>),
+    NewClient(Sender<StealerMessage>),
 
     /// A layer wants to subscribe to this [`Port`].
     ///

--- a/mirrord/agent/src/steal/connection.rs
+++ b/mirrord/agent/src/steal/connection.rs
@@ -88,12 +88,6 @@ enum PassRequestError {
     ClientDisconnected,
 }
 
-impl From<SendError<DaemonTcp>> for PassRequestError {
-    fn from(_: SendError<DaemonTcp>) -> Self {
-        Self::ClientDisconnected
-    }
-}
-
 impl From<SendError<StealerMessage>> for PassRequestError {
     fn from(_: SendError<StealerMessage>) -> Self {
         Self::ClientDisconnected

--- a/mirrord/agent/src/steal/connections.rs
+++ b/mirrord/agent/src/steal/connections.rs
@@ -163,7 +163,7 @@ pub enum ConnectionMessageOut {
     },
     /// The client recevied a log message from the connection.
     ///
-    /// This variant translates to [`DaemonMessage::LogMessage`].
+    /// This variant translates to [`LogMessage`].
     LogMessage {
         client_id: ClientId,
         connection_id: ConnectionId,

--- a/mirrord/agent/src/steal/connections.rs
+++ b/mirrord/agent/src/steal/connections.rs
@@ -6,7 +6,7 @@ use std::{collections::HashMap, fmt, io, net::SocketAddr, time::Duration};
 use hyper::{body::Incoming, Request, Response};
 use mirrord_protocol::{
     tcp::{HttpRequestMetadata, HttpRequestTransportType, NewTcpConnection},
-    ConnectionId, RequestId,
+    ConnectionId, LogMessage, RequestId,
 };
 use original_destination::OriginalDestination;
 use thiserror::Error;
@@ -161,6 +161,14 @@ pub enum ConnectionMessageOut {
         client_id: ClientId,
         connection_id: ConnectionId,
     },
+    /// The client recevied a log message from the connection.
+    ///
+    /// This variant translates to [`DaemonMessage::LogMessage`].
+    LogMessage {
+        client_id: ClientId,
+        connection_id: ConnectionId,
+        message: LogMessage,
+    },
     /// The connection was closed for the given client.
     ///
     /// This variant translates to [`DaemonTcp::Close`](mirrord_protocol::tcp::DaemonTcp::Close).
@@ -218,6 +226,16 @@ impl fmt::Debug for ConnectionMessageOut {
                 debug_struct.field("type", &"SubscribedHttp");
                 debug_struct.field("connection_id", connection_id);
                 debug_struct.field("client_id", client_id);
+            }
+            Self::LogMessage {
+                client_id,
+                connection_id,
+                message,
+            } => {
+                debug_struct.field("type", &"LogMessage");
+                debug_struct.field("connection_id", connection_id);
+                debug_struct.field("client_id", client_id);
+                debug_struct.field("message", message);
             }
             Self::Closed {
                 client_id,

--- a/mirrord/agent/src/steal/connections/filtered.rs
+++ b/mirrord/agent/src/steal/connections/filtered.rs
@@ -684,7 +684,11 @@ where
             tx.send(ConnectionMessageOut::LogMessage {
                 client_id,
                 connection_id: self.connection_id,
-                message: LogMessage::warn("Matching HTTP request stolen by another client".into()),
+                message: LogMessage::warn(format!(
+                    "An HTTP request was stolen by another user. URI=({:?}), HEADERS=({:?})",
+                    request.request.uri(),
+                    request.request.headers(),
+                )),
             })
             .await?;
         }

--- a/mirrord/agent/src/steal/connections/filtered.rs
+++ b/mirrord/agent/src/steal/connections/filtered.rs
@@ -1326,7 +1326,7 @@ mod test {
                     other => unreachable!("unexpected message: {other:?}"),
                 };
 
-                // The remaining two cleints receive the warning
+                // The remaining two clients receive the warning
                 for _ in 0..2 {
                     match setup.task_out_rx.recv().await.unwrap() {
                         ConnectionMessageOut::LogMessage {

--- a/mirrord/agent/src/steal/connections/filtered.rs
+++ b/mirrord/agent/src/steal/connections/filtered.rs
@@ -1163,7 +1163,7 @@ mod test {
         /// # Params
         ///
         /// 1. `client_ids` - For each client_id, insert a header filter. The request will contain a
-        ///    corresponding header such that the [`FilteredStealTask`] will steal it..
+        ///    corresponding header such that the [`FilteredStealTask`] will steal it.
         fn prepare_request_for_multiple(&self, client_ids: &[ClientId]) -> Request<DynamicBody> {
             let filter = (
                 HttpFilter::Header("x-subscription: ABCD".parse().unwrap()),

--- a/mirrord/agent/src/steal/connections/filtered.rs
+++ b/mirrord/agent/src/steal/connections/filtered.rs
@@ -644,6 +644,9 @@ where
             return Ok(());
         };
 
+        let request_uri = request.request.uri().to_owned();
+        let request_headers = request.request.headers().to_owned();
+
         if self.subscribed.insert(client_id, true).is_none() {
             // First time this client will receive a request from this connection.
             tx.send(ConnectionMessageOut::SubscribedHttp {
@@ -686,8 +689,7 @@ where
                 connection_id: self.connection_id,
                 message: LogMessage::warn(format!(
                     "An HTTP request was stolen by another user. URI=({:?}), HEADERS=({:?})",
-                    request.request.uri(),
-                    request.request.headers(),
+                    request_uri, request_headers,
                 )),
             })
             .await?;

--- a/mirrord/agent/src/steal/http/filter.rs
+++ b/mirrord/agent/src/steal/http/filter.rs
@@ -3,7 +3,7 @@ use hyper::Request;
 use tracing::Level;
 
 /// Currently supported filtering criterias.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum HttpFilter {
     /// Header based filter.
     /// This [`Regex`] should be used against each header after transforming it to `k: v` format.


### PR DESCRIPTION
* Steal API now sends type StealerMessage to the agent, which can contain either DaemonTcp or LogMessage.
* If an HTTP request matches more than one filter, the request is forwarded to the first matching client, while the other matching clients recevive a warning via LogMessage.