### PR TITLE
MirrordProfile

### DIFF
--- a/changelog.d/+mirrord-profil.added.md
+++ b/changelog.d/+mirrord-profil.added.md
@@ -1,0 +1,1 @@
+Added support for new CRD - MirrordProfile. mirrord profiles allow for storing mirrord config templates in the cluster and applying them to the mirrord config at runtime.

--- a/mirrord-schema.json
+++ b/mirrord-schema.json
@@ -102,6 +102,14 @@
         "null"
       ]
     },
+    "profile": {
+      "title": "profile {#root-profile}",
+      "description": "Name of the mirrord profile to use.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "sip_binaries": {
       "title": "sip_binaries {#root-sip_binaries}",
       "description": "Binaries to patch (macOS SIP).\n\nUse this when mirrord isn't loaded to protected binaries that weren't automatically patched.\n\nRuns `endswith` on the binary path (so `bash` would apply to any binary ending with `bash` while `/usr/bin/bash` would apply only for that binary).\n\n```json { \"sip_binaries\": \"bash;python\" } ```",

--- a/mirrord/cli/src/error.rs
+++ b/mirrord/cli/src/error.rs
@@ -15,6 +15,7 @@ use thiserror::Error;
 use crate::{
     container::{CommandDisplay, IntproxySidecarError},
     port_forward::PortForwardError,
+    profile::ProfileError,
 };
 
 pub(crate) type CliResult<T, E = CliError> = core::result::Result<T, E>;
@@ -391,6 +392,9 @@ pub(crate) enum CliError {
 
     #[error(transparent)]
     ParseInt(ParseIntError),
+
+    #[error(transparent)]
+    ProfileError(#[from] ProfileError),
 }
 
 impl CliError {

--- a/mirrord/cli/src/extension.rs
+++ b/mirrord/cli/src/extension.rs
@@ -39,7 +39,8 @@ pub(crate) async fn extension_exec(args: ExtensionExecArgs, watch: drain::Watch)
         .override_env_opt(LayerConfig::FILE_PATH_ENV, args.config_file)
         .override_env_opt("MIRRORD_IMPERSONATED_TARGET", args.target);
 
-    let config = LayerConfig::resolve(&mut cfg_context)?;
+    let mut config = LayerConfig::resolve(&mut cfg_context)?;
+    crate::profile::apply_profile_if_configured(&mut config, &progress).await?;
 
     let mut analytics = AnalyticsReporter::only_error(config.telemetry, Default::default(), watch);
 

--- a/mirrord/cli/src/main.rs
+++ b/mirrord/cli/src/main.rs
@@ -56,6 +56,7 @@ mod list;
 mod logging;
 mod operator;
 mod port_forward;
+mod profile;
 mod teams;
 mod util;
 mod verify_config;

--- a/mirrord/cli/src/main.rs
+++ b/mirrord/cli/src/main.rs
@@ -350,7 +350,8 @@ async fn exec(args: &ExecArgs, watch: drain::Watch) -> CliResult<()> {
 
     let mut cfg_context = ConfigContext::default().override_envs(args.params.as_env_vars());
     let config_file_path = cfg_context.get_env(LayerConfig::FILE_PATH_ENV).ok();
-    let config = LayerConfig::resolve(&mut cfg_context)?;
+    let mut config = LayerConfig::resolve(&mut cfg_context)?;
+    crate::profile::apply_profile_if_configured(&mut config, &progress).await?;
 
     let mut analytics = AnalyticsReporter::only_error(config.telemetry, Default::default(), watch);
     (&config).collect_analytics(analytics.get_mut());
@@ -442,7 +443,8 @@ async fn port_forward(args: &PortForwardArgs, watch: drain::Watch) -> CliResult<
         )
         .override_env_opt("MIRRORD_KUBE_CONTEXT", args.context.as_ref())
         .override_env_opt(LayerConfig::FILE_PATH_ENV, args.config_file.as_ref());
-    let config = LayerConfig::resolve(&mut cfg_context)?;
+    let mut config = LayerConfig::resolve(&mut cfg_context)?;
+    crate::profile::apply_profile_if_configured(&mut config, &progress).await?;
 
     let mut analytics = AnalyticsReporter::new(config.telemetry, ExecutionKind::PortForward, watch);
     (&config).collect_analytics(analytics.get_mut());

--- a/mirrord/cli/src/profile.rs
+++ b/mirrord/cli/src/profile.rs
@@ -1,0 +1,196 @@
+//! This module contains utilities for working with [`MirrordProfile`]s.
+
+use kube::{Api, Client};
+use miette::Diagnostic;
+use mirrord_config::{
+    feature::{network::incoming::IncomingMode, FeatureConfig},
+    util::VecOrSingle,
+    LayerConfig,
+};
+use mirrord_kube::{api::kubernetes::create_kube_config, error::KubeApiError};
+use mirrord_operator::crd::profile::{
+    FeatureAdjustment, FeatureChange, FeatureKind, MirrordProfile, MirrordProfileSpec,
+};
+use mirrord_progress::Progress;
+use thiserror::Error;
+
+use crate::CliError;
+
+/// Errors that can occur when fetching or applying a [`MirrordProfile`].
+#[derive(Error, Debug, Diagnostic)]
+pub enum ProfileError {
+    #[error("mirrord profile contains an unknown value")]
+    #[diagnostic(help("Consider upgrading your mirrord binary."))]
+    UnknownVariant,
+
+    #[error("mirrord profile contains an unknown field `{0}`")]
+    #[diagnostic(help("Consider upgrading your mirrord binary."))]
+    UnknownField(String),
+
+    #[error("mirrord profile was not found in the cluster")]
+    #[diagnostic(help(
+        "Use `kubectl get mirrordprofiles <profile-name>` \
+        to verify that the profile exists \
+        and its name is spelled correctly in your mirrord config."
+    ))]
+    ProfileNotFound,
+
+    #[error("failed to fetch the mirrord profile: {0}")]
+    #[diagnostic(help(
+        "Check if you have sufficient permissions to fetch the profile from the cluster."
+    ))]
+    ProfileFetchError(KubeApiError),
+
+    #[error("mirrord profile contains an invalid entry with change `{change}` that does not apply to feature kind `{kind}`")]
+    #[diagnostic(help(
+        // Some combinations might become valid in the future,
+        // so let's advice upgrading first.
+        "Consider upgrading your mirrord binary. \
+        If the error persists, contact your cluster admin."
+    ))]
+    FeatureChangeNotApplicable {
+        kind: FeatureKind,
+        change: FeatureChange,
+    },
+}
+
+/// Convenience trait for [`FeatureAdjustment`].
+trait FeatureAdjustmentExt: Sized {
+    /// Tries to apply this adjustment to the given [`FeatureConfig`].
+    fn apply_to(self, config: &mut FeatureConfig) -> Result<(), ProfileError>;
+}
+
+impl FeatureAdjustmentExt for FeatureAdjustment {
+    fn apply_to(self, config: &mut FeatureConfig) -> Result<(), ProfileError> {
+        let Self {
+            kind,
+            change,
+            unknown_fields,
+        } = self;
+
+        if let Some(field) = unknown_fields.into_keys().next() {
+            return Err(ProfileError::UnknownField(field));
+        }
+
+        match kind {
+            FeatureKind::Incoming => match change {
+                FeatureChange::Disabled => {
+                    config.network.incoming.mode = IncomingMode::Off;
+                }
+                FeatureChange::Mirror => {
+                    config.network.incoming.mode = IncomingMode::Mirror;
+                }
+                FeatureChange::Steal => config.network.incoming.mode = IncomingMode::Steal,
+                FeatureChange::Remote => {
+                    return Err(ProfileError::FeatureChangeNotApplicable { kind, change });
+                }
+                FeatureChange::Unknown => return Err(ProfileError::UnknownVariant),
+            },
+
+            FeatureKind::Outgoing => match change {
+                FeatureChange::Disabled => {
+                    config.network.outgoing.tcp = false;
+                    config.network.outgoing.udp = false;
+                    config.network.outgoing.filter = None;
+                    config.network.outgoing.unix_streams = None;
+                }
+                FeatureChange::Remote => {
+                    config.network.outgoing.tcp = true;
+                    config.network.outgoing.udp = true;
+                    config.network.outgoing.filter = None;
+                    config.network.outgoing.unix_streams = Some(VecOrSingle::Single(".*".into()));
+                }
+                FeatureChange::Mirror | FeatureChange::Steal => {
+                    return Err(ProfileError::FeatureChangeNotApplicable { kind, change });
+                }
+                FeatureChange::Unknown => return Err(ProfileError::UnknownVariant),
+            },
+
+            FeatureKind::Dns => match change {
+                FeatureChange::Disabled => {
+                    config.network.dns.enabled = false;
+                    config.network.dns.filter = None;
+                }
+                FeatureChange::Remote => {
+                    config.network.dns.enabled = true;
+                    config.network.dns.filter = None;
+                }
+                FeatureChange::Mirror | FeatureChange::Steal => {
+                    return Err(ProfileError::FeatureChangeNotApplicable { kind, change });
+                }
+                FeatureChange::Unknown => return Err(ProfileError::UnknownVariant),
+            },
+
+            FeatureKind::Unknown => {
+                return Err(ProfileError::UnknownVariant);
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Applies the given [`MirrordProfile`] to the given [`FeatureConfig`].
+fn apply_profile(config: &mut FeatureConfig, profile: MirrordProfile) -> Result<(), ProfileError> {
+    let MirrordProfileSpec {
+        feature_adjustments,
+        unknown_fields,
+    } = profile.spec;
+
+    if let Some(field) = unknown_fields.into_keys().next() {
+        return Err(ProfileError::UnknownField(field));
+    }
+
+    for adjustment in feature_adjustments {
+        adjustment.apply_to(config)?;
+    }
+
+    Ok(())
+}
+
+/// If the [`LayerConfig::profile`] field specifies a [`MirrordProfile`] to use,
+/// fetches that profile from the cluster and applies it to the config.
+///
+/// Verifies that the fetched profile does not contain any unknown fields or values.
+pub async fn apply_profile_if_configured<P: Progress>(
+    config: &mut LayerConfig,
+    progress: &P,
+) -> Result<(), CliError> {
+    let Some(name) = config.profile.as_deref() else {
+        return Ok(());
+    };
+
+    let mut subtask = progress.subtask(&format!("fetching mirrord profile `{name}`"));
+    let profile: Result<MirrordProfile, KubeApiError> = try {
+        let client: Client = create_kube_config(
+            config.accept_invalid_certificates,
+            config.kubeconfig.as_deref(),
+            config.kube_context.clone(),
+        )
+        .await?
+        .try_into()
+        .map_err(KubeApiError::from)?;
+
+        let api = Api::<MirrordProfile>::all(client);
+        api.get(name).await?
+    };
+
+    let profile = match profile {
+        Ok(profile) => profile,
+        Err(KubeApiError::KubeError(kube::Error::Api(error))) if error.code == 404 => {
+            return Err(CliError::ProfileError(ProfileError::ProfileNotFound));
+        }
+        Err(error) => {
+            return Err(CliError::friendlier_error_or_else(error, |error| {
+                CliError::ProfileError(ProfileError::ProfileFetchError(error))
+            }));
+        }
+    };
+    subtask.success(Some(&format!("mirrord profile `{name}` fetched")));
+
+    let mut subtask = progress.subtask(&format!("applying mirrord profile `{name}`"));
+    apply_profile(&mut config.feature, profile)?;
+    subtask.success(Some(&format!("mirrord profile `{name}` applied")));
+
+    Ok(())
+}

--- a/mirrord/cli/src/profile.rs
+++ b/mirrord/cli/src/profile.rs
@@ -74,7 +74,7 @@ impl FeatureAdjustmentExt for FeatureAdjustment {
 
         match kind {
             FeatureKind::Incoming => match change {
-                FeatureChange::Disabled => {
+                FeatureChange::Off => {
                     config.network.incoming.mode = IncomingMode::Off;
                 }
                 FeatureChange::Mirror => {
@@ -88,7 +88,7 @@ impl FeatureAdjustmentExt for FeatureAdjustment {
             },
 
             FeatureKind::Outgoing => match change {
-                FeatureChange::Disabled => {
+                FeatureChange::Off => {
                     config.network.outgoing.tcp = false;
                     config.network.outgoing.udp = false;
                     config.network.outgoing.filter = None;
@@ -107,7 +107,7 @@ impl FeatureAdjustmentExt for FeatureAdjustment {
             },
 
             FeatureKind::Dns => match change {
-                FeatureChange::Disabled => {
+                FeatureChange::Off => {
                     config.network.dns.enabled = false;
                     config.network.dns.filter = None;
                 }

--- a/mirrord/config/configuration.md
+++ b/mirrord/config/configuration.md
@@ -1656,6 +1656,10 @@ Whether mirrord should use the operator.
 If not set, mirrord will first attempt to use the operator, but continue without it in case
 of failure.
 
+## profile {#root-profile}
+
+Name of the mirrord profile to use.
+
 ## sip_binaries {#root-sip_binaries}
 
 Binaries to patch (macOS SIP).

--- a/mirrord/config/src/config/context.rs
+++ b/mirrord/config/src/config/context.rs
@@ -2,6 +2,7 @@ use std::{
     collections::HashMap,
     env::VarError,
     ffi::{OsStr, OsString},
+    ops::Not,
     os::unix::ffi::OsStrExt,
 };
 
@@ -119,6 +120,11 @@ impl ConfigContext {
     /// Returns all warnings previously stored with [`ConfigContext::add_warning`].
     pub fn into_warnings(self) -> Vec<String> {
         self.warnings
+    }
+
+    /// Returns whether this context stores any warnings.
+    pub fn has_warnings(&self) -> bool {
+        self.warnings.is_empty().not()
     }
 }
 

--- a/mirrord/config/src/lib.rs
+++ b/mirrord/config/src/lib.rs
@@ -608,6 +608,7 @@ impl CollectAnalytics for &LayerConfig {
             analytics.add("accept_invalid_certificates", value);
         };
         analytics.add("use_kubeconfig", self.kubeconfig.is_some());
+        analytics.add("use_profile", self.profile.is_some());
         (&self.target).collect_analytics(analytics);
         (&self.agent).collect_analytics(analytics);
         (&self.feature).collect_analytics(analytics);

--- a/mirrord/config/src/lib.rs
+++ b/mirrord/config/src/lib.rs
@@ -598,6 +598,15 @@ impl LayerConfig {
             );
         }
 
+        if let (Some(profile), true) = (&self.profile, context.has_warnings()) {
+            // It might be that the user config is fine,
+            // but the mirrord profile introduced changes that triggered the warnings.
+            context.add_warning(format!(
+                "Config verification was done after applying mirrord profile `{profile}`. \
+                You can inspect the profile with `kubectl get mirrordprofile {profile} -o yaml`.",
+            ));
+        }
+
         Ok(())
     }
 }

--- a/mirrord/config/src/lib.rs
+++ b/mirrord/config/src/lib.rs
@@ -228,6 +228,11 @@ pub struct LayerConfig {
     #[config(env = "MIRRORD_OPERATOR_ENABLE")]
     pub operator: Option<bool>,
 
+    /// ## profile {#root-profile}
+    ///
+    /// Name of the mirrord profile to use.
+    pub profile: Option<String>,
+
     /// ## kubeconfig {#root-kubeconfig}
     ///
     /// Path to a kubeconfig file, if not specified, will use `KUBECONFIG`, or `~/.kube/config`, or
@@ -948,6 +953,7 @@ mod tests {
             }),
             container: None,
             operator: None,
+            profile: None,
             sip_binaries: None,
             kube_context: None,
             external_proxy: None,

--- a/mirrord/operator/src/crd.rs
+++ b/mirrord/operator/src/crd.rs
@@ -23,6 +23,7 @@ pub mod kafka;
 pub mod kube_target;
 pub mod label_selector;
 pub mod policy;
+pub mod profile;
 pub mod steal_tls;
 
 pub const TARGETLESS_TARGET_NAME: &str = "targetless";

--- a/mirrord/operator/src/crd/profile.rs
+++ b/mirrord/operator/src/crd/profile.rs
@@ -32,6 +32,7 @@ pub struct MirrordProfileSpec {
 
 /// A single adjustment to the mirrord config's `feature` section.
 #[derive(Deserialize, Serialize, JsonSchema, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct FeatureAdjustment {
     /// The kind of feature to which this adjustment applies.
     pub kind: FeatureKind,
@@ -48,7 +49,7 @@ pub struct FeatureAdjustment {
 
 /// A kind of mirrord feature that can be adjusted in a mirrord policy.
 #[derive(Deserialize, Serialize, JsonSchema, Debug, Clone, Copy)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "kebab-case")]
 pub enum FeatureKind {
     /// Incoming traffic.
     Incoming,
@@ -79,7 +80,7 @@ impl fmt::Display for FeatureKind {
 
 /// An adjustment to some mirrord feature.
 #[derive(Deserialize, Serialize, JsonSchema, Debug, Clone, Copy)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "kebab-case")]
 pub enum FeatureChange {
     /// Incoming traffic will be mirrored.
     ///

--- a/mirrord/operator/src/crd/profile.rs
+++ b/mirrord/operator/src/crd/profile.rs
@@ -95,7 +95,7 @@ pub enum FeatureChange {
     /// * `incoming` - no remote traffic will be intercepted
     /// * `outgoing` - all outgoing traffic will be fully local
     /// * `dns` - all DNS resolution will be fully local
-    Disabled,
+    Off,
     /// Outgoing traffic or DNS resolution will be fully remote.
     ///
     /// Applies only to the `outgoing` and `dns` feature kinds.
@@ -113,7 +113,7 @@ impl fmt::Display for FeatureChange {
         let as_str = match self {
             Self::Mirror => "mirror",
             Self::Steal => "steal",
-            Self::Disabled => "disabled",
+            Self::Off => "off",
             Self::Remote => "remote",
             Self::Unknown => "unknown",
         };

--- a/mirrord/operator/src/crd/profile.rs
+++ b/mirrord/operator/src/crd/profile.rs
@@ -1,0 +1,123 @@
+use std::{collections::HashMap, fmt};
+
+use kube::CustomResource;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// Custom cluster-wide resource for storing a reusable mirrord config template.
+///
+/// Can be selected from the user's mirrord config.
+#[derive(CustomResource, Clone, Debug, Deserialize, Serialize, JsonSchema)]
+#[kube(
+    // The operator group is handled by the operator, we want profiles to be handled by k8s.
+    group = "profiles.mirrord.metalbear.co",
+    version = "v1alpha",
+    kind = "MirrordProfile"
+)]
+#[serde(rename_all = "camelCase")]
+pub struct MirrordProfileSpec {
+    /// A list of adjustments to be made in the user's feature config.
+    ///
+    /// The adjustments are applied in order.
+    pub feature_adjustments: Vec<FeatureAdjustment>,
+
+    /// For future compatibility.
+    ///
+    /// The CLI should error when the profile contains unknown fields.
+    #[schemars(skip)]
+    #[serde(flatten, skip_serializing)]
+    pub unknown_fields: HashMap<String, Value>,
+}
+
+/// A single adjustment to the mirrord config's `feature` section.
+#[derive(Deserialize, Serialize, JsonSchema, Debug, Clone)]
+pub struct FeatureAdjustment {
+    /// The kind of feature to which this adjustment applies.
+    pub kind: FeatureKind,
+    /// The change to be made.
+    pub change: FeatureChange,
+
+    /// For future compatibility.
+    ///
+    /// The CLI should error when the profile contains unknown fields.
+    #[schemars(skip)]
+    #[serde(flatten, skip_serializing)]
+    pub unknown_fields: HashMap<String, Value>,
+}
+
+/// A kind of mirrord feature that can be adjusted in a mirrord policy.
+#[derive(Deserialize, Serialize, JsonSchema, Debug, Clone, Copy)]
+#[serde(rename_all = "camelCase")]
+pub enum FeatureKind {
+    /// Incoming traffic.
+    Incoming,
+    /// Outgoing traffic.
+    Outgoing,
+    /// DNS resolution.
+    Dns,
+    /// For forward compatibility.
+    ///
+    /// We don't want a single deserialization failure to fail listing policies.
+    #[schemars(skip)]
+    #[serde(other)]
+    Unknown,
+}
+
+impl fmt::Display for FeatureKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let as_str = match self {
+            Self::Incoming => "incoming",
+            Self::Outgoing => "outgoing",
+            Self::Dns => "dns",
+            Self::Unknown => "unknown",
+        };
+
+        f.write_str(as_str)
+    }
+}
+
+/// An adjustment to some mirrord feature.
+#[derive(Deserialize, Serialize, JsonSchema, Debug, Clone, Copy)]
+#[serde(rename_all = "camelCase")]
+pub enum FeatureChange {
+    /// Incoming traffic will be mirrored.
+    ///
+    /// Applies only to the `incoming` feature kind.
+    Mirror,
+    /// Incoming traffic will be stolen.
+    ///
+    /// Applies only to the `incoming` feature kind.
+    Steal,
+    /// Disables the feature.
+    ///
+    /// When applied to:
+    /// * `incoming` - no remote traffic will be intercepted
+    /// * `outgoing` - all outgoing traffic will be fully local
+    /// * `dns` - all DNS resolution will be fully local
+    Disabled,
+    /// Outgoing traffic or DNS resolution will be fully remote.
+    ///
+    /// Applies only to the `outgoing` and `dns` feature kinds.
+    Remote,
+    /// For forward compatibility.
+    ///
+    /// We don't want a single deserialization failure to fail listing policies.
+    #[schemars(skip)]
+    #[serde(other)]
+    Unknown,
+}
+
+impl fmt::Display for FeatureChange {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let as_str = match self {
+            Self::Mirror => "mirror",
+            Self::Steal => "steal",
+            Self::Disabled => "disabled",
+            Self::Remote => "remote",
+            Self::Unknown => "unknown",
+        };
+
+        f.write_str(as_str)
+    }
+}

--- a/mirrord/operator/src/setup.rs
+++ b/mirrord/operator/src/setup.rs
@@ -29,6 +29,7 @@ use thiserror::Error;
 use crate::crd::{
     kafka::{MirrordKafkaClientConfig, MirrordKafkaEphemeralTopic, MirrordKafkaTopicsConsumer},
     policy::{MirrordClusterPolicy, MirrordPolicy},
+    profile::MirrordProfile,
     steal_tls::{MirrordClusterTlsStealConfig, MirrordTlsStealConfig},
     MirrordOperatorUser, MirrordSqsSession, MirrordWorkloadQueueRegistry, TargetCrd,
 };
@@ -240,6 +241,9 @@ impl OperatorSetup for Operator {
 
         writer.write_all(b"---\n")?;
         MirrordClusterTlsStealConfig::crd().to_writer(&mut writer)?;
+
+        writer.write_all(b"---\n")?;
+        MirrordProfile::crd().to_writer(&mut writer)?;
 
         if self.sqs_splitting {
             writer.write_all(b"---\n")?;

--- a/tests/src/operator.rs
+++ b/tests/src/operator.rs
@@ -2,6 +2,7 @@
 
 mod concurrent_steal;
 mod policies;
+mod profiles;
 mod queue_splitting;
 mod setup;
 mod steal_tls;

--- a/tests/src/operator/profiles.rs
+++ b/tests/src/operator/profiles.rs
@@ -1,0 +1,112 @@
+#![cfg(feature = "operator")]
+
+use std::time::Duration;
+
+use kube::{api::ObjectMeta, Api};
+use mirrord_operator::crd::profile::{
+    FeatureAdjustment, FeatureChange, FeatureKind, MirrordProfile, MirrordProfileSpec,
+};
+use rstest::rstest;
+use tempfile::NamedTempFile;
+
+use crate::utils::{
+    kube_client, port_forwarder::PortForwarder, service, Application, KubeService, ResourceGuard,
+};
+
+#[rstest]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[timeout(Duration::from_secs(120))]
+pub async fn create_cluster_policy_and_try_to_mirror(
+    #[future] kube_client: kube::Client,
+    #[future] service: KubeService,
+) {
+    let kube_client = kube_client.await;
+    let service = service.await;
+    let target_path = service.pod_container_target();
+
+    // The `KubeService` resources are created in a random namespace,
+    // which will be deleted after this test.
+    // However, mirrord profiles are clusterwide, so they need a separate guard.
+    let (_profile_guard, profile_name) = {
+        let profile = MirrordProfile {
+            metadata: ObjectMeta {
+                generate_name: Some("test-profile-".into()),
+                ..Default::default()
+            },
+            spec: MirrordProfileSpec {
+                feature_adjustments: vec![FeatureAdjustment {
+                    kind: FeatureKind::Incoming,
+                    change: FeatureChange::Steal,
+                    unknown_fields: Default::default(),
+                }],
+                unknown_fields: Default::default(),
+            },
+        };
+        let (guard, profile) = ResourceGuard::create(
+            Api::<MirrordProfile>::all(kube_client.clone()),
+            &profile,
+            true,
+        )
+        .await
+        .unwrap();
+
+        (guard, profile.metadata.name.unwrap())
+    };
+
+    let port_forwarder =
+        PortForwarder::new(kube_client, &service.pod_name, &service.namespace, 80).await;
+    let service_url = format!("http://{}", port_forwarder.address());
+
+    // Before we start the session, verify that the service responds.
+    let response = reqwest::get(&service_url)
+        .await
+        .unwrap()
+        .bytes()
+        .await
+        .unwrap();
+    assert_eq!(response.as_ref(), b"OK - GET: Request completed\n");
+
+    let test_process = Application::PythonFlaskHTTP
+        .run(&target_path, Some(&service.namespace), None, None)
+        .await;
+    test_process
+        .wait_for_line(Duration::from_secs(40), "daemon subscribed")
+        .await;
+
+    // The local application should mirror the traffic.
+    let response = reqwest::get(&service_url)
+        .await
+        .unwrap()
+        .bytes()
+        .await
+        .unwrap();
+    assert_eq!(response.as_ref(), b"OK - GET: Request completed\n"); // got response from remote
+    test_process
+        .wait_for_line(Duration::from_secs(20), "GET: Request completed")
+        .await; // local received the request
+    std::mem::drop(test_process); // kill the app
+
+    let mut config_file = NamedTempFile::with_suffix(".json").unwrap();
+    let config = serde_json::json!({
+        "profile": profile_name,
+    });
+    serde_json::to_writer_pretty(config_file.as_file_mut(), &config).unwrap();
+    let test_process = Application::PythonFlaskHTTP
+        .run(
+            &target_path,
+            Some(&service.namespace),
+            Some(vec!["-f", config_file.path().to_str().unwrap()]),
+            None,
+        )
+        .await;
+
+    // The local application should steal the traffic.
+    let response = reqwest::get(&service_url)
+        .await
+        .unwrap()
+        .bytes()
+        .await
+        .unwrap();
+    assert_eq!(response.as_ref(), b"GET"); // got response from local
+    std::mem::drop(test_process); // kill the app
+}

--- a/tests/src/operator/profiles.rs
+++ b/tests/src/operator/profiles.rs
@@ -16,7 +16,7 @@ use crate::utils::{
 #[rstest]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[timeout(Duration::from_secs(120))]
-pub async fn create_cluster_policy_and_try_to_mirror(
+pub async fn mirrord_profile_enforces_stealing(
     #[future] kube_client: kube::Client,
     #[future] service: KubeService,
 ) {
@@ -30,7 +30,7 @@ pub async fn create_cluster_policy_and_try_to_mirror(
     let (_profile_guard, profile_name) = {
         let profile = MirrordProfile {
             metadata: ObjectMeta {
-                generate_name: Some("test-profile-".into()),
+                name: Some(format!("test-profile-{}", service.name)),
                 ..Default::default()
             },
             spec: MirrordProfileSpec {

--- a/tests/src/utils.rs
+++ b/tests/src/utils.rs
@@ -276,6 +276,19 @@ impl TestProcess {
         panic!("Timeout waiting for line: {line}");
     }
 
+    pub async fn wait_for_line_stdout(&self, timeout: Duration, line: &str) {
+        let now = std::time::Instant::now();
+        while now.elapsed() < timeout {
+            let stdout = self.get_stdout().await;
+            if stdout.contains(line) {
+                return;
+            }
+            // avoid busyloop
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+        panic!("Timeout waiting for line: {line}");
+    }
+
     /// Wait for the test app to output (at least) the given amount of lines.
     ///
     /// # Arguments


### PR DESCRIPTION
Example profile:
```yaml
apiVersion: profiles.mirrord.metalbear.co/v1alpha
kind: MirrordProfile # clusterwide resource
metadata:
  name: mirror-and-outgoing-local
spec:
  # Changes to be made in the feature config.
  featureAdjustments:
  - kind: incoming
    change: mirror
  - kind: outgoing
    change: off
  - kind: dns
    change: off
```