### PR TITLE
Separate traffic redirector task

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -292,12 +292,12 @@ jobs:
           candidate: java
           version: 17.0.6-tem
       - run: java -version
-      - uses: actions/setup-node@v3 # For http mirroring test.
+      - uses: actions/setup-node@v3
         with:
           node-version: 14
-      - run: npm install express # For http mirroring test with node.
-      - uses: actions/setup-python@v5 # For http mirroring tests with Flask and FastAPI.
-      - run: pip3 install --break-system-packages flask fastapi uvicorn[standard] # For http mirroring test with Flask.
+      - run: npm install express@4.21.2
+      - uses: actions/setup-python@v5
+      - run: pip3 install --break-system-packages flask fastapi uvicorn[standard]
       # don't use "cache" for other Gos since it will try to overwrite and have bad results.
       - uses: actions/setup-go@v5
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4293,7 +4293,6 @@ name = "mirrord-agent"
 version = "3.137.0"
 dependencies = [
  "actix-codec",
- "async-trait",
  "axum",
  "bollard",
  "bytes",

--- a/changelog.d/+separate-redirector-task.internal.md
+++ b/changelog.d/+separate-redirector-task.internal.md
@@ -1,0 +1,1 @@
+Extracted incoming traffic redirection logic to a separate task running in the target's network namespace.

--- a/mirrord/agent/Cargo.toml
+++ b/mirrord/agent/Cargo.toml
@@ -61,7 +61,6 @@ httparse = "1"
 fancy-regex = { workspace = true }
 dashmap = { version = "6" }
 oci-spec = "0.7.0"
-async-trait = "0.1"
 tonic = "0.12"
 tower.workspace = true
 http.workspace = true

--- a/mirrord/agent/iptables/src/chain.rs
+++ b/mirrord/agent/iptables/src/chain.rs
@@ -36,9 +36,9 @@ where
         let existing_rules = inner.list_rules(&chain_name)?.len();
 
         if existing_rules == 0 {
-            return Err(IPTablesError::from(format!(
-                "Unable to load rules for chain {chain_name}"
-            )));
+            return Err(IPTablesError(
+                format!("Unable to load rules for chain {chain_name}").into(),
+            ));
         }
 
         // Start with 1 because the chain will allways have atleast `-A <chain name>` as a rule

--- a/mirrord/agent/iptables/src/error.rs
+++ b/mirrord/agent/iptables/src/error.rs
@@ -1,10 +1,11 @@
-use std::{error::Error, fmt, io};
+use std::{error::Error, fmt, io, sync::Arc};
 
-pub struct IPTablesError(pub Box<dyn Error>);
+pub struct IPTablesError(pub Box<dyn Error + Send + Sync + 'static>);
 
+/// [`iptables`] produces errors that are not [`Send`].
 impl From<Box<dyn Error>> for IPTablesError {
     fn from(value: Box<dyn Error>) -> Self {
-        Self(value)
+        Self(value.to_string().into())
     }
 }
 
@@ -14,9 +15,9 @@ impl From<io::Error> for IPTablesError {
     }
 }
 
-impl From<String> for IPTablesError {
-    fn from(value: String) -> Self {
-        Self(value.into())
+impl From<IPTablesError> for Arc<dyn Error + Send + Sync + 'static> {
+    fn from(value: IPTablesError) -> Self {
+        value.0.into()
     }
 }
 

--- a/mirrord/agent/src/entrypoint.rs
+++ b/mirrord/agent/src/entrypoint.rs
@@ -16,9 +16,10 @@ use futures::TryFutureExt;
 use metrics::{start_metrics, CLIENT_COUNT};
 use mirrord_agent_env::envs;
 use mirrord_agent_iptables::{
-    new_iptables, IPTablesWrapper, SafeIpTables, IPTABLE_IPV4_ROUTE_LOCALNET_ORIGINAL,
-    IPTABLE_IPV4_ROUTE_LOCALNET_ORIGINAL_ENV, IPTABLE_MESH, IPTABLE_MESH_ENV, IPTABLE_PREROUTING,
-    IPTABLE_PREROUTING_ENV, IPTABLE_STANDARD, IPTABLE_STANDARD_ENV,
+    error::IPTablesError, new_iptables, IPTablesWrapper, SafeIpTables,
+    IPTABLE_IPV4_ROUTE_LOCALNET_ORIGINAL, IPTABLE_IPV4_ROUTE_LOCALNET_ORIGINAL_ENV, IPTABLE_MESH,
+    IPTABLE_MESH_ENV, IPTABLE_PREROUTING, IPTABLE_PREROUTING_ENV, IPTABLE_STANDARD,
+    IPTABLE_STANDARD_ENV,
 };
 use mirrord_protocol::{ClientMessage, DaemonMessage, GetEnvVarsRequest, LogMessage};
 use sniffer::tcp_capture::RawSocketTcpCapture;
@@ -782,7 +783,7 @@ async fn start_agent(args: Args) -> AgentResult<()> {
     Ok(())
 }
 
-async fn clear_iptable_chain() -> AgentResult<()> {
+async fn clear_iptable_chain() -> Result<(), IPTablesError> {
     let ipt = new_iptables();
 
     let tables = SafeIpTables::load(IPTablesWrapper::from(ipt), false).await?;

--- a/mirrord/agent/src/entrypoint/setup.rs
+++ b/mirrord/agent/src/entrypoint/setup.rs
@@ -7,6 +7,9 @@ use crate::{
     util::run_thread_in_namespace,
 };
 
+/// Starts a [`RedirectorTask`] in the target's network namespace.
+///
+/// Returns the [`StealHandle`] that can be used to steal incoming traffic.
 pub(crate) async fn start_traffic_redirector(target_pid: u64) -> AgentResult<StealHandle> {
     let flush_connections = envs::STEALER_FLUSH_CONNECTIONS.from_env_or_default();
     let pod_ips = envs::POD_IPS.from_env_or_default();
@@ -45,6 +48,6 @@ pub(crate) async fn start_traffic_redirector(target_pid: u64) -> AgentResult<Ste
 
     match handle_rx.await {
         Ok(result) => result.map_err(|error| AgentError::IPTablesSetupError(error.into())),
-        Err(..) => Err(AgentError::IPTablesError("task panicked".into())),
+        Err(..) => Err(AgentError::IPTablesSetupError("task panicked".into())),
     }
 }

--- a/mirrord/agent/src/entrypoint/setup.rs
+++ b/mirrord/agent/src/entrypoint/setup.rs
@@ -1,0 +1,50 @@
+use mirrord_agent_env::envs;
+use tokio::sync::oneshot;
+
+use crate::{
+    error::{AgentError, AgentResult},
+    incoming::{self, RedirectorTask, StealHandle},
+    util::run_thread_in_namespace,
+};
+
+pub(crate) async fn start_traffic_redirector(target_pid: u64) -> AgentResult<StealHandle> {
+    let flush_connections = envs::STEALER_FLUSH_CONNECTIONS.from_env_or_default();
+    let pod_ips = envs::POD_IPS.from_env_or_default();
+    let support_ipv6 = envs::IPV6_SUPPORT.from_env_or_default();
+
+    let (handle_tx, handle_rx) = oneshot::channel();
+
+    run_thread_in_namespace(
+        async move {
+            let redirector_result =
+                incoming::create_iptables_redirector(flush_connections, &pod_ips, support_ipv6)
+                    .await;
+
+            let redirector = match redirector_result {
+                Ok(redirector) => redirector,
+                Err(error) => {
+                    let _ = handle_tx.send(Err(error));
+                    return;
+                }
+            };
+
+            let (task, handle) = RedirectorTask::new(redirector);
+
+            if handle_tx.send(Ok(handle)).is_err() {
+                return;
+            }
+
+            let _ = task.run().await.inspect_err(|error| {
+                tracing::error!(%error, "Incoming traffic redirector task failed");
+            });
+        },
+        "IncomingTrafficRedirector".into(),
+        Some(target_pid),
+        "net",
+    );
+
+    match handle_rx.await {
+        Ok(result) => result.map_err(|error| AgentError::IPTablesSetupError(error.into())),
+        Err(..) => Err(AgentError::IPTablesError("task panicked".into())),
+    }
+}

--- a/mirrord/agent/src/error.rs
+++ b/mirrord/agent/src/error.rs
@@ -1,6 +1,5 @@
 use std::process::ExitStatus;
 
-use mirrord_agent_iptables::error::IPTablesError;
 use mirrord_protocol::outgoing::udp::DaemonUdpOutgoing;
 use thiserror::Error;
 use tokio::sync::mpsc::{self, error::SendError};
@@ -32,12 +31,6 @@ pub(crate) enum AgentError {
 
     #[error("Path failed with `{0}`")]
     StripPrefixError(#[from] std::path::StripPrefixError),
-
-    #[error("iptables operation failed: {0}")]
-    IPTablesError(
-        /// Message from the original [`IPTablesError`], which is not [`Send`].
-        String,
-    ),
 
     #[error("Join task failed")]
     JoinTask,
@@ -99,12 +92,6 @@ pub(crate) enum AgentError {
 impl From<mpsc::error::SendError<StealerCommand>> for AgentError {
     fn from(_: mpsc::error::SendError<StealerCommand>) -> Self {
         Self::TcpStealerTaskDead
-    }
-}
-
-impl From<IPTablesError> for AgentError {
-    fn from(value: IPTablesError) -> Self {
-        Self::IPTablesError(value.to_string())
     }
 }
 

--- a/mirrord/agent/src/file.rs
+++ b/mirrord/agent/src/file.rs
@@ -84,7 +84,7 @@ impl Drop for FileManager {
     fn drop(&mut self) {
         let descriptors =
             self.open_files.len() + self.dir_streams.len() + self.getdents_streams.len();
-        OPEN_FD_COUNT.fetch_sub(descriptors as i64, std::sync::atomic::Ordering::Relaxed);
+        OPEN_FD_COUNT.fetch_sub(descriptors, std::sync::atomic::Ordering::Relaxed);
     }
 }
 

--- a/mirrord/agent/src/incoming.rs
+++ b/mirrord/agent/src/incoming.rs
@@ -1,0 +1,225 @@
+mod composed;
+mod connection;
+mod error;
+mod iptables;
+mod steal_handle;
+mod task;
+
+use std::{
+    future::Future,
+    io,
+    net::{IpAddr, SocketAddr},
+};
+
+use composed::ComposedRedirector;
+pub use connection::RedirectedConnection;
+pub use error::RedirectorTaskError;
+use iptables::IpTablesRedirector;
+pub use steal_handle::StealHandle;
+pub use task::RedirectorTask;
+use tokio::net::TcpStream;
+
+/// A component that implements redirecting incoming TCP connections.
+///
+/// Returning an error from any of the methods means that the redirector is no longer valid.
+pub trait PortRedirector {
+    type Error: Sized;
+
+    /// Start redirecting connections from the given port.
+    ///
+    /// # Note
+    ///
+    /// If a redirection from the given port already exists, implementations are free to do nothing
+    /// or return an [`Err`].
+    fn add_redirection(&mut self, from_port: u16) -> impl Future<Output = Result<(), Self::Error>>;
+
+    /// Stop redirecting connections from the given port.
+    ///
+    /// # Note
+    ///
+    /// If the redirection does no exist, implementations are free to do nothing or return an
+    /// [`Err`].
+    fn remove_redirection(
+        &mut self,
+        from_port: u16,
+    ) -> impl Future<Output = Result<(), Self::Error>>;
+
+    /// Clean any external state.
+    fn cleanup(&mut self) -> impl Future<Output = Result<(), Self::Error>>;
+
+    /// Accept an incoming redirected connection.
+    ///
+    /// Implementors are allowed to return a connection to a port that is no longer redirected.
+    fn next_connection(&mut self) -> impl Future<Output = Result<Redirected, Self::Error>>;
+}
+
+/// A redirected TCP connection.
+///
+/// Returned from [`PortRedirector::next_connection`].
+pub struct Redirected {
+    /// IO stream.
+    stream: TcpStream,
+    /// Source of the connection.
+    source: SocketAddr,
+    /// Destination of the connection.
+    ///
+    /// Note that this address might be different than the local address of [`Self::stream`].
+    destination: SocketAddr,
+}
+
+/// Creates a [`ComposedRedirector`] based on [`IpTablesRedirector`]s.
+///
+/// Fails when no inner redirector can be created.
+///
+/// # Params
+///
+/// * `flush_connections` - passed to inner redirectors.
+/// * `pod_ips` - passed to inner redirectors.
+/// * `support_ipv6` - if set, this function will attempt to create both an IPv4 and an IPv6
+///   redirector. Otherwise, it will only attempt to create an IPv4 redirector.
+pub async fn create_iptables_redirector(
+    flush_connections: bool,
+    pod_ips: &[IpAddr],
+    support_ipv6: bool,
+) -> io::Result<ComposedRedirector<IpTablesRedirector>> {
+    let ipv4 = IpTablesRedirector::create(flush_connections, pod_ips, false)
+        .await
+        .inspect_err(|error| {
+            tracing::error!(
+                %error,
+                "Failed to create an IPv4 traffic redirector",
+            )
+        });
+
+    let ipv6 = if support_ipv6 {
+        IpTablesRedirector::create(flush_connections, pod_ips, true)
+            .await
+            .inspect_err(|error| {
+                tracing::error!(
+                    %error,
+                    "Failed to create an IPv6 traffic redirector",
+                )
+            })
+            .into()
+    } else {
+        None
+    };
+
+    let redirectors = match (ipv4, ipv6) {
+        (Ok(ipv4), ipv6) => {
+            let mut redirectors = vec![ipv4];
+            redirectors.extend(ipv6.transpose().ok().flatten());
+            redirectors
+        }
+        (Err(error), None | Some(Err(..))) => return Err(error),
+        (Err(..), Some(Ok(ipv6))) => vec![ipv6],
+    };
+
+    Ok(ComposedRedirector::new(redirectors))
+}
+
+#[cfg(test)]
+pub mod test {
+    use std::{collections::HashSet, error::Error, ops::Not};
+
+    use tokio::sync::{mpsc, watch};
+
+    use super::{PortRedirector, Redirected};
+
+    pub struct DummyRedirector {
+        state: watch::Sender<DummyRedirectorState>,
+        conn_rx: mpsc::Receiver<Redirected>,
+    }
+
+    #[derive(Default)]
+    pub struct DummyRedirectorState {
+        pub dirty: bool,
+        pub redirections: HashSet<u16>,
+    }
+
+    impl DummyRedirectorState {
+        pub fn has_redirections<I>(&self, redirections: I) -> bool
+        where
+            I: IntoIterator<Item = u16>,
+        {
+            let expected = redirections.into_iter().collect::<HashSet<_>>();
+
+            self.redirections == expected && expected.is_empty() != self.dirty
+        }
+    }
+
+    impl DummyRedirector {
+        pub fn new() -> (
+            Self,
+            watch::Receiver<DummyRedirectorState>,
+            mpsc::Sender<Redirected>,
+        ) {
+            let (conn_tx, conn_rx) = mpsc::channel(8);
+            let (state_tx, state_rx) = watch::channel(DummyRedirectorState::default());
+
+            (
+                Self {
+                    state: state_tx,
+                    conn_rx,
+                },
+                state_rx,
+                conn_tx,
+            )
+        }
+    }
+
+    impl PortRedirector for DummyRedirector {
+        type Error = Box<dyn Error + Send + Sync + 'static>;
+
+        async fn add_redirection(&mut self, from_port: u16) -> Result<(), Self::Error> {
+            let changed = self.state.send_if_modified(|state| {
+                if state.redirections.insert(from_port) {
+                    state.dirty = true;
+                    true
+                } else {
+                    false
+                }
+            });
+
+            if changed {
+                Ok(())
+            } else {
+                Err(format!("{from_port} was already redirected").into())
+            }
+        }
+
+        async fn remove_redirection(&mut self, from_port: u16) -> Result<(), Self::Error> {
+            let changed = self.state.send_if_modified(|state| {
+                if state.redirections.remove(&from_port) {
+                    true
+                } else {
+                    false
+                }
+            });
+
+            if changed {
+                Ok(())
+            } else {
+                Err(format!("{from_port} was not redirected").into())
+            }
+        }
+
+        async fn cleanup(&mut self) -> Result<(), Self::Error> {
+            self.state.send_if_modified(|state| {
+                let changed = state.dirty || state.redirections.is_empty().not();
+                state.dirty = false;
+                state.redirections.clear();
+                changed
+            });
+
+            Ok(())
+        }
+
+        async fn next_connection(&mut self) -> Result<Redirected, Self::Error> {
+            self.conn_rx
+                .recv()
+                .await
+                .ok_or_else(|| "channel closed".into())
+        }
+    }
+}

--- a/mirrord/agent/src/incoming.rs
+++ b/mirrord/agent/src/incoming.rs
@@ -1,3 +1,5 @@
+//! This module contains components that implement redirecting incoming traffic.
+
 mod composed;
 mod connection;
 mod error;
@@ -20,8 +22,6 @@ pub use task::RedirectorTask;
 use tokio::net::TcpStream;
 
 /// A component that implements redirecting incoming TCP connections.
-///
-/// Returning an error from any of the methods means that the redirector is no longer valid.
 pub trait PortRedirector {
     type Error: Sized;
 
@@ -126,11 +126,13 @@ pub mod test {
 
     use super::{PortRedirector, Redirected};
 
+    /// Implementation of [`PortRedirector`] that can be used in unit tests.
     pub struct DummyRedirector {
         state: watch::Sender<DummyRedirectorState>,
         conn_rx: mpsc::Receiver<Redirected>,
     }
 
+    /// State of [`DummyRedirector`].
     #[derive(Default)]
     pub struct DummyRedirectorState {
         pub dirty: bool,
@@ -149,6 +151,13 @@ pub mod test {
     }
 
     impl DummyRedirector {
+        /// Creates a new dummy redirector.
+        ///
+        /// Returns:
+        /// 1. the redirector,
+        /// 2. a [`watch::Receiver`] that can be used to inspect the redirector's state,
+        /// 3. an [`mpsc::Sender`] that can be used to send mocked [`Redirected`] connections
+        ///    through the redirector.
         pub fn new() -> (
             Self,
             watch::Receiver<DummyRedirectorState>,

--- a/mirrord/agent/src/incoming.rs
+++ b/mirrord/agent/src/incoming.rs
@@ -198,13 +198,9 @@ pub mod test {
         }
 
         async fn remove_redirection(&mut self, from_port: u16) -> Result<(), Self::Error> {
-            let changed = self.state.send_if_modified(|state| {
-                if state.redirections.remove(&from_port) {
-                    true
-                } else {
-                    false
-                }
-            });
+            let changed = self
+                .state
+                .send_if_modified(|state| state.redirections.remove(&from_port));
 
             if changed {
                 Ok(())

--- a/mirrord/agent/src/incoming/composed.rs
+++ b/mirrord/agent/src/incoming/composed.rs
@@ -1,0 +1,87 @@
+use std::{fmt, future};
+
+use futures::{stream::FuturesUnordered, StreamExt};
+
+use super::{PortRedirector, Redirected};
+
+/// An implementation of a [`PortRedirector`] that uses multiple inner redirectors.
+#[derive(Debug)]
+pub struct ComposedRedirector<R> {
+    redirectors: Vec<R>,
+}
+
+impl<R> ComposedRedirector<R> {
+    pub fn new(redirectors: Vec<R>) -> Self {
+        Self { redirectors }
+    }
+}
+
+impl<R> PortRedirector for ComposedRedirector<R>
+where
+    R: PortRedirector + fmt::Debug,
+    R::Error: fmt::Display,
+{
+    type Error = R::Error;
+
+    /// Called in order on all inner redirectors.
+    ///
+    /// Stops at the first error.
+    async fn add_redirection(&mut self, from_port: u16) -> Result<(), Self::Error> {
+        for redirector in &mut self.redirectors {
+            redirector.add_redirection(from_port).await?;
+        }
+
+        Ok(())
+    }
+
+    /// Called in order on all inner redirectors.
+    ///
+    /// Stops at the first error.
+    async fn remove_redirection(&mut self, from_port: u16) -> Result<(), Self::Error> {
+        for redirector in &mut self.redirectors {
+            redirector.remove_redirection(from_port).await?;
+        }
+
+        Ok(())
+    }
+
+    /// Called in order on all inner redirectors.
+    ///
+    /// Returns the last encountered error.
+    /// All errors are logged.
+    async fn cleanup(&mut self) -> Result<(), Self::Error> {
+        let mut result = Ok(());
+
+        for redirector in &mut self.redirectors {
+            if let Err(error) = redirector.cleanup().await {
+                tracing::error!(
+                    %error,
+                    ?redirector,
+                    "Failed to do cleanup on a port redirector",
+                );
+
+                result = Err(error);
+            }
+        }
+
+        result
+    }
+
+    /// Concurrently polls all inner redirectors for the next connection.
+    ///
+    /// Returns the first result.
+    async fn next_connection(&mut self) -> Result<Redirected, Self::Error> {
+        let result = self
+            .redirectors
+            .iter_mut()
+            .map(R::next_connection)
+            .collect::<FuturesUnordered<_>>()
+            .next()
+            .await;
+
+        match result {
+            Some(result) => result,
+            None => future::pending().await,
+        }
+    }
+}

--- a/mirrord/agent/src/incoming/connection.rs
+++ b/mirrord/agent/src/incoming/connection.rs
@@ -14,11 +14,6 @@ use tokio::{
 /// A redirected TCP connection.
 ///
 /// Allows for reading and writing data (implements [`AsyncRead`] and [`AsyncWrite`]).
-///
-/// Reading data from this handle automatically broadcasts the data
-/// to all mirroring clients using a [`broadcast::Sender`]. This way the incoming data stream
-/// throughput is limited only by the "real" reader (original destination or a stealing client).
-/// Stalling mirroring clients do not affect the communication.
 #[derive(Debug)]
 pub struct RedirectedConnection {
     pub(super) source: SocketAddr,
@@ -27,14 +22,17 @@ pub struct RedirectedConnection {
 }
 
 impl RedirectedConnection {
+    /// Returns the source of this connection (address of the remote TCP client).
     pub fn source(&self) -> SocketAddr {
         self.source
     }
 
+    /// Returns the original destination of this connection.
     pub fn destination(&self) -> SocketAddr {
         self.destination
     }
 
+    /// Returns the address of the TCP socket that accepted this connection.
     pub fn local_addr(&self) -> io::Result<SocketAddr> {
         self.stream.local_addr()
     }

--- a/mirrord/agent/src/incoming/connection.rs
+++ b/mirrord/agent/src/incoming/connection.rs
@@ -1,0 +1,86 @@
+use std::{
+    io,
+    net::SocketAddr,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use actix_codec::ReadBuf;
+use tokio::{
+    io::{AsyncRead, AsyncWrite},
+    net::TcpStream,
+};
+
+/// A redirected TCP connection.
+///
+/// Allows for reading and writing data (implements [`AsyncRead`] and [`AsyncWrite`]).
+///
+/// Reading data from this handle automatically broadcasts the data
+/// to all mirroring clients using a [`broadcast::Sender`]. This way the incoming data stream
+/// throughput is limited only by the "real" reader (original destination or a stealing client).
+/// Stalling mirroring clients do not affect the communication.
+#[derive(Debug)]
+pub struct RedirectedConnection {
+    pub(super) source: SocketAddr,
+    pub(super) destination: SocketAddr,
+    pub(super) stream: TcpStream,
+}
+
+impl RedirectedConnection {
+    pub fn source(&self) -> SocketAddr {
+        self.source
+    }
+
+    pub fn destination(&self) -> SocketAddr {
+        self.destination
+    }
+
+    pub fn local_addr(&self) -> io::Result<SocketAddr> {
+        self.stream.local_addr()
+    }
+}
+
+impl AsyncRead for RedirectedConnection {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        let this = self.get_mut();
+        Pin::new(&mut this.stream).poll_read(cx, buf)
+    }
+}
+
+impl AsyncWrite for RedirectedConnection {
+    fn is_write_vectored(&self) -> bool {
+        self.stream.is_write_vectored()
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+        let this = self.get_mut();
+        Pin::new(&mut this.stream).poll_flush(cx)
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+        let this = self.get_mut();
+        Pin::new(&mut this.stream).poll_shutdown(cx)
+    }
+
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, io::Error>> {
+        let this = self.get_mut();
+        Pin::new(&mut this.stream).poll_write(cx, buf)
+    }
+
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &[io::IoSlice<'_>],
+    ) -> Poll<Result<usize, io::Error>> {
+        let this = self.get_mut();
+        Pin::new(&mut this.stream).poll_write_vectored(cx, bufs)
+    }
+}

--- a/mirrord/agent/src/incoming/error.rs
+++ b/mirrord/agent/src/incoming/error.rs
@@ -2,10 +2,17 @@ use std::{error::Error, sync::Arc};
 
 use thiserror::Error;
 
+/// Errors that can occur in the [`RedirectorTask`](super::RedirectorTask).
 #[derive(Error, Debug, Clone)]
 pub enum RedirectorTaskError {
+    /// A runtime error that occurred in the task.
+    ///
+    /// For simplicity, the inner error is opaque.
+    /// Any redirector task error should terminate the agent,
+    /// so we're not really interested in the concrete type.
     #[error("port redirector failed: {0}")]
     RedirectorError(Arc<dyn Error + Send + Sync + 'static>),
+    /// The task panicked.
     #[error("port redirector task panicked")]
     Panicked,
 }

--- a/mirrord/agent/src/incoming/error.rs
+++ b/mirrord/agent/src/incoming/error.rs
@@ -1,0 +1,11 @@
+use std::{error::Error, sync::Arc};
+
+use thiserror::Error;
+
+#[derive(Error, Debug, Clone)]
+pub enum RedirectorTaskError {
+    #[error("port redirector failed: {0}")]
+    RedirectorError(Arc<dyn Error + Send + Sync + 'static>),
+    #[error("port redirector task panicked")]
+    Panicked,
+}

--- a/mirrord/agent/src/incoming/iptables.rs
+++ b/mirrord/agent/src/incoming/iptables.rs
@@ -1,0 +1,172 @@
+use std::{
+    fmt, io,
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
+    ops::Not,
+};
+
+use mirrord_agent_iptables::{error::IPTablesError, IPTablesWrapper, SafeIpTables};
+use nix::sys::socket::{
+    self,
+    sockopt::{Ip6tOriginalDst, OriginalDst},
+    SockaddrIn, SockaddrIn6,
+};
+use tokio::net::TcpListener;
+use tracing::Level;
+
+use super::{PortRedirector, Redirected};
+
+/// A [`PortRedirector`] implementation that uses a [`TcpListener`]
+/// and an iptables wrapper to set rules that send traffic to that listener.
+pub struct IpTablesRedirector {
+    /// For altering iptables rules.
+    iptables: Option<SafeIpTables<IPTablesWrapper>>,
+    /// Port of [`Self::listener`](Self::listener).
+    redirect_to: u16,
+    /// Listener to which the connections are redirected.
+    listener: TcpListener,
+    /// Optional comma-seperated list of pod's IPs.
+    pod_ips: Option<String>,
+    /// Whether existing connections should be flushed when adding new redirects.
+    flush_connections: bool,
+    /// If this redirector is for IPv6 traffic.
+    ipv6: bool,
+}
+
+impl IpTablesRedirector {
+    /// Creates a new redirector.
+    ///
+    /// # Params
+    ///
+    /// * `flush_connections` - when a new redirection is created, flush existing connections (based
+    ///   on their destination port).
+    /// * `pod_ips` - list of pod IPs.
+    /// * `ipv6` - whether to redirect IPv4 or IPv6 traffic.
+    #[tracing::instrument(level = Level::DEBUG, ret, err)]
+    pub async fn create(
+        flush_connections: bool,
+        pod_ips: &[IpAddr],
+        ipv6: bool,
+    ) -> io::Result<Self> {
+        let listener_addr = if ipv6 {
+            SocketAddr::new(Ipv6Addr::UNSPECIFIED.into(), 0)
+        } else {
+            SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), 0)
+        };
+        let listener = TcpListener::bind(listener_addr).await?;
+        let listener_addr = listener.local_addr()?.port();
+
+        let pod_ips = pod_ips
+            .iter()
+            .filter(|ip| ip.is_ipv6() == ipv6)
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join(",");
+
+        Ok(Self {
+            iptables: None,
+            redirect_to: listener_addr,
+            listener,
+            pod_ips: pod_ips.is_empty().not().then_some(pod_ips),
+            flush_connections,
+            ipv6,
+        })
+    }
+}
+
+impl PortRedirector for IpTablesRedirector {
+    type Error = IPTablesError;
+
+    #[tracing::instrument(level = Level::DEBUG, err, ret)]
+    async fn add_redirection(&mut self, from_port: u16) -> Result<(), Self::Error> {
+        let iptables = match self.iptables.as_ref() {
+            Some(iptables) => iptables,
+            None => {
+                let iptables = if self.ipv6 {
+                    mirrord_agent_iptables::new_ip6tables()
+                } else {
+                    mirrord_agent_iptables::new_iptables()
+                };
+
+                let safe = SafeIpTables::create(
+                    iptables.into(),
+                    self.flush_connections,
+                    self.pod_ips.as_deref(),
+                    self.ipv6,
+                )
+                .await?;
+
+                self.iptables.insert(safe)
+            }
+        };
+
+        iptables.add_redirect(from_port, self.redirect_to).await
+    }
+
+    #[tracing::instrument(level = Level::DEBUG, err, ret)]
+    async fn remove_redirection(&mut self, from_port: u16) -> Result<(), Self::Error> {
+        if let Some(iptables) = self.iptables.as_ref() {
+            iptables
+                .remove_redirect(from_port, self.redirect_to)
+                .await?;
+        }
+
+        Ok(())
+    }
+
+    #[tracing::instrument(level = Level::DEBUG, err, ret)]
+    async fn cleanup(&mut self) -> Result<(), Self::Error> {
+        if let Some(iptables) = self.iptables.take() {
+            iptables.cleanup().await?;
+        }
+
+        Ok(())
+    }
+
+    async fn next_connection(&mut self) -> Result<Redirected, Self::Error> {
+        loop {
+            let (stream, source) = self.listener.accept().await?;
+
+            let destination = if source.is_ipv6() {
+                socket::getsockopt(&stream, Ip6tOriginalDst)
+                    .map(SockaddrIn6::from)
+                    .map(|addr| SocketAddr::new(addr.ip().into(), addr.port()))
+            } else {
+                socket::getsockopt(&stream, OriginalDst)
+                    .map(SockaddrIn::from)
+                    .map(|addr| SocketAddr::new(addr.ip().into(), addr.port()))
+            };
+
+            match destination {
+                Ok(destination) => {
+                    break Ok(Redirected {
+                        stream,
+                        source,
+                        destination,
+                    })
+                }
+                Err(error) => {
+                    // Resolving the original destination can fail,
+                    // e.g if someone made connection directly to our socket.
+                    // However, as it is very unlikely, we log this as an error.
+                    tracing::error!(
+                        %error,
+                        connection_source = %source,
+                        "Failed to obtain the original destination of a redirected TCP connection. \
+                        Dropping the connection.",
+                    );
+                }
+            }
+        }
+    }
+}
+
+impl fmt::Debug for IpTablesRedirector {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("IpTablesRedirector")
+            .field("redirect_to", &self.redirect_to)
+            .field("pod_ips", &self.pod_ips)
+            .field("flush_connections", &self.flush_connections)
+            .field("ipv6", &self.ipv6)
+            .finish()
+    }
+}

--- a/mirrord/agent/src/incoming/steal_handle.rs
+++ b/mirrord/agent/src/incoming/steal_handle.rs
@@ -1,0 +1,83 @@
+use std::fmt;
+
+use futures::StreamExt;
+use tokio::sync::{mpsc, oneshot};
+use tokio_stream::{wrappers::ReceiverStream, StreamMap, StreamNotifyClose};
+
+use super::{
+    connection::RedirectedConnection,
+    error::RedirectorTaskError,
+    task::{StealRequest, TaskError},
+};
+
+/// Handle to a running [`RedirectorTask`](super::task::RedirectorTask).
+///
+/// Allows for stealing incoming TCP connections.
+pub struct StealHandle {
+    /// For sending steal requests to the task.
+    message_tx: mpsc::Sender<StealRequest>,
+    /// For fetching the task termination reason.
+    task_error: TaskError,
+    /// For receiving stolen connections.
+    stolen_ports: StreamMap<u16, StreamNotifyClose<ReceiverStream<RedirectedConnection>>>,
+}
+
+impl StealHandle {
+    pub(super) fn new(message_tx: mpsc::Sender<StealRequest>, task_error: TaskError) -> Self {
+        Self {
+            message_tx,
+            task_error,
+            stolen_ports: Default::default(),
+        }
+    }
+
+    pub async fn steal(&mut self, port: u16) -> Result<(), RedirectorTaskError> {
+        if self.stolen_ports.contains_key(&port) {
+            return Ok(());
+        };
+
+        let (receiver_tx, receiver_rx) = oneshot::channel();
+        if self
+            .message_tx
+            .send(StealRequest { port, receiver_tx })
+            .await
+            .is_err()
+        {
+            return Err(self.task_error.get().await);
+        }
+
+        let Ok(rx) = receiver_rx.await else {
+            return Err(self.task_error.get().await);
+        };
+
+        self.stolen_ports
+            .insert(port, StreamNotifyClose::new(ReceiverStream::new(rx)));
+
+        Ok(())
+    }
+
+    pub fn stop_steal(&mut self, port: u16) {
+        self.stolen_ports.remove(&port);
+    }
+
+    pub async fn next(&mut self) -> Option<Result<RedirectedConnection, RedirectorTaskError>> {
+        match self.stolen_ports.next().await? {
+            (.., Some(conn)) => Some(Ok(conn)),
+            (.., None) => Some(Err(self.task_error.get().await)),
+        }
+    }
+}
+
+impl fmt::Debug for StealHandle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("StealHandle")
+            .field("task_error", &self.task_error)
+            .field("channel_closed", &self.message_tx.is_closed())
+            .field(
+                "queued_messages",
+                &(self.message_tx.max_capacity() - self.message_tx.capacity()),
+            )
+            .field("stolen_ports", &self.stolen_ports.len())
+            .finish()
+    }
+}

--- a/mirrord/agent/src/incoming/task.rs
+++ b/mirrord/agent/src/incoming/task.rs
@@ -1,0 +1,200 @@
+use std::{
+    collections::{hash_map::Entry, HashMap},
+    error::Error,
+    fmt,
+    ops::Not,
+    sync::Arc,
+};
+
+use futures::{
+    future::{BoxFuture, Shared},
+    stream::FuturesUnordered,
+    FutureExt, StreamExt,
+};
+use tokio::sync::{mpsc, oneshot};
+
+use super::{
+    connection::RedirectedConnection, error::RedirectorTaskError, steal_handle::StealHandle,
+    PortRedirector, Redirected,
+};
+
+pub struct RedirectorTask<R> {
+    /// Implements traffic interception.
+    redirector: R,
+    /// Provides the [`StealHandle`] with this task's failure reason.
+    error_tx: oneshot::Sender<RedirectorTaskError>,
+    /// Allows for receiving steal requests from the [`StealHandle`].
+    message_rx: mpsc::Receiver<StealRequest>,
+    /// Allows for detecting dead steal requests.
+    dead_channels: FuturesUnordered<DeadChannelFut>,
+    /// Active steal requests.
+    ///
+    /// Maps the port number to the [`StealHandle`]'s exclusive channel.
+    steals: HashMap<u16, mpsc::Sender<RedirectedConnection>>,
+}
+
+impl<R> RedirectorTask<R>
+where
+    R: 'static + PortRedirector,
+    R::Error: Into<Arc<dyn Error + Send + Sync + 'static>>,
+{
+    pub fn new(redirector: R) -> (Self, StealHandle) {
+        let (error_tx, error_rx) = oneshot::channel();
+        let (message_tx, message_rx) = mpsc::channel(16);
+
+        let task = Self {
+            redirector,
+            error_tx,
+            message_rx,
+            dead_channels: Default::default(),
+            steals: Default::default(),
+        };
+
+        let task_error = TaskError(error_rx.shared());
+        let steal_handle = StealHandle::new(message_tx.clone(), task_error.clone());
+
+        (task, steal_handle)
+    }
+
+    async fn run_inner(&mut self) -> Result<(), R::Error> {
+        let mut dead_channels = FuturesUnordered::<DeadChannelFut>::new();
+
+        loop {
+            tokio::select! {
+                next_conn = self.redirector.next_connection() => {
+                    let conn = next_conn?;
+                    self.handle_connection(conn).await;
+                },
+
+                next_message = self.message_rx.recv() => {
+                    let Some(message) = next_message else {
+                        // All handles dropped, we can exit.
+                        break Ok(());
+                    };
+
+                    self.handle_message(message).await?;
+                },
+
+                Some(dead) = dead_channels.next() => {
+                    self.handle_dead_channel(dead).await?;
+                }
+            }
+        }
+    }
+
+    /// Handles a redirected connection coming from [`Self::redirector`].
+    ///
+    /// This function does not do any cleanup if the steal channel is closed.
+    /// The cleanup is handled in [`Self::handle_dead_channel`].
+    ///
+    /// # Unstolen connections
+    ///
+    /// If the connection is not stolen, this functions simply drops it.
+    /// It happens when our port redirector returns a connection
+    /// to a port that is no longer stolen.
+    /// We consider this to be an unlikely race condition.
+    async fn handle_connection(&mut self, conn: Redirected) {
+        let redirected = RedirectedConnection {
+            source: conn.source,
+            destination: conn.destination,
+            stream: conn.stream,
+        };
+
+        let Some(steal) = self.steals.get(&redirected.destination.port()) else {
+            return;
+        };
+
+        let _ = steal.send(redirected).await;
+    }
+
+    async fn handle_message(&mut self, message: StealRequest) -> Result<(), R::Error> {
+        let StealRequest { port, receiver_tx } = message;
+
+        let entry = self.steals.entry(port);
+
+        if matches!(&entry, Entry::Occupied(e) if e.get().is_closed().not()) {
+            panic!("detected duplicate steal port subscription for port {port}, StealHandle should not allow this")
+        }
+
+        let (conn_tx, conn_rx) = mpsc::channel(32);
+        if receiver_tx.send(conn_rx).is_err() {
+            return Ok(());
+        }
+
+        if matches!(entry, Entry::Vacant(..)) {
+            self.redirector.add_redirection(port).await?;
+        }
+
+        entry.insert_entry(conn_tx.clone());
+        self.dead_channels.push(
+            async move {
+                conn_tx.closed().await;
+                port
+            }
+            .boxed(),
+        );
+
+        Ok(())
+    }
+
+    async fn handle_dead_channel(&mut self, port: u16) -> Result<(), R::Error> {
+        let Entry::Occupied(e) = self.steals.entry(port) else {
+            panic!("the stolen connections sender is only removed here");
+        };
+
+        if e.get().is_closed().not() {
+            // The handle started a new steal and this is a different channel.
+            // `DeadChannelFut` for this one was spawned in `handle_message`.
+            return Ok(());
+        }
+
+        self.redirector.remove_redirection(port).await?;
+        if self.steals.is_empty() {
+            self.redirector.cleanup().await?;
+        }
+
+        Ok(())
+    }
+
+    pub async fn run(mut self) -> Result<(), RedirectorTaskError> {
+        let main_result = self.run_inner().await;
+        let cleanup_result = self.redirector.cleanup().await;
+
+        let result = main_result
+            .and(cleanup_result)
+            .map_err(|error| RedirectorTaskError::RedirectorError(error.into()));
+
+        if let Err(e) = result.clone() {
+            let _ = self.error_tx.send(e);
+        }
+
+        result
+    }
+}
+
+pub(super) type StolenConnectionsRx = mpsc::Receiver<RedirectedConnection>;
+
+pub(super) struct StealRequest {
+    pub(super) port: u16,
+    pub(super) receiver_tx: oneshot::Sender<StolenConnectionsRx>,
+}
+
+type DeadChannelFut = BoxFuture<'static, u16>;
+
+#[derive(Clone)]
+pub(super) struct TaskError(Shared<oneshot::Receiver<RedirectorTaskError>>);
+
+impl TaskError {
+    pub(super) async fn get(&self) -> RedirectorTaskError {
+        self.0
+            .clone()
+            .await
+            .unwrap_or(RedirectorTaskError::Panicked)
+    }
+}
+
+impl fmt::Debug for TaskError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.get().now_or_never().fmt(f)
+    }
+}

--- a/mirrord/agent/src/main.rs
+++ b/mirrord/agent/src/main.rs
@@ -22,6 +22,7 @@ mod env;
 mod error;
 mod file;
 mod http;
+mod incoming;
 mod metrics;
 mod namespace;
 mod outgoing;

--- a/mirrord/agent/src/metrics.rs
+++ b/mirrord/agent/src/metrics.rs
@@ -72,7 +72,7 @@ impl AtomicUsizeExt for AtomicUsize {
 ///
 /// **Do not** modify the gauges directly!
 ///
-/// Instead rely on [`Metrics::gather_metrics`], as we actually use a bunch of [`AtomicI64`]s to
+/// Instead rely on [`Metrics::gather_metrics`], as we actually use a bunch of [`AtomicUsize`]s to
 /// keep track of the values, they are the ones being (de|in)cremented. These gauges are just set
 /// when it's time to send them via [`get_metrics`].
 #[derive(Debug)]
@@ -250,7 +250,7 @@ impl Metrics {
     }
 
     /// Calls [`IntGauge::set`] on every [`IntGauge`] of `Self`, setting it to the value of
-    /// the corresponding [`AtomicI64`] global (the uppercase named version of the gauge).
+    /// the corresponding [`AtomicUsize`] global (the uppercase named version of the gauge).
     ///
     /// Returns the list of [`MetricFamily`] registered in our [`Metrics::registry`], ready to be
     /// encoded and sent to prometheus.

--- a/mirrord/agent/src/metrics.rs
+++ b/mirrord/agent/src/metrics.rs
@@ -33,9 +33,9 @@ pub(crate) static MIRROR_PORT_SUBSCRIPTION: AtomicI64 = AtomicI64::new(0);
 
 pub(crate) static MIRROR_CONNECTION_SUBSCRIPTION: AtomicI64 = AtomicI64::new(0);
 
-pub(crate) static STEAL_FILTERED_PORT_SUBSCRIPTION: AtomicI64 = AtomicI64::new(0);
+pub(crate) static STEAL_FILTERED_PORT_SUBSCRIPTION: AtomicUsize = AtomicUsize::new(0);
 
-pub(crate) static STEAL_UNFILTERED_PORT_SUBSCRIPTION: AtomicI64 = AtomicI64::new(0);
+pub(crate) static STEAL_UNFILTERED_PORT_SUBSCRIPTION: AtomicUsize = AtomicUsize::new(0);
 
 pub(crate) static STEAL_FILTERED_CONNECTION_SUBSCRIPTION: AtomicI64 = AtomicI64::new(0);
 
@@ -269,10 +269,18 @@ impl Metrics {
         open_fd_count.set(OPEN_FD_COUNT.load(Ordering::Relaxed));
         mirror_port_subscription.set(MIRROR_PORT_SUBSCRIPTION.load(Ordering::Relaxed));
         mirror_connection_subscription.set(MIRROR_CONNECTION_SUBSCRIPTION.load(Ordering::Relaxed));
-        steal_filtered_port_subscription
-            .set(STEAL_FILTERED_PORT_SUBSCRIPTION.load(Ordering::Relaxed));
-        steal_unfiltered_port_subscription
-            .set(STEAL_UNFILTERED_PORT_SUBSCRIPTION.load(Ordering::Relaxed));
+        steal_filtered_port_subscription.set(
+            STEAL_FILTERED_PORT_SUBSCRIPTION
+                .load(Ordering::Relaxed)
+                .try_into()
+                .unwrap_or(i64::MAX),
+        );
+        steal_unfiltered_port_subscription.set(
+            STEAL_UNFILTERED_PORT_SUBSCRIPTION
+                .load(Ordering::Relaxed)
+                .try_into()
+                .unwrap_or(i64::MAX),
+        );
         steal_filtered_connection_subscription
             .set(STEAL_FILTERED_CONNECTION_SUBSCRIPTION.load(Ordering::Relaxed));
         steal_unfiltered_connection_subscription

--- a/mirrord/agent/src/outgoing.rs
+++ b/mirrord/agent/src/outgoing.rs
@@ -116,7 +116,7 @@ struct TcpOutgoingTask {
 impl Drop for TcpOutgoingTask {
     fn drop(&mut self) {
         let connections = self.readers.keys().chain(self.writers.keys()).count();
-        TCP_OUTGOING_CONNECTION.fetch_sub(connections as i64, std::sync::atomic::Ordering::Relaxed);
+        TCP_OUTGOING_CONNECTION.fetch_sub(connections, std::sync::atomic::Ordering::Relaxed);
     }
 }
 

--- a/mirrord/agent/src/outgoing/udp.rs
+++ b/mirrord/agent/src/outgoing/udp.rs
@@ -56,7 +56,7 @@ struct UdpOutgoingTask {
 impl Drop for UdpOutgoingTask {
     fn drop(&mut self) {
         let connections = self.readers.keys().chain(self.writers.keys()).count();
-        UDP_OUTGOING_CONNECTION.fetch_sub(connections as i64, std::sync::atomic::Ordering::Relaxed);
+        UDP_OUTGOING_CONNECTION.fetch_sub(connections, std::sync::atomic::Ordering::Relaxed);
     }
 }
 

--- a/mirrord/agent/src/sniffer.rs
+++ b/mirrord/agent/src/sniffer.rs
@@ -251,7 +251,7 @@ where
     #[tracing::instrument(level = Level::TRACE, err)]
     fn update_packet_filter(&mut self) -> AgentResult<()> {
         let ports = self.port_subscriptions.get_subscribed_topics();
-        MIRROR_PORT_SUBSCRIPTION.store(ports.len() as i64, std::sync::atomic::Ordering::Relaxed);
+        MIRROR_PORT_SUBSCRIPTION.store(ports.len(), std::sync::atomic::Ordering::Relaxed);
 
         let filter = if ports.is_empty() {
             tracing::trace!("No ports subscribed, setting dummy bpf");

--- a/mirrord/agent/src/steal/api.rs
+++ b/mirrord/agent/src/steal/api.rs
@@ -111,7 +111,7 @@ impl TcpStealerApi {
                     self.response_body_txs
                         .retain(|(key_id, _), _| *key_id != close.connection_id);
                     HTTP_REQUEST_IN_PROGRESS_COUNT.fetch_sub(
-                        (all_in_progress - self.response_body_txs.len()) as i64,
+                        all_in_progress - self.response_body_txs.len(),
                         std::sync::atomic::Ordering::Relaxed,
                     );
                 }
@@ -189,7 +189,7 @@ impl TcpStealerApi {
                 self.response_body_txs
                     .retain(|(key_id, _), _| *key_id != connection_id);
                 HTTP_REQUEST_IN_PROGRESS_COUNT.fetch_sub(
-                    (all_in_progress - self.response_body_txs.len()) as i64,
+                    all_in_progress - self.response_body_txs.len(),
                     Ordering::Relaxed,
                 );
 

--- a/mirrord/agent/src/steal/connections.rs
+++ b/mirrord/agent/src/steal/connections.rs
@@ -450,7 +450,7 @@ struct ConnectionTask {
 }
 
 impl ConnectionTask {
-    /// Timeout for detemining if the owned [`StolenConnection::stream`] is an incoming HTTP
+    /// Timeout for detemining if the owned [`StolenConnection`] is an incoming HTTP
     /// connection. Used to pick between [`UnfilteredStealTask`] and [`FilteredStealTask`] when
     /// [`PortSubscription::Filtered`] is in use.
     const HTTP_DETECTION_TIMEOUT: Duration = Duration::from_secs(10);

--- a/mirrord/agent/src/steal/subscriptions.rs
+++ b/mirrord/agent/src/steal/subscriptions.rs
@@ -1,335 +1,55 @@
 use std::{
     collections::{hash_map::Entry, HashMap},
-    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
     ops::Not,
-    sync::Arc,
+    sync::{atomic::Ordering, Arc},
 };
 
 use dashmap::{mapref::entry::Entry as DashMapEntry, DashMap};
-use mirrord_agent_iptables::{new_ip6tables, new_iptables, IPTablesWrapper, SafeIpTables};
 use mirrord_protocol::{Port, RemoteResult, ResponseError};
-use tokio::{
-    net::{TcpListener, TcpStream},
-    select,
-};
 
 use super::http::HttpFilter;
 use crate::{
-    error::{AgentError, AgentResult},
+    incoming::{RedirectedConnection, RedirectorTaskError, StealHandle},
     metrics::{STEAL_FILTERED_PORT_SUBSCRIPTION, STEAL_UNFILTERED_PORT_SUBSCRIPTION},
     util::ClientId,
 };
 
-/// For stealing incoming TCP connections.
-#[async_trait::async_trait]
-pub trait PortRedirector {
-    type Error;
-
-    /// Start stealing connections from the given port.
-    ///
-    /// # Note
-    ///
-    /// If a redirection from the given port already exists, implementations are free to do nothing
-    /// or return an [`Err`].
-    async fn add_redirection(&mut self, from: Port) -> Result<(), Self::Error>;
-
-    /// Stop stealing connections from the given port.
-    ///
-    /// # Note
-    ///
-    /// If the redirection does no exist, implementations are free to do nothing or return an
-    /// [`Err`].
-    async fn remove_redirection(&mut self, from: Port) -> Result<(), Self::Error>;
-
-    /// Clean any external state.
-    async fn cleanup(&mut self) -> Result<(), Self::Error>;
-
-    /// Accept an incoming redirected connection.
-    ///
-    /// # Returns
-    ///
-    /// * [`TcpStream`] - redirected connection
-    /// * [`SocketAddr`] - peer address
-    async fn next_connection(&mut self) -> Result<(TcpStream, SocketAddr), Self::Error>;
-}
-
-/// A TCP listener, together with an iptables wrapper to set rules that send traffic to the
-/// listener.
-pub(crate) struct IptablesListener {
-    /// For altering iptables rules.
-    iptables: Option<SafeIpTables<IPTablesWrapper>>,
-    /// Port of [`listener`](Self::listener).
-    redirect_to: Port,
-    /// Listener to which redirect all connections.
-    listener: TcpListener,
-    /// Optional comma-seperated list of IPs of the pod, originating in the pod's `Status.PodIps`
-    pod_ips: Option<String>,
-    /// Whether existing connections should be flushed when adding new redirects.
-    flush_connections: bool,
-    /// Is this for connections incoming over IPv6
-    ipv6: bool,
-}
-
-#[async_trait::async_trait]
-impl PortRedirector for IptablesListener {
-    type Error = AgentError;
-
-    #[tracing::instrument(skip(self), err, ret, level=tracing::Level::DEBUG, fields(self.ipv6 = %self.ipv6))]
-    async fn add_redirection(&mut self, from: Port) -> Result<(), Self::Error> {
-        let iptables = if let Some(iptables) = self.iptables.as_ref() {
-            iptables
-        } else {
-            let safe = SafeIpTables::create(
-                if self.ipv6 {
-                    new_ip6tables()
-                } else {
-                    new_iptables()
-                }
-                .into(),
-                self.flush_connections,
-                self.pod_ips.as_deref(),
-                self.ipv6,
-            )
-            .await?;
-            self.iptables.insert(safe)
-        };
-
-        iptables
-            .add_redirect(from, self.redirect_to)
-            .await
-            .map_err(From::from)
-    }
-
-    async fn remove_redirection(&mut self, from: Port) -> Result<(), Self::Error> {
-        if let Some(iptables) = self.iptables.as_ref() {
-            iptables.remove_redirect(from, self.redirect_to).await?;
-        }
-
-        Ok(())
-    }
-
-    async fn cleanup(&mut self) -> Result<(), Self::Error> {
-        if let Some(iptables) = self.iptables.take() {
-            iptables.cleanup().await?;
-        }
-
-        Ok(())
-    }
-
-    async fn next_connection(&mut self) -> Result<(TcpStream, SocketAddr), Self::Error> {
-        self.listener.accept().await.map_err(Into::into)
-    }
-}
-
-/// Implementation of [`PortRedirector`] that manipulates iptables to steal connections by
-/// redirecting TCP packets to inner [`TcpListener`].
-///
-/// Holds TCP listeners + iptables, for redirecting IPv4 and/or IPv6 connections.
-pub(crate) enum IpTablesRedirector {
-    Ipv4Only(IptablesListener),
-    /// Could be used if IPv6 support is enabled, and we cannot bind an IPv4 address.
-    Ipv6Only(IptablesListener),
-    Dual {
-        ipv4_listener: IptablesListener,
-        ipv6_listener: IptablesListener,
-    },
-}
-
-impl IpTablesRedirector {
-    /// Create a new instance of this struct. Open an IPv4 TCP listener on an
-    /// [`Ipv4Addr::UNSPECIFIED`] address and a random port. This listener will be used to accept
-    /// redirected connections.
-    ///
-    /// If `support_ipv6` is set, will also listen on IPv6, and a fail to listen over IPv4 will be
-    /// accepted.
-    ///
-    /// # Note
-    ///
-    /// Does not yet alter iptables.
-    ///
-    /// # Params
-    ///
-    /// * `flush_connections` - whether existing connections should be flushed when adding new
-    ///   redirects
-    pub(crate) async fn new(
-        flush_connections: bool,
-        pod_ips: Vec<IpAddr>,
-        support_ipv6: bool,
-    ) -> AgentResult<Self> {
-        let (pod_ips4, pod_ips6) = pod_ips
-            .into_iter()
-            .partition::<Vec<IpAddr>, _>(IpAddr::is_ipv4);
-        tracing::debug!(?pod_ips4, ?pod_ips6, "Resolved pod IP addresses from env",);
-
-        tracing::debug!("Creating IPv4 iptables redirection listener");
-        let listener4 = TcpListener::bind((Ipv4Addr::UNSPECIFIED, 0)).await
-            .inspect_err(
-                |error| tracing::debug!(%error, "Failed to bind the IPv4 listener."),
-            )
-            .ok()
-            .and_then(|listener| {
-                let redirect_to = listener
-                    .local_addr()
-                    .inspect_err(
-                        |error| tracing::debug!(%error, "Failed to obtain the IPv4 listener local address."),
-                    )
-                    .ok()?
-                    .port();
-                let pod_ips = pod_ips4.is_empty().not().then(|| pod_ips4.iter().map(ToString::to_string).collect::<Vec<_>>().join(","));
-                Some(IptablesListener {
-                    iptables: None,
-                    redirect_to,
-                    listener,
-                    pod_ips,
-                    flush_connections,
-                    ipv6: false,
-                })
-            });
-
-        tracing::debug!("Creating IPv6 iptables redirection listener");
-        let listener6 = if support_ipv6 {
-            TcpListener::bind((Ipv6Addr::UNSPECIFIED, 0)).await
-                .inspect_err(
-                    |error| tracing::debug!(%error, "Failed to bind the IPv6 listener."),
-                )
-                .ok()
-                .and_then(|listener| {
-                    let redirect_to = listener
-                        .local_addr()
-                        .inspect_err(
-                            |error| tracing::debug!(%error, "Failed to obtain the IPv6 listener local address."),
-                        )
-                        .ok()?
-                        .port();
-                    let pod_ips = pod_ips6.is_empty().not().then(|| pod_ips6.iter().map(ToString::to_string).collect::<Vec<_>>().join(","));
-                    Some(IptablesListener {
-                        iptables: None,
-                        redirect_to,
-                        listener,
-                        pod_ips,
-                        flush_connections,
-                        ipv6: true,
-                    })
-                })
-        } else {
-            None
-        };
-
-        match (listener4, listener6) {
-            (None, None) => Err(AgentError::CannotListenForStolenConnections),
-            (Some(ipv4_listener), None) => {
-                tracing::debug!("Continuing with only the IPv4 steal listener.");
-                Ok(Self::Ipv4Only(ipv4_listener))
-            }
-            (None, Some(ipv6_listener)) => {
-                tracing::debug!("Continuing with only the IPv6 steal listener.");
-                Ok(Self::Ipv6Only(ipv6_listener))
-            }
-            (Some(ipv4_listener), Some(ipv6_listener)) => {
-                tracing::debug!("Continuing with both the IPv4 and the IPv6 steal listeners.");
-                Ok(Self::Dual {
-                    ipv4_listener,
-                    ipv6_listener,
-                })
-            }
-        }
-    }
-
-    pub(crate) fn get_listeners_mut(
-        &mut self,
-    ) -> (Option<&mut IptablesListener>, Option<&mut IptablesListener>) {
-        match self {
-            IpTablesRedirector::Ipv4Only(ipv4_listener) => (Some(ipv4_listener), None),
-            IpTablesRedirector::Ipv6Only(ipv6_listener) => (None, Some(ipv6_listener)),
-            IpTablesRedirector::Dual {
-                ipv4_listener,
-                ipv6_listener,
-            } => (Some(ipv4_listener), Some(ipv6_listener)),
-        }
-    }
-}
-
-#[async_trait::async_trait]
-impl PortRedirector for IpTablesRedirector {
-    type Error = AgentError;
-
-    async fn add_redirection(&mut self, from: Port) -> Result<(), Self::Error> {
-        let (ipv4_listener, ipv6_listener) = self.get_listeners_mut();
-        if let Some(ip4_listener) = ipv4_listener {
-            tracing::debug!("Adding IPv4 redirection from port {from}");
-            ip4_listener.add_redirection(from).await?;
-        }
-        if let Some(ip6_listener) = ipv6_listener {
-            tracing::debug!("Adding IPv6 redirection from port {from}");
-            ip6_listener.add_redirection(from).await?;
-        }
-        Ok(())
-    }
-
-    async fn remove_redirection(&mut self, from: Port) -> Result<(), Self::Error> {
-        let (ipv4_listener, ipv6_listener) = self.get_listeners_mut();
-        if let Some(ip4_listener) = ipv4_listener {
-            ip4_listener.remove_redirection(from).await?;
-        }
-        if let Some(ip6_listener) = ipv6_listener {
-            ip6_listener.remove_redirection(from).await?;
-        }
-        Ok(())
-    }
-
-    async fn cleanup(&mut self) -> Result<(), Self::Error> {
-        let (ipv4_listener, ipv6_listener) = self.get_listeners_mut();
-        if let Some(ip4_listener) = ipv4_listener {
-            ip4_listener.cleanup().await?;
-        }
-        if let Some(ip6_listener) = ipv6_listener {
-            ip6_listener.cleanup().await?;
-        }
-        Ok(())
-    }
-
-    async fn next_connection(&mut self) -> Result<(TcpStream, SocketAddr), Self::Error> {
-        match self {
-            Self::Dual {
-                ipv4_listener,
-                ipv6_listener,
-            } => {
-                select! {
-                    con = ipv4_listener.next_connection() => con,
-                    con = ipv6_listener.next_connection() => con,
-                }
-            }
-            Self::Ipv4Only(listener) | Self::Ipv6Only(listener) => listener.next_connection().await,
-        }
-    }
-}
-
 /// Set of active port subscriptions.
-pub struct PortSubscriptions<R: PortRedirector> {
-    /// Used to implement stealing connections.
-    redirector: R,
+pub struct PortSubscriptions {
+    /// Used to request port redirections and fetch redirected connections.
+    handle: StealHandle,
     /// Maps ports to active subscriptions.
     subscriptions: HashMap<Port, PortSubscription>,
 }
 
-impl<R: PortRedirector> Drop for PortSubscriptions<R> {
+impl Drop for PortSubscriptions {
     fn drop(&mut self) {
-        STEAL_FILTERED_PORT_SUBSCRIPTION.store(0, std::sync::atomic::Ordering::Relaxed);
-        STEAL_UNFILTERED_PORT_SUBSCRIPTION.store(0, std::sync::atomic::Ordering::Relaxed);
+        let (filtered, unfiltered) =
+            self.subscriptions
+                .values()
+                .fold(
+                    (0, 0),
+                    |(unfiltered, filtered), subscription| match subscription {
+                        PortSubscription::Filtered(..) => (unfiltered, filtered + 1),
+                        PortSubscription::Unfiltered(..) => (unfiltered + 1, filtered),
+                    },
+                );
+
+        STEAL_UNFILTERED_PORT_SUBSCRIPTION.fetch_sub(unfiltered, Ordering::Relaxed);
+        STEAL_FILTERED_PORT_SUBSCRIPTION.fetch_sub(filtered, Ordering::Relaxed);
     }
 }
 
-impl<R: PortRedirector> PortSubscriptions<R> {
+impl PortSubscriptions {
     /// Create an empty instance of this struct.
     ///
     /// # Params
     ///
-    /// * `redirector` - will be used to enforce connection stealing according to the state of this
-    ///   set
-    /// * `initial_capacity` - initial capacity for the inner (port -> subscription) mapping
-    pub fn new(redirector: R, initial_capacity: usize) -> Self {
+    /// * `handle` - will be used to enforce connection stealing according to the state of this set.
+    /// * `initial_capacity` - initial capacity for the inner (port -> subscription) mapping.
+    pub fn new(handle: StealHandle, initial_capacity: usize) -> Self {
         Self {
-            redirector,
+            handle,
             subscriptions: HashMap::with_capacity(initial_capacity),
         }
     }
@@ -348,66 +68,43 @@ impl<R: PortRedirector> PortSubscriptions<R> {
     /// * `client_protocol_version` - version of client's [`mirrord_protocol`], [`None`] if the
     ///   version has not been negotiated yet
     /// * `filter` - optional [`HttpFilter`]
-    ///
-    /// # Warning
-    ///
-    /// If this method returns an [`Err`], it means that this set is out of sync with the inner
-    /// [`PortRedirector`] and it is no longer usable. It is a caller's responsibility to clean
-    /// up any external state.
     pub async fn add(
         &mut self,
         client_id: ClientId,
         port: Port,
         client_protocol_version: Option<semver::Version>,
         filter: Option<HttpFilter>,
-    ) -> Result<RemoteResult<Port>, R::Error> {
-        let add_redirect = match self.subscriptions.entry(port) {
+    ) -> Result<RemoteResult<Port>, RedirectorTaskError> {
+        let filtered = filter.is_some();
+
+        match self.subscriptions.entry(port) {
             Entry::Occupied(mut e) => {
-                let filtered = filter.is_some();
                 if e.get_mut()
                     .try_extend(client_id, client_protocol_version, filter)
+                    .not()
                 {
-                    if filtered {
-                        STEAL_FILTERED_PORT_SUBSCRIPTION
-                            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                    } else {
-                        STEAL_UNFILTERED_PORT_SUBSCRIPTION
-                            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                    }
-
-                    Ok(false)
-                } else {
-                    Err(ResponseError::PortAlreadyStolen(port))
+                    return Ok(Err(ResponseError::PortAlreadyStolen(port)));
                 }
             }
 
             Entry::Vacant(e) => {
-                if filter.is_some() {
-                    STEAL_FILTERED_PORT_SUBSCRIPTION
-                        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                } else {
-                    STEAL_UNFILTERED_PORT_SUBSCRIPTION
-                        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                }
+                self.handle.steal(port).await?;
 
                 e.insert(PortSubscription::new(
                     client_id,
                     client_protocol_version,
                     filter,
                 ));
-                Ok(true)
             }
         };
 
-        match add_redirect {
-            Ok(true) => {
-                self.redirector.add_redirection(port).await?;
-
-                Ok(Ok(port))
-            }
-            Ok(false) => Ok(Ok(port)),
-            Err(e) => Ok(Err(e)),
+        if filtered {
+            STEAL_FILTERED_PORT_SUBSCRIPTION.fetch_add(1, Ordering::Relaxed);
+        } else {
+            STEAL_UNFILTERED_PORT_SUBSCRIPTION.fetch_add(1, Ordering::Relaxed);
         }
+
+        Ok(Ok(port))
     }
 
     /// Remove a subscription from this set, if it exists.
@@ -416,26 +113,20 @@ impl<R: PortRedirector> PortSubscriptions<R> {
     ///
     /// * `client_id` - identifier of the client that issued the subscription
     /// * `port` - number of the subscription port
-    ///
-    /// # Warning
-    ///
-    /// If this method returns an [`Err`], it means that this set is out of sync with the inner
-    /// [`PortRedirector`] and it is no longer usable. It is a caller's responsibility to clean
-    /// up any external state.
-    pub async fn remove(&mut self, client_id: ClientId, port: Port) -> Result<(), R::Error> {
+    pub fn remove(&mut self, client_id: ClientId, port: Port) {
         let Entry::Occupied(mut e) = self.subscriptions.entry(port) else {
-            return Ok(());
+            return;
         };
 
-        let remove_redirect = match e.get_mut() {
+        match e.get_mut() {
             PortSubscription::Unfiltered(subscribed_client) if *subscribed_client == client_id => {
                 e.remove();
                 STEAL_UNFILTERED_PORT_SUBSCRIPTION
                     .fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
 
-                true
+                self.handle.stop_steal(port);
             }
-            PortSubscription::Unfiltered(..) => false,
+            PortSubscription::Unfiltered(..) => {}
             PortSubscription::Filtered(filters) => {
                 if filters.remove(&client_id).is_some() {
                     STEAL_FILTERED_PORT_SUBSCRIPTION
@@ -444,22 +135,10 @@ impl<R: PortRedirector> PortSubscriptions<R> {
 
                 if filters.is_empty() {
                     e.remove();
-                    true
-                } else {
-                    false
+                    self.handle.stop_steal(port);
                 }
             }
-        };
-
-        if remove_redirect {
-            self.redirector.remove_redirection(port).await?;
-
-            if self.subscriptions.is_empty() {
-                self.redirector.cleanup().await?;
-            }
         }
-
-        Ok(())
     }
 
     /// Remove all client subscriptions from this set.
@@ -467,13 +146,7 @@ impl<R: PortRedirector> PortSubscriptions<R> {
     /// # Params
     ///
     /// * `client_id` - identifier of the client that issued the subscriptions
-    ///
-    /// # Warning
-    ///
-    /// If this method returns an [`Err`], it means that this set is out of sync with the inner
-    /// [`PortRedirector`] and it is no longer usable. It is a caller's responsibility to clean
-    /// up any external state.
-    pub async fn remove_all(&mut self, client_id: ClientId) -> Result<(), R::Error> {
+    pub fn remove_all(&mut self, client_id: ClientId) {
         let ports = self
             .subscriptions
             .iter()
@@ -481,20 +154,25 @@ impl<R: PortRedirector> PortSubscriptions<R> {
             .collect::<Vec<_>>();
 
         for port in ports {
-            self.remove(client_id, port).await?;
+            self.remove(client_id, port);
         }
-
-        Ok(())
     }
 
-    /// Return a subscription for the given `port`.
-    pub fn get(&self, port: Port) -> Option<&PortSubscription> {
-        self.subscriptions.get(&port)
-    }
+    /// Wait until there's a new redirected connection.
+    pub async fn next_connection(
+        &mut self,
+    ) -> Result<(RedirectedConnection, PortSubscription), RedirectorTaskError> {
+        loop {
+            let conn = self.handle.next().await.transpose()?;
 
-    /// Call [`PortRedirector::next_connection`] on the inner [`PortRedirector`].
-    pub async fn next_connection(&mut self) -> Result<(TcpStream, SocketAddr), R::Error> {
-        self.redirector.next_connection().await
+            let Some(conn) = conn else {
+                break std::future::pending().await;
+            };
+
+            if let Some(subscription) = self.subscriptions.get(&conn.destination().port()) {
+                break Ok((conn, subscription.clone()));
+            }
+        }
     }
 }
 
@@ -568,74 +246,15 @@ impl PortSubscription {
 
 #[cfg(test)]
 mod test {
-    use std::collections::HashSet;
+    use mirrord_protocol::ResponseError;
 
-    use super::*;
-
-    /// Implementation of [`PortRedirector`] that stores redirections in memory.
-    /// Disallows duplicate redirections or removing a non-existent redirection.
-    #[derive(Default)]
-    struct DummyRedirector {
-        redirections: HashSet<Port>,
-        dirty: bool,
-    }
-
-    /// Checks the redirections in the given [`DummyRedirector`] against a sequence of ports.
-    ///
-    /// # Usage
-    ///
-    /// * To assert exact set of redirections: `check_redirector!(redirector, 80, 81, 3000)`
-    /// * To assert no redirections: `check_redirector!(redirector)`
-    ///
-    /// # Note
-    ///
-    /// It's implemented as a macro only to preserve the original line number should the test fail.
-    macro_rules! check_redirector {
-        ( $redirector: expr $(, $x:expr )* ) => {
-            {
-                let mut temp_vec: Vec<u16> = vec![$($x,)*];
-                temp_vec.sort();
-
-                let mut redirections = $redirector.redirections.iter().copied().collect::<Vec<_>>();
-                redirections.sort();
-
-                assert_eq!(redirections, temp_vec, "redirector in bad state");
-            }
-        };
-    }
-
-    #[async_trait::async_trait]
-    impl PortRedirector for DummyRedirector {
-        type Error = Port;
-
-        async fn add_redirection(&mut self, from: Port) -> Result<(), Self::Error> {
-            if self.redirections.insert(from) {
-                self.dirty = true;
-                Ok(())
-            } else {
-                Err(from)
-            }
-        }
-
-        async fn remove_redirection(&mut self, from: Port) -> Result<(), Self::Error> {
-            if self.redirections.remove(&from) {
-                Ok(())
-            } else {
-                Err(from)
-            }
-        }
-
-        async fn cleanup(&mut self) -> Result<(), Self::Error> {
-            self.redirections.clear();
-            self.dirty = false;
-
-            Ok(())
-        }
-
-        async fn next_connection(&mut self) -> Result<(TcpStream, SocketAddr), Self::Error> {
-            unimplemented!()
-        }
-    }
+    use crate::{
+        incoming::{test::DummyRedirector, RedirectorTask},
+        steal::{
+            http::HttpFilter,
+            subscriptions::{PortSubscription, PortSubscriptions},
+        },
+    };
 
     fn dummy_filter() -> HttpFilter {
         HttpFilter::Header(".*".parse().unwrap())
@@ -643,14 +262,15 @@ mod test {
 
     #[tokio::test]
     async fn multiple_subscriptions_one_port() {
-        let redirector = DummyRedirector::default();
-        let mut subscriptions = PortSubscriptions::new(redirector, 8);
-        check_redirector!(subscriptions.redirector);
+        let (redirector, mut state, _tx) = DummyRedirector::new();
+        let (redirector_task, steal_handle) = RedirectorTask::new(redirector);
+        tokio::spawn(redirector_task.run());
+        let mut subscriptions = PortSubscriptions::new(steal_handle, 8);
 
         // Adding unfiltered subscription.
         subscriptions.add(0, 80, None, None).await.unwrap().unwrap();
-        check_redirector!(subscriptions.redirector, 80);
-        let sub = subscriptions.get(80).unwrap();
+        assert!(state.borrow().has_redirections([80]));
+        let sub = subscriptions.subscriptions.get(&80).unwrap();
         assert!(matches!(sub, PortSubscription::Unfiltered(0)), "{sub:?}");
 
         // Same client cannot subscribe again (unfiltered).
@@ -658,8 +278,8 @@ mod test {
             subscriptions.add(0, 80, None, None).await.unwrap(),
             Err(ResponseError::PortAlreadyStolen(80)),
         );
-        check_redirector!(subscriptions.redirector, 80);
-        let sub = subscriptions.get(80).unwrap();
+        assert!(state.borrow().has_redirections([80]));
+        let sub = subscriptions.subscriptions.get(&80).unwrap();
         assert!(matches!(sub, PortSubscription::Unfiltered(0)), "{sub:?}");
 
         // Same client cannot subscribe again (filtered).
@@ -670,8 +290,8 @@ mod test {
                 .unwrap(),
             Err(ResponseError::PortAlreadyStolen(80)),
         );
-        check_redirector!(subscriptions.redirector, 80);
-        let sub = subscriptions.get(80).unwrap();
+        assert!(state.borrow().has_redirections([80]));
+        let sub = subscriptions.subscriptions.get(&80).unwrap();
         assert!(matches!(sub, PortSubscription::Unfiltered(0)), "{sub:?}");
 
         // Another client cannot subscribe (unfiltered).
@@ -679,8 +299,8 @@ mod test {
             subscriptions.add(1, 80, None, None).await.unwrap(),
             Err(ResponseError::PortAlreadyStolen(80)),
         );
-        check_redirector!(subscriptions.redirector, 80);
-        let sub = subscriptions.get(80).unwrap();
+        assert!(state.borrow().has_redirections([80]));
+        let sub = subscriptions.subscriptions.get(&80).unwrap();
         assert!(matches!(sub, PortSubscription::Unfiltered(0)), "{sub:?}");
 
         // Another client cannot subscribe (filtered).
@@ -691,17 +311,19 @@ mod test {
                 .unwrap(),
             Err(ResponseError::PortAlreadyStolen(80)),
         );
-        check_redirector!(subscriptions.redirector, 80);
-        let sub = subscriptions.get(80).unwrap();
+        assert!(state.borrow().has_redirections([80]));
+        let sub = subscriptions.subscriptions.get(&80).unwrap();
         assert!(matches!(sub, PortSubscription::Unfiltered(0)), "{sub:?}");
 
         // Removing unfiltered subscription.
-        subscriptions.remove(0, 80).await.unwrap();
+        subscriptions.remove(0, 80);
 
         // Checking if all is cleaned up.
-        check_redirector!(subscriptions.redirector);
-        assert!(!subscriptions.redirector.dirty);
-        let sub = subscriptions.get(80);
+        state
+            .wait_for(|state| state.has_redirections([]))
+            .await
+            .unwrap();
+        let sub = subscriptions.subscriptions.get(&80);
         assert!(sub.is_none(), "{sub:?}");
 
         // Adding filtered subscription.
@@ -710,8 +332,8 @@ mod test {
             .await
             .unwrap()
             .unwrap();
-        check_redirector!(subscriptions.redirector, 80);
-        let sub = subscriptions.get(80).unwrap();
+        assert!(state.borrow().has_redirections([80]));
+        let sub = subscriptions.subscriptions.get(&80).unwrap();
         assert!(
             matches!(sub, PortSubscription::Filtered(filters) if filters.len() == 1),
             "{sub:?}"
@@ -722,8 +344,8 @@ mod test {
             subscriptions.add(0, 80, None, None).await.unwrap(),
             Err(ResponseError::PortAlreadyStolen(80)),
         );
-        check_redirector!(subscriptions.redirector, 80);
-        let sub = subscriptions.get(80).unwrap();
+        assert!(state.borrow().has_redirections([80]));
+        let sub = subscriptions.subscriptions.get(&80).unwrap();
         assert!(
             matches!(sub, PortSubscription::Filtered(filters) if filters.len() == 1),
             "{sub:?}"
@@ -737,8 +359,8 @@ mod test {
                 .unwrap(),
             Err(ResponseError::PortAlreadyStolen(80)),
         );
-        check_redirector!(subscriptions.redirector, 80);
-        let sub = subscriptions.get(80).unwrap();
+        assert!(state.borrow().has_redirections([80]));
+        let sub = subscriptions.subscriptions.get(&80).unwrap();
         assert!(
             matches!(sub, PortSubscription::Filtered(filters) if filters.len() == 1),
             "{sub:?}"
@@ -749,8 +371,8 @@ mod test {
             subscriptions.add(1, 80, None, None).await.unwrap(),
             Err(ResponseError::PortAlreadyStolen(80)),
         );
-        check_redirector!(subscriptions.redirector, 80);
-        let sub = subscriptions.get(80).unwrap();
+        assert!(state.borrow().has_redirections([80]));
+        let sub = subscriptions.subscriptions.get(&80).unwrap();
         assert!(
             matches!(sub, PortSubscription::Filtered(filters) if filters.len() == 1),
             "{sub:?}"
@@ -762,39 +384,41 @@ mod test {
             .await
             .unwrap()
             .unwrap();
-        check_redirector!(subscriptions.redirector, 80);
-        let sub = subscriptions.get(80).unwrap();
+        assert!(state.borrow().has_redirections([80]));
+        let sub = subscriptions.subscriptions.get(&80).unwrap();
         assert!(
             matches!(sub, PortSubscription::Filtered(filters) if filters.len() == 2),
             "{sub:?}"
         );
 
         // Removing first subscription.
-        subscriptions.remove(0, 80).await.unwrap();
+        subscriptions.remove(0, 80);
 
         // Checking if the second subscription still exists.
-        check_redirector!(subscriptions.redirector, 80);
-        let sub = subscriptions.get(80).unwrap();
+        let sub = subscriptions.subscriptions.get(&80).unwrap();
         assert!(
             matches!(sub, PortSubscription::Filtered(filters) if filters.len() == 1),
             "{sub:?}"
         );
 
         // Removing second subscription.
-        subscriptions.remove(1, 80).await.unwrap();
+        subscriptions.remove(1, 80);
 
         // Checking if all is cleaned up.
-        check_redirector!(subscriptions.redirector);
-        assert!(!subscriptions.redirector.dirty);
-        let sub = subscriptions.get(80);
+        state
+            .wait_for(|state| state.has_redirections([]))
+            .await
+            .unwrap();
+        let sub = subscriptions.subscriptions.get(&80);
         assert!(sub.is_none(), "{sub:?}");
     }
 
     #[tokio::test]
     async fn multiple_subscriptions_multiple_ports() {
-        let redirector = DummyRedirector::default();
-        let mut subscriptions = PortSubscriptions::new(redirector, 8);
-        check_redirector!(subscriptions.redirector);
+        let (redirector, mut state, _tx) = DummyRedirector::new();
+        let (redirector_task, steal_handle) = RedirectorTask::new(redirector);
+        tokio::spawn(redirector_task.run());
+        let mut subscriptions = PortSubscriptions::new(steal_handle, 8);
 
         // Adding unfiltered subscription for port 80.
         subscriptions.add(0, 80, None, None).await.unwrap().unwrap();
@@ -807,11 +431,11 @@ mod test {
             .unwrap();
 
         // Checking state.
-        check_redirector!(subscriptions.redirector, 80, 81);
-        let sub = subscriptions.get(80).unwrap();
+        assert!(state.borrow().has_redirections([80, 81]));
+        let sub = subscriptions.subscriptions.get(&80).unwrap();
         assert!(sub.has_client(0));
         assert!(matches!(sub, PortSubscription::Unfiltered(0)), "{sub:?}");
-        let sub = subscriptions.get(81).unwrap();
+        let sub = subscriptions.subscriptions.get(&81).unwrap();
         assert!(sub.has_client(1));
         assert!(
             matches!(sub, PortSubscription::Filtered(filters) if filters.len() == 1),
@@ -819,23 +443,27 @@ mod test {
         );
 
         // Removing subscriptions.
-        subscriptions.remove(0, 80).await.unwrap();
-        subscriptions.remove(1, 81).await.unwrap();
+        subscriptions.remove(0, 80);
+        subscriptions.remove(1, 81);
 
         // Checking if all is cleaned up.
-        check_redirector!(subscriptions.redirector);
-        assert!(!subscriptions.redirector.dirty);
-        let sub = subscriptions.get(80);
+        // check_redirector!(subscriptions.redirector);
+        state
+            .wait_for(|state| state.has_redirections([]))
+            .await
+            .unwrap();
+        let sub = subscriptions.subscriptions.get(&80);
         assert!(sub.is_none(), "{sub:?}");
-        let sub = subscriptions.get(81);
+        let sub = subscriptions.subscriptions.get(&81);
         assert!(sub.is_none(), "{sub:?}");
     }
 
     #[tokio::test]
     async fn remove_all_from_client() {
-        let redirector = DummyRedirector::default();
-        let mut subscriptions = PortSubscriptions::new(redirector, 8);
-        check_redirector!(subscriptions.redirector);
+        let (redirector, mut state, _tx) = DummyRedirector::new();
+        let (redirector_task, steal_handle) = RedirectorTask::new(redirector);
+        tokio::spawn(redirector_task.run());
+        let mut subscriptions = PortSubscriptions::new(steal_handle, 8);
 
         // Adding unfiltered subscription for port 80.
         subscriptions.add(0, 80, None, None).await.unwrap().unwrap();
@@ -848,11 +476,11 @@ mod test {
             .unwrap();
 
         // Checking state.
-        check_redirector!(subscriptions.redirector, 80, 81);
-        let sub = subscriptions.get(80).unwrap();
+        assert!(state.borrow().has_redirections([80, 81]));
+        let sub = subscriptions.subscriptions.get(&80).unwrap();
         assert!(sub.has_client(0));
         assert!(matches!(sub, PortSubscription::Unfiltered(0)), "{sub:?}");
-        let sub = subscriptions.get(81).unwrap();
+        let sub = subscriptions.subscriptions.get(&81).unwrap();
         assert!(sub.has_client(0));
         assert!(
             matches!(sub, PortSubscription::Filtered(filters) if filters.len() == 1),
@@ -860,14 +488,16 @@ mod test {
         );
 
         // Removing all subscriptions of a client.
-        subscriptions.remove_all(0).await.unwrap();
+        subscriptions.remove_all(0);
 
         // Checking if all is cleaned up.
-        check_redirector!(subscriptions.redirector);
-        assert!(!subscriptions.redirector.dirty);
-        let sub = subscriptions.get(80);
+        state
+            .wait_for(|state| state.has_redirections([]))
+            .await
+            .unwrap();
+        let sub = subscriptions.subscriptions.get(&80);
         assert!(sub.is_none(), "{sub:?}");
-        let sub = subscriptions.get(81);
+        let sub = subscriptions.subscriptions.get(&81);
         assert!(sub.is_none(), "{sub:?}");
     }
 }

--- a/tests/src/traffic/steal.rs
+++ b/tests/src/traffic/steal.rs
@@ -3,6 +3,7 @@ mod steal_tests {
     use std::{path::Path, time::Duration};
 
     use futures_util::{SinkExt, StreamExt};
+    use hyper::StatusCode;
     use k8s_openapi::api::core::v1::Pod;
     use kube::{Api, Client};
     use reqwest::{header::HeaderMap, Url};
@@ -204,21 +205,8 @@ mod steal_tests {
             .wait_for_line(Duration::from_secs(40), "Closed socket")
             .await;
 
-        // Flake-proofing the test:
-        // If we connect to the service between the time the test application had closed its socket
-        // and the agent was informed about it, our connection would still get stolen at first, but
-        // then reset without response data once the agent learns the socket was closed.
-        //
-        // To try to prevent this from happening in the test, we wait after the app closes the
-        // socket, to make sure mirrord has time to handle the close, before we send a request.
-        // Because things could go slow on GitHub Actions, we wait for 3 full seconds.
-        //
-        // In order to make this test deterministic, we could make the agent send a confirmation
-        // once it's done handling the `PortUnsubscribe`, but that would require adding a new
-        // message to the protocol, which we only do on major protocol version bumps.
-        sleep(Duration::from_secs(3)).await;
-
-        // Send HTTP request and verify it is handled by the REMOTE app - NOT STOLEN.
+        // Keep sending HTTP requests until we get a response from the remote app.
+        // Agent should eventually process the unsubscribe request.
         let portforwarder = PortForwarder::new(
             kube_client.clone(),
             &service.pod_name,
@@ -228,14 +216,29 @@ mod steal_tests {
         .await;
         let url = format!("http://{}", portforwarder.address());
         let client = reqwest::Client::new();
-        let req_builder = client.get(url);
-        eprintln!("Sending request to remote service");
-        send_request(
-            req_builder,
-            Some("OK - GET: Request completed\n"),
-            Default::default(),
-        )
-        .await;
+        loop {
+            let response = match client.get(&url).send().await {
+                Ok(response) => response,
+                Err(error) => {
+                    println!("Failed to send the request, agent still didn't process port unsubsribe, error: {error}");
+                    sleep(Duration::from_secs(1)).await;
+                    continue;
+                }
+            };
+
+            let status = response.status();
+            let body =
+                String::from_utf8_lossy(response.bytes().await.unwrap().as_ref()).into_owned();
+
+            assert_eq!(
+                status,
+                StatusCode::OK,
+                "unexpected status, response body: {body}"
+            );
+
+            assert_eq!(body, "OK - GET: Request completed\n");
+            break;
+        }
 
         process
             .write_to_stdin(b"Hey test app, please stop running and just exit successfuly.\n")


### PR DESCRIPTION
Preparation for passthrough traffic mirroring.

Since both stealing and mirroring will use iptables redirections, we need to extract this logic from the stealer.