### PR TITLE
Change SQS-splitting E2E test to use a queue URL instead of queue name for one of the queues

### DIFF
--- a/changelog.d/+test-using-queue-url.internal.md
+++ b/changelog.d/+test-using-queue-url.internal.md
@@ -1,0 +1,1 @@
+Test specifying a queue by URL instead of by name in SQS splitting.

--- a/tests/src/operator/queue_splitting.rs
+++ b/tests/src/operator/queue_splitting.rs
@@ -69,7 +69,7 @@ async fn expect_messages_in_queue<const N: usize>(
     client: &aws_sdk_sqs::Client,
     echo_queue: &QueueInfo,
 ) {
-    tokio::time::timeout(Duration::from_secs(20), async {
+    tokio::time::timeout(Duration::from_secs(40), async {
         println!("Verifying correct messages in echo queue {} (verifying the deployed application got the messages it was supposed to)", echo_queue.name);
         let mut expected_messages = HashSet::from(messages);
         loop {

--- a/tests/src/operator/queue_splitting.rs
+++ b/tests/src/operator/queue_splitting.rs
@@ -73,16 +73,18 @@ async fn expect_messages_in_queue<const N: usize>(
         println!("Verifying correct messages in echo queue {} (verifying the deployed application got the messages it was supposed to)", echo_queue.name);
         let mut expected_messages = HashSet::from(messages);
         loop {
-            if let Ok(ReceiveMessageOutput {
-                          messages: Some(received_messages),
-                          ..
-                      }) = client
+            let receive_message_output = client
                 .receive_message()
                 .queue_url(&echo_queue.url)
                 .visibility_timeout(15)
                 .wait_time_seconds(20)
                 .send()
-                .await
+                .await;
+            println!("Receive message request output: {:?}", receive_message_output);
+            if let Ok(ReceiveMessageOutput {
+                          messages: Some(received_messages),
+                          ..
+                      }) = receive_message_output
             {
                 for Message {
                     receipt_handle, body, ..

--- a/tests/src/utils/sqs_resources.rs
+++ b/tests/src/utils/sqs_resources.rs
@@ -511,8 +511,8 @@ async fn wait_for_operator_patch(
     tokio::time::timeout(timeout, watcher.run()).await.unwrap();
 }
 
-/// Attempts to find the `localstack` service in the `default` namespace.
-async fn localstack_in_default_namespace(kube_client: &Client) -> Option<Service> {
+/// Attempts to find the `localstack` service in the `localstack` namespace.
+async fn get_localstack_service(kube_client: &Client) -> Option<Service> {
     let service_api = Api::<Service>::namespaced(kube_client.clone(), "localstack");
     service_api.get("localstack").await.ok()
 }
@@ -559,7 +559,7 @@ pub async fn sqs_test_resources(#[future] kube_client: Client) -> SqsTestResourc
     let kube_client = kube_client.await;
     let mut guards = Vec::new();
     let localstack_portforwarder =
-        if let Some(localstack) = localstack_in_default_namespace(&kube_client).await {
+        if let Some(localstack) = get_localstack_service(&kube_client).await {
             println!("localstack detected, using localstack for SQS");
             patch_operator_for_localstack(&kube_client, &mut guards).await;
             Some(PortForwarder::new_for_service(kube_client.clone(), &localstack, 4566).await)

--- a/tests/src/utils/sqs_resources.rs
+++ b/tests/src/utils/sqs_resources.rs
@@ -239,11 +239,6 @@ async fn sqs_consumer_service(
     echo_queue2: &QueueInfo,
 ) -> KubeService {
     let namespace = format!("e2e-tests-sqs-splitting-{}", crate::utils::random_string());
-    let queue2_url = format!(
-        "http://sqs.eu-north-1.localhost.localstack.cloud:4566/000000000000/{}",
-        queue2.name.as_str()
-    );
-    println!("queue 2 URL: {queue2_url}");
     service_with_env(
         &namespace,
         "ClusterIP",
@@ -259,7 +254,7 @@ async fn sqs_consumer_service(
             },
             {
               "name": QUEUE2_URL_ENV_VAR,
-              "value": queue2_url
+              "value": queue2.url.as_str()
             },
             {
               "name": ECHO_QUEUE_NAME_ENV_VAR1,

--- a/tests/src/utils/sqs_resources.rs
+++ b/tests/src/utils/sqs_resources.rs
@@ -58,7 +58,7 @@ const QUEUE_REGISTRY_RESOURCE_NAME: &str = "mirrord-e2e-test-queue-registry";
 /// To mark the operator deployment is currently patched to use localstack.
 const LOCALSTACK_PATCH_LABEL_NAME: &str = "sqs-e2e-tests-localstack-patch";
 
-const LOCALSTACK_ENDPOINT_URL: &str = "http://localstack.default.svc.cluster.local:4566";
+const LOCALSTACK_ENDPOINT_URL: &str = "http://localstack.localstack.svc.cluster.local:4566";
 
 pub struct QueueInfo {
     pub name: String,
@@ -116,7 +116,7 @@ async fn get_sqs_client(localstack_url: Option<String>) -> aws_sdk_sqs::Client {
         config = config
             .endpoint_url(endpoint_url)
             .credentials_provider(LocalstackTestCredentialsProvider)
-            .region(aws_types::region::Region::new("us-east-1"));
+            .region(aws_types::region::Region::new("eu-north-1"));
     }
     let config = config.load().await;
     aws_sdk_sqs::Client::new(&config)
@@ -269,7 +269,7 @@ async fn sqs_consumer_service(
             },
             {
               "name": "AWS_REGION",
-              "value": "us-east-1"
+              "value": "eu-north-1"
             },
             // All these auth variables must be set to something, but it doesn't matter to what.
             {
@@ -291,7 +291,7 @@ async fn sqs_consumer_service(
 
 const AWS_ENV: [(&str, &str); 5] = [
     ("AWS_ENDPOINT_URL", LOCALSTACK_ENDPOINT_URL),
-    ("AWS_REGION", "us-east-1"),
+    ("AWS_REGION", "eu-north-1"),
     ("AWS_SECRET_ACCESS_KEY", "test"),
     ("AWS_ACCESS_KEY_ID", "test"),
     ("AWS_SECRET_KEY", "test"),
@@ -507,7 +507,7 @@ async fn wait_for_operator_patch(
 
 /// Attempts to find the `localstack` service in the `default` namespace.
 async fn localstack_in_default_namespace(kube_client: &Client) -> Option<Service> {
-    let service_api = Api::<Service>::namespaced(kube_client.clone(), "default");
+    let service_api = Api::<Service>::namespaced(kube_client.clone(), "localstack");
     service_api.get("localstack").await.ok()
 }
 

--- a/tests/src/utils/sqs_resources.rs
+++ b/tests/src/utils/sqs_resources.rs
@@ -242,8 +242,7 @@ async fn sqs_consumer_service(
     service_with_env(
         &namespace,
         "ClusterIP",
-        // "ghcr.io/metalbear-co/mirrord-sqs-forwarder:latest",
-        "docker.io/t4lz/sqs-forwarder:2025.03.28",
+        "ghcr.io/metalbear-co/mirrord-sqs-forwarder:latest",
         "queue-forwarder",
         false,
         kube_client.clone(),


### PR DESCRIPTION
For testing https://github.com/metalbear-co/operator/issues/807

Also - change the localstack setup to match the playground's so that they can be run on the same local cluster and share the localstack service and the operator.