### PR TITLE
Rename mirrord profile to cluster profile

### DIFF
--- a/changelog.d/mirorrdprofile.changed.md
+++ b/changelog.d/mirorrdprofile.changed.md
@@ -1,0 +1,1 @@
+Renamed `MirorrdProfile` to `MirrordClusterProfile` and support both.

--- a/mirrord/config/src/lib.rs
+++ b/mirrord/config/src/lib.rs
@@ -645,7 +645,7 @@ impl LayerConfig {
             // but the mirrord profile introduced changes that triggered the warnings.
             context.add_warning(format!(
                 "Config verification was done after applying mirrord profile `{profile}`. \
-                You can inspect the profile with `kubectl get mirrordprofile {profile} -o yaml`.",
+                You can inspect the profile with `kubectl get mirrordclusterprofile {profile} -o yaml`.",
             ));
         }
 

--- a/mirrord/operator/src/crd/profile.rs
+++ b/mirrord/operator/src/crd/profile.rs
@@ -19,6 +19,34 @@ use serde_json::Value;
     // The operator group is handled by the operator, we want profiles to be handled by k8s.
     group = "profiles.mirrord.metalbear.co",
     version = "v1alpha",
+    kind = "MirrordClusterProfile"
+)]
+#[serde(rename_all = "camelCase")]
+pub struct MirrordClusterProfileSpec {
+    /// A list of adjustments to be made in the user's feature config.
+    ///
+    /// The adjustments are applied in order.
+    pub feature_adjustments: Vec<FeatureAdjustment>,
+
+    /// For future compatibility.
+    ///
+    /// The CLI should error when the profile contains unknown fields.
+    #[schemars(skip)]
+    #[serde(flatten, skip_serializing)]
+    pub unknown_fields: HashMap<String, Value>,
+}
+
+/// This custom resource has been superseded by [`MirrordClusterProfileSpec`] and should
+/// no longer be exposed in setup. During the migration period, we support both this and
+/// the new [`MirrordClusterProfileSpec`] custom resource definition.
+///
+/// Once users have migrated, we plan to re-introduce the kind name `MirrordProfile` in
+/// future releases for namespaced mirrord profile.
+#[derive(CustomResource, Clone, Debug, Deserialize, Serialize, JsonSchema)]
+#[kube(
+    // The operator group is handled by the operator, we want profiles to be handled by k8s.
+    group = "profiles.mirrord.metalbear.co",
+    version = "v1alpha",
     kind = "MirrordProfile"
 )]
 #[serde(rename_all = "camelCase")]

--- a/mirrord/operator/src/crd/profile.rs
+++ b/mirrord/operator/src/crd/profile.rs
@@ -16,7 +16,6 @@ use serde_json::Value;
 /// This feature should not be used in order to prevent malicious actions.
 #[derive(CustomResource, Clone, Debug, Deserialize, Serialize, JsonSchema)]
 #[kube(
-    // The operator group is handled by the operator, we want profiles to be handled by k8s.
     group = "profiles.mirrord.metalbear.co",
     version = "v1alpha",
     kind = "MirrordClusterProfile"

--- a/mirrord/operator/src/setup.rs
+++ b/mirrord/operator/src/setup.rs
@@ -29,7 +29,7 @@ use thiserror::Error;
 use crate::crd::{
     kafka::{MirrordKafkaClientConfig, MirrordKafkaEphemeralTopic, MirrordKafkaTopicsConsumer},
     policy::{MirrordClusterPolicy, MirrordPolicy},
-    profile::MirrordProfile,
+    profile::MirrordClusterProfile,
     steal_tls::{MirrordClusterTlsStealConfig, MirrordTlsStealConfig},
     MirrordOperatorUser, MirrordSqsSession, MirrordWorkloadQueueRegistry, TargetCrd,
 };
@@ -243,7 +243,8 @@ impl OperatorSetup for Operator {
         MirrordClusterTlsStealConfig::crd().to_writer(&mut writer)?;
 
         writer.write_all(b"---\n")?;
-        MirrordProfile::crd().to_writer(&mut writer)?;
+        // expose only the cluster profile and not the legacy profile
+        MirrordClusterProfile::crd().to_writer(&mut writer)?;
 
         if self.sqs_splitting {
             writer.write_all(b"---\n")?;

--- a/tests/src/operator/profiles.rs
+++ b/tests/src/operator/profiles.rs
@@ -4,7 +4,7 @@ use std::time::{Duration, Instant};
 
 use kube::{api::ObjectMeta, Api};
 use mirrord_operator::crd::profile::{
-    FeatureAdjustment, FeatureChange, MirrordProfile, MirrordProfileSpec,
+    FeatureAdjustment, FeatureChange, MirrordClusterProfile, MirrordClusterProfileSpec,
 };
 use rstest::rstest;
 use tempfile::NamedTempFile;
@@ -27,13 +27,13 @@ pub async fn mirrord_profile_enforces_stealing(
     let target_path = service.pod_container_target();
 
     let (_profile_guard, profile_name) = {
-        let profile = MirrordProfile {
+        let profile = MirrordClusterProfile {
             metadata: ObjectMeta {
                 // Service name is randomized, so there should be no conflict.
                 name: Some(format!("test-profile-{}", service.name)),
                 ..Default::default()
             },
-            spec: MirrordProfileSpec {
+            spec: MirrordClusterProfileSpec {
                 feature_adjustments: vec![FeatureAdjustment {
                     change: FeatureChange::IncomingSteal,
                     unknown_fields: Default::default(),
@@ -42,7 +42,7 @@ pub async fn mirrord_profile_enforces_stealing(
             },
         };
         let (guard, profile) = ResourceGuard::create(
-            Api::<MirrordProfile>::all(kube_client.clone()),
+            Api::<MirrordClusterProfile>::all(kube_client.clone()),
             &profile,
             true,
         )


### PR DESCRIPTION
`MirrordProfile` was introduced in #3181. The linked PR
* adds the `MirrordProfile`  **cluster-wise** CRD
* writes the yaml in set up output
* fetch the resource and apply it to the configuration if profile identifier is specified in user's config

We later realized that we want to add a namespaced profile CRD as well. Thus, we will have to rename `MirrordProfile` to `MirrordClusterProfile` to follow the same kube resource naming convention.
In this PR, we add the `MirrordClusterProfile` which is identical to the existing one but has the desired name/kind. We stop exposing the old mirrord profile CRD in setup (charts need to be updated as well for this). In the operator, we will throw a warning to the user if any old profile CRD or CR is detected and ask the user to migrate. During the migration period, we must support both profile CR mirrord. Once all user's have migrated, we will re-introduce the `MirrordProfile` for namespaced profiles.

When user specify a profile in their config that matches the legacy CR, we throw a warning like shown below:
![image](https://github.com/user-attachments/assets/e42da85d-ec30-4d6d-9f25-ade28e9d6e96)
