### PR TITLE
feat: Implement chdir hook for file operations 

### DIFF
--- a/mirrord/agent/src/file.rs
+++ b/mirrord/agent/src/file.rs
@@ -223,7 +223,21 @@ impl FileManager {
                 pathname,
                 flags,
             }) => Some(FileResponse::Unlink(self.unlinkat(dirfd, &pathname, flags))),
+            FileRequest::Chdir(ChdirRequest { path }) => {
+                Some(FileResponse::Chdir(self.handle_chdir_request(path)))
+            }
         })
+    }
+
+    #[tracing::instrument(level = Level::TRACE, skip(self), ret, err(level = Level::DEBUG))]
+    fn handle_chdir_request(&mut self, path: PathBuf) -> RemoteResult<ChdirResponse> {
+        // Path resolution should be handled here if necessary, similar to `open` or `access`.
+        // For now, directly using the provided path.
+        // Consider if `self.resolve_path` is needed.
+        // let resolved_path = self.resolve_path(&path)?;
+        std::env::set_current_dir(&path)
+            .map(|()| ChdirResponse {})
+            .map_err(ResponseError::from)
     }
 
     #[tracing::instrument(level = Level::TRACE, ret)]

--- a/mirrord/protocol/src/codec.rs
+++ b/mirrord/protocol/src/codec.rs
@@ -100,6 +100,7 @@ pub enum FileRequest {
 
     /// Same as StatFs, but results in the V2 response.
     StatFsV2(StatFsRequestV2),
+    Chdir(ChdirRequest),
 }
 
 /// Minimal mirrord-protocol version that allows `ClientMessage::ReadyForLogs` message.
@@ -167,6 +168,7 @@ pub enum FileResponse {
     RemoveDir(RemoteResult<()>),
     Unlink(RemoteResult<()>),
     XstatFsV2(RemoteResult<XstatFsResponseV2>),
+    Chdir(RemoteResult<ChdirResponse>),
 }
 
 /// `-agent` --> `-layer` messages.

--- a/mirrord/protocol/src/file.rs
+++ b/mirrord/protocol/src/file.rs
@@ -12,6 +12,7 @@ use std::{
 use bincode::{Decode, Encode};
 #[cfg(target_os = "linux")]
 use nix::sys::statfs::Statfs;
+use serde::{Deserialize, Serialize};
 use semver::VersionReq;
 
 /// Minimal mirrord-protocol version that allows [`ReadLinkFileRequest`].
@@ -641,3 +642,11 @@ pub struct GetDEnts64Response {
     pub entries: Vec<DirEntryInternal>,
     pub result_size: u64,
 }
+
+#[derive(Encode, Decode, Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
+pub struct ChdirRequest {
+    pub path: PathBuf,
+}
+
+#[derive(Encode, Decode, Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
+pub struct ChdirResponse;


### PR DESCRIPTION
This change was done by [Jules](https://jules.google.com/)

This change introduces hooking for the `chdir` (change directory) syscall to ensure that my file operations correctly reflect your application's current working directory.

Key changes:

1.  **Layer Hooks (`mirrord/layer/src/file/hooks.rs`):**
    *   Added `chdir_detour` to intercept `chdir` calls.
    *   Registered `chdir` in `enable_file_hooks` using the `replace!` macro.

2.  **Layer Operations (`mirrord/layer/src/file/ops.rs`):**
    *   Implemented `ops::chdir` to handle the logic for changing directories.
    *   This function sends a `ChdirRequest` to me.
    *   I maintain a global static variable `CURRENT_DIR` (a `LazyLock<Mutex<PathBuf>>`) in the layer, which is updated upon successful `chdir` operations. This variable stores my understanding of your application's current working directory.
    *   Added `ops::get_current_dir()` to allow other file operations to access my current working directory, which is necessary for resolving relative paths.

3.  **Protocol (`mirrord/protocol/src/file.rs`, `mirrord/protocol/src/codec.rs`):**
    *   Defined `ChdirRequest` (containing the target path) and `ChdirResponse` (empty, signifying success) structs.
    *   Added these to the `FileRequest` and `FileResponse` enums.

4.  **Agent (`mirrord/agent/src/file.rs`):**
    *   I implemented `handle_chdir_request` to process `ChdirRequest`.
    *   This handler calls `std::env::set_current_dir` on my side to change my own working directory.
    *   The `FileManager::handle_message` was updated to route `ChdirRequest` to this new handler.

5.  **Testing (`mirrord/layer/tests/fileops.rs`):**
    *   Added a new integration test `test_chdir_and_relative_file_creation`.
    *   This test verifies that after `chdir` is called, subsequent file operations using relative paths are correctly resolved based on the new current working directory on the remote target. It uses the `RustFileOps` test application and mocks my responses to ensure correct layer behavior.

This implementation addresses the issue where applications changing their working directory would not have those changes reflected in my remote file operations, leading to files being created or accessed in incorrect locations.

Thank you for contributing to mirrord!

Please make sure you added a CHANGELOG file in `changelog.d/` named `issue_number.category.md`.
For example, `1054.changed.md` or `+towncrier.added.md` (if no issue).