### PR TITLE
Improve copy target reuse

### DIFF
--- a/changelog.d/+copy-target-reuse.fixed.md
+++ b/changelog.d/+copy-target-reuse.fixed.md
@@ -1,0 +1,1 @@
+Fixed an issue where copy target sessions could fail to reuse an existing copy.

--- a/mirrord/operator/src/client.rs
+++ b/mirrord/operator/src/client.rs
@@ -692,6 +692,7 @@ impl OperatorApi<PreparedClientCert> {
     /// Creates a new [`OperatorSession`] with the given `id` and `connect_url`.
     ///
     /// If `id` is not passed, a random one is generated.
+    #[tracing::instrument(level = Level::DEBUG, err, ret)]
     fn make_operator_session(
         &self,
         id: Option<&str>,


### PR DESCRIPTION
This fix requires that the operator returns 404 when copied target is not found. Right now it returns a generic 400, but PR for this is open