### PR TITLE
Add unit tests for recent SIP-regressions

### DIFF
--- a/changelog.d/+sip-regression-tests.internal.md
+++ b/changelog.d/+sip-regression-tests.internal.md
@@ -1,0 +1,1 @@
+Add unit tests for recent regressions.

--- a/mirrord/sip/src/lib.rs
+++ b/mirrord/sip/src/lib.rs
@@ -686,6 +686,12 @@ mod main {
             assert!(err.to_string().contains("executable file not found"));
         }
 
+        /// Verify the SIP-patch worked.
+        ///
+        /// Run the given binary with `DYLD_PRINT_LIBRARIES=1`. This env var asks dyld to print all
+        /// the mach-o images loaded to the process. However, it is stripped away by SIP, so we can
+        /// use it to test the patch worked. If we're getting libsystem_kernel.dylib printed, it
+        /// means the binary is not SIP protected.
         fn run_and_verify_dyld_print(patched_bin_path: &Path) {
             let output = std::process::Command::new(patched_bin_path)
                 .env("DYLD_PRINT_LIBRARIES", "1")

--- a/mirrord/sip/src/lib.rs
+++ b/mirrord/sip/src/lib.rs
@@ -736,7 +736,8 @@ mod main {
         }
 
         /// Test that after patching we can Successfully use DYLD features on a binary that had
-        /// the RUNTIME flag set before the patch.
+        /// [the runtime flag](https://developer.apple.com/documentation/security/seccodesignatureflags/runtime)
+        /// set before the patch.
         /// No binary in `/bin/` has any flag set, so we first do a kind of an opposite patch to
         /// create a binary with that flag, then we do our normal patch and test that it worked.
         #[test]


### PR DESCRIPTION
Part of #3149 and #3184.
The fixes were already merged, now adding regression tests for those two regressions.