### PR TITLE
Added missing permissions for `PodTemplate`s

### DIFF
--- a/changelog.d/+pod-template-permissions.fixed.md
+++ b/changelog.d/+pod-template-permissions.fixed.md
@@ -1,0 +1,1 @@
+Added missing `PodTemplate` permissions to the `ClusterRole` produced by `mirrord operator setup`.

--- a/mirrord/cli/src/extension.rs
+++ b/mirrord/cli/src/extension.rs
@@ -25,8 +25,8 @@ where
     #[cfg(not(target_os = "macos"))]
     let mut execution_info = MirrordExecution::start(&mut config, &mut progress, analytics).await?;
 
-    // We don't execute so set envs aren't passed, so we need to add config file and target to
-    // env.
+    // We don't execute so set envs aren't passed,
+    // so we need to add config file and target to env.
     execution_info.environment.extend(env);
 
     let output = serde_json::to_string(&execution_info)?;

--- a/mirrord/operator/src/setup.rs
+++ b/mirrord/operator/src/setup.rs
@@ -5,9 +5,9 @@ use k8s_openapi::{
         apps::v1::{Deployment, DeploymentSpec},
         core::v1::{
             Container, ContainerPort, EnvVar, HTTPGetAction, Namespace, PodSecurityContext,
-            PodSpec, PodTemplateSpec, Probe, ResourceRequirements, Secret, SecretVolumeSource,
-            SecurityContext, Service, ServiceAccount, ServicePort, ServiceSpec, Sysctl, Volume,
-            VolumeMount,
+            PodSpec, PodTemplate, PodTemplateSpec, Probe, ResourceRequirements, Secret,
+            SecretVolumeSource, SecurityContext, Service, ServiceAccount, ServicePort, ServiceSpec,
+            Sysctl, Volume, VolumeMount,
         },
         rbac::v1::{
             ClusterRole, ClusterRoleBinding, PolicyRule, Role, RoleBinding, RoleRef, Subject,
@@ -622,6 +622,13 @@ impl OperatorClusterRole {
                     MirrordClusterTlsStealConfig::plural(&()).into_owned(),
                 ]),
                 verbs: vec!["list".to_owned(), "get".to_owned()],
+                ..Default::default()
+            },
+            // `PodTemplate`s can be used as `workloadRef`s in Rollouts.
+            PolicyRule {
+                api_groups: Some(vec![PodTemplate::group(&()).into_owned()]),
+                resources: Some(vec![PodTemplate::plural(&()).into_owned()]),
+                verbs: vec!["get".to_owned(), "list".to_owned(), "watch".to_owned()],
                 ..Default::default()
             },
         ];


### PR DESCRIPTION
We need to fetch the workload ref when preparing the session