### PR TITLE
3.144.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,33 @@ This project uses [*towncrier*](https://towncrier.readthedocs.io/) and the chang
 
 <!-- towncrier release notes start -->
 
+## [3.144.0](https://github.com/metalbear-co/mirrord/tree/3.144.0) - 2025-06-10
+
+
+### Added
+
+- Add user-agent to version check
+- Added an option to exclude agent's communication port from sidecar proxy if
+  the target is in a service mesh.
+
+
+### Changed
+
+- Automatically add health probe ports to http_filter ports (if a filter is
+  set). [#3244](https://github.com/metalbear-co/mirrord/issues/3244)
+
+
+### Fixed
+
+- Fixed big packets crashing mirrord agent - skip and warn, allow user to
+  override max packet size
+
+
+### Internal
+
+- Add a badge for the community Slack to README
+- Added an E2E test for splitting SQS queues based on env var regex.
+
 ## [3.143.0](https://github.com/metalbear-co/mirrord/tree/3.143.0) - 2025-05-29
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2533,7 +2533,7 @@ dependencies = [
 
 [[package]]
 name = "fileops"
-version = "3.143.0"
+version = "3.144.0"
 dependencies = [
  "libc",
 ]
@@ -3639,7 +3639,7 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "issue1317"
-version = "3.143.0"
+version = "3.144.0"
 dependencies = [
  "actix-web",
  "env_logger",
@@ -3649,7 +3649,7 @@ dependencies = [
 
 [[package]]
 name = "issue1776"
-version = "3.143.0"
+version = "3.144.0"
 dependencies = [
  "errno 0.3.12",
  "libc",
@@ -3658,7 +3658,7 @@ dependencies = [
 
 [[package]]
 name = "issue1776portnot53"
-version = "3.143.0"
+version = "3.144.0"
 dependencies = [
  "libc",
  "socket2",
@@ -3666,14 +3666,14 @@ dependencies = [
 
 [[package]]
 name = "issue1899"
-version = "3.143.0"
+version = "3.144.0"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "issue2001"
-version = "3.143.0"
+version = "3.144.0"
 dependencies = [
  "libc",
 ]
@@ -4034,7 +4034,7 @@ checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "listen_ports"
-version = "3.143.0"
+version = "3.144.0"
 
 [[package]]
 name = "litemap"
@@ -4270,7 +4270,7 @@ dependencies = [
 
 [[package]]
 name = "mirrord"
-version = "3.143.0"
+version = "3.144.0"
 dependencies = [
  "actix-codec",
  "clap",
@@ -4324,7 +4324,7 @@ dependencies = [
 
 [[package]]
 name = "mirrord-agent"
-version = "3.143.0"
+version = "3.144.0"
 dependencies = [
  "actix-codec",
  "axum",
@@ -4381,7 +4381,7 @@ dependencies = [
 
 [[package]]
 name = "mirrord-agent-env"
-version = "3.143.0"
+version = "3.144.0"
 dependencies = [
  "base64 0.22.1",
  "k8s-openapi",
@@ -4394,7 +4394,7 @@ dependencies = [
 
 [[package]]
 name = "mirrord-agent-iptables"
-version = "3.143.0"
+version = "3.144.0"
 dependencies = [
  "async-trait",
  "enum_dispatch",
@@ -4410,7 +4410,7 @@ dependencies = [
 
 [[package]]
 name = "mirrord-analytics"
-version = "3.143.0"
+version = "3.144.0"
 dependencies = [
  "assert-json-diff",
  "base64 0.22.1",
@@ -4424,7 +4424,7 @@ dependencies = [
 
 [[package]]
 name = "mirrord-auth"
-version = "3.143.0"
+version = "3.144.0"
 dependencies = [
  "bcder",
  "chrono",
@@ -4445,7 +4445,7 @@ dependencies = [
 
 [[package]]
 name = "mirrord-config"
-version = "3.143.0"
+version = "3.144.0"
 dependencies = [
  "base64 0.22.1",
  "bimap",
@@ -4473,7 +4473,7 @@ dependencies = [
 
 [[package]]
 name = "mirrord-config-derive"
-version = "3.143.0"
+version = "3.144.0"
 dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
@@ -4483,7 +4483,7 @@ dependencies = [
 
 [[package]]
 name = "mirrord-console"
-version = "3.143.0"
+version = "3.144.0"
 dependencies = [
  "bincode",
  "drain",
@@ -4499,7 +4499,7 @@ dependencies = [
 
 [[package]]
 name = "mirrord-intproxy"
-version = "3.143.0"
+version = "3.144.0"
 dependencies = [
  "bytes",
  "futures",
@@ -4529,7 +4529,7 @@ dependencies = [
 
 [[package]]
 name = "mirrord-intproxy-protocol"
-version = "3.143.0"
+version = "3.144.0"
 dependencies = [
  "bincode",
  "mirrord-protocol",
@@ -4539,7 +4539,7 @@ dependencies = [
 
 [[package]]
 name = "mirrord-kube"
-version = "3.143.0"
+version = "3.144.0"
 dependencies = [
  "actix-codec",
  "async-stream",
@@ -4564,7 +4564,7 @@ dependencies = [
 
 [[package]]
 name = "mirrord-layer"
-version = "3.143.0"
+version = "3.144.0"
 dependencies = [
  "actix-codec",
  "apple-codesign",
@@ -4606,7 +4606,7 @@ dependencies = [
 
 [[package]]
 name = "mirrord-layer-macro"
-version = "3.143.0"
+version = "3.144.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4615,7 +4615,7 @@ dependencies = [
 
 [[package]]
 name = "mirrord-macros"
-version = "3.143.0"
+version = "3.144.0"
 dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
@@ -4625,7 +4625,7 @@ dependencies = [
 
 [[package]]
 name = "mirrord-operator"
-version = "3.143.0"
+version = "3.144.0"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -4660,7 +4660,7 @@ dependencies = [
 
 [[package]]
 name = "mirrord-progress"
-version = "3.143.0"
+version = "3.144.0"
 dependencies = [
  "enum_dispatch",
  "indicatif",
@@ -4692,7 +4692,7 @@ dependencies = [
 
 [[package]]
 name = "mirrord-sip"
-version = "3.143.0"
+version = "3.144.0"
 dependencies = [
  "apple-codesign",
  "hex",
@@ -4707,7 +4707,7 @@ dependencies = [
 
 [[package]]
 name = "mirrord-tls-util"
-version = "3.143.0"
+version = "3.144.0"
 dependencies = [
  "http 1.3.1",
  "pem",
@@ -4724,7 +4724,7 @@ dependencies = [
 
 [[package]]
 name = "mirrord-vpn"
-version = "3.143.0"
+version = "3.144.0"
 dependencies = [
  "futures",
  "ipnet",
@@ -5093,7 +5093,7 @@ dependencies = [
 
 [[package]]
 name = "outgoing"
-version = "3.143.0"
+version = "3.144.0"
 
 [[package]]
 name = "outref"
@@ -6225,14 +6225,14 @@ dependencies = [
 
 [[package]]
 name = "rust-bypassed-unix-socket"
-version = "3.143.0"
+version = "3.144.0"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "rust-e2e-fileops"
-version = "3.143.0"
+version = "3.144.0"
 dependencies = [
  "libc",
 ]
@@ -6248,7 +6248,7 @@ dependencies = [
 
 [[package]]
 name = "rust-unix-socket-client"
-version = "3.143.0"
+version = "3.144.0"
 dependencies = [
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ resolver = "2"
 
 # latest commits on rustls suppress certificate verification
 [workspace.package]
-version = "3.143.0"
+version = "3.144.0"
 edition = "2021"
 license = "MIT"
 readme = "README.md"

--- a/changelog.d/+add-slack-to-readme.internal.md
+++ b/changelog.d/+add-slack-to-readme.internal.md
@@ -1,1 +1,0 @@
-Add a badge for the community Slack to README

--- a/changelog.d/+add-user-agent-to-version-check.added.md
+++ b/changelog.d/+add-user-agent-to-version-check.added.md
@@ -1,1 +1,0 @@
-Add user-agent to version check

--- a/changelog.d/+agent-mesh-exclusion.added.md
+++ b/changelog.d/+agent-mesh-exclusion.added.md
@@ -1,1 +1,0 @@
-Added an option to exclude agent's communication port from sidecar proxy if the target is in a service mesh.

--- a/changelog.d/+big-mirror-packets-crash.fixed.md
+++ b/changelog.d/+big-mirror-packets-crash.fixed.md
@@ -1,1 +1,0 @@
-Fixed big packets crashing mirrord agent - skip and warn, allow user to override max packet size

--- a/changelog.d/+sqs-regex-test.internal.md
+++ b/changelog.d/+sqs-regex-test.internal.md
@@ -1,1 +1,0 @@
-Added an E2E test for splitting SQS queues based on env var regex.

--- a/changelog.d/3244.changed.md
+++ b/changelog.d/3244.changed.md
@@ -1,1 +1,0 @@
-Automatically add health probe ports to http_filter ports (if a filter is set).


### PR DESCRIPTION
## [3.144.0](https://github.com/metalbear-co/mirrord/tree/3.144.0) - 2025-06-10


### Added

- Add user-agent to version check
- Added an option to exclude agent's communication port from sidecar proxy if
  the target is in a service mesh.


### Changed

- Automatically add health probe ports to http_filter ports (if a filter is
  set). [#3244](https://github.com/metalbear-co/mirrord/issues/3244)


### Fixed

- Fixed big packets crashing mirrord agent - skip and warn, allow user to
  override max packet size


### Internal

- Add a badge for the community Slack to README
- Added an E2E test for splitting SQS queues based on env var regex.