### PR TITLE
Issue #3161 - IntProxy broken state introduction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ This project uses [*towncrier*](https://towncrier.readthedocs.io/) and the chang
 
 ### Added
 
+- Introduced new error handling for critical internal proxy failures, 
+  ensuring the state is marked as broken and propagated to layers. 
+  Added related mechanisms to send meaningful failure messages to layers 
+  whenever the proxy's internal state is compromised. Includes a test 
+  validating this behavior.
+  [#3161](https://github.com/metalbear-co/mirrord/issues/3161)
+
+
+### Added
+
 - Added a link to Slack to error messages and documentation.
 
 

--- a/mirrord/intproxy/protocol/src/lib.rs
+++ b/mirrord/intproxy/protocol/src/lib.rs
@@ -218,6 +218,8 @@ pub enum ProxyToLayerMessage {
     Incoming(IncomingResponse),
     /// A response to layer's [`LayerToProxyMessage::GetEnv`].
     GetEnv(RemoteResult<HashMap<String, String>>),
+    /// Internal proxy encountered a fatal error.
+    ProxyFailed(String),
 }
 
 /// A response to layer's [`IncomingRequest`].

--- a/mirrord/layer/src/proxy_connection.rs
+++ b/mirrord/layer/src/proxy_connection.rs
@@ -24,7 +24,9 @@ pub enum ProxyError {
     #[error("connection closed")]
     ConnectionClosed,
     #[error("unexpected response: {0:?}")]
-    UnexpectedResponse(ProxyToLayerMessage),
+    UnexpectedResponse(ProxyToLayerMessage),    
+    #[error("critical error: {0}")]
+    ProxyFailure(String),
     #[error("connection lock poisoned")]
     LockPoisoned,
     #[error("{0}")]
@@ -102,7 +104,12 @@ impl ProxyConnection {
     }
 
     pub fn receive(&self, response_id: u64) -> Result<ProxyToLayerMessage> {
-        self.responses.lock()?.receive(response_id)
+        let response = self.responses.lock()?.receive(response_id)?;
+        if let ProxyToLayerMessage::ProxyFailed(error_msg) = response {
+            Err(ProxyError::ProxyFailure(error_msg))
+        }else {
+            Ok(response)   
+        }
     }
 
     #[mirrord_layer_macro::instrument(level = "trace", skip(self), ret)]


### PR DESCRIPTION
Introduced new error handling for critical internal proxy failures, ensuring the state is marked as broken and propagated to layers. Added related mechanisms to send meaningful failure messages to layers whenever the proxy's internal state is compromised. Includes a test validating this behavior.