### PR TITLE
3.150.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,31 @@ This project uses [*towncrier*](https://towncrier.readthedocs.io/) and the chang
 
 <!-- towncrier release notes start -->
 
+## [3.150.0](https://github.com/metalbear-co/mirrord/tree/3.150.0) - 2025-07-14
+
+
+### Changed
+
+- Changed semantics of the `agent.nftables` configuration field.
+
+  When the field is not set, the agent will pick between `iptables-legacy` and
+  `iptables-nft` at runtime,
+  based on kernel support and existing mesh rules.
+
+  When the field is set, the agent will always use either `iptables-legacy` or
+  `iptables-nft`.
+- The agent now eagerly detects HTTP in incoming connections.
+
+
+### Internal
+
+- Add E2E test for using an asterisk queue-id on client config, together with
+  SQS json in fallback field.
+- Added an E2E test for splitting SQS queues based on env var regex.
+- E2E tests for splitting SQS with queue names in env vars originating in
+  ConfigMaps.
+- Improved SQS E2E tests, removing unnecessary sleeps.
+
 ## [3.149.0](https://github.com/metalbear-co/mirrord/tree/3.149.0) - 2025-07-11
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2519,7 +2519,7 @@ dependencies = [
 
 [[package]]
 name = "fileops"
-version = "3.149.0"
+version = "3.150.0"
 dependencies = [
  "libc",
 ]
@@ -3625,7 +3625,7 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "issue1317"
-version = "3.149.0"
+version = "3.150.0"
 dependencies = [
  "actix-web",
  "env_logger",
@@ -3635,7 +3635,7 @@ dependencies = [
 
 [[package]]
 name = "issue1776"
-version = "3.149.0"
+version = "3.150.0"
 dependencies = [
  "errno 0.3.12",
  "libc",
@@ -3644,7 +3644,7 @@ dependencies = [
 
 [[package]]
 name = "issue1776portnot53"
-version = "3.149.0"
+version = "3.150.0"
 dependencies = [
  "libc",
  "socket2",
@@ -3652,14 +3652,14 @@ dependencies = [
 
 [[package]]
 name = "issue1899"
-version = "3.149.0"
+version = "3.150.0"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "issue2001"
-version = "3.149.0"
+version = "3.150.0"
 dependencies = [
  "libc",
 ]
@@ -4020,7 +4020,7 @@ checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "listen_ports"
-version = "3.149.0"
+version = "3.150.0"
 
 [[package]]
 name = "litemap"
@@ -4256,7 +4256,7 @@ dependencies = [
 
 [[package]]
 name = "mirrord"
-version = "3.149.0"
+version = "3.150.0"
 dependencies = [
  "actix-codec",
  "base64 0.22.1",
@@ -4311,7 +4311,7 @@ dependencies = [
 
 [[package]]
 name = "mirrord-agent"
-version = "3.149.0"
+version = "3.150.0"
 dependencies = [
  "actix-codec",
  "axum",
@@ -4367,7 +4367,7 @@ dependencies = [
 
 [[package]]
 name = "mirrord-agent-env"
-version = "3.149.0"
+version = "3.150.0"
 dependencies = [
  "base64 0.22.1",
  "k8s-openapi",
@@ -4380,7 +4380,7 @@ dependencies = [
 
 [[package]]
 name = "mirrord-agent-iptables"
-version = "3.149.0"
+version = "3.150.0"
 dependencies = [
  "async-trait",
  "enum_dispatch",
@@ -4396,7 +4396,7 @@ dependencies = [
 
 [[package]]
 name = "mirrord-analytics"
-version = "3.149.0"
+version = "3.150.0"
 dependencies = [
  "assert-json-diff",
  "base64 0.22.1",
@@ -4410,7 +4410,7 @@ dependencies = [
 
 [[package]]
 name = "mirrord-auth"
-version = "3.149.0"
+version = "3.150.0"
 dependencies = [
  "bcder",
  "chrono",
@@ -4431,7 +4431,7 @@ dependencies = [
 
 [[package]]
 name = "mirrord-config"
-version = "3.149.0"
+version = "3.150.0"
 dependencies = [
  "base64 0.22.1",
  "bimap",
@@ -4459,7 +4459,7 @@ dependencies = [
 
 [[package]]
 name = "mirrord-config-derive"
-version = "3.149.0"
+version = "3.150.0"
 dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
@@ -4469,7 +4469,7 @@ dependencies = [
 
 [[package]]
 name = "mirrord-console"
-version = "3.149.0"
+version = "3.150.0"
 dependencies = [
  "bincode",
  "drain",
@@ -4485,7 +4485,7 @@ dependencies = [
 
 [[package]]
 name = "mirrord-intproxy"
-version = "3.149.0"
+version = "3.150.0"
 dependencies = [
  "bytes",
  "futures",
@@ -4515,7 +4515,7 @@ dependencies = [
 
 [[package]]
 name = "mirrord-intproxy-protocol"
-version = "3.149.0"
+version = "3.150.0"
 dependencies = [
  "bincode",
  "mirrord-protocol",
@@ -4525,7 +4525,7 @@ dependencies = [
 
 [[package]]
 name = "mirrord-kube"
-version = "3.149.0"
+version = "3.150.0"
 dependencies = [
  "actix-codec",
  "async-stream",
@@ -4550,7 +4550,7 @@ dependencies = [
 
 [[package]]
 name = "mirrord-layer"
-version = "3.149.0"
+version = "3.150.0"
 dependencies = [
  "actix-codec",
  "apple-codesign",
@@ -4592,7 +4592,7 @@ dependencies = [
 
 [[package]]
 name = "mirrord-layer-macro"
-version = "3.149.0"
+version = "3.150.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4601,7 +4601,7 @@ dependencies = [
 
 [[package]]
 name = "mirrord-macros"
-version = "3.149.0"
+version = "3.150.0"
 dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
@@ -4611,7 +4611,7 @@ dependencies = [
 
 [[package]]
 name = "mirrord-operator"
-version = "3.149.0"
+version = "3.150.0"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -4646,7 +4646,7 @@ dependencies = [
 
 [[package]]
 name = "mirrord-progress"
-version = "3.149.0"
+version = "3.150.0"
 dependencies = [
  "enum_dispatch",
  "indicatif",
@@ -4678,7 +4678,7 @@ dependencies = [
 
 [[package]]
 name = "mirrord-sip"
-version = "3.149.0"
+version = "3.150.0"
 dependencies = [
  "apple-codesign",
  "hex",
@@ -4693,7 +4693,7 @@ dependencies = [
 
 [[package]]
 name = "mirrord-tls-util"
-version = "3.149.0"
+version = "3.150.0"
 dependencies = [
  "http 1.3.1",
  "pem",
@@ -4710,7 +4710,7 @@ dependencies = [
 
 [[package]]
 name = "mirrord-vpn"
-version = "3.149.0"
+version = "3.150.0"
 dependencies = [
  "futures",
  "ipnet",
@@ -5079,7 +5079,7 @@ dependencies = [
 
 [[package]]
 name = "outgoing"
-version = "3.149.0"
+version = "3.150.0"
 
 [[package]]
 name = "outref"
@@ -6212,14 +6212,14 @@ dependencies = [
 
 [[package]]
 name = "rust-bypassed-unix-socket"
-version = "3.149.0"
+version = "3.150.0"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "rust-e2e-fileops"
-version = "3.149.0"
+version = "3.150.0"
 dependencies = [
  "libc",
 ]
@@ -6236,7 +6236,7 @@ dependencies = [
 
 [[package]]
 name = "rust-unix-socket-client"
-version = "3.149.0"
+version = "3.150.0"
 dependencies = [
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ resolver = "2"
 
 # latest commits on rustls suppress certificate verification
 [workspace.package]
-version = "3.149.0"
+version = "3.150.0"
 edition = "2021"
 license = "MIT"
 readme = "README.md"

--- a/changelog.d/+agent-iptables-backend.changed.md
+++ b/changelog.d/+agent-iptables-backend.changed.md
@@ -1,6 +1,0 @@
-Changed semantics of the `agent.nftables` configuration field.
-
-When the field is not set, the agent will pick between `iptables-legacy` and `iptables-nft` at runtime,
-based on kernel support and existing mesh rules.
-
-When the field is set, the agent will always use either `iptables-legacy` or `iptables-nft`.

--- a/changelog.d/+asterisk-test.internal.md
+++ b/changelog.d/+asterisk-test.internal.md
@@ -1,1 +1,0 @@
-Add E2E test for using an asterisk queue-id on client config, together with SQS json in fallback field.

--- a/changelog.d/+eager-http-detection.changed.md
+++ b/changelog.d/+eager-http-detection.changed.md
@@ -1,1 +1,0 @@
-The agent now eagerly detects HTTP in incoming connections.

--- a/changelog.d/+improve-sqs-e2e.internal.md
+++ b/changelog.d/+improve-sqs-e2e.internal.md
@@ -1,1 +1,0 @@
-Improved SQS E2E tests, removing unnecessary sleeps.

--- a/changelog.d/+sqs-e2e-config-map.internal.md
+++ b/changelog.d/+sqs-e2e-config-map.internal.md
@@ -1,1 +1,0 @@
-E2E tests for splitting SQS with queue names in env vars originating in ConfigMaps.

--- a/changelog.d/+sqs-regex-test.internal.md
+++ b/changelog.d/+sqs-regex-test.internal.md
@@ -1,1 +1,0 @@
-Added an E2E test for splitting SQS queues based on env var regex.


### PR DESCRIPTION
## [3.150.0](https://github.com/metalbear-co/mirrord/tree/3.150.0) - 2025-07-14


### Changed

- Changed semantics of the `agent.nftables` configuration field.

  When the field is not set, the agent will pick between `iptables-legacy` and
  `iptables-nft` at runtime,
  based on kernel support and existing mesh rules.

  When the field is set, the agent will always use either `iptables-legacy` or
  `iptables-nft`.
- The agent now eagerly detects HTTP in incoming connections.


### Internal

- Add E2E test for using an asterisk queue-id on client config, together with
  SQS json in fallback field.
- Added an E2E test for splitting SQS queues based on env var regex.
- E2E tests for splitting SQS with queue names in env vars originating in
  ConfigMaps.
- Improved SQS E2E tests, removing unnecessary sleeps.