### PR TITLE
Add config file arg for operator session commands

### DIFF
--- a/changelog.d/+3178.added.md
+++ b/changelog.d/+3178.added.md
@@ -1,0 +1,1 @@
+Added config file option for `mirrord operator session` commands.

--- a/mirrord/cli/src/config.rs
+++ b/mirrord/cli/src/config.rs
@@ -670,8 +670,14 @@ pub(super) enum OperatorCommand {
     /// Operator session management commands.
     ///
     /// Allows the user to forcefully kill living sessions.
-    #[command(subcommand)]
-    Session(SessionCommand),
+    Session {
+        #[command(subcommand)]
+        command: SessionCommand,
+        /// Load config from config file.
+        /// When using -f flag without a value, defaults to "./.mirrord/mirrord.json"
+        #[arg(short = 'f', long, value_hint = ValueHint::FilePath, default_missing_value = "./.mirrord/mirrord.json", num_args = 0..=1)]
+        config_file: Option<PathBuf>,
+    },
 }
 
 #[derive(Args, Debug)]

--- a/mirrord/cli/src/operator.rs
+++ b/mirrord/cli/src/operator.rs
@@ -119,8 +119,11 @@ pub(crate) async fn operator_command(args: OperatorArgs) -> CliResult<()> {
                 .and_then(StatusCommandHandler::handle)
                 .await
         }
-        OperatorCommand::Session(session_command) => {
-            SessionCommandHandler::new(session_command)
+        OperatorCommand::Session {
+            command,
+            config_file,
+        } => {
+            SessionCommandHandler::new(command, config_file)
                 .and_then(SessionCommandHandler::handle)
                 .await
         }


### PR DESCRIPTION
Add `-f` option for specifying mirrord config file for `mirrord operator session` sub commands.