### PR TITLE
Improve mirrord CLI progress message

### DIFF
--- a/changelog.d/+3167.changed.md
+++ b/changelog.d/+3167.changed.md
@@ -1,0 +1,1 @@
+Improved mirrord progress message from spawning the agent without an operator.

--- a/mirrord/kube/src/api/container/ephemeral.rs
+++ b/mirrord/kube/src/api/container/ephemeral.rs
@@ -117,7 +117,12 @@ where
         .fields(&format!("metadata.name={}", &runtime_data.pod_name))
         .timeout(60);
 
-    container_progress.success(Some("container created"));
+    container_progress.success(Some(&format!(
+        "agent container {container_name} created in {pod_namespace}/{pod_name}",
+        container_name = &params.name,
+        pod_namespace = &runtime_data.pod_namespace,
+        pod_name = &runtime_data.pod_name,
+    )));
 
     let mut container_progress = progress.subtask("waiting for container to be ready...");
 


### PR DESCRIPTION
The updated progress message looks like the following:

* when spawning a mirrord agent as an ephemeral container inside a target pod
```
⠒ mirrord exec
    ✓ running on latest (3.137.0)!
    ✓ ready to launch process
      ✓ layer extracted
      ✓ operator not found
      ✓ container created
      ✓ mirrord-agent-vujeksdvd1 container is ready in py-serv-deployment-5949cc9645-qvkcf pod and default namespace
      ✓ arm64 layer library extracted
    ✓ config summary 
```

* when spawning a mirrord agent as a pod in the cluster
```
⠐ mirrord exec
    ✓ running on latest (3.137.0)!
    ✓ ready to launch process
      ✓ layer extracted
      ✓ operator not found
      ✓ agent pod created
      ✓ mirrord-agent-p9vnpnflcs-dxh8x pod is ready in default namespace
      ✓ arm64 layer library extracted
    ✓ config summary 
```