### PR TITLE
Fixed test HTTP servers

### DIFF
--- a/changelog.d/+e2e-apps-fixed.internal.md
+++ b/changelog.d/+e2e-apps-fixed.internal.md
@@ -1,0 +1,2 @@
+Fixed 3 test HTTP servers used in E2E tests.
+ 

--- a/tests/node-e2e/app.mjs
+++ b/tests/node-e2e/app.mjs
@@ -10,12 +10,6 @@ server.on('request', (request, response) => {
     'content-type': 'text/html; charset=utf-8',
   });
   response.end(request.method);
-
-  response.on('finish', () => {
-    if (request.method == 'DELETE') {
-      server.close();
-    }
-  });
 });
 
 server.on('error', (fail) => {

--- a/tests/python-e2e/app_fastapi.py
+++ b/tests/python-e2e/app_fastapi.py
@@ -1,16 +1,6 @@
-import time
-import threading
 from fastapi import FastAPI, Response
-from os import getpid, kill
-from signal import SIGTERM
 
 app = FastAPI()
-
-def kill_later():
-    def kill_thread():
-        time.sleep(1)
-        kill(getpid(), SIGTERM)
-    threading.Thread(target=kill_thread).start()
 
 @app.get("/")
 def get():
@@ -30,5 +20,4 @@ def put():
 @app.delete("/")
 def delete():
     print("DELETE: Request completed")
-    kill_later()
     return Response(content = "DELETE", media_type="text/plain")

--- a/tests/python-e2e/app_flask.py
+++ b/tests/python-e2e/app_flask.py
@@ -1,10 +1,6 @@
-from os import getpid, kill, getenv
-from signal import SIGTERM
-import time
 from flask import Flask
 import logging
 import sys
-import threading
 
 log = logging.getLogger("werkzeug")
 log.disabled = True
@@ -16,13 +12,6 @@ cli.show_server_banner = lambda *x: print("Server listening on port 80")
 app = Flask(__name__)
 
 TEXT = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
-
-def kill_later():
-    def kill_thread():
-        time.sleep(1)
-        kill(getpid(), SIGTERM)
-    threading.Thread(target=kill_thread).start()
-
 
 @app.route("/", methods=["GET"])
 def get():
@@ -45,7 +34,6 @@ def put():
 @app.route("/", methods=["DELETE"])
 def delete():
     print("DELETE: Request completed")
-    kill_later()
     return "DELETE"
 
 

--- a/tests/src/http.rs
+++ b/tests/src/http.rs
@@ -5,7 +5,6 @@ mod http_tests {
 
     use kube::Client;
     use rstest::*;
-    use tokio::time::timeout;
 
     use crate::utils::{
         kube_client, port_forwarder::PortForwarder, send_requests, service, Application,
@@ -46,7 +45,7 @@ mod http_tests {
         )
         .await;
         let url = format!("http://{}", portforwarder.address());
-        let mut process = application
+        let process = application
             .run(
                 &service.pod_container_target(),
                 Some(&service.namespace),
@@ -64,9 +63,6 @@ mod http_tests {
         process
             .wait_for_line(Duration::from_secs(10), "DELETE")
             .await;
-        timeout(Duration::from_secs(40), process.wait())
-            .await
-            .unwrap();
 
         application.assert(&process).await;
     }

--- a/tests/src/operator/concurrent_steal.rs
+++ b/tests/src/operator/concurrent_steal.rs
@@ -28,7 +28,7 @@ pub async fn two_clients_steal_same_target(
 
     let flags = vec!["--steal", "--fs-mode=local"];
 
-    let mut client_a = application
+    let client_a = application
         .run(
             &service.pod_container_target(),
             Some(&service.namespace),
@@ -63,14 +63,6 @@ pub async fn two_clients_steal_same_target(
     let mut headers = HeaderMap::default();
     headers.insert("x-filter", "yes".parse().unwrap());
     send_request(req_builder, Some("DELETE"), headers.clone()).await;
-
-    tokio::time::timeout(Duration::from_secs(15), client_a.wait())
-        .await
-        .unwrap();
-
-    client_a
-        .assert_stdout_contains("DELETE: Request completed")
-        .await;
 }
 
 #[rstest]
@@ -88,7 +80,7 @@ pub async fn two_clients_steal_same_target_pod_deployment(
 
     let flags = vec!["--steal", "--fs-mode=local"];
 
-    let mut client_a = application
+    let client_a = application
         .run(
             &service.pod_container_target(),
             Some(&service.namespace),
@@ -125,14 +117,6 @@ pub async fn two_clients_steal_same_target_pod_deployment(
     let mut headers = HeaderMap::default();
     headers.insert("x-filter", "yes".parse().unwrap());
     send_request(req_builder, Some("DELETE"), headers.clone()).await;
-
-    tokio::time::timeout(Duration::from_secs(15), client_a.wait())
-        .await
-        .unwrap();
-
-    client_a
-        .assert_stdout_contains("DELETE: Request completed")
-        .await;
 }
 
 #[rstest]
@@ -159,7 +143,7 @@ pub async fn two_clients_steal_with_http_filter(
 
     let flags = vec!["--steal", "--fs-mode=local"];
 
-    let mut client_a = application
+    let client_a = application
         .run(
             &service.pod_container_target(),
             Some(&service.namespace),
@@ -175,7 +159,7 @@ pub async fn two_clients_steal_with_http_filter(
     let mut config_path = config_dir.to_path_buf();
     config_path.push("http_filter_header_no.json");
 
-    let mut client_b = application
+    let client_b = application
         .run(
             &service.pod_container_target(),
             Some(&service.namespace),
@@ -192,29 +176,11 @@ pub async fn two_clients_steal_with_http_filter(
     let req_builder = client.delete(&url);
     let mut headers = HeaderMap::default();
     headers.insert("x-filter", "yes".parse().unwrap());
-
     send_request(req_builder, Some("DELETE"), headers.clone()).await;
-
-    tokio::time::timeout(Duration::from_secs(10), client_a.wait())
-        .await
-        .unwrap();
-
-    client_a
-        .assert_stdout_contains("DELETE: Request completed")
-        .await;
 
     let client = reqwest::Client::new();
     let req_builder = client.delete(&url);
     let mut headers = HeaderMap::default();
     headers.insert("x-filter", "no".parse().unwrap());
-
     send_request(req_builder, Some("DELETE"), headers.clone()).await;
-
-    tokio::time::timeout(Duration::from_secs(10), client_b.wait())
-        .await
-        .unwrap();
-
-    client_b
-        .assert_stdout_contains("DELETE: Request completed")
-        .await;
 }

--- a/tests/src/traffic/steal.rs
+++ b/tests/src/traffic/steal.rs
@@ -56,7 +56,7 @@ mod steal_tests {
             flags.extend(["-e"].into_iter());
         }
 
-        let mut process = application
+        let process = application
             .run(
                 &service.pod_container_target(),
                 Some(&service.namespace),
@@ -69,9 +69,6 @@ mod steal_tests {
             .wait_for_line(Duration::from_secs(40), "daemon subscribed")
             .await;
         send_requests(&url, true, Default::default()).await;
-        tokio::time::timeout(Duration::from_secs(40), process.wait())
-            .await
-            .unwrap();
 
         application.assert(&process).await;
     }
@@ -148,7 +145,7 @@ mod steal_tests {
             flags.extend(["-e"].into_iter());
         }
 
-        let mut process = application
+        let process = application
             .run(
                 &service.pod_container_target(),
                 Some(&service.namespace),
@@ -161,9 +158,6 @@ mod steal_tests {
             .wait_for_line(Duration::from_secs(40), "daemon subscribed")
             .await;
         send_requests(&url, true, Default::default()).await;
-        tokio::time::timeout(Duration::from_secs(40), process.wait())
-            .await
-            .unwrap();
 
         application.assert(&process).await;
     }
@@ -372,7 +366,7 @@ mod steal_tests {
         let url = format!("http://{}", portforwarder.address());
         let flags = vec!["--steal"];
 
-        let mut client = application
+        let client = application
             .run(
                 &service.pod_container_target(),
                 Some(&service.namespace),
@@ -388,10 +382,6 @@ mod steal_tests {
         let mut headers = HeaderMap::default();
         headers.insert("x-filter", "yes".parse().unwrap());
         send_requests(&url, true, headers).await;
-
-        let _ = tokio::time::timeout(Duration::from_secs(40), client.child.wait())
-            .await
-            .unwrap();
 
         application.assert(&client).await;
     }
@@ -420,7 +410,7 @@ mod steal_tests {
         let mut config_path = config_dir.to_path_buf();
         config_path.push("http_filter_header.json");
 
-        let mut client = application
+        let client = application
             .run(
                 &service.pod_container_target(),
                 Some(&service.namespace),
@@ -436,10 +426,6 @@ mod steal_tests {
         let mut headers = HeaderMap::default();
         headers.insert("x-filter", "yes".parse().unwrap());
         send_requests(&url, true, headers).await;
-
-        let _ = tokio::time::timeout(Duration::from_secs(40), client.child.wait())
-            .await
-            .unwrap();
 
         application.assert(&client).await;
     }
@@ -468,7 +454,7 @@ mod steal_tests {
         let mut config_path = config_dir.to_path_buf();
         config_path.push("http_filter_path.json");
 
-        let mut client = application
+        let client = application
             .run(
                 &service.pod_container_target(),
                 Some(&service.namespace),
@@ -492,17 +478,12 @@ mod steal_tests {
         )
         .await;
 
-        // Send a DELETE that should match and cause the local app to return specific response
-        // and also make the process quit.
+        // Send a DELETE that should match and cause the local app to return specific response.
         let req_client = reqwest::Client::new();
         let mut match_url = Url::parse(&url).unwrap();
         match_url.set_path("/api/v1");
         let req_builder = req_client.delete(match_url);
         send_request(req_builder, Some("DELETE"), headers.clone()).await;
-
-        let _ = tokio::time::timeout(Duration::from_secs(40), client.child.wait())
-            .await
-            .unwrap();
 
         application.assert(&client).await;
     }
@@ -606,7 +587,7 @@ mod steal_tests {
 
         let flags = vec!["--steal"];
 
-        let mut mirrorded_process = application
+        let mirrorded_process = application
             .run(
                 &service.pod_container_target(),
                 Some(&service.namespace),
@@ -633,20 +614,12 @@ mod steal_tests {
         headers.insert("x-filter", "no".parse().unwrap()); // header does NOT match.
         send_request(req_builder, None, headers.clone()).await;
 
-        // Since the app exits on DELETE, if there's a bug and the DELETE was stolen even though it
-        // was not supposed to, the app would now exit and the next request would fail.
-
-        // Send a DELETE that should be matched and thus stolen, closing the app.
+        // Send a DELETE that should be matched and thus stolen.
         let client = reqwest::Client::new();
         let req_builder = client.delete(&url);
         let mut headers = HeaderMap::default();
         headers.insert("x-filter", "yes".parse().unwrap()); // header DOES match.
-
         send_request(req_builder, Some("DELETE"), headers.clone()).await;
-
-        tokio::time::timeout(Duration::from_secs(10), mirrorded_process.wait())
-            .await
-            .unwrap();
 
         application.assert(&mirrorded_process).await;
     }
@@ -678,7 +651,7 @@ mod steal_tests {
 
         let flags = vec!["--steal"];
 
-        let mut mirrorded_process = application
+        let mirrorded_process = application
             .run(
                 &service.pod_container_target(),
                 Some(&service.namespace),
@@ -706,16 +679,12 @@ mod steal_tests {
         let stdout_after = mirrorded_process.get_stdout().await;
         assert!(!stdout_after.contains("LOCAL APP GOT DATA"));
 
-        // Send a DELETE that should be matched and thus stolen, closing the app.
+        // Send a DELETE that should be matched and thus stolen.
         let client = reqwest::Client::new();
         let req_builder = client.delete(&url);
         let mut headers = HeaderMap::default();
         headers.insert("x-filter", "yes".parse().unwrap()); // header DOES match.
         send_request(req_builder, Some("DELETE"), headers.clone()).await;
-
-        tokio::time::timeout(Duration::from_secs(10), mirrorded_process.wait())
-            .await
-            .unwrap();
 
         application.assert(&mirrorded_process).await;
     }
@@ -753,7 +722,7 @@ mod steal_tests {
 
         let flags = vec!["--steal"];
 
-        let mut mirrorded_process = application
+        let mirrorded_process = application
             .run(
                 &service.pod_container_target(),
                 Some(&service.namespace),
@@ -799,16 +768,12 @@ mod steal_tests {
         let stdout_after = mirrorded_process.get_stdout().await;
         assert!(!stdout_after.contains("LOCAL APP GOT DATA"));
 
-        // Send a DELETE that should be matched and thus stolen, closing the app.
+        // Send a DELETE that should be matched and thus stolen.
         let client = reqwest::Client::new();
         let req_builder = client.delete(&url);
         let mut headers = HeaderMap::default();
         headers.insert("x-filter", "yes".parse().unwrap()); // header DOES match.
         send_request(req_builder, Some("DELETE"), headers.clone()).await;
-
-        tokio::time::timeout(Duration::from_secs(10), mirrorded_process.wait())
-            .await
-            .unwrap();
 
         application.assert(&mirrorded_process).await;
     }


### PR DESCRIPTION
3 test HTTP servers (node, python fastapi, python flask) were implemented to exit after receiving a `DELETE` request. This was introducing flakes - in the test code we were expecting a correct response, but reading the response body was often failing with IO errors.

I don't think there's any reason to implement graceful exit logic in these apps, since the tests do verify what they're meant to verify anyway.
