### PR TITLE
Small improvements to SQS E2E tests

### DIFF
--- a/changelog.d/+sqs-e2e-config-map.internal.md
+++ b/changelog.d/+sqs-e2e-config-map.internal.md
@@ -1,0 +1,1 @@
+E2E tests for splitting SQS with queue names in env vars originating in ConfigMaps.


### PR DESCRIPTION
Seems like with the version from the operator's `main`, at least on my sick, old system, the tests need longer timeouts to pass.
Also added some helpful prints to the tests.