### PR TITLE
Agent communication port now uses SO_REUSEADDR flag

### DIFF
--- a/changelog.d/+agent-reuse-addr.fixed.md
+++ b/changelog.d/+agent-reuse-addr.fixed.md
@@ -1,0 +1,1 @@
+Agent communication port now uses SO_REUSEADDR flag, fixing cases where agent port is reused in a fast consecutive manner and fails

--- a/mirrord/agent/src/entrypoint.rs
+++ b/mirrord/agent/src/entrypoint.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::HashMap,
     mem,
-    net::{Ipv4Addr, Ipv6Addr, SocketAddrV4, SocketAddrV6},
+    net::{Ipv4Addr, Ipv6Addr, SocketAddrV4, SocketAddrV6, SocketAddr},
     ops::Not,
     path::PathBuf,
     sync::{
@@ -630,12 +630,12 @@ async fn start_agent(args: Args) -> AgentResult<()> {
     let setup_listener = |ipv6: bool| -> AgentResult<TcpListener> {
         let (socket, addr) = if ipv6 {
             (
-                TcpSocket::new_v6()?,
+                Socket::new(Domain::IPV6, Type::STREAM, Protocol::TCP)?,
                 SocketAddr::new(Ipv6Addr::UNSPECIFIED.into(), args.communicate_port),
             )
         } else {
             (
-                TcpSocket::new_v4()?,
+                Socket::new(Domain::IPV4, Type::STREAM, Protocol::TCP)?,
                 SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), args.communicate_port),
             )
         };

--- a/mirrord/agent/src/entrypoint.rs
+++ b/mirrord/agent/src/entrypoint.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::HashMap,
     mem,
-    net::{Ipv4Addr, Ipv6Addr, SocketAddrV4, SocketAddrV6, SocketAddr},
+    net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6},
     ops::Not,
     path::PathBuf,
     sync::{
@@ -645,6 +645,7 @@ async fn start_agent(args: Args) -> AgentResult<()> {
         socket.listen(1024).map_err(From::from)
     };
 
+    let listener = setup_listener(args.ipv6).await?;
     let client_listener_address = listener.local_addr()?;
 
     debug!(%client_listener_address, "Created the client listener.");


### PR DESCRIPTION
Agent communication port now uses SO_REUSEADDR flag, fixing cases where agent port is reused in a fast consecutive manner and fails
