### PR TITLE
namespaced mirrrod profile

### DIFF
--- a/changelog.d/+namespaced-profile.added.md
+++ b/changelog.d/+namespaced-profile.added.md
@@ -1,0 +1,1 @@
+Introduced namespaced mirrord profile.

--- a/mirrord/cli/src/profile.rs
+++ b/mirrord/cli/src/profile.rs
@@ -34,7 +34,7 @@ pub enum ProfileError {
     #[diagnostic(help(
         "Verify that the profile exists \
         and its name is spelled correctly in your mirrord config. \
-        For cluster-wise profile, use `kubectl get mirrordclusterprofiles <profile-name>`. \
+        For cluster-wide profile, use `kubectl get mirrordclusterprofiles <profile-name>`. \
         For namespaced profile, use `kubectl get mirrordprofiles <profile-name> -n <namespace>`."
     ))]
     ProfileNotFound,

--- a/mirrord/cli/src/profile.rs
+++ b/mirrord/cli/src/profile.rs
@@ -1,7 +1,9 @@
 //! This module contains utilities for working with [`MirrordClusterProfile`]s and
 //! [`MirrordProfile`]s.
 
-use kube::{Api, Client, Resource};
+use std::{fmt::Display, str::FromStr};
+
+use kube::{Api, Client};
 use miette::Diagnostic;
 use mirrord_config::{
     feature::{network::incoming::IncomingMode, FeatureConfig},
@@ -10,8 +12,7 @@ use mirrord_config::{
 };
 use mirrord_kube::{api::kubernetes::create_kube_config, error::KubeApiError};
 use mirrord_operator::crd::profile::{
-    FeatureAdjustment, FeatureChange, MirrordClusterProfile, MirrordClusterProfileSpec,
-    MirrordProfile, MirrordProfileSpec,
+    FeatureAdjustment, FeatureChange, MirrordClusterProfile, MirrordProfile,
 };
 use mirrord_progress::Progress;
 use thiserror::Error;
@@ -31,9 +32,10 @@ pub enum ProfileError {
 
     #[error("mirrord profile was not found in the cluster")]
     #[diagnostic(help(
-        "Use `kubectl get mirrordclusterprofiles <profile-name>` \
-        to verify that the profile exists \
-        and its name is spelled correctly in your mirrord config."
+        "Verify that the profile exists \
+        and its name is spelled correctly in your mirrord config. \
+        For cluster-wise profile, use `kubectl get mirrordclusterprofiles <profile-name>`. \
+        For namespaced profile, use `kubectl get mirrordprofiles <profile-name> -n <namespace>`."
     ))]
     ProfileNotFound,
 
@@ -42,23 +44,101 @@ pub enum ProfileError {
         "Check if you have sufficient permissions to fetch the profile from the cluster."
     ))]
     ProfileFetchError(KubeApiError),
+
+    #[error("failed to parse mirrord profile name: {0}")]
+    #[diagnostic(help(
+        "Use `<namespace>/<profile>` for namespaced profile. \
+        Or the field will be used as a single value for fetchting cluster-wise profile."
+    ))]
+    InvalidProfileName(String),
+}
+
+/// Identifier of [`MirrordClusterProfile`] and [`MirrordProfile`].
+#[derive(Debug, Eq, PartialEq)]
+enum ProfileIdentifier {
+    Namespaced { namespace: String, profile: String },
+    Cluster(String),
+}
+
+impl Display for ProfileIdentifier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ProfileIdentifier::Cluster(profile) => write!(f, "{profile}"),
+            ProfileIdentifier::Namespaced { namespace, profile } => {
+                write!(f, "{namespace}/{profile}")
+            }
+        }
+    }
+}
+
+impl FromStr for ProfileIdentifier {
+    type Err = ProfileError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let vals: Vec<_> = s.split('/').collect();
+        match vals.len() {
+            1 => Ok(Self::Cluster(
+                vals.first()
+                    .ok_or(ProfileError::InvalidProfileName(s.to_string()))?
+                    .to_string(),
+            )),
+            2 => Ok(Self::Namespaced {
+                namespace: vals
+                    .first()
+                    .ok_or(ProfileError::InvalidProfileName(s.to_string()))?
+                    .to_string(),
+                profile: vals
+                    .get(1)
+                    .ok_or(ProfileError::InvalidProfileName(s.to_string()))?
+                    .to_string(),
+            }),
+            _ => Err(ProfileError::InvalidProfileName(s.to_string())),
+        }
+    }
+}
+
+enum ProfileFetchResult {
+    Cluster(MirrordClusterProfile),
+    Namespaced(MirrordProfile),
+}
+
+/// Extension trait for [`MirrordProfile`] and [`MirrordClusterProfile`].
+trait ProfileView {
+    fn feature_adjustments(&self) -> impl Iterator<Item = &FeatureAdjustment>;
+
+    fn unknown_fields(&self) -> impl Iterator<Item = (&String, &serde_json::Value)>;
+}
+
+impl ProfileView for ProfileFetchResult {
+    fn feature_adjustments(&self) -> impl Iterator<Item = &FeatureAdjustment> {
+        match self {
+            ProfileFetchResult::Cluster(profile) => profile.spec.feature_adjustments.iter(),
+            ProfileFetchResult::Namespaced(profile) => profile.spec.feature_adjustments.iter(),
+        }
+    }
+
+    fn unknown_fields(&self) -> impl Iterator<Item = (&String, &serde_json::Value)> {
+        match self {
+            ProfileFetchResult::Cluster(profile) => profile.spec.unknown_fields.iter(),
+            ProfileFetchResult::Namespaced(profile) => profile.spec.unknown_fields.iter(),
+        }
+    }
 }
 
 /// Convenience trait for [`FeatureAdjustment`].
 trait FeatureAdjustmentExt: Sized {
     /// Tries to apply this adjustment to the given [`FeatureConfig`].
-    fn apply_to(self, config: &mut FeatureConfig) -> Result<(), ProfileError>;
+    fn apply_to(&self, config: &mut FeatureConfig) -> Result<(), ProfileError>;
 }
 
 impl FeatureAdjustmentExt for FeatureAdjustment {
-    fn apply_to(self, config: &mut FeatureConfig) -> Result<(), ProfileError> {
+    fn apply_to(&self, config: &mut FeatureConfig) -> Result<(), ProfileError> {
         let Self {
             change,
             unknown_fields,
         } = self;
 
-        if let Some(field) = unknown_fields.into_keys().next() {
-            return Err(ProfileError::UnknownField(field));
+        if let Some(field) = unknown_fields.keys().next() {
+            return Err(ProfileError::UnknownField(field.to_string()));
         }
 
         match change {
@@ -96,42 +176,16 @@ impl FeatureAdjustmentExt for FeatureAdjustment {
     }
 }
 
-/// Applies the given legacy [`MirrordProfile`] to the given [`FeatureConfig`].
-fn apply_legacy_profile(
-    config: &mut FeatureConfig,
-    profile: MirrordProfile,
-) -> Result<(), ProfileError> {
-    let MirrordProfileSpec {
-        feature_adjustments,
-        unknown_fields,
-    } = profile.spec;
-
-    if let Some(field) = unknown_fields.into_keys().next() {
-        return Err(ProfileError::UnknownField(field));
-    }
-
-    for adjustment in feature_adjustments {
-        adjustment.apply_to(config)?;
-    }
-
-    Ok(())
-}
-
 /// Applies the given [`MirrordClusterProfile`] to the given [`FeatureConfig`].
 fn apply_profile(
     config: &mut FeatureConfig,
-    profile: MirrordClusterProfile,
+    profile: impl ProfileView,
 ) -> Result<(), ProfileError> {
-    let MirrordClusterProfileSpec {
-        feature_adjustments,
-        unknown_fields,
-    } = profile.spec;
-
-    if let Some(field) = unknown_fields.into_keys().next() {
-        return Err(ProfileError::UnknownField(field));
+    if let Some((field, _)) = profile.unknown_fields().next() {
+        return Err(ProfileError::UnknownField(field.to_string()));
     }
 
-    for adjustment in feature_adjustments {
+    for adjustment in profile.feature_adjustments() {
         adjustment.apply_to(config)?;
     }
 
@@ -150,67 +204,75 @@ pub async fn apply_profile_if_configured<P: Progress>(
         return Ok(());
     };
 
-    let mut subtask = progress.subtask(&format!("fetching mirrord profile `{name}`"));
-    let profile: Result<MirrordClusterProfile, KubeApiError> = try {
-        let client: Client = create_kube_config(
-            config.accept_invalid_certificates,
-            config.kubeconfig.as_deref(),
-            config.kube_context.clone(),
-        )
-        .await?
-        .try_into()
-        .map_err(KubeApiError::from)?;
+    let profile_identifier = name.parse()?;
+    let mut subtask = progress.subtask(&format!("fetching mirrord profile `{profile_identifier}`"));
 
-        let api = Api::<MirrordClusterProfile>::all(client);
-        api.get(name).await?
-    };
-    let legacy_profile: Result<MirrordProfile, KubeApiError> = try {
-        let client: Client = create_kube_config(
-            config.accept_invalid_certificates,
-            config.kubeconfig.as_deref(),
-            config.kube_context.clone(),
-        )
-        .await?
-        .try_into()
-        .map_err(KubeApiError::from)?;
-
-        let api = Api::<MirrordProfile>::all(client);
-        api.get(name).await?
-    };
-    if legacy_profile.is_ok() {
-        subtask.warning(
-            &format!(
-                "Legacy resource kind detected, please contact your admin to migrate all resources of kind {} to {}", 
-                MirrordProfile::kind(&()),
-                MirrordClusterProfile::kind(&()),
-            )
-        );
-    }
-
-    match (profile, legacy_profile) {
-        (Ok(profile), _) => {
-            subtask.success(Some(&format!("mirrord cluster profile `{name}` fetched")));
-            let mut subtask = progress.subtask(&format!("applying mirrord profile `{name}`"));
-            apply_profile(&mut config.feature, profile)?;
-            subtask.success(Some(&format!("mirrord profile `{name}` applied")));
-            Ok(())
-        }
-        (_, Ok(legacy_profile)) => {
-            subtask.success(Some(&format!("legacy mirrord profile `{name}` fetched")));
+    match fetch_profile(config, &profile_identifier).await {
+        Ok(profile) => {
+            subtask.success(Some(&format!(
+                "mirrord cluster profile `{profile_identifier}` fetched"
+            )));
             let mut subtask =
-                progress.subtask(&format!("applying legacy mirrord profile `{name}`"));
-            apply_legacy_profile(&mut config.feature, legacy_profile)?;
-            subtask.success(Some(&format!("legacy mirrord profile `{name}` applied")));
+                progress.subtask(&format!("applying mirrord profile `{profile_identifier}`"));
+            apply_profile(&mut config.feature, profile)?;
+            subtask.success(Some(&format!(
+                "mirrord profile `{profile_identifier}` applied"
+            )));
             Ok(())
         }
-        (Err(KubeApiError::KubeError(kube::Error::Api(error))), _) if error.code == 404 => {
+        Err(KubeApiError::KubeError(kube::Error::Api(error))) if error.code == 404 => {
             Err(CliError::ProfileError(ProfileError::ProfileNotFound))
         }
-        (_, Err(KubeApiError::KubeError(kube::Error::Api(error)))) if error.code == 404 => {
-            Err(CliError::ProfileError(ProfileError::ProfileNotFound))
-        }
-        (Err(error), _) => Err(CliError::friendlier_error_or_else(error, |error| {
+        Err(error) => Err(CliError::friendlier_error_or_else(error, |error| {
             CliError::ProfileError(ProfileError::ProfileFetchError(error))
         })),
+    }
+}
+
+async fn fetch_profile(
+    config: &LayerConfig,
+    profile_identifier: &ProfileIdentifier,
+) -> Result<ProfileFetchResult, KubeApiError> {
+    let client: Client = create_kube_config(
+        config.accept_invalid_certificates,
+        config.kubeconfig.as_deref(),
+        config.kube_context.clone(),
+    )
+    .await?
+    .try_into()
+    .map_err(KubeApiError::from)?;
+
+    match profile_identifier {
+        ProfileIdentifier::Cluster(profile) => {
+            let api = Api::<MirrordClusterProfile>::all(client);
+            Ok(ProfileFetchResult::Cluster(api.get(profile).await?))
+        }
+        ProfileIdentifier::Namespaced { namespace, profile } => {
+            let api = Api::<MirrordProfile>::namespaced(client, namespace);
+            Ok(ProfileFetchResult::Namespaced(api.get(profile).await?))
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::profile::ProfileIdentifier;
+
+    #[test]
+    fn test_profile_name() {
+        assert_eq!(
+            "my-profile".parse::<ProfileIdentifier>().unwrap(),
+            ProfileIdentifier::Cluster("my-profile".to_string())
+        );
+        assert_eq!(
+            "my-namespace/my-profile"
+                .parse::<ProfileIdentifier>()
+                .unwrap(),
+            ProfileIdentifier::Namespaced {
+                namespace: "my-namespace".to_string(),
+                profile: "my-profile".to_string()
+            }
+        );
+        assert!("a/b/c".parse::<ProfileIdentifier>().is_err());
     }
 }

--- a/mirrord/operator/src/crd/profile.rs
+++ b/mirrord/operator/src/crd/profile.rs
@@ -35,18 +35,23 @@ pub struct MirrordClusterProfileSpec {
     pub unknown_fields: HashMap<String, Value>,
 }
 
-/// This custom resource has been superseded by [`MirrordClusterProfileSpec`] and should
-/// no longer be exposed in setup. During the migration period, we support both this and
-/// the new [`MirrordClusterProfileSpec`] custom resource definition.
+/// Custom namespaced resource for storing a reusable mirrord config template.
 ///
-/// Once users have migrated, we plan to re-introduce the kind name `MirrordProfile` in
-/// future releases for namespaced mirrord profile.
+/// Can be selected from the user's mirrord config.
+///
+/// Examle:
+/// ```json
+/// {
+///     "profile": "my-namespace/my-profile"
+/// }
+/// ```
 #[derive(CustomResource, Clone, Debug, Deserialize, Serialize, JsonSchema)]
 #[kube(
     // The operator group is handled by the operator, we want profiles to be handled by k8s.
     group = "profiles.mirrord.metalbear.co",
     version = "v1alpha",
-    kind = "MirrordProfile"
+    kind = "MirrordProfile",
+    namespaced
 )]
 #[serde(rename_all = "camelCase")]
 pub struct MirrordProfileSpec {

--- a/mirrord/operator/src/setup.rs
+++ b/mirrord/operator/src/setup.rs
@@ -30,7 +30,7 @@ use thiserror::Error;
 use crate::crd::{
     kafka::{MirrordKafkaClientConfig, MirrordKafkaEphemeralTopic, MirrordKafkaTopicsConsumer},
     policy::{MirrordClusterPolicy, MirrordPolicy},
-    profile::MirrordClusterProfile,
+    profile::{MirrordClusterProfile, MirrordProfile},
     steal_tls::{MirrordClusterTlsStealConfig, MirrordTlsStealConfig},
     MirrordOperatorUser, MirrordSqsSession, MirrordWorkloadQueueRegistry, TargetCrd,
 };
@@ -244,8 +244,10 @@ impl OperatorSetup for Operator {
         MirrordClusterTlsStealConfig::crd().to_writer(&mut writer)?;
 
         writer.write_all(b"---\n")?;
-        // expose only the cluster profile and not the legacy profile
         MirrordClusterProfile::crd().to_writer(&mut writer)?;
+
+        writer.write_all(b"---\n")?;
+        MirrordProfile::crd().to_writer(&mut writer)?;
 
         if self.sqs_splitting {
             writer.write_all(b"---\n")?;

--- a/tests/src/operator/profiles.rs
+++ b/tests/src/operator/profiles.rs
@@ -18,7 +18,7 @@ use crate::utils::{
 #[rstest]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[timeout(Duration::from_secs(120))]
-pub async fn mirrord_cluster_profile_enforces_stealing(
+pub async fn mirrord_profile_enforces_stealing(
     #[future] kube_client: kube::Client,
     #[future] basic_service: KubeService,
 ) {
@@ -27,7 +27,7 @@ pub async fn mirrord_cluster_profile_enforces_stealing(
     let deployed_at = Instant::now();
     let target_path = service.pod_container_target();
 
-    let (_profile_guard, profile_name) = {
+    let (_profile_guard, cluster_profile_name) = {
         let profile = MirrordClusterProfile {
             metadata: ObjectMeta {
                 // Service name is randomized, so there should be no conflict.
@@ -44,6 +44,32 @@ pub async fn mirrord_cluster_profile_enforces_stealing(
         };
         let (guard, profile) = ResourceGuard::create(
             Api::<MirrordClusterProfile>::all(kube_client.clone()),
+            &profile,
+            true,
+        )
+        .await
+        .unwrap();
+
+        (guard, profile.metadata.name.unwrap())
+    };
+
+    let (_profile_guard, namespaced_profile_name) = {
+        let profile = MirrordProfile {
+            metadata: ObjectMeta {
+                // Service name is randomized, so there should be no conflict.
+                name: Some(format!("test-profile-{}", service.name)),
+                ..Default::default()
+            },
+            spec: MirrordProfileSpec {
+                feature_adjustments: vec![FeatureAdjustment {
+                    change: FeatureChange::IncomingSteal,
+                    unknown_fields: Default::default(),
+                }],
+                unknown_fields: Default::default(),
+            },
+        };
+        let (guard, profile) = ResourceGuard::create(
+            Api::<MirrordProfile>::namespaced(kube_client.clone(), &service.namespace),
             &profile,
             true,
         )
@@ -111,7 +137,7 @@ pub async fn mirrord_cluster_profile_enforces_stealing(
     // With the cluster-wise profile, the local application should steal the traffic.
     let mut config_file = NamedTempFile::with_suffix(".json").unwrap();
     let config = serde_json::json!({
-        "profile": profile_name,
+        "profile": cluster_profile_name,
     });
     serde_json::to_writer_pretty(config_file.as_file_mut(), &config).unwrap();
     let test_process = Application::PythonFlaskHTTP
@@ -137,105 +163,12 @@ pub async fn mirrord_cluster_profile_enforces_stealing(
         "expected response from the local app, got: {}",
         String::from_utf8_lossy(response.as_ref())
     );
-}
-
-#[rstest]
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[timeout(Duration::from_secs(120))]
-pub async fn mirrord_namespaced_profile_enforces_stealing(
-    #[future] kube_client: kube::Client,
-    #[future] basic_service: KubeService,
-) {
-    let kube_client = kube_client.await;
-    let service = basic_service.await;
-    let deployed_at = Instant::now();
-    let target_path = service.pod_container_target();
-
-    let (_profile_guard, profile_name) = {
-        let profile = MirrordProfile {
-            metadata: ObjectMeta {
-                // Service name is randomized, so there should be no conflict.
-                name: Some(format!("test-profile-{}", service.name)),
-                ..Default::default()
-            },
-            spec: MirrordProfileSpec {
-                feature_adjustments: vec![FeatureAdjustment {
-                    change: FeatureChange::IncomingSteal,
-                    unknown_fields: Default::default(),
-                }],
-                unknown_fields: Default::default(),
-            },
-        };
-        let (guard, profile) = ResourceGuard::create(
-            Api::<MirrordProfile>::namespaced(kube_client.clone(), &service.namespace),
-            &profile,
-            true,
-        )
-        .await
-        .unwrap();
-
-        (guard, profile.metadata.name.unwrap())
-    };
-
-    let port_forwarder =
-        PortForwarder::new(kube_client, &service.pod_name, &service.namespace, 80).await;
-    let service_url = format!("http://{}", port_forwarder.address());
-
-    // Before we start the session, wait until the service is responsive.
-    // TODO: remove when we add readiness probes to deployed containers.
-    let response = tokio::time::timeout(Duration::from_secs(20), async {
-        loop {
-            match reqwest::get(&service_url).await {
-                Ok(response) => break response,
-                Err(error) => {
-                    println!(
-                        "Failed to reach the remote service {}s after deployment: {error}",
-                        deployed_at.elapsed().as_secs_f32()
-                    );
-                    tokio::time::sleep(Duration::from_millis(100)).await;
-                }
-            }
-        }
-    })
-    .await
-    .unwrap();
-    println!("Reached remote service, status code {}", response.status());
-    let response = response.bytes().await.unwrap();
-    assert_eq!(
-        response.as_ref(),
-        b"OK - GET: Request completed\n",
-        "expected a response from the remote app, got: {}",
-        String::from_utf8_lossy(response.as_ref())
-    );
-
-    // The local application should mirrord the traffic.
-    let test_process = Application::PythonFlaskHTTP
-        .run(&target_path, Some(&service.namespace), None, None)
-        .await;
-    test_process
-        .wait_for_line(Duration::from_secs(40), "daemon subscribed")
-        .await;
-    let response = reqwest::get(&service_url)
-        .await
-        .unwrap()
-        .bytes()
-        .await
-        .unwrap();
-    assert_eq!(
-        response.as_ref(),
-        b"OK - GET: Request completed\n",
-        "expected response from the remote app, got: {}",
-        String::from_utf8_lossy(response.as_ref())
-    );
-    test_process
-        .wait_for_line_stdout(Duration::from_secs(40), "GET: Request completed")
-        .await; // verify that the local app received the request as well
     std::mem::drop(test_process); // kill the app
 
     // With the namespaced profile, the local application should steal the traffic.
     let mut config_file = NamedTempFile::with_suffix(".json").unwrap();
     let config = serde_json::json!({
-        "profile": format!("{}/{}", &service.namespace, profile_name),
+        "profile": format!("{}/{}", &service.namespace, namespaced_profile_name),
     });
     serde_json::to_writer_pretty(config_file.as_file_mut(), &config).unwrap();
     let test_process = Application::PythonFlaskHTTP

--- a/tests/src/operator/profiles.rs
+++ b/tests/src/operator/profiles.rs
@@ -18,7 +18,7 @@ use crate::utils::{
 #[rstest]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[timeout(Duration::from_secs(120))]
-pub async fn mirrord_profile_enforces_stealing(
+pub async fn mirrord_cluster_profile_enforces_stealing(
     #[future] kube_client: kube::Client,
     #[future] basic_service: KubeService,
 ) {
@@ -27,7 +27,7 @@ pub async fn mirrord_profile_enforces_stealing(
     let deployed_at = Instant::now();
     let target_path = service.pod_container_target();
 
-    let (_profile_guard, cluster_profile_name) = {
+    let (_profile_guard, profile_name) = {
         let profile = MirrordClusterProfile {
             metadata: ObjectMeta {
                 // Service name is randomized, so there should be no conflict.
@@ -52,7 +52,106 @@ pub async fn mirrord_profile_enforces_stealing(
 
         (guard, profile.metadata.name.unwrap())
     };
-    let (_profile_guard, namespaced_profile_name) = {
+
+    let port_forwarder =
+        PortForwarder::new(kube_client, &service.pod_name, &service.namespace, 80).await;
+    let service_url = format!("http://{}", port_forwarder.address());
+
+    // Before we start the session, wait until the service is responsive.
+    // TODO: remove when we add readiness probes to deployed containers.
+    let response = tokio::time::timeout(Duration::from_secs(20), async {
+        loop {
+            match reqwest::get(&service_url).await {
+                Ok(response) => break response,
+                Err(error) => {
+                    println!(
+                        "Failed to reach the remote service {}s after deployment: {error}",
+                        deployed_at.elapsed().as_secs_f32()
+                    );
+                    tokio::time::sleep(Duration::from_millis(100)).await;
+                }
+            }
+        }
+    })
+    .await
+    .unwrap();
+    println!("Reached remote service, status code {}", response.status());
+    let response = response.bytes().await.unwrap();
+    assert_eq!(
+        response.as_ref(),
+        b"OK - GET: Request completed\n",
+        "expected a response from the remote app, got: {}",
+        String::from_utf8_lossy(response.as_ref())
+    );
+
+    // The local application should mirror the traffic.
+    let test_process = Application::PythonFlaskHTTP
+        .run(&target_path, Some(&service.namespace), None, None)
+        .await;
+    test_process
+        .wait_for_line(Duration::from_secs(40), "daemon subscribed")
+        .await;
+    let response = reqwest::get(&service_url)
+        .await
+        .unwrap()
+        .bytes()
+        .await
+        .unwrap();
+    assert_eq!(
+        response.as_ref(),
+        b"OK - GET: Request completed\n",
+        "expected response from the remote app, got: {}",
+        String::from_utf8_lossy(response.as_ref())
+    );
+    test_process
+        .wait_for_line_stdout(Duration::from_secs(40), "GET: Request completed")
+        .await; // verify that the local app received the request as well
+    std::mem::drop(test_process); // kill the app
+
+    // With the cluster-wise profile, the local application should steal the traffic.
+    let mut config_file = NamedTempFile::with_suffix(".json").unwrap();
+    let config = serde_json::json!({
+        "profile": profile_name,
+    });
+    serde_json::to_writer_pretty(config_file.as_file_mut(), &config).unwrap();
+    let test_process = Application::PythonFlaskHTTP
+        .run(
+            &target_path,
+            Some(&service.namespace),
+            Some(vec!["-f", config_file.path().to_str().unwrap()]),
+            None,
+        )
+        .await;
+    test_process
+        .wait_for_line(Duration::from_secs(40), "daemon subscribed")
+        .await;
+    let response = reqwest::get(&service_url)
+        .await
+        .unwrap()
+        .bytes()
+        .await
+        .unwrap();
+    assert_eq!(
+        response.as_ref(),
+        b"GET",
+        "expected response from the local app, got: {}",
+        String::from_utf8_lossy(response.as_ref())
+    );
+}
+
+#[rstest]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[timeout(Duration::from_secs(120))]
+pub async fn mirrord_namespaced_profile_enforces_stealing(
+    #[future] kube_client: kube::Client,
+    #[future] basic_service: KubeService,
+) {
+    let kube_client = kube_client.await;
+    let service = basic_service.await;
+    let deployed_at = Instant::now();
+    let target_path = service.pod_container_target();
+
+    let (_profile_guard, profile_name) = {
         let profile = MirrordProfile {
             metadata: ObjectMeta {
                 // Service name is randomized, so there should be no conflict.
@@ -68,7 +167,7 @@ pub async fn mirrord_profile_enforces_stealing(
             },
         };
         let (guard, profile) = ResourceGuard::create(
-            Api::<MirrordClusterProfile>::namespaced(kube_client.clone(), &service.namespace),
+            Api::<MirrordProfile>::namespaced(kube_client.clone(), &service.namespace),
             &profile,
             true,
         )
@@ -133,40 +232,10 @@ pub async fn mirrord_profile_enforces_stealing(
         .await; // verify that the local app received the request as well
     std::mem::drop(test_process); // kill the app
 
-    // With the cluster-wise profile, the local application should steal the traffic.
-    let mut config_file = NamedTempFile::with_suffix(".json").unwrap();
-    let config = serde_json::json!({
-        "profile": cluster_profile_name,
-    });
-    serde_json::to_writer_pretty(config_file.as_file_mut(), &config).unwrap();
-    let test_process = Application::PythonFlaskHTTP
-        .run(
-            &target_path,
-            Some(&service.namespace),
-            Some(vec!["-f", config_file.path().to_str().unwrap()]),
-            None,
-        )
-        .await;
-    test_process
-        .wait_for_line(Duration::from_secs(40), "daemon subscribed")
-        .await;
-    let response = reqwest::get(&service_url)
-        .await
-        .unwrap()
-        .bytes()
-        .await
-        .unwrap();
-    assert_eq!(
-        response.as_ref(),
-        b"GET",
-        "expected response from the local app, got: {}",
-        String::from_utf8_lossy(response.as_ref())
-    );
-
     // With the namespaced profile, the local application should steal the traffic.
     let mut config_file = NamedTempFile::with_suffix(".json").unwrap();
     let config = serde_json::json!({
-        "profile": format!("{}/{}", &service.namespace, namespaced_profile_name),
+        "profile": format!("{}/{}", &service.namespace, profile_name),
     });
     serde_json::to_writer_pretty(config_file.as_file_mut(), &config).unwrap();
     let test_process = Application::PythonFlaskHTTP
@@ -192,7 +261,10 @@ pub async fn mirrord_profile_enforces_stealing(
         "expected response from the local app, got: {}",
         String::from_utf8_lossy(response.as_ref())
     );
-    // when namespace is not set, we should use the profile namespace
+    std::mem::drop(test_process); // kill the app
+
+    // when target namespace is not set,
+    // we should automatically use the profile namespace
     let test_process = Application::PythonFlaskHTTP
         .run(
             &target_path,

--- a/tests/src/operator/profiles.rs
+++ b/tests/src/operator/profiles.rs
@@ -5,6 +5,7 @@ use std::time::{Duration, Instant};
 use kube::{api::ObjectMeta, Api};
 use mirrord_operator::crd::profile::{
     FeatureAdjustment, FeatureChange, MirrordClusterProfile, MirrordClusterProfileSpec,
+    MirrordProfile, MirrordProfileSpec,
 };
 use rstest::rstest;
 use tempfile::NamedTempFile;
@@ -26,7 +27,7 @@ pub async fn mirrord_profile_enforces_stealing(
     let deployed_at = Instant::now();
     let target_path = service.pod_container_target();
 
-    let (_profile_guard, profile_name) = {
+    let (_profile_guard, cluster_profile_name) = {
         let profile = MirrordClusterProfile {
             metadata: ObjectMeta {
                 // Service name is randomized, so there should be no conflict.
@@ -43,6 +44,31 @@ pub async fn mirrord_profile_enforces_stealing(
         };
         let (guard, profile) = ResourceGuard::create(
             Api::<MirrordClusterProfile>::all(kube_client.clone()),
+            &profile,
+            true,
+        )
+        .await
+        .unwrap();
+
+        (guard, profile.metadata.name.unwrap())
+    };
+    let (_profile_guard, namespaced_profile_name) = {
+        let profile = MirrordProfile {
+            metadata: ObjectMeta {
+                // Service name is randomized, so there should be no conflict.
+                name: Some(format!("test-profile-{}", service.name)),
+                ..Default::default()
+            },
+            spec: MirrordProfileSpec {
+                feature_adjustments: vec![FeatureAdjustment {
+                    change: FeatureChange::IncomingSteal,
+                    unknown_fields: Default::default(),
+                }],
+                unknown_fields: Default::default(),
+            },
+        };
+        let (guard, profile) = ResourceGuard::create(
+            Api::<MirrordClusterProfile>::namespaced(kube_client.clone(), &service.namespace),
             &profile,
             true,
         )
@@ -107,16 +133,70 @@ pub async fn mirrord_profile_enforces_stealing(
         .await; // verify that the local app received the request as well
     std::mem::drop(test_process); // kill the app
 
-    // With the profile, the local application should steal the traffic.
+    // With the cluster-wise profile, the local application should steal the traffic.
     let mut config_file = NamedTempFile::with_suffix(".json").unwrap();
     let config = serde_json::json!({
-        "profile": profile_name,
+        "profile": cluster_profile_name,
     });
     serde_json::to_writer_pretty(config_file.as_file_mut(), &config).unwrap();
     let test_process = Application::PythonFlaskHTTP
         .run(
             &target_path,
             Some(&service.namespace),
+            Some(vec!["-f", config_file.path().to_str().unwrap()]),
+            None,
+        )
+        .await;
+    test_process
+        .wait_for_line(Duration::from_secs(40), "daemon subscribed")
+        .await;
+    let response = reqwest::get(&service_url)
+        .await
+        .unwrap()
+        .bytes()
+        .await
+        .unwrap();
+    assert_eq!(
+        response.as_ref(),
+        b"GET",
+        "expected response from the local app, got: {}",
+        String::from_utf8_lossy(response.as_ref())
+    );
+
+    // With the namespaced profile, the local application should steal the traffic.
+    let mut config_file = NamedTempFile::with_suffix(".json").unwrap();
+    let config = serde_json::json!({
+        "profile": format!("{}/{}", &service.namespace, namespaced_profile_name),
+    });
+    serde_json::to_writer_pretty(config_file.as_file_mut(), &config).unwrap();
+    let test_process = Application::PythonFlaskHTTP
+        .run(
+            &target_path,
+            Some(&service.namespace),
+            Some(vec!["-f", config_file.path().to_str().unwrap()]),
+            None,
+        )
+        .await;
+    test_process
+        .wait_for_line(Duration::from_secs(40), "daemon subscribed")
+        .await;
+    let response = reqwest::get(&service_url)
+        .await
+        .unwrap()
+        .bytes()
+        .await
+        .unwrap();
+    assert_eq!(
+        response.as_ref(),
+        b"GET",
+        "expected response from the local app, got: {}",
+        String::from_utf8_lossy(response.as_ref())
+    );
+    // when namespace is not set, we should use the profile namespace
+    let test_process = Application::PythonFlaskHTTP
+        .run(
+            &target_path,
+            None,
             Some(vec!["-f", config_file.path().to_str().unwrap()]),
             None,
         )


### PR DESCRIPTION
Before merging, confirm that all users' `MirrordProfile` CRs are migrated to `MirrordClusterProfile` and the old `MirrordProfile` CRD is removed.
Depend on https://github.com/metalbear-co/charts/pull/196 being released and applied by users first.