### PR TITLE
Cause too many open files error to stop execution and fail SIP patching

### DIFF
--- a/changelog.d/+too-many-files-error.fixed.md
+++ b/changelog.d/+too-many-files-error.fixed.md
@@ -1,0 +1,1 @@
+Fixed a bug where SIP patching would discard the error when too many files are open and cause problems with layer injection.


### PR DESCRIPTION
Issue: https://linear.app/metalbear/issue/MBE-1070/mirrord-exec-air-mirrord-layer-not-injected-into-air-process-binary