### PR TITLE
Mbe 859 handle e2big in mirrord exec

### DIFF
--- a/changelog.d/3254.added.md
+++ b/changelog.d/3254.added.md
@@ -1,0 +1,3 @@
+Added E2BIG error handling in mirrord cli, this means that 
+everytime the hosted process exits with E2BIG error, mirrord 
+panics and also shows an appropriate error 

--- a/mirrord/cli/src/error.rs
+++ b/mirrord/cli/src/error.rs
@@ -395,6 +395,13 @@ pub(crate) enum CliError {
 
     #[error(transparent)]
     ProfileError(#[from] ProfileError),
+
+    #[error("Could not load environment: it's too large. execv failed with code {0}(E2BIG)")]
+    #[diagnostic(help(
+        "Mirrord tried to load environment for the host process but is too large.
+         In order to let mirrord run this executable, you need to set the feature.env.load_from_process in the settings to false."
+    ))]
+    E2Big(i32),
 }
 
 impl CliError {

--- a/mirrord/cli/src/main.rs
+++ b/mirrord/cli/src/main.rs
@@ -399,6 +399,10 @@ where
         }
     }
 
+    if let Errno::E2BIG = errno {
+        return Err(CliError::E2Big(errno as i32));
+    }
+
     Err(CliError::BinaryExecuteFailed(binary, binary_args))
 }
 


### PR DESCRIPTION
Added E2BIG error handling in mirrord cli, this means that 
everytime the hosted process exits with E2BIG error, mirrord 
panics and also shows an appropriate error