### PR TITLE
Verify queue deletion after clients exit in SQS E2E test

### DIFF
--- a/changelog.d/+verify-queue-deletion.internal.md
+++ b/changelog.d/+verify-queue-deletion.internal.md
@@ -1,0 +1,1 @@
+Verify temp queue deletion in SQS E2E test.

--- a/tests/src/operator/queue_splitting.rs
+++ b/tests/src/operator/queue_splitting.rs
@@ -253,8 +253,19 @@ pub async fn two_users(#[future] sqs_test_resources: SqsTestResources, config_di
     .await;
     println!("Queue 2 was split correctly!");
 
+    let num_temp_queues = sqs_test_resources.count_temp_queues().await;
+
+    assert_eq!(
+        num_temp_queues, 6,
+        "For each test queue, there should be one main temporary queue that is for the deployed \
+        app, and two temporary queues for the clients. If we could not identify them all, the test \
+        is invalid, and `count_temp_queues` might need to be updated."
+    );
+
     // TODO: verify queue tags.
 
     client_a.child.kill().await.unwrap();
     client_b.child.kill().await.unwrap();
+
+    sqs_test_resources.wait_for_temp_queue_deletion(30).await;
 }

--- a/tests/src/utils/sqs_resources.rs
+++ b/tests/src/utils/sqs_resources.rs
@@ -89,6 +89,37 @@ impl SqsTestResources {
     pub fn deployment_target(&self) -> String {
         self.k8s_service.deployment_target()
     }
+
+    /// Count the temp queues created by the SQS-operator for this test instance.
+    pub async fn count_temp_queues(&self) -> usize {
+        self.sqs_client
+            .list_queues()
+            .queue_name_prefix("mirrord-")
+            .send()
+            .await
+            .unwrap()
+            .queue_urls
+            .unwrap_or_default()
+            .iter()
+            .filter(|q_url| q_url.contains(&self.queue1.name) || q_url.contains(&self.queue2.name))
+            .count()
+    }
+
+    /// Wait for all the temp queues created by the SQS operator for queues from this test instance
+    /// to be deleted.
+    /// Waiting for `secs` seconds.
+    pub async fn wait_for_temp_queue_deletion(&self, secs: u64) {
+        tokio::time::timeout(Duration::from_secs(secs), async {
+            loop {
+                if self.count_temp_queues().await == 0 {
+                    return;
+                }
+                tokio::time::sleep(Duration::from_secs(2)).await;
+            }
+        })
+        .await
+        .expect("temp SQS queues were not deleted in time after clients exited.");
+    }
 }
 
 /// A credential provider that makes the SQS SDK use localstack.
@@ -131,7 +162,7 @@ async fn random_name_sqs_queue_with_echo_queue(
     guards: &mut Vec<ResourceGuard>,
 ) -> (QueueInfo, QueueInfo) {
     let q_name = format!(
-        "MirrordE2ESplitterTests-{}{}",
+        "E2ETest-{}{}",
         crate::utils::random_string(),
         if fifo { ".fifo" } else { "" }
     );


### PR DESCRIPTION
The SQS operator creates SQS queues for SQS splitting. When the clients exit those queues should be deleted. Now this is verified in the E2E test.