### PR TITLE
chore: refresh devcontainer configuration

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,9 +1,8 @@
-# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.224.2/containers/rust/.devcontainer/base.Dockerfile
+# See here for image contents: https://github.com/devcontainers/images/blob/main/src/rust/.devcontainer/Dockerfile
 
-# [Choice] Debian OS version (use bullseye on local arm64/Apple Silicon): buster, bullseye
+# [Choice] Debian OS version (use bookworm, or bullseye on local arm64/Apple Silicon): bookworm, buster, bullseye
 ARG VARIANT="buster"
-FROM mcr.microsoft.com/vscode/devcontainers/rust:0-${VARIANT}
+FROM mcr.microsoft.com/devcontainers/rust:1-${VARIANT}
 
-RUN rustup toolchain install nightly-x86_64-unknown-linux-gnu && rustup component add rustfmt --toolchain nightly-x86_64-unknown-linux-gnu && rustup component add clippy --toolchain nightly-x86_64-unknown-linux-gnu
 RUN apt-get update && apt-get install -y clang
 RUN curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.16.0/kind-linux-amd64 && chmod +x ./kind && mv ./kind /usr/local/bin/kind

--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,29 @@
+{
+  "features": {
+    "ghcr.io/devcontainers-extra/features/protoc:1": {
+      "version": "1.0.2",
+      "resolved": "ghcr.io/devcontainers-extra/features/protoc@sha256:9cf56bff763a2997130c21d3d4b9ae7a7119243067c0c8f818a9c0e98bec2a7f",
+      "integrity": "sha256:9cf56bff763a2997130c21d3d4b9ae7a7119243067c0c8f818a9c0e98bec2a7f"
+    },
+    "ghcr.io/devcontainers/features/common-utils:2": {
+      "version": "2.5.3",
+      "resolved": "ghcr.io/devcontainers/features/common-utils@sha256:3cf7ca93154faf9bdb128f3009cf1d1a91750ec97cc52082cf5d4edef5451f85",
+      "integrity": "sha256:3cf7ca93154faf9bdb128f3009cf1d1a91750ec97cc52082cf5d4edef5451f85"
+    },
+    "ghcr.io/devcontainers/features/docker-in-docker:1": {
+      "version": "1.0.9",
+      "resolved": "ghcr.io/devcontainers/features/docker-in-docker@sha256:b4c04ba88371a8ec01486356cce10eb9fe8274627d8d170aaec87ed0d333080d",
+      "integrity": "sha256:b4c04ba88371a8ec01486356cce10eb9fe8274627d8d170aaec87ed0d333080d"
+    },
+    "ghcr.io/devcontainers/features/git:1": {
+      "version": "1.3.2",
+      "resolved": "ghcr.io/devcontainers/features/git@sha256:63c96e8ac33f5630300d8883e2ec3123278de70d318589af596ea1954846014d",
+      "integrity": "sha256:63c96e8ac33f5630300d8883e2ec3123278de70d318589af596ea1954846014d"
+    },
+    "ghcr.io/devcontainers/features/rust:1": {
+      "version": "1.3.1",
+      "resolved": "ghcr.io/devcontainers/features/rust@sha256:2f9cfd1fda3ab3a8839760f1854ec5909aade2e95a7acc0bc3cb90bc8af4b810",
+      "integrity": "sha256:2f9cfd1fda3ab3a8839760f1854ec5909aade2e95a7acc0bc3cb90bc8af4b810"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,36 +8,43 @@
 		},
 		"dockerfile": "Dockerfile"
 	},
-	"runArgs": [
-		"--cap-add=SYS_PTRACE",
-		"--security-opt",
-		"seccomp=unconfined",
-		"--init",
-		"--privileged"
-	],
-
-	// Set *default* container specific settings.json values on container create.
-	"settings": {
-		"lldb.executable": "/usr/bin/lldb",
-		"files.watcherExclude": {
-			"**/target/**": true
-		},
-		"rust-analyzer.checkOnSave.command": "clippy"
+	"customizations": {
+		"vscode": {
+			// Set *default* container specific settings.json values on container create.
+			"settings": {
+				"lldb.executable": "/usr/bin/lldb",
+				"files.watcherExclude": {
+					"**/target/**": true
+				},
+				"rust-analyzer.checkOnSave.command": "clippy"
+			},
+			// Add the IDs of extensions you want installed when the container is created.
+			"extensions": [
+				"vadimcn.vscode-lldb",
+				"mutantdino.resourcemonitor",
+				"rust-lang.rust-analyzer",
+				"tamasfe.even-better-toml",
+				"fill-labs.dependi"
+			]
+		}
 	},
-
-	// Add the IDs of extensions you want installed when the container is created.
-	"extensions": [
-		"vadimcn.vscode-lldb",
-		"mutantdino.resourcemonitor",
-		"rust-lang.rust-analyzer",
-		"tamasfe.even-better-toml",
-		"serayuzgur.crates"
-	],
-
 	"features": {
-        "ghcr.io/devcontainers/features/docker-in-docker:1": {
-            "version": "latest"
-        }
+		"ghcr.io/devcontainers/features/docker-in-docker:1": {
+			"version": "latest"
+		},
+		"ghcr.io/devcontainers/features/common-utils:2": {
+			"installZsh": "true",
+			"username": "vscode",
+			"userUid": "1000",
+			"userGid": "1000",
+			"upgradePackages": "true"
+		},
+		"ghcr.io/devcontainers/features/rust:1": "latest",
+		"ghcr.io/devcontainers/features/git:1": {
+			"version": "latest",
+			"ppa": "false"
+		},
+		"ghcr.io/devcontainers-extra/features/protoc:1": "latest"
 	}
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],

--- a/changelog.d/+dev-contrainer-config.changed.md
+++ b/changelog.d/+dev-contrainer-config.changed.md
@@ -1,0 +1,1 @@
+Updated dev container base image and JSON configuration file.


### PR DESCRIPTION
### Refreshed devcontainer configuration
* Current docker base image we use was archived. Replaced it with the one maintained in [devcontainers/images](https://github.com/devcontainers/images).
* Addressed all warnings in `devcontainer.json` configuration file
  * removed discontinued vscode extension
  * add `protoc` feature
  * move vscode settings under the recommended JSON key path