### PR TITLE
mirrord now extracts layer to temp_dir()/mirrord 

### DIFF
--- a/changelog.d/3373.changed.md
+++ b/changelog.d/3373.changed.md
@@ -1,0 +1,1 @@
+mirrord now extracts layer to temp_dir()/mirrord to allow easier whitelisting with Carbon Black

--- a/mirrord/cli/src/extract.rs
+++ b/mirrord/cli/src/extract.rs
@@ -54,7 +54,15 @@ where
 
     let file_path = match dest_dir {
         Some(dest_dir) => std::path::Path::new(&dest_dir).join(file_name),
-        None => temp_dir().as_path().join(file_name),
+        None => {
+            let dir = temp_dir().join("mirrord");
+            // make dir if it doesn't exist
+            if !dir.exists() {
+                std::fs::create_dir_all(&dir)
+                    .map_err(|e| CliError::LayerExtractError(dir.clone(), e))?;
+            }
+            dir.as_path().join(file_name)
+        }
     };
     if !file_path.exists() {
         let mut file = File::create(&file_path)


### PR DESCRIPTION
mirrord now extracts layer to temp_dir()/mirrord to allow easier whitelisting with Carbon Black
