### PR TITLE
3.137.0-fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ This project uses [*towncrier*](https://towncrier.readthedocs.io/) and the chang
 - Moved the `readonly_file_buffer` configuration option from experimental to
   `config.feature.fs`.
   [#2984](https://github.com/metalbear-co/mirrord/issues/2984)
+- Allow ping-pong an extra timeout period if intproxy recives other messages
+  from the agent in last period.
 
 
 ### Fixed
@@ -30,6 +32,9 @@ This project uses [*towncrier*](https://towncrier.readthedocs.io/) and the chang
   [#3206](https://github.com/metalbear-co/mirrord/issues/3206)
 - Fixed a bug related to stealing IPv6 traffic (resolving original destination
   of a stolen connection).
+- Fixed an issue where mirrord was preventing the local application from making
+  gRPC connections to sidecar containers.
+  [#3212](https://github.com/metalbear-co/mirrord/issues/3212)
 
 
 ### Internal
@@ -41,6 +46,8 @@ This project uses [*towncrier*](https://towncrier.readthedocs.io/) and the chang
 - Extracted agent's iptables logic to a separate crate.
 - Added crate level docs to mirrord-cli.
   [#168](https://github.com/metalbear-co/mirrord/issues/168)
+- Changed the release workflow to use GHCR cache when building and pushing the
+  `mirrord-cli` image.
 
 ## [3.136.0](https://github.com/metalbear-co/mirrord/tree/3.136.0) - 2025-03-21
 

--- a/changelog.d/+ghrc-cache.internal.md
+++ b/changelog.d/+ghrc-cache.internal.md
@@ -1,1 +1,0 @@
-Changed the release workflow to use GHCR cache when building and pushing the `mirrord-cli` image.

--- a/changelog.d/+laxer-ping-pong.changed.md
+++ b/changelog.d/+laxer-ping-pong.changed.md
@@ -1,1 +1,0 @@
-Allow ping-pong an extra timeout period if intproxy recives other messages from the agent in last period.

--- a/changelog.d/3212.fixed.md
+++ b/changelog.d/3212.fixed.md
@@ -1,1 +1,0 @@
-Fixed an issue where mirrord was preventing the local application from making gRPC connections to sidecar containers.


### PR DESCRIPTION
Version in `Cargo.toml` is already at 3.137.0, but the release failed