### PR TITLE
Add logging to a file while patching SIP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4681,6 +4681,7 @@ name = "mirrord-sip"
 version = "3.151.0"
 dependencies = [
  "apple-codesign",
+ "fs4",
  "hex",
  "object",
  "once_cell",

--- a/changelog.d/3407.added.md
+++ b/changelog.d/3407.added.md
@@ -1,0 +1,1 @@
+Added an experimental config option to write basic SIP logs to a file.

--- a/mirrord-schema.json
+++ b/mirrord-schema.json
@@ -934,6 +934,14 @@
           "format": "uint64",
           "minimum": 0.0
         },
+        "sip_log_destination": {
+          "title": "_experimental_ sip_log_destination {#experimental-sip_log_destination}",
+          "description": "Writes basic fork-safe SIP patching logs to a destination file. Useful for seeing the state of SIP when `stdout` may be affected by another process.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "tcp_ping4_mock": {
           "title": "_experimental_ tcp_ping4_mock {#experimental-tcp_ping4_mock}",
           "description": "<https://github.com/metalbear-co/mirrord/issues/2421#issuecomment-2093200904>",

--- a/mirrord/cli/src/execution.rs
+++ b/mirrord/cli/src/execution.rs
@@ -318,6 +318,10 @@ impl MirrordExecution {
                             .map(|x| x.to_vec())
                             .unwrap_or_default(),
                         skip: &config.skip_sip,
+                        log_destination: config
+                            .experimental
+                            .sip_log_destination
+                            .as_ref(),
                     },
                 )
                 .transpose() // We transpose twice to propagate a possible error out of this

--- a/mirrord/cli/src/execution.rs
+++ b/mirrord/cli/src/execution.rs
@@ -309,14 +309,15 @@ impl MirrordExecution {
         );
 
         #[cfg(target_os = "macos")]
-        let log_info = match config.experimental.sip_log_destination.as_ref() {
-            None => None,
-            Some(log_destination) => Some(mirrord_sip::SipLogInfo {
+        let log_info = config
+            .experimental
+            .sip_log_destination
+            .as_ref()
+            .map(|log_destination| mirrord_sip::SipLogInfo {
                 log_destination,
                 args,
                 load_type: None,
-            }),
-        };
+            });
 
         #[cfg(target_os = "macos")]
         let patched_path = executable

--- a/mirrord/cli/src/execution.rs
+++ b/mirrord/cli/src/execution.rs
@@ -1,6 +1,7 @@
+#[cfg(target_os = "macos")]
+use std::ffi::OsString;
 use std::{
     collections::{HashMap, HashSet},
-    ffi::OsString,
     net::SocketAddr,
     time::Duration,
 };
@@ -183,7 +184,7 @@ impl MirrordExecution {
         config: &mut LayerConfig,
         // We only need the executable and args on macos, for SIP handling.
         #[cfg(target_os = "macos")] executable: Option<&str>,
-        #[cfg(target_os = "macos")] args: Option<&Vec<OsString>>,
+        #[cfg(target_os = "macos")] args: Option<&[OsString]>,
         progress: &mut P,
         analytics: &mut AnalyticsReporter,
     ) -> CliResult<Self>

--- a/mirrord/cli/src/execution.rs
+++ b/mirrord/cli/src/execution.rs
@@ -307,6 +307,16 @@ impl MirrordExecution {
         );
 
         #[cfg(target_os = "macos")]
+        let log_info = match config.experimental.sip_log_destination.as_ref() {
+            None => None,
+            Some(log_destination) => Some(mirrord_sip::SipLogInfo {
+                log_destination,
+                args: &args,
+                load_type
+            })
+        };
+
+        #[cfg(target_os = "macos")]
         let patched_path = executable
             .and_then(|exe| {
                 sip_patch(
@@ -318,11 +328,12 @@ impl MirrordExecution {
                             .map(|x| x.to_vec())
                             .unwrap_or_default(),
                         skip: &config.skip_sip,
-                        log_destination: config
-                            .experimental
-                            .sip_log_destination
-                            .as_ref(),
+                        // log_destination: config
+                        //     .experimental
+                        //     .sip_log_destination
+                        //     .as_ref(),
                     },
+                    log_info
                 )
                 .transpose() // We transpose twice to propagate a possible error out of this
                              // closure.

--- a/mirrord/cli/src/extension.rs
+++ b/mirrord/cli/src/extension.rs
@@ -18,6 +18,8 @@ where
         &mut config,
         #[cfg(target_os = "macos")]
         executable,
+        #[cfg(target_os = "macos")]
+        None,
         &mut progress,
         analytics,
     )

--- a/mirrord/cli/src/main.rs
+++ b/mirrord/cli/src/main.rs
@@ -239,7 +239,11 @@
 #![deny(unused_crate_dependencies)]
 
 use std::{
-    collections::HashMap, env::vars, ffi::CString, net::SocketAddr, os::unix::ffi::OsStrExt,
+    collections::HashMap,
+    env::vars,
+    ffi::{CString, OsString},
+    net::SocketAddr,
+    os::unix::ffi::OsStrExt,
     time::Duration,
 };
 
@@ -322,6 +326,14 @@ where
         &mut config,
         #[cfg(target_os = "macos")]
         Some(&args.binary),
+        #[cfg(target_os = "macos")]
+        Some(
+            &args
+                .binary_args
+                .iter()
+                .map(|str| str.parse::<OsString>().unwrap())
+                .collect(),
+        ),
         &mut sub_progress,
         analytics,
     )

--- a/mirrord/config/src/experimental.rs
+++ b/mirrord/config/src/experimental.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use mirrord_analytics::CollectAnalytics;
 use mirrord_config_derive::MirrordConfig;
 use schemars::JsonSchema;
@@ -96,6 +97,13 @@ pub struct ExperimentalConfig {
     /// `feature.network.incoming.http_filter.header_filter`.
     #[config(default = false)]
     pub browser_extension_config: bool,
+
+    /// ### _experimental_ sip_log_destination {#experimental-sip_log_destination}
+    ///
+    /// Writes basic fork-safe SIP patching logs to a destination file.
+    /// Useful for seeing the state of SIP when `stdout` may be affected by another process.
+    #[config(default = None)]
+    pub sip_log_destination: Option<PathBuf>,
 }
 
 impl CollectAnalytics for &ExperimentalConfig {

--- a/mirrord/config/src/experimental.rs
+++ b/mirrord/config/src/experimental.rs
@@ -1,4 +1,5 @@
 use std::path::PathBuf;
+
 use mirrord_analytics::CollectAnalytics;
 use mirrord_config_derive::MirrordConfig;
 use schemars::JsonSchema;

--- a/mirrord/layer/src/exec_utils.rs
+++ b/mirrord/layer/src/exec_utils.rs
@@ -73,8 +73,7 @@ pub(super) fn patch_if_sip(path: &str) -> Detour<String> {
     // use args for logging only, so no need to fail if they're not set
     let args = EXECUTABLE_ARGS
         .get()
-        .map(|exec_args| exec_args.args.clone())
-        .unwrap_or_default();
+        .map(|exec_args| exec_args.args.clone());
     let log_info = crate::setup()
         .layer_config()
         .experimental
@@ -82,7 +81,7 @@ pub(super) fn patch_if_sip(path: &str) -> Detour<String> {
         .as_ref()
         .map(|log_destination| mirrord_sip::SipLogInfo {
             log_destination,
-            args: Some(&args),
+            args: args.as_deref(),
             load_type: None,
         });
     match sip_patch(

--- a/mirrord/layer/src/exec_utils.rs
+++ b/mirrord/layer/src/exec_utils.rs
@@ -75,19 +75,16 @@ pub(super) fn patch_if_sip(path: &str) -> Detour<String> {
         .get()
         .map(|exec_args| exec_args.args.clone())
         .unwrap_or_default();
-    let log_info = match crate::setup()
+    let log_info = crate::setup()
         .layer_config()
         .experimental
         .sip_log_destination
         .as_ref()
-    {
-        None => None,
-        Some(log_destination) => Some(mirrord_sip::SipLogInfo {
+        .map(|log_destination| mirrord_sip::SipLogInfo {
             log_destination,
             args: Some(&args),
             load_type: None,
-        }),
-    };
+        });
     match sip_patch(
         path,
         SipPatchOptions {

--- a/mirrord/layer/src/exec_utils.rs
+++ b/mirrord/layer/src/exec_utils.rs
@@ -84,8 +84,8 @@ pub(super) fn patch_if_sip(path: &str) -> Detour<String> {
         None => None,
         Some(log_destination) => Some(mirrord_sip::SipLogInfo {
             log_destination,
-            args: &args,
-            load_type: "",
+            args: Some(&args),
+            load_type: None,
         }),
     };
     match sip_patch(

--- a/mirrord/layer/src/exec_utils.rs
+++ b/mirrord/layer/src/exec_utils.rs
@@ -75,6 +75,11 @@ pub(super) fn patch_if_sip(path: &str) -> Detour<String> {
         SipPatchOptions {
             patch: patch_binaries,
             skip: skip_patch_binaries,
+            log_destination: crate::setup()
+                .layer_config()
+                .experimental
+                .sip_log_destination
+                .as_ref(),
         },
     ) {
         Ok(None) => Bypass(NoSipDetected(path.to_string())),

--- a/mirrord/layer/src/lib.rs
+++ b/mirrord/layer/src/lib.rs
@@ -225,7 +225,7 @@ fn layer_pre_initialization() -> Result<(), LayerError> {
             .as_ref()
             .map(|log_destination| mirrord_sip::SipLogInfo {
                 log_destination,
-                args: Some(&args),
+                args: Some(args.as_slice()),
                 load_type: Some(load_type),
             });
 

--- a/mirrord/layer/src/lib.rs
+++ b/mirrord/layer/src/lib.rs
@@ -75,6 +75,7 @@ use std::{
     sync::OnceLock,
     time::Duration,
 };
+
 use ctor::ctor;
 use error::{LayerError, Result};
 use file::OPEN_FILES;
@@ -222,9 +223,9 @@ fn layer_pre_initialization() -> Result<(), LayerError> {
             None => None,
             Some(log_destination) => Some(mirrord_sip::SipLogInfo {
                 log_destination,
-                args: &args,
-                load_type
-            })
+                args: Some(&args),
+                load_type: Some(load_type),
+            }),
         };
 
         if let Ok(Some(binary)) = mirrord_sip::sip_patch(
@@ -233,12 +234,9 @@ fn layer_pre_initialization() -> Result<(), LayerError> {
                 patch: &patch_binaries,
                 skip: &skip_patch_binaries,
             },
-            log_info
+            log_info,
         ) {
-            let err = exec::execvp(
-                binary,
-                args,
-            );
+            let err = exec::execvp(binary, args);
             tracing::error!("Couldn't execute {:?}", err);
             return Err(LayerError::ExecFailed(err));
         }

--- a/mirrord/layer/src/lib.rs
+++ b/mirrord/layer/src/lib.rs
@@ -214,6 +214,7 @@ fn layer_pre_initialization() -> Result<(), LayerError> {
             mirrord_sip::SipPatchOptions {
                 patch: &patch_binaries,
                 skip: &skip_patch_binaries,
+                log_destination: config.experimental.sip_log_destination.as_ref(),
             },
         ) {
             let err = exec::execvp(

--- a/mirrord/layer/src/lib.rs
+++ b/mirrord/layer/src/lib.rs
@@ -219,14 +219,15 @@ fn layer_pre_initialization() -> Result<(), LayerError> {
             LoadType::SIPOnly => "SIP only",
             LoadType::Skip => "skip",
         };
-        let log_info = match config.experimental.sip_log_destination.as_ref() {
-            None => None,
-            Some(log_destination) => Some(mirrord_sip::SipLogInfo {
+        let log_info = config
+            .experimental
+            .sip_log_destination
+            .as_ref()
+            .map(|log_destination| mirrord_sip::SipLogInfo {
                 log_destination,
                 args: Some(&args),
                 load_type: Some(load_type),
-            }),
-        };
+            });
 
         if let Ok(Some(binary)) = mirrord_sip::sip_patch(
             path,

--- a/mirrord/layer/tests/bash.rs
+++ b/mirrord/layer/tests/bash.rs
@@ -37,7 +37,7 @@ async fn bash_script(dylib_path: &Path, config_dir: &Path) {
     println!("Listening for messages from the layer on {addr}");
     let env = get_env(dylib_path, addr, vec![], Some(&config_path));
     #[cfg(target_os = "macos")]
-    let executable = sip_patch(&executable, SipPatchOptions::default())
+    let executable = sip_patch(&executable, SipPatchOptions::default(), None)
         .unwrap()
         .unwrap();
     let test_process = TestProcess::start_process(executable, application.get_args(), env).await;

--- a/mirrord/layer/tests/common/mod.rs
+++ b/mirrord/layer/tests/common/mod.rs
@@ -1287,7 +1287,7 @@ impl Application {
     pub async fn get_test_process(&self, env: HashMap<String, String>) -> TestProcess {
         let executable = self.get_executable().await;
         #[cfg(target_os = "macos")]
-        let executable = sip_patch(&executable, SipPatchOptions::default())
+        let executable = sip_patch(&executable, SipPatchOptions::default(), None)
             .unwrap()
             .unwrap_or(executable);
         println!("Using executable: {}", &executable);

--- a/mirrord/layer/tests/fileops.rs
+++ b/mirrord/layer/tests/fileops.rs
@@ -81,7 +81,7 @@ async fn read_from_mirrord_bin(dylib_path: &Path) {
     // Make sure we write and read from different paths (this is "meta check").
     assert_ne!(file_path, path_in_mirrord_bin);
 
-    let executable = sip_patch("cat", SipPatchOptions::default())
+    let executable = sip_patch("cat", SipPatchOptions::default(), None)
         .unwrap()
         .unwrap();
 

--- a/mirrord/layer/tests/sip.rs
+++ b/mirrord/layer/tests/sip.rs
@@ -23,7 +23,7 @@ use mirrord_sip::{sip_patch, SipPatchOptions};
 async fn tmp_dir_read_locally(dylib_path: &Path) {
     let application = Application::BashShebang;
     let executable = application.get_executable().await;
-    let executable = sip_patch(&executable, SipPatchOptions::default())
+    let executable = sip_patch(&executable, SipPatchOptions::default(), None)
         .unwrap()
         .unwrap();
     println!("Using executable: {}", &executable);

--- a/mirrord/sip/Cargo.toml
+++ b/mirrord/sip/Cargo.toml
@@ -25,6 +25,8 @@ tempfile.workspace = true
 
 once_cell = "1"
 
+fs4 = { version = "0.12" }
+
 tracing.workspace = true
 thiserror.workspace = true
 which.workspace = true

--- a/mirrord/sip/src/lib.rs
+++ b/mirrord/sip/src/lib.rs
@@ -656,7 +656,7 @@ mod main {
         log_info: &SipLogInfo,
     ) -> Result<()> {
         if let Some(ref mut file) = file {
-            file.lock_exclusive().map_err(|error| SipError::IO(error))?;
+            file.lock_exclusive().map_err(SipError::IO)?;
             writeln!(
                 file,
                 "[{}] (pid {}, binary: {binary_path}, args: {:?}) SIP Status: {status:?}, layer load type: {:?}",
@@ -668,15 +668,15 @@ mod main {
                 log_info.args,
                 log_info.load_type
             )
-            .map_err(|error| SipError::IO(error))?;
-            file.unlock().map_err(|error| SipError::IO(error))?;
+            .map_err(SipError::IO)?;
+            file.unlock().map_err(SipError::IO)?;
         };
         Ok(())
     }
 
     fn write_result_to_file(file: &mut Option<File>, result: &str) -> Result<()> {
         if let Some(ref mut file) = file {
-            file.lock_exclusive().map_err(|error| SipError::IO(error))?;
+            file.lock_exclusive().map_err(SipError::IO)?;
             writeln!(
                 file,
                 "[{}] (pid {}) SIP patch result: {result}",
@@ -686,8 +686,8 @@ mod main {
                     .as_secs(),
                 std::process::id()
             )
-            .map_err(|error| SipError::IO(error))?;
-            file.unlock().map_err(|error| SipError::IO(error))?;
+            .map_err(SipError::IO)?;
+            file.unlock().map_err(SipError::IO)?;
         };
         Ok(())
     }
@@ -709,7 +709,7 @@ mod main {
                 .create(true)
                 .append(true)
                 .open(log_info.log_destination)?;
-            Some(File::from(output_file))
+            Some(output_file)
         } else {
             None
         };


### PR DESCRIPTION
### sample output

```
[1752748605] (pid 22090, binary: /Users/gem/sdk/go1.24.1/pkg/tool/darwin_arm64/compile, args: Some(["/Users/gem/sdk/go1.24.1/bin/go", "build", "-o", "./application", "./main.go"])) SIP Status: Ok(SipBinary("/Users/gem/sdk/go1.24.1/pkg/tool/darwin_arm64/compile")), layer load type: None
[1752748605] (pid 22090) SIP patch result: patched successfully
```