### PR TITLE
Fix code signing in SIP-patching

### DIFF
--- a/changelog.d/3149.fixed.md
+++ b/changelog.d/3149.fixed.md
@@ -1,0 +1,1 @@
+Regression in running some SIP-protected binaries with mirrord.

--- a/mirrord/sip/src/codesign.rs
+++ b/mirrord/sip/src/codesign.rs
@@ -13,6 +13,9 @@ pub(crate) fn sign<PI: AsRef<Path>, PO: AsRef<Path>>(input: PI, output: PO) -> R
     // but if we sign in place we get permission error, probably because someone is holding the
     // handle to the named temp file.
     let mut settings = SigningSettings::default();
+    // Replace any existing flags with just the adhoc flag.
+    // Important because some binaries (e.g. `go`), have the "runtime" flag set, which means,
+    // opting into the hardened runtime, which strips away DYLD_INSERT_LIBRARIES etc.
     settings.set_code_signature_flags(SettingsScope::Main, CodeSignatureFlags::ADHOC);
     let signer = UnifiedSigner::new(settings);
     signer.sign_path(input, output)?;

--- a/mirrord/sip/src/codesign.rs
+++ b/mirrord/sip/src/codesign.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use apple_codesign::{SigningSettings, UnifiedSigner};
+use apple_codesign::{CodeSignatureFlags, SettingsScope, SigningSettings, UnifiedSigner};
 
 use crate::error::Result;
 
@@ -12,7 +12,8 @@ pub(crate) fn sign<PI: AsRef<Path>, PO: AsRef<Path>>(input: PI, output: PO) -> R
     // we switched to use apple codesign crate to avoid this issue (of creating process)
     // but if we sign in place we get permission error, probably because someone is holding the
     // handle to the named temp file.
-    let settings = SigningSettings::default();
+    let mut settings = SigningSettings::default();
+    settings.set_code_signature_flags(SettingsScope::Main, CodeSignatureFlags::ADHOC);
     let signer = UnifiedSigner::new(settings);
     signer.sign_path(input, output)?;
     Ok(())


### PR DESCRIPTION
 Fix #3149 

The new signing method was not overwriting the existing flags of a binary, so binaries like the `go` binary, that have the "runtime" flag set, were running in a hardened runtime even after the patch, and were therefore resistant to dynamic library injection.