### PR TITLE
Add fixed header output tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,7 +104,7 @@ dependencies = [
  "actix-utils",
  "futures-core",
  "futures-util",
- "mio",
+ "mio 1.0.4",
  "socket2",
  "tokio",
  "tracing",
@@ -1496,6 +1496,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
+name = "castaway"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0abae9be0aaf9ea96a3b1b8b1b55c602ca751eba1b1500220cea4ecbafe7c0d5"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cbc"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1657,6 +1672,19 @@ name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+
+[[package]]
+name = "compact_str"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f86b9c4c00838774a6d902ef931eff7470720c51d90c2e32cfe15dc304737b3f"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "ryu",
+ "static_assertions",
+]
 
 [[package]]
 name = "concurrent-queue"
@@ -1828,6 +1856,31 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crossterm"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
+dependencies = [
+ "bitflags 2.9.1",
+ "crossterm_winapi",
+ "libc",
+ "mio 0.8.11",
+ "parking_lot",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "crunchy"
@@ -4088,6 +4141,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.3",
+]
+
+[[package]]
 name = "lru-cache"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4258,6 +4320,18 @@ dependencies = [
 
 [[package]]
 name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
@@ -4276,6 +4350,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "const-random",
+ "crossterm",
  "dotenvy",
  "drain",
  "futures",
@@ -4303,6 +4378,7 @@ dependencies = [
  "mirrord-vpn",
  "nix 0.29.0",
  "prettytable-rs",
+ "ratatui",
  "rcgen",
  "regex",
  "reqwest",
@@ -5955,6 +6031,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f44c9e68fd46eda15c646fbb85e1040b657a58cdc8c98db1d97a55930d991eef"
+dependencies = [
+ "bitflags 2.9.1",
+ "cassowary",
+ "compact_str",
+ "crossterm",
+ "itertools 0.12.1",
+ "lru",
+ "paste",
+ "stability",
+ "strum 0.26.3",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
 name = "rawsocket"
 version = "0.1.0"
 source = "git+https://github.com/metalbear-co/rawsocket.git?rev=86bba7dbe971e166d5153227dd0099fe47da4489#86bba7dbe971e166d5153227dd0099fe47da4489"
@@ -6820,6 +6916,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
+dependencies = [
+ "libc",
+ "mio 0.8.11",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6941,6 +7058,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "stability"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d904e7009df136af5297832a3ace3370cd14ff1546a232f4f185036c2736fcac"
+dependencies = [
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6972,6 +7099,9 @@ name = "strum"
 version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros 0.26.4",
+]
 
 [[package]]
 name = "strum"
@@ -7349,7 +7479,7 @@ dependencies = [
  "backtrace",
  "bytes",
  "libc",
- "mio",
+ "mio 1.0.4",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
@@ -7873,6 +8003,23 @@ name = "unicode-linebreak"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools 0.13.0",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
 
 [[package]]
 name = "unicode-width"

--- a/mirrord/cli/Cargo.toml
+++ b/mirrord/cli/Cargo.toml
@@ -64,6 +64,8 @@ tokio-rustls.workspace = true
 tokio-stream = { workspace = true, features = ["io-util", "net"] }
 regex.workspace = true
 mid = "3.0.0"
+ratatui = "0.26"
+crossterm = "0.27"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 mirrord-sip = { path = "../sip" }

--- a/mirrord/cli/src/config.rs
+++ b/mirrord/cli/src/config.rs
@@ -146,6 +146,13 @@ pub enum FsMode {
     LocalWithOverrides,
 }
 
+#[derive(Copy, Clone, PartialEq, Eq, ValueEnum, Debug)]
+pub enum OutputMode {
+    Standard,
+    #[value(name = "fixed-header")]
+    FixedHeader,
+}
+
 impl core::fmt::Display for FsMode {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.write_str(match self {
@@ -232,6 +239,14 @@ pub(super) struct ExecParams {
     /// These variables will override environment fetched from the remote target.
     #[arg(long, value_hint = ValueHint::FilePath)]
     pub env_file: Option<PathBuf>,
+
+    /// Output mode for logs
+    #[arg(long, value_enum)]
+    pub output_mode: Option<OutputMode>,
+
+    /// Messages to display in fixed header mode
+    #[arg(long = "header", action = clap::ArgAction::Append)]
+    pub header: Option<Vec<String>>,
 }
 
 impl ExecParams {

--- a/mirrord/cli/src/fixed_header.rs
+++ b/mirrord/cli/src/fixed_header.rs
@@ -1,0 +1,203 @@
+use std::{io::{self, Write}, sync::mpsc::{Receiver, Sender}};
+
+use crossterm::{event::{self, Event, KeyCode}, execute, terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen}};
+use ratatui::{backend::CrosstermBackend, Terminal, widgets::Paragraph, layout::Rect, prelude::Frame};
+use tracing_subscriber::fmt::MakeWriter;
+
+pub struct ChannelMakeWriter {
+    tx: Sender<String>,
+}
+
+impl ChannelMakeWriter {
+    pub fn new(tx: Sender<String>) -> Self {
+        Self { tx }
+    }
+}
+
+impl<'a> MakeWriter<'a> for ChannelMakeWriter {
+    type Writer = ChannelWriter;
+    fn make_writer(&'a self) -> Self::Writer {
+        ChannelWriter { tx: self.tx.clone() }
+    }
+}
+
+pub struct ChannelWriter {
+    tx: Sender<String>,
+}
+
+/// Draws the fixed header and log area onto the provided frame.
+pub fn draw_ui(f: &mut Frame<'_>, messages: &[String], logs: &[String], offset: usize) {
+    let size = f.size();
+    let header_height = messages.len() as u16;
+    for (idx, line) in messages.iter().enumerate() {
+        let area = Rect::new(0, idx as u16, size.width, 1);
+        f.render_widget(Paragraph::new(line.as_str()), area);
+    }
+    let log_area = Rect::new(0, header_height, size.width, size.height.saturating_sub(header_height));
+    let start = logs.len().saturating_sub(offset + log_area.height as usize);
+    let end = logs.len().saturating_sub(offset);
+    let text = logs[start..end].join("\n");
+    f.render_widget(Paragraph::new(text), log_area);
+}
+
+impl Write for ChannelWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let _ = self.tx.send(String::from_utf8_lossy(buf).into_owned());
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+pub fn run(messages: Vec<String>, rx: Receiver<String>) -> io::Result<()> {
+    enable_raw_mode()?;
+    let mut stdout = io::stdout();
+    execute!(stdout, EnterAlternateScreen)?;
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
+
+    let mut logs: Vec<String> = Vec::new();
+    let mut offset = 0usize;
+
+    loop {
+        terminal.draw(|f| draw_ui(f, &messages, &logs, offset))?;
+
+        while let Ok(line) = rx.try_recv() {
+            logs.push(line);
+        }
+
+        if event::poll(std::time::Duration::from_millis(50))? {
+            if let Event::Key(key) = event::read()? {
+                match key.code {
+                    KeyCode::Up => {
+                        if offset + 1 < logs.len() {
+                            offset += 1;
+                        }
+                    }
+                    KeyCode::Down => {
+                        if offset > 0 {
+                            offset -= 1;
+                        }
+                    }
+                    KeyCode::Esc | KeyCode::Char('q') => break,
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    disable_raw_mode()?;
+    execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
+    terminal.show_cursor()?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::draw_ui;
+    use crate::config::{Cli, OutputMode};
+    use crate::logging::init_tracing_registry;
+    use ratatui::{backend::TestBackend, Terminal};
+    use clap::Parser;
+    use drain::channel as drain_channel;
+
+    #[test]
+    fn header_single_line() {
+        let backend = TestBackend::new(20, 3);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let messages = vec!["header".to_string()];
+        let logs: Vec<String> = vec![];
+        terminal.draw(|f| draw_ui(f, &messages, &logs, 0)).unwrap();
+        terminal.backend().assert_buffer_lines([
+            "header              ",
+            "                    ",
+            "                    ",
+        ]);
+    }
+
+    #[test]
+    fn header_two_lines() {
+        let backend = TestBackend::new(20, 4);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let messages = vec!["line1".to_string(), "line2".to_string()];
+        let logs: Vec<String> = vec![];
+        terminal.draw(|f| draw_ui(f, &messages, &logs, 0)).unwrap();
+        terminal.backend().assert_buffer_lines([
+            "line1               ",
+            "line2               ",
+            "                    ",
+            "                    ",
+        ]);
+    }
+
+    #[test]
+    fn header_static_while_logs_scroll() {
+        let backend = TestBackend::new(20, 4);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let messages = vec!["hdr".to_string()];
+        let mut logs = vec!["first".to_string()];
+        terminal.draw(|f| draw_ui(f, &messages, &logs, 0)).unwrap();
+        logs.push("second".to_string());
+        terminal.draw(|f| draw_ui(f, &messages, &logs, 0)).unwrap();
+        terminal.backend().assert_buffer_lines([
+            "hdr                 ",
+            "first               ",
+            "second              ",
+            "                    ",
+        ]);
+    }
+
+    #[test]
+    fn scrolling_doesnt_move_header() {
+        let backend = TestBackend::new(20, 4);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let messages = vec!["hdr".to_string()];
+        let logs = vec!["one".to_string(), "two".to_string(), "three".to_string()];
+        terminal.draw(|f| draw_ui(f, &messages, &logs, 1)).unwrap();
+        terminal.backend().assert_buffer_lines([
+            "hdr                 ",
+            "one                 ",
+            "two                 ",
+            "                    ",
+        ]);
+    }
+
+    #[test]
+    fn parse_fixed_header_args() {
+        let cli = Cli::try_parse_from([
+            "mirrord",
+            "exec",
+            "--output-mode",
+            "fixed-header",
+            "--header",
+            "a",
+            "--header",
+            "b",
+            "echo",
+        ])
+        .unwrap();
+        if let crate::config::Commands::Exec(args) = cli.commands {
+            assert_eq!(args.params.output_mode, Some(OutputMode::FixedHeader));
+            assert_eq!(args.params.header.unwrap(), vec!["a", "b"]);
+        } else {
+            panic!("expected exec command");
+        }
+    }
+
+    #[tokio::test]
+    async fn standard_mode_disables_fixed_header() {
+        let cli = Cli::try_parse_from([
+            "mirrord",
+            "exec",
+            "--output-mode",
+            "standard",
+            "echo",
+        ])
+        .unwrap();
+        let (_, watch) = drain_channel();
+        let handle = init_tracing_registry(&cli.commands, watch).await.unwrap();
+        assert!(handle.is_none());
+    }
+}

--- a/mirrord/cli/src/main.rs
+++ b/mirrord/cli/src/main.rs
@@ -292,6 +292,7 @@ mod logging;
 mod operator;
 mod port_forward;
 mod profile;
+mod fixed_header;
 mod teams;
 mod util;
 mod verify_config;
@@ -759,7 +760,7 @@ fn main() -> miette::Result<()> {
     let (signal, watch) = drain::channel();
 
     let res: CliResult<(), CliError> = rt.block_on(async move {
-        logging::init_tracing_registry(&cli.commands, watch.clone()).await?;
+        let _tui = logging::init_tracing_registry(&cli.commands, watch.clone()).await?;
 
         match cli.commands {
             Commands::Exec(args) => exec(&args, watch).await?,


### PR DESCRIPTION
## Summary
- expose a `draw_ui` helper in `fixed_header` for rendering
- embed tests for the fixed-header output mode using `ratatui`'s `TestBackend`

## Testing
- `cargo test -p mirrord --manifest-path mirrord/cli/Cargo.toml`
- `cargo check -p mirrord --manifest-path mirrord/cli/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_b_685839ff5f248333905f157dfaf3b365