### PR TITLE
Exclude DOTNET_STARTUP_HOOKS env var by default

### DIFF
--- a/changelog.d/+dotnet-env-var.changed.md
+++ b/changelog.d/+dotnet-env-var.changed.md
@@ -1,0 +1,1 @@
+By default, the `DOTNET_STARTUP_HOOKS` env var will not be fetched from the target.

--- a/mirrord/agent/src/env.rs
+++ b/mirrord/agent/src/env.rs
@@ -45,7 +45,9 @@ impl EnvFilter {
                 WildMatch::new("BUNDLE_GEM_PATH"),
                 WildMatch::new("BUNDLE_PATH"),
                 WildMatch::new("BUNDLE_WITHOUT"),
+                WildMatch::new("CATALINA_HOME"),
                 WildMatch::new("CLASSPATH"),
+                WildMatch::new("DOTNET_EnableDiagnostics"),
                 WildMatch::new("GEM_HOME"),
                 WildMatch::new("GEM_PATH"),
                 WildMatch::new("HOME"),
@@ -60,8 +62,6 @@ impl EnvFilter {
                 WildMatch::new("RUBYOPT"),
                 WildMatch::new("RUST_LOG"),
                 WildMatch::new("_JAVA_OPTIONS"),
-                WildMatch::new("DOTNET_EnableDiagnostics"),
-                WildMatch::new("CATALINA_HOME"),
             ];
 
             for selector in &filter_env_vars {

--- a/mirrord/agent/src/env.rs
+++ b/mirrord/agent/src/env.rs
@@ -48,6 +48,7 @@ impl EnvFilter {
                 WildMatch::new("CATALINA_HOME"),
                 WildMatch::new("CLASSPATH"),
                 WildMatch::new("DOTNET_EnableDiagnostics"),
+                WildMatch::new("DOTNET_STARTUP_HOOKS"),
                 WildMatch::new("GEM_HOME"),
                 WildMatch::new("GEM_PATH"),
                 WildMatch::new("HOME"),


### PR DESCRIPTION
When not excluded .NET tries to load dlls from a location that is on the target container.