### PR TITLE
Fix running binaries with entitlements on macOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4646,6 +4646,7 @@ dependencies = [
  "apple-codesign",
  "object",
  "once_cell",
+ "rand 0.9.0",
  "tempfile",
  "thiserror 2.0.12",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4644,6 +4644,7 @@ name = "mirrord-sip"
 version = "3.135.0"
 dependencies = [
  "apple-codesign",
+ "hex",
  "object",
  "once_cell",
  "rand 0.9.0",

--- a/changelog.d/3184.fixed.md
+++ b/changelog.d/3184.fixed.md
@@ -1,0 +1,1 @@
+Regression in running SIP-protected binaries that have entitelements.

--- a/mirrord/sip/Cargo.toml
+++ b/mirrord/sip/Cargo.toml
@@ -19,6 +19,7 @@ workspace = true
 [target.'cfg(target_os = "macos")'.dependencies]
 apple-codesign = { version = "0.29", default-features = false }
 object = "0.36"
+rand = "0.9.0"
 tempfile.workspace = true
 
 once_cell = "1"
@@ -30,5 +31,3 @@ which.workspace = true
 
 [target.'cfg(target_os = "macos")'.dev-dependencies]
 tempfile.workspace = true
-[dependencies]
-rand = "0.9.0"

--- a/mirrord/sip/Cargo.toml
+++ b/mirrord/sip/Cargo.toml
@@ -18,6 +18,7 @@ workspace = true
 
 [target.'cfg(target_os = "macos")'.dependencies]
 apple-codesign = { version = "0.29", default-features = false }
+hex = "0.4"
 object = "0.36"
 rand = "0.9.0"
 tempfile.workspace = true

--- a/mirrord/sip/Cargo.toml
+++ b/mirrord/sip/Cargo.toml
@@ -30,3 +30,5 @@ which.workspace = true
 
 [target.'cfg(target_os = "macos")'.dev-dependencies]
 tempfile.workspace = true
+[dependencies]
+rand = "0.9.0"

--- a/mirrord/sip/src/codesign.rs
+++ b/mirrord/sip/src/codesign.rs
@@ -1,4 +1,7 @@
-use std::{fmt::Display, path::Path};
+use std::{
+    fmt::{Display, Write},
+    path::Path,
+};
 
 use apple_codesign::{CodeSignatureFlags, SettingsScope, SigningSettings, UnifiedSigner};
 use rand::Rng;
@@ -11,8 +14,11 @@ const EMPTY_ENTITLEMENTS_PLIST: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
 fn generate_hex_string<const N: usize>() -> String {
     let mut rng = rand::rng();
     (0..N / 2) // N/2 bytes = N hexadecimal digits.
-        .map(|_| format!("{:02x}", rng.random::<u8>()))
-        .collect()
+        .fold(String::new(), |mut acc, _next_in_range| {
+            // ignoring result: writing to String can't fail.
+            let _ = write!(acc, "{:02x}", rng.random::<u8>());
+            acc
+        })
 }
 
 pub(crate) fn sign<PI: AsRef<Path>, PO: AsRef<Path>, PR: Display>(

--- a/mirrord/sip/src/codesign.rs
+++ b/mirrord/sip/src/codesign.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Display, path::Path};
+use std::path::Path;
 
 use apple_codesign::{CodeSignatureFlags, SettingsScope, SigningSettings, UnifiedSigner};
 use rand::RngCore;
@@ -15,11 +15,7 @@ fn generate_hex_string() -> String {
     hex::encode(bytes)
 }
 
-pub(crate) fn sign<PI: AsRef<Path>, PO: AsRef<Path>, PR: Display>(
-    input: PI,
-    output: PO,
-    bin_id_prefix: Option<PR>,
-) -> Result<()> {
+pub(crate) fn sign<PI: AsRef<Path>, PO: AsRef<Path>>(input: PI, output: PO) -> Result<()> {
     // in the past, we used the codesign binary
     // but we had an issue where it received EBADF (bad file descriptor)
     // probably since in some flows, like Go,
@@ -38,10 +34,7 @@ pub(crate) fn sign<PI: AsRef<Path>, PO: AsRef<Path>, PR: Display>(
     // > It is a **very bad idea** to sign different programs with the same identifier.
     settings.set_binary_identifier(
         SettingsScope::Main,
-        bin_id_prefix.map_or_else(
-            || format!("mirrord-patched-bin-{}", generate_hex_string()),
-            |prefix| format!("{}-{}", prefix, generate_hex_string()),
-        ),
+        format!("mirrord-patched-bin-{}", generate_hex_string()),
     );
 
     // Set an empty entitlements XML, as the default settings leave the existing entitlements set.

--- a/mirrord/sip/src/lib.rs
+++ b/mirrord/sip/src/lib.rs
@@ -305,7 +305,11 @@ mod main {
         }
 
         let signed_temp_file = tempfile::NamedTempFile::new()?;
-        codesign::sign(&temp_binary, &signed_temp_file)?;
+        codesign::sign(
+            &temp_binary,
+            &signed_temp_file,
+            path.file_name().map(OsStr::to_string_lossy).as_deref(),
+        )?;
 
         // Give the new file the same permissions as the old file.
         // This needs to happen after the sign because it might change the permissions.

--- a/mirrord/sip/src/lib.rs
+++ b/mirrord/sip/src/lib.rs
@@ -305,11 +305,7 @@ mod main {
         }
 
         let signed_temp_file = tempfile::NamedTempFile::new()?;
-        codesign::sign(
-            &temp_binary,
-            &signed_temp_file,
-            path.file_name().map(OsStr::to_string_lossy).as_deref(),
-        )?;
+        codesign::sign(&temp_binary, &signed_temp_file)?;
 
         // Give the new file the same permissions as the old file.
         // This needs to happen after the sign because it might change the permissions.


### PR DESCRIPTION
Fix #3184 

Recently the method of signing SIP-patched binaries on macOS was changed, and apparently the library that is now used has a different default behaviour than the cli tool used before.

When re-signing with the CLI, any existing entitlements are cleared. When signing with the library, they remain, unless overwritten with a plist passed in xml format.

Since the patched binary was no longer signed by the entity that was granted those entitlements, the signature was invalid and the process was killed by `taskgated`.

So in order to clear any entitlements the binary might have, we set a constant xml plist that contains an empty entitlement dict.

In addition, we also change the identifier, as the codesign man page says we should, to my understanding.

I'll also add a small unit test for the case of a binary with entitlements, but since this is urgent, it will be in a different PR, to not delay the release of the fix.