### PR TITLE
Automatically add config for user when we detect it's `mirrord container docker` in wsl.

### DIFF
--- a/mirrord/cli/src/container.rs
+++ b/mirrord/cli/src/container.rs
@@ -23,6 +23,7 @@ use crate::{
     execution::{MirrordExecution, LINUX_INJECTION_ENV_VAR},
     logging::pipe_intproxy_sidecar_logs,
     util::MIRRORD_CONSOLE_ADDR_ENV,
+    wsl::container_config_for_wsl,
 };
 
 mod command_builder;
@@ -181,6 +182,8 @@ pub async fn container_command(
     let (mut config, mut analytics) =
         create_config_and_analytics(&mut progress, cfg_context, watch).await?;
 
+    container_config_for_wsl(&mut config);
+
     let (runtime_command, _execution_info, _tls_setup) =
         prepare_proxies(&mut analytics, &progress, &mut config, runtime_args.runtime).await?;
 
@@ -235,6 +238,8 @@ pub async fn container_ext_command(
         .override_env_opt("MIRRORD_IMPERSONATED_TARGET", target);
     let (mut config, mut analytics) =
         create_config_and_analytics(&mut progress, cfg_context, watch).await?;
+
+    container_config_for_wsl(&mut config);
 
     let container_runtime = std::env::var("MIRRORD_CONTAINER_USE_RUNTIME")
         .ok()

--- a/mirrord/cli/src/container.rs
+++ b/mirrord/cli/src/container.rs
@@ -182,7 +182,7 @@ pub async fn container_command(
     let (mut config, mut analytics) =
         create_config_and_analytics(&mut progress, cfg_context, watch).await?;
 
-    container_config_for_wsl(&mut config);
+    container_config_for_wsl(runtime_args.runtime, &mut config);
 
     let (runtime_command, _execution_info, _tls_setup) =
         prepare_proxies(&mut analytics, &progress, &mut config, runtime_args.runtime).await?;
@@ -239,12 +239,12 @@ pub async fn container_ext_command(
     let (mut config, mut analytics) =
         create_config_and_analytics(&mut progress, cfg_context, watch).await?;
 
-    container_config_for_wsl(&mut config);
-
     let container_runtime = std::env::var("MIRRORD_CONTAINER_USE_RUNTIME")
         .ok()
         .and_then(|value| ContainerRuntime::from_str(&value, true).ok())
         .unwrap_or(ContainerRuntime::Docker);
+
+    container_config_for_wsl(container_runtime, &mut config);
 
     let (runtime_command, execution_info, _tls_setup) =
         prepare_proxies(&mut analytics, &progress, &mut config, container_runtime).await?;

--- a/mirrord/cli/src/error.rs
+++ b/mirrord/cli/src/error.rs
@@ -77,7 +77,11 @@ pub(crate) enum ExternalProxyError {
     Intproxy(#[from] IntProxyError),
 
     #[error("Failed to set up TCP listener for accepting intproxy connections: {0}")]
-    #[diagnostic(help("{GENERAL_BUG}"))]
+    #[diagnostic(help(
+        "If you're trying to run `mirrord container` in WSL, try setting the\
+        `container.override_host_ip` to the internal container runtime address.\
+        {GENERAL_BUG}"
+    ))]
     ListenerSetup(std::io::Error),
 
     #[error("Failed to open log file at `{0}`: {1}")]

--- a/mirrord/cli/src/main.rs
+++ b/mirrord/cli/src/main.rs
@@ -296,6 +296,7 @@ mod teams;
 mod util;
 mod verify_config;
 mod vpn;
+mod wsl;
 
 pub(crate) use error::{CliError, CliResult};
 use verify_config::verify_config;

--- a/mirrord/cli/src/wsl.rs
+++ b/mirrord/cli/src/wsl.rs
@@ -1,0 +1,37 @@
+use core::net::{IpAddr, Ipv4Addr};
+use std::{env, fs};
+
+use mirrord_config::LayerConfig;
+
+pub(super) fn container_config_for_wsl(config: &mut LayerConfig) {
+    if is_wsl()
+        && config.external_proxy.host_ip.is_none()
+        && config.container.override_host_ip.is_none()
+    {
+        config.external_proxy.host_ip = Some(IpAddr::V4(Ipv4Addr::UNSPECIFIED));
+        config.container.override_host_ip =
+            Some("192.168.65.254".parse().expect("Valid hardcoded IP"));
+    }
+}
+
+/// Detect if we're running inside Windows Subsystem for Linux (WSL).
+///
+/// This function checks several indicators to determine if the current environment
+/// is running under WSL:
+///
+/// 1. Checks for WSL-specific environment variables
+/// 2. Reads `/proc/version` for Microsoft signature
+/// 3. Checks for WSL interop socket
+///
+/// - returns: `true` if WSL is detected, `false` otherwise.
+fn is_wsl() -> bool {
+    // Check for WSL environment variables
+    env::var("WSL_DISTRO_NAME").is_ok()
+        || env::var("WSLENV").is_ok()
+        || env::var("WSL_INTEROP").is_ok()
+        // Check /proc/version for Microsoft signature
+        || fs::read_to_string("/proc/version")
+            .is_ok_and(|version_info| version_info.to_lowercase().contains("microsoft"))
+        // Check for WSL interop socket (WSL2)
+        || fs::metadata("/run/WSL").is_ok()
+}

--- a/mirrord/cli/src/wsl.rs
+++ b/mirrord/cli/src/wsl.rs
@@ -5,6 +5,11 @@ use mirrord_config::LayerConfig;
 
 use crate::ContainerRuntime;
 
+/// Modifies the [`LayerConfig`] for WSL environments when running the `mirrord container`.
+///
+/// - Only when the runtime is Docker, and the user has not specified neither the
+///   `external_proxy.host_ip` nor the `container.override_host_ip`, so we use the default docker
+///   values.
 pub(super) fn container_config_for_wsl(runtime: ContainerRuntime, config: &mut LayerConfig) {
     if is_wsl()
         && config.external_proxy.host_ip.is_none()

--- a/mirrord/cli/src/wsl.rs
+++ b/mirrord/cli/src/wsl.rs
@@ -3,10 +3,13 @@ use std::{env, fs};
 
 use mirrord_config::LayerConfig;
 
-pub(super) fn container_config_for_wsl(config: &mut LayerConfig) {
+use crate::ContainerRuntime;
+
+pub(super) fn container_config_for_wsl(runtime: ContainerRuntime, config: &mut LayerConfig) {
     if is_wsl()
         && config.external_proxy.host_ip.is_none()
         && config.container.override_host_ip.is_none()
+        && matches!(runtime, ContainerRuntime::Docker)
     {
         config.external_proxy.host_ip = Some(IpAddr::V4(Ipv4Addr::UNSPECIFIED));
         config.container.override_host_ip =

--- a/mirrord/config/src/container.rs
+++ b/mirrord/config/src/container.rs
@@ -69,5 +69,10 @@ pub struct ContainerConfig {
     ///
     /// This should be useful if your host machine is exposed with a different IP address than the
     /// one bound as host.
+    ///
+    /// - If you're running inside WSL, and encountering problems, try setting
+    ///   `external_proxy.host_ip` T `0.0.0.0`, and this to the internal container runtime address
+    ///   (for docker, this  would be what `host.docker.internal` resolved to, which by default is
+    ///   `192.168.65.254`).
     pub override_host_ip: Option<IpAddr>,
 }

--- a/mirrord/config/src/container.rs
+++ b/mirrord/config/src/container.rs
@@ -73,6 +73,7 @@ pub struct ContainerConfig {
     /// - If you're running inside WSL, and encountering problems, try setting
     ///   `external_proxy.host_ip` T `0.0.0.0`, and this to the internal container runtime address
     ///   (for docker, this  would be what `host.docker.internal` resolved to, which by default is
-    ///   `192.168.65.254`).
+    ///   `192.168.65.254`). You can find this ip by resolving it from inside a running container,
+    ///   e.g. `docker run --rm -it {image-with-nslookup} nslookup host.docker.internal`
     pub override_host_ip: Option<IpAddr>,
 }

--- a/mirrord/config/src/external_proxy.rs
+++ b/mirrord/config/src/external_proxy.rs
@@ -104,5 +104,10 @@ pub struct ExternalProxyConfig {
     ///
     /// This address must be accessible from within the container.
     /// If not specified, mirrord will try and resolve a local address to use.
+    ///
+    /// - If you're running inside WSL, and encountering problems, try setting this to `0.0.0.0`,
+    ///   and `container.override_host_ip` to the internal container runtime address (for docker,
+    ///   this would be what `host.docker.internal` resolved to, which by default is
+    ///   `192.168.65.254`).
     pub host_ip: Option<IpAddr>,
 }


### PR DESCRIPTION
- Issue: https://github.com/metalbear-co/mirrord/issues/3285

Sometimes defaulting to `localhost` and random address may cause problems. We have the configs that allows the user to set the correct addresses, so this PR just sets it for them by default (using default docker values).

- Another approach would be to resolve the container address from within a container;