### PR TITLE
Operator setup command add license server

### DIFF
--- a/changelog.d/+operator-license-server-setup.internal.md
+++ b/changelog.d/+operator-license-server-setup.internal.md
@@ -1,0 +1,1 @@
+Add `--license-server` argument to `mirrord operator setup` command.

--- a/mirrord/cli/src/config.rs
+++ b/mirrord/cli/src/config.rs
@@ -688,6 +688,7 @@ pub(super) struct OperatorSetupParams {
     #[arg(long)]
     pub(super) license_path: Option<PathBuf>,
 
+    /// License server url if a standalone instance is available. (see https://mirrord.dev/docs/managing-mirrord/license-server/)
     #[arg(long)]
     pub(super) license_server: Option<String>,
 

--- a/mirrord/cli/src/config.rs
+++ b/mirrord/cli/src/config.rs
@@ -688,6 +688,9 @@ pub(super) struct OperatorSetupParams {
     #[arg(long)]
     pub(super) license_path: Option<PathBuf>,
 
+    #[arg(long)]
+    pub(super) license_server: Option<String>,
+
     /// Output Kubernetes specs to file instead of stdout
     #[arg(short, long)]
     pub(super) file: Option<PathBuf>,

--- a/mirrord/cli/src/operator.rs
+++ b/mirrord/cli/src/operator.rs
@@ -1,7 +1,7 @@
 use std::fs::File;
 
 use futures::TryFutureExt;
-use mirrord_operator::setup::{LicenseType, Operator, OperatorSetup, SetupOptions};
+use mirrord_operator::setup::{LicenseType, Operator, SetupOptions, SetupWriter as _};
 use serde::Deserialize;
 use status::StatusCommandHandler;
 use tokio::fs;
@@ -40,6 +40,7 @@ async fn operator_setup(
         accept_tos,
         license_key,
         license_path,
+        license_server,
         file,
         namespace,
         aws_role_arn,
@@ -87,6 +88,7 @@ async fn operator_setup(
 
         let operator = Operator::new(SetupOptions {
             license,
+            license_server,
             namespace,
             image,
             aws_role_arn,

--- a/mirrord/operator/src/setup.rs
+++ b/mirrord/operator/src/setup.rs
@@ -183,77 +183,40 @@ impl SetupWriter for Operator {
         self.namespace.to_writer(&mut writer)?;
 
         if let Some(secret) = self.license_secret.as_ref() {
-            writer.write_all(b"---\n")?;
             secret.to_writer(&mut writer)?;
         }
 
-        writer.write_all(b"---\n")?;
         self.service_account.to_writer(&mut writer)?;
-
-        writer.write_all(b"---\n")?;
         self.cluster_role.to_writer(&mut writer)?;
-
-        writer.write_all(b"---\n")?;
         self.user_cluster_role.to_writer(&mut writer)?;
-
-        writer.write_all(b"---\n")?;
         self.client_ca_role.to_writer(&mut writer)?;
-
-        writer.write_all(b"---\n")?;
         self.cluster_role_binding.to_writer(&mut writer)?;
-
-        writer.write_all(b"---\n")?;
         self.client_ca_role_binding.to_writer(&mut writer)?;
-
-        writer.write_all(b"---\n")?;
         self.deployment.to_writer(&mut writer)?;
-
-        writer.write_all(b"---\n")?;
         self.service.to_writer(&mut writer)?;
-
-        writer.write_all(b"---\n")?;
         self.api_service.to_writer(&mut writer)?;
 
-        writer.write_all(b"---\n")?;
         MirrordPolicy::crd().to_writer(&mut writer)?;
-
-        writer.write_all(b"---\n")?;
         MirrordClusterPolicy::crd().to_writer(&mut writer)?;
-
-        writer.write_all(b"---\n")?;
         MirrordTlsStealConfig::crd().to_writer(&mut writer)?;
-
-        writer.write_all(b"---\n")?;
         MirrordClusterTlsStealConfig::crd().to_writer(&mut writer)?;
-
-        writer.write_all(b"---\n")?;
         MirrordProfile::crd().to_writer(&mut writer)?;
 
         if self.sqs_splitting {
-            writer.write_all(b"---\n")?;
             MirrordWorkloadQueueRegistry::crd().to_writer(&mut writer)?;
-
-            writer.write_all(b"---\n")?;
             MirrordSqsSession::crd().to_writer(&mut writer)?;
         }
 
         if self.kafka_splitting {
-            writer.write_all(b"---\n")?;
             MirrordKafkaClientConfig::crd().to_writer(&mut writer)?;
-
-            writer.write_all(b"---\n")?;
             MirrordKafkaEphemeralTopic::crd().to_writer(&mut writer)?;
-
-            writer.write_all(b"---\n")?;
             MirrordKafkaTopicsConsumer::crd().to_writer(&mut writer)?;
 
             if let Some(role) = self.role.as_ref() {
-                writer.write_all(b"---\n")?;
                 role.to_writer(&mut writer)?;
             }
 
             if let Some(role_binding) = self.role_binding.as_ref() {
-                writer.write_all(b"---\n")?;
                 role_binding.to_writer(&mut writer)?;
             }
         }

--- a/mirrord/operator/src/setup/writer.rs
+++ b/mirrord/operator/src/setup/writer.rs
@@ -1,0 +1,86 @@
+use std::io::Write;
+
+use serde::Serialize;
+use thiserror::Error;
+
+macro_rules! setup_writer {
+    ($($tt:tt)*) => {
+        $crate::setup::writer::setup_writer_parse!{ $($tt)* }
+    }
+}
+
+macro_rules! setup_writer_parse {
+    ($(#[$attr:ident($($att:tt)*)])+ $($tt:tt)*) => {
+        $crate::setup::writer::setup_writer_parse_with_args!{ [$($attr($($att)*),)+] $($tt)* }
+    };
+    ($($tt:tt)*) => {
+        $crate::setup::writer::setup_writer_parse_with_args!{ [] $($tt)* }
+    }
+}
+
+macro_rules! setup_writer_parse_with_args {
+    ([$($attr:ident($($att:tt)*),)*] $vis:vis struct $ident:ident $($tt:tt)*) => {
+        $(#[$attr($($att)*)])*
+        $vis struct $ident $($tt)*
+
+        $crate::setup::writer::setup_writer_struct_parse!($ident $($tt)*);
+    };
+}
+
+macro_rules! setup_writer_struct_parse {
+    ($ident:ident { $($vis:vis $arg:ident: $ty:ty,)* }) => {
+        $crate::setup::writer::setup_writer_struct_impl!([$($arg,)*] $ident);
+    };
+    ($ident:ident ($arg0:ty, $arg1:ty, $arg2:ty);) => {
+        $crate::setup::writer::setup_writer_struct_impl!([0, 1, 2,] $ident);
+    };
+    ($ident:ident ($arg0:ty, $arg1:ty);) => {
+        $crate::setup::writer::setup_writer_struct_impl!([0, 1,] $ident);
+    };
+    ($ident:ident ($arg0:ty);) => {
+        $crate::setup::writer::setup_writer_struct_impl!([0,] $ident);
+    };
+}
+
+macro_rules! setup_writer_struct_impl {
+    ([$($field:tt,)*] $ident:ident) => {
+        impl $crate::setup::writer::SetupWriter for $ident {
+            fn to_writer<W: std::io::Write>(&self, mut writer: W) -> Result<(), $crate::setup::writer::SetupWriteError> {
+                $(
+                    writer.write_all(b"---\n")?;
+                    $crate::setup::writer::SetupWriter::to_writer(&self.$field, &mut writer)?;
+                )*
+
+                Ok(())
+            }
+        }
+    };
+}
+
+pub(crate) use setup_writer;
+pub(crate) use setup_writer_parse;
+pub(crate) use setup_writer_parse_with_args;
+pub(crate) use setup_writer_struct_impl;
+pub(crate) use setup_writer_struct_parse;
+
+/// General Operator Error
+#[derive(Debug, Error)]
+pub enum SetupWriteError {
+    #[error(transparent)]
+    YamlSerialization(#[from] serde_yaml::Error),
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+}
+
+pub trait SetupWriter {
+    fn to_writer<W: Write>(&self, writer: W) -> Result<(), SetupWriteError>;
+}
+
+impl<T> SetupWriter for T
+where
+    T: Serialize,
+{
+    fn to_writer<W: Write>(&self, writer: W) -> Result<(), SetupWriteError> {
+        serde_yaml::to_writer(writer, &self).map_err(SetupWriteError::from)
+    }
+}

--- a/mirrord/operator/src/setup/writer.rs
+++ b/mirrord/operator/src/setup/writer.rs
@@ -47,7 +47,6 @@ macro_rules! setup_writer_struct_impl {
         impl $crate::setup::writer::SetupWriter for $ident {
             fn to_writer<W: std::io::Write>(&self, mut writer: W) -> Result<(), $crate::setup::writer::SetupWriteError> {
                 $(
-                    writer.write_all(b"---\n")?;
                     $crate::setup::writer::SetupWriter::to_writer(&self.$field, &mut writer)?;
                 )*
 
@@ -80,7 +79,9 @@ impl<T> SetupWriter for T
 where
     T: Serialize,
 {
-    fn to_writer<W: Write>(&self, writer: W) -> Result<(), SetupWriteError> {
+    fn to_writer<W: Write>(&self, mut writer: W) -> Result<(), SetupWriteError> {
+        writer.write_all(b"---\n")?;
+
         serde_yaml::to_writer(writer, &self).map_err(SetupWriteError::from)
     }
 }


### PR DESCRIPTION
Add `--license-server` argument to `mirrord operator setup` command.