### PR TITLE
Mbe 829 issue a warning when an http filter is used with copy target

### DIFF
--- a/changelog.d/3223.added.md
+++ b/changelog.d/3223.added.md
@@ -1,0 +1,3 @@
+added a warning that notifies about the possibility of losing packets 
+unmatched by the http filter when http filter and copy target 
+configuration are enabled and configured

--- a/mirrord/config/src/lib.rs
+++ b/mirrord/config/src/lib.rs
@@ -675,6 +675,16 @@ impl LayerConfig {
             ));
         }
 
+        if self.feature.copy_target.enabled
+            && self.feature.network.incoming.http_filter.is_filter_set()
+        {
+            context.add_warning(
+                "copy target is enabled and http filter is set, this means that all \
+            unmatched HTTP requests are discarded"
+                    .to_string(),
+            );
+        }
+
         Ok(())
     }
 }


### PR DESCRIPTION
added a warning that notifies about the possibility of losing packets unmatched by the http filter when http filter and copy target configuration are enabled and configured