### PR TITLE
Update Rust to fresh nightly, and change edition to 2024.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ dependencies = [
  "flate2",
  "foldhash",
  "futures-core",
- "h2 0.3.26",
+ "h2 0.3.27",
  "http 0.2.12",
  "httparse",
  "httpdate",
@@ -49,7 +49,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rand 0.9.1",
+ "rand 0.9.2",
  "sha1",
  "smallvec",
  "tokio",
@@ -65,7 +65,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
 dependencies = [
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -105,7 +105,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "mio",
- "socket2",
+ "socket2 0.5.10",
  "tokio",
  "tracing",
 ]
@@ -167,7 +167,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "smallvec",
- "socket2",
+ "socket2 0.5.10",
  "time",
  "tracing",
  "url",
@@ -182,7 +182,7 @@ dependencies = [
  "actix-router",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -196,9 +196,9 @@ dependencies = [
 
 [[package]]
 name = "adler2"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "ahash"
@@ -260,9 +260,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.18"
+version = "0.6.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -275,33 +275,33 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
 dependencies = [
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.8"
+version = "3.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6680de5231bd6ee4c6191b8a1325daa282b415391ec9d3a37bd34f2060dc73fa"
+checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
@@ -504,7 +504,7 @@ checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
  "synstructure",
 ]
 
@@ -516,7 +516,7 @@ checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
  "synstructure",
 ]
 
@@ -528,7 +528,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -555,9 +555,9 @@ dependencies = [
 
 [[package]]
 name = "async-channel"
-version = "2.3.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
 dependencies = [
  "concurrent-queue",
  "event-listener-strategy",
@@ -594,7 +594,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -611,14 +611,14 @@ checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "atomic"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d818003e740b63afc82337e3160717f4f63078720a810b7b903e70a5d1d2994"
+checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
 dependencies = [
  "bytemuck",
 ]
@@ -631,15 +631,15 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-config"
-version = "1.6.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02a18fd934af6ae7ca52410d4548b98eb895aab0f1ea417d168d85db1434a141"
+checksum = "c0baa720ebadea158c5bda642ac444a2af0cdf7bb66b46d1e4533de5d1f449d0"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -667,9 +667,9 @@ dependencies = [
 
 [[package]]
 name = "aws-credential-types"
-version = "1.2.3"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "687bc16bc431a8533fe0097c7f0182874767f920989d7260950172ae8e3c4465"
+checksum = "b68c2194a190e1efc999612792e25b1ab3abfefe4306494efaaabc25933c0cbe"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -679,9 +679,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.13.1"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fcc8f365936c834db5514fc45aee5b1202d677e6b40e48468aaaa8183ca8c7"
+checksum = "5c953fe1ba023e6b7730c0d4b031d06f267f23a46167dcbd40316644b10a17ba"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -689,9 +689,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61b1d86e7705efe1be1b569bab41d4fa1e14e220b60a160f78de2db687add079"
+checksum = "dbfd150b5dbdb988bcc8fb1fe787eb6b7ee6180ca24da683b61ea5405f3d43ff"
 dependencies = [
  "bindgen",
  "cc",
@@ -702,9 +702,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.5.7"
+version = "1.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c4063282c69991e57faab9e5cb21ae557e59f5b0fb285c196335243df8dc25c"
+checksum = "b2090e664216c78e766b6bac10fe74d2f451c02441d43484cd76ac9a295075f7"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -726,9 +726,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sqs"
-version = "1.71.0"
+version = "1.78.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0519921fc7065a54b8dec1d10de2893d99a61d030b9f8eb00ee83eb62d2a2676"
+checksum = "010fe18815b43842c4c04657e6a22387a760382c71099e984887e0cffc6d325c"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -748,9 +748,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.71.0"
+version = "1.78.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a4fd09d6e863655d99cd2260f271c6d1030dc6bfad68e19e126d2e4c8ceb18"
+checksum = "dbd7bc4bd34303733bded362c4c997a39130eac4310257c79aae8484b1c4b724"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -770,9 +770,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.72.0"
+version = "1.79.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3224ab02ebb3074467a33d57caf6fcb487ca36f3697fdd381b0428dc72380696"
+checksum = "77358d25f781bb106c1a69531231d4fd12c6be904edb0c47198c604df5a2dbca"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -792,9 +792,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.72.0"
+version = "1.80.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6933f189ed1255e78175fbd73fb200c0aae7240d220ed3346f567b0ddca3083"
+checksum = "06e3ed2a9b828ae7763ddaed41d51724d2661a50c45f845b08967e52f4939cfc"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -815,9 +815,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.3.2"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3734aecf9ff79aa401a6ca099d076535ab465ff76b46440cf567c8e70b65dc13"
+checksum = "ddfb9021f581b71870a17eac25b52335b82211cdc092e02b6876b2bcefa61666"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-http",
@@ -848,9 +848,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.62.1"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99335bec6cdc50a346fda1437f9fefe33abf8c99060739a546a16457f2862ca9"
+checksum = "43c82ba4cab184ea61f6edaafc1072aad3c2a17dcf4c0fce19ac5694b90d8b5f"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -868,25 +868,26 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.0.2"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e44697a9bded898dcd0b1cb997430d949b87f4f8940d91023ae9062bf218250"
+checksum = "f108f1ca850f3feef3009bdcc977be201bca9a91058864d9de0684e64514bee0"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "h2 0.4.10",
+ "h2 0.3.27",
+ "h2 0.4.11",
  "http 0.2.12",
  "http 1.3.1",
  "http-body 0.4.6",
  "hyper 0.14.32",
  "hyper 1.6.0",
  "hyper-rustls 0.24.2",
- "hyper-rustls 0.27.6",
+ "hyper-rustls 0.27.7",
  "hyper-util",
  "pin-project-lite",
  "rustls 0.21.12",
- "rustls 0.23.27",
+ "rustls 0.23.29",
  "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "tokio",
@@ -896,9 +897,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.61.3"
+version = "0.61.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92144e45819cae7dc62af23eac5a038a58aa544432d2102609654376a900bd07"
+checksum = "a16e040799d29c17412943bdbf488fd75db04112d0c0d4b9290bacf5ae0014b9"
 dependencies = [
  "aws-smithy-types",
 ]
@@ -924,9 +925,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.8.3"
+version = "1.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14302f06d1d5b7d333fd819943075b13d27c7700b414f574c3c35859bfb55d5e"
+checksum = "660f70d9d8af6876b4c9aa8dcb0dbaf0f89b04ee9a4455bea1b4ba03b15f26f6"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -948,9 +949,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.8.0"
+version = "1.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e5d9e3a80a18afa109391fb5ad09c3daf887b516c6fd805a157c6ea7994a57"
+checksum = "937a49ecf061895fca4a6dd8e864208ed9be7546c0527d04bc07d502ec5fba1c"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-types",
@@ -965,9 +966,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.3.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40076bd09fadbc12d5e026ae080d0930defa606856186e31d83ccc6a255eeaf3"
+checksum = "d498595448e43de7f4296b7b7a18a8a02c61ec9349128c80a368f7c3b4ab11a8"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -991,18 +992,18 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-xml"
-version = "0.60.9"
+version = "0.60.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab0b0166827aa700d3dc519f72f8b3a91c35d0b8d042dc5d643a91e6f80648fc"
+checksum = "3db87b96cb1b16c024980f133968d52882ca0daaee3a086c6decc500f6c99728"
 dependencies = [
  "xmlparser",
 ]
 
 [[package]]
 name = "aws-types"
-version = "1.3.7"
+version = "1.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a322fec39e4df22777ed3ad8ea868ac2f94cd15e1a55f6ee8d8d6305057689a"
+checksum = "b069d19bf01e46298eaedd7c6f283fe565a59263e53eebec945f3e6398f42390"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
@@ -1079,7 +1080,7 @@ checksum = "57d123550fa8d071b7255cb0cc04dc302baa6c8c4a79f55701552684d8399bce"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1147,9 +1148,9 @@ dependencies = [
 
 [[package]]
 name = "base64ct"
-version = "1.7.3"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
+checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 
 [[package]]
 name = "bcder"
@@ -1206,7 +1207,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.101",
+ "syn 2.0.104",
  "which 4.4.2",
 ]
 
@@ -1288,9 +1289,9 @@ dependencies = [
 
 [[package]]
 name = "blocking"
-version = "1.6.1"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
 dependencies = [
  "async-channel",
  "async-task",
@@ -1385,9 +1386,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.17.0"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "byte-strings-proc_macros"
@@ -1402,9 +1403,9 @@ dependencies = [
 
 [[package]]
 name = "bytemuck"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9134a6ef01ce4b366b50689c94f82c14bc72bc5d0386829828a2e2752ef7958c"
+checksum = "5c76a5792e44e4abe34d3abf15636779261d45a7450612059293d1d2cfc63422"
 
 [[package]]
 name = "byteorder"
@@ -1465,18 +1466,18 @@ dependencies = [
 
 [[package]]
 name = "c2rust-bitfields"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "367e5d1b30f28be590b6b3868da1578361d29d9bfac516d22f497d28ed7c9055"
+checksum = "46dc7d2bffa0d0b3d47eb2dc69973466858281446c2ac9f6d8a10e92ab1017df"
 dependencies = [
  "c2rust-bitfields-derive",
 ]
 
 [[package]]
 name = "c2rust-bitfields-derive"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a279db9c50c4024eeca1a763b6e0f033848ce74e83e47454bcf8a8a98f7b0b56"
+checksum = "ebe1117afa5937ce280034e31fa1e84ed1824a252f75380327eed438535333f8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1506,9 +1507,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.24"
+version = "1.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16595d3be041c03b09d08d0858631facccee9221e579704070e6e9e4915d3bc7"
+checksum = "deec109607ca693028562ed836a5f1c4b8bd77755c4e132fc5ce11b0b6211ae7"
 dependencies = [
  "jobserver",
  "libc",
@@ -1526,9 +1527,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "cfg_aliases"
@@ -1596,9 +1597,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.39"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd60e63e9be68e5fb56422e397cf9baddded06dae1d2e523401542383bc72a9f"
+checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1606,9 +1607,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.39"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89cc6392a1f72bbeb820d71f32108f61fdaf18bc526e1d23954168a67759ef51"
+checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1618,30 +1619,30 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.51"
+version = "4.5.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d2267df7f3c8e74e38268887ea5235d4dfadd39bfff2d56ab82d61776be355e"
+checksum = "a5abde44486daf70c5be8b8f8f1b66c49f86236edf6fa2abadb4d961c4c6229a"
 dependencies = [
  "clap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.5.32"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
+checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "cmake"
@@ -1654,9 +1655,9 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "concurrent-queue"
@@ -1676,7 +1677,7 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
- "unicode-width 0.2.0",
+ "unicode-width 0.2.1",
  "windows-sys 0.59.0",
 ]
 
@@ -1708,9 +1709,9 @@ dependencies = [
 
 [[package]]
 name = "const_panic"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2459fc9262a1aa204eb4b5764ad4f189caec88aea9634389c0a25f8be7f6265e"
+checksum = "b98d1483e98c9d67f341ab4b3915cfdc54740bd6f5cccc9226ee0535d86aa8fb"
 
 [[package]]
 name = "containerd-client"
@@ -1797,9 +1798,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
@@ -1831,9 +1832,9 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
@@ -1912,7 +1913,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1944,7 +1945,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1968,7 +1969,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1979,7 +1980,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2031,7 +2032,7 @@ checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2052,7 +2053,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2062,7 +2063,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2082,7 +2083,7 @@ checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
  "unicode-xid",
 ]
 
@@ -2181,7 +2182,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2213,7 +2214,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2249,9 +2250,9 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ecdsa"
@@ -2275,7 +2276,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2327,7 +2328,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2347,7 +2348,7 @@ checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2359,7 +2360,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2410,12 +2411,12 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2512,7 +2513,7 @@ dependencies = [
  "atomic",
  "pear",
  "serde",
- "toml 0.8.22",
+ "toml 0.8.23",
  "uncased",
  "version_check",
 ]
@@ -2544,9 +2545,9 @@ checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
+checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -2704,7 +2705,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2763,7 +2764,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -2783,14 +2784,14 @@ dependencies = [
 
 [[package]]
 name = "getset"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3586f256131df87204eb733da72e3d3eb4f343c639f4b7be279ac7c48baeafe"
+checksum = "9cf0fc11e47561d47397154977bc219f4cf809b2974facc3ccb3b89e2436f912"
 dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2865,9 +2866,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
 dependencies = [
  "bytes",
  "fnv",
@@ -2875,7 +2876,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2884,9 +2885,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5"
+checksum = "17da50a276f1e01e0ba6c029e47b7100754904ee8a278f886546e98575380785"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2894,7 +2895,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.3.1",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2918,9 +2919,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.3"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -2929,11 +2930,11 @@ dependencies = [
 
 [[package]]
 name = "headers"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322106e6bd0cba2d5ead589ddb8150a13d7c4217cf80d7c4f682ca994ccc6aa9"
+checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "bytes",
  "headers-core",
  "http 1.3.1",
@@ -2959,9 +2960,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f154ce46856750ed433c8649605bf7ed2de3bc35fd9d2a9f30cddd873c80cb08"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -3162,14 +3163,14 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.3.26",
+ "h2 0.3.27",
  "http 0.2.12",
  "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -3185,7 +3186,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.10",
+ "h2 0.4.11",
  "http 1.3.1",
  "http-body 1.0.1",
  "httparse",
@@ -3208,7 +3209,7 @@ dependencies = [
  "headers",
  "http 1.3.1",
  "hyper 1.6.0",
- "hyper-rustls 0.27.6",
+ "hyper-rustls 0.27.7",
  "hyper-util",
  "pin-project-lite",
  "rustls-native-certs 0.7.3",
@@ -3250,15 +3251,15 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.6"
+version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a01595e11bdcec50946522c32dde3fc6914743000a68b93000965f2f02406d"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
  "http 1.3.1",
  "hyper 1.6.0",
  "hyper-util",
  "log",
- "rustls 0.23.27",
+ "rustls 0.23.29",
  "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "tokio",
@@ -3297,9 +3298,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.13"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c293b6b3d21eca78250dc7dbebd6b9210ec5530e038cbfe0661b5c47ab06e8"
+checksum = "8d9b05277c7e8da2c93a568989bb6207bef0112e8d17df7a6eda4a3cf143bc5e"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -3313,7 +3314,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.0",
  "tokio",
  "tower-service",
  "tracing",
@@ -3506,12 +3507,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.3",
+ "hashbrown 0.15.4",
  "serde",
 ]
 
@@ -3524,7 +3525,7 @@ dependencies = [
  "console",
  "number_prefix",
  "portable-atomic",
- "unicode-width 0.2.0",
+ "unicode-width 0.2.1",
  "web-time",
 ]
 
@@ -3545,12 +3546,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-uring"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
+dependencies = [
+ "bitflags 2.9.1",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "ipconfig"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
 dependencies = [
- "socket2",
+ "socket2 0.5.10",
  "widestring",
  "windows-sys 0.48.0",
  "winreg",
@@ -3637,9 +3649,9 @@ dependencies = [
 name = "issue1776"
 version = "3.153.0"
 dependencies = [
- "errno 0.3.12",
+ "errno 0.3.13",
  "libc",
- "socket2",
+ "socket2 0.5.10",
 ]
 
 [[package]]
@@ -3647,7 +3659,7 @@ name = "issue1776portnot53"
 version = "3.153.0"
 dependencies = [
  "libc",
- "socket2",
+ "socket2 0.5.10",
 ]
 
 [[package]]
@@ -3710,9 +3722,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jiff"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a194df1107f33c79f4f93d02c80798520551949d59dfad22b6157048a88cca93"
+checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
 dependencies = [
  "jiff-static",
  "log",
@@ -3723,13 +3735,13 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c6e1db7ed32c6c71b759497fae34bf7933636f75a251b9e736555da426f6442"
+checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3807,7 +3819,7 @@ checksum = "2c75b990324f09bef15e791606b7b7a296d02fc88a344f6eba9390970a870ad5"
 dependencies = [
  "base64 0.22.1",
  "chrono",
- "schemars",
+ "schemars 0.8.22",
  "serde",
  "serde-value",
  "serde_json",
@@ -3864,7 +3876,7 @@ dependencies = [
  "http-body-util",
  "hyper 1.6.0",
  "hyper-http-proxy",
- "hyper-rustls 0.27.6",
+ "hyper-rustls 0.27.7",
  "hyper-socks2",
  "hyper-timeout",
  "hyper-util",
@@ -3872,7 +3884,7 @@ dependencies = [
  "k8s-openapi",
  "kube-core",
  "pem",
- "rustls 0.23.27",
+ "rustls 0.23.29",
  "secrecy",
  "serde",
  "serde_json",
@@ -3897,7 +3909,7 @@ dependencies = [
  "http 1.3.1",
  "json-patch",
  "k8s-openapi",
- "schemars",
+ "schemars 0.8.22",
  "serde",
  "serde-value",
  "serde_json",
@@ -3915,7 +3927,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3931,7 +3943,7 @@ dependencies = [
  "backon",
  "educe",
  "futures",
- "hashbrown 0.15.3",
+ "hashbrown 0.15.4",
  "hostname",
  "json-patch",
  "k8s-openapi",
@@ -3969,9 +3981,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "libloading"
@@ -3980,7 +3992,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.0",
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -3991,9 +4003,9 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libredox"
-version = "0.1.3"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+checksum = "360e552c93fa0e8152ab463bc4c4837fce76a225df11dfaeea66c313de5e61f7"
 dependencies = [
  "bitflags 2.9.1",
  "libc",
@@ -4059,9 +4071,9 @@ checksum = "4d873d7c67ce09b42110d801813efbc9364414e356be9935700d368351657487"
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -4130,8 +4142,8 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "glob",
- "rand 0.9.1",
- "syn 2.0.101",
+ "rand 0.9.2",
+ "syn 2.0.104",
  "thiserror 2.0.12",
  "tracing",
  "tracing-subscriber",
@@ -4139,9 +4151,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "memoffset"
@@ -4163,9 +4175,9 @@ dependencies = [
 
 [[package]]
 name = "mid"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "967fa53bf9833568696f5ffe368d6508420280d844ab902141d268725297be01"
+checksum = "a1e7bdae9f63797e5ddd4d82efba0436f45f1c285e8427d2bb3e9c5f9de93ccc"
 dependencies = [
  "hex",
  "hmac-sha256",
@@ -4198,7 +4210,7 @@ checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4224,7 +4236,7 @@ checksum = "bd2209fff77f705b00c737016a48e73733d7fbccb8b007194db148f03561fb70"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4235,9 +4247,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
 ]
@@ -4250,7 +4262,7 @@ checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.59.0",
 ]
 
@@ -4295,11 +4307,11 @@ dependencies = [
  "regex",
  "reqwest",
  "rstest",
- "rustls 0.23.27",
+ "rustls 0.23.29",
  "semver 1.0.26",
  "serde",
  "serde_json",
- "socket2",
+ "socket2 0.5.10",
  "thiserror 2.0.12",
  "tokio",
  "tokio-rustls 0.26.2",
@@ -4346,11 +4358,11 @@ dependencies = [
  "rcgen",
  "reqwest",
  "rstest",
- "rustls 0.23.27",
+ "rustls 0.23.29",
  "semver 1.0.26",
  "serde",
  "serde_json",
- "socket2",
+ "socket2 0.5.10",
  "streammap-ext",
  "tempfile",
  "thiserror 2.0.12",
@@ -4372,7 +4384,7 @@ version = "3.153.0"
 dependencies = [
  "base64 0.22.1",
  "k8s-openapi",
- "schemars",
+ "schemars 0.8.22",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -4390,7 +4402,7 @@ dependencies = [
  "mirrord-agent-env",
  "mockall",
  "nix 0.29.0",
- "rand 0.9.1",
+ "rand 0.9.2",
  "tokio",
  "tracing",
 ]
@@ -4443,18 +4455,18 @@ dependencies = [
  "mirrord-analytics",
  "mirrord-config-derive",
  "nom",
- "rand 0.9.1",
+ "rand 0.9.2",
  "rstest",
- "rustls 0.23.27",
- "schemars",
+ "rustls 0.23.29",
+ "schemars 0.8.22",
  "serde",
  "serde_json",
  "serde_yaml",
- "strum 0.27.1",
- "strum_macros 0.27.1",
+ "strum 0.27.2",
+ "strum_macros 0.27.2",
  "tera",
  "thiserror 2.0.12",
- "toml 0.8.22",
+ "toml 0.8.23",
  "tracing",
 ]
 
@@ -4465,7 +4477,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4500,10 +4512,10 @@ dependencies = [
  "mirrord-operator",
  "mirrord-protocol",
  "mirrord-tls-util",
- "rand 0.9.1",
+ "rand 0.9.2",
  "rcgen",
  "rstest",
- "rustls 0.23.27",
+ "rustls 0.23.29",
  "semver 1.0.26",
  "serde",
  "thiserror 2.0.12",
@@ -4537,7 +4549,7 @@ dependencies = [
  "mirrord-config",
  "mirrord-progress",
  "mirrord-protocol",
- "rand 0.9.1",
+ "rand 0.9.2",
  "regex",
  "rstest",
  "serde",
@@ -4575,12 +4587,12 @@ dependencies = [
  "null-terminated",
  "num-traits",
  "objc2-core-foundation",
- "rand 0.9.1",
+ "rand 0.9.2",
  "regex",
  "resolv-conf",
  "rstest",
  "serde_json",
- "socket2",
+ "socket2 0.5.10",
  "syscalls",
  "tempfile",
  "test-cdylib",
@@ -4597,7 +4609,7 @@ version = "3.153.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4607,7 +4619,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "semver 1.0.26",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4631,9 +4643,9 @@ dependencies = [
  "mirrord-kube",
  "mirrord-progress",
  "mirrord-protocol",
- "rand 0.9.1",
+ "rand 0.9.2",
  "rstest",
- "schemars",
+ "schemars 0.8.22",
  "semver 1.0.26",
  "serde",
  "serde_json",
@@ -4672,7 +4684,7 @@ dependencies = [
  "nix 0.29.0",
  "semver 1.0.26",
  "serde",
- "socket2",
+ "socket2 0.5.10",
  "thiserror 2.0.12",
  "tracing",
 ]
@@ -4686,7 +4698,7 @@ dependencies = [
  "hex",
  "object",
  "once_cell",
- "rand 0.9.1",
+ "rand 0.9.2",
  "tempfile",
  "thiserror 2.0.12",
  "tracing",
@@ -4700,7 +4712,7 @@ dependencies = [
  "http 1.3.1",
  "pem",
  "rcgen",
- "rustls 0.23.27",
+ "rustls 0.23.29",
  "rustls-pemfile 2.2.0",
  "tempfile",
  "thiserror 2.0.12",
@@ -4751,7 +4763,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4921,7 +4933,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -5006,8 +5018,8 @@ checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "crc32fast",
  "flate2",
- "hashbrown 0.15.3",
- "indexmap 2.9.0",
+ "hashbrown 0.15.4",
+ "indexmap 2.10.0",
  "memchr",
  "ruzstd",
 ]
@@ -5097,9 +5109,9 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "owo-colors"
-version = "4.2.1"
+version = "4.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26995317201fa17f3656c36716aed4a7c81743a9634ac4c99c0eeda495db0cec"
+checksum = "48dd4f4a2c8405440fd0462561f0e5806bd0f77e86f51c761481bdd4018b545e"
 
 [[package]]
 name = "p12"
@@ -5137,9 +5149,9 @@ checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -5147,9 +5159,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if",
  "libc",
@@ -5193,7 +5205,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -5223,9 +5235,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "198db74531d58c70a361c42201efde7e2591e976d518caf7662a47dc5720e7b6"
+checksum = "1db05f56d34358a8b1066f67cbb203ee3e7ed2ba674a6263a1d5ec6db2204323"
 dependencies = [
  "memchr",
  "thiserror 2.0.12",
@@ -5234,9 +5246,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d725d9cfd79e87dccc9341a2ef39d1b6f6353d68c4b33c177febbe1a402c97c5"
+checksum = "bb056d9e8ea77922845ec74a1c4e8fb17e7c218cc4fc11a15c5d25e189aa40bc"
 dependencies = [
  "pest",
  "pest_generator",
@@ -5244,24 +5256,23 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db7d01726be8ab66ab32f9df467ae8b1148906685bbe75c82d1e65d7f5b3f841"
+checksum = "87e404e638f781eb3202dc82db6760c8ae8a1eeef7fb3fa8264b2ef280504966"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9f832470494906d1fca5329f8ab5791cc60beb230c74815dff541cbd2b5ca0"
+checksum = "edd1101f170f5903fde0914f899bb503d9ff5271d7ba76bbb70bea63690cc0d5"
 dependencies = [
- "once_cell",
  "pest",
  "sha2",
 ]
@@ -5273,7 +5284,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
 ]
 
 [[package]]
@@ -5331,7 +5342,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -5392,12 +5403,12 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plist"
-version = "1.7.1"
+version = "1.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac26e981c03a6e53e0aee43c113e3202f5581d5360dae7bd2c70e800dd0451d"
+checksum = "3af6b589e163c5a788fab00ce0c0366f6efbb9959c2f9874b224936af7fce7e1"
 dependencies = [
  "base64 0.22.1",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "quick-xml",
  "serde",
  "time",
@@ -5448,7 +5459,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -5496,9 +5507,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
 name = "portable-atomic-util"
@@ -5561,12 +5572,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.32"
+version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "664ec5419c51e34154eec046ebcba56312d5a2fc3b09a06da188e1ad21afadf6"
+checksum = "ff24dfcda44452b9816fff4cd4227e1bb73ff5a2f1bc1105aa92fb8565ce44d2"
 dependencies = [
  "proc-macro2",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -5620,7 +5631,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -5640,7 +5651,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
  "version_check",
  "yansi",
 ]
@@ -5713,7 +5724,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn 2.0.101",
+ "syn 2.0.104",
  "tempfile",
 ]
 
@@ -5727,7 +5738,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -5761,9 +5772,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.32.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d3a6e5838b60e0e8fa7a43f22ade549a37d61f8bdbe636d0d7816191de969c2"
+checksum = "8927b0664f5c5a98265138b7e3f90aa19a6b21353182469ace36d4ac527b7b1b"
 dependencies = [
  "memchr",
 ]
@@ -5780,8 +5791,8 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.1.1",
- "rustls 0.23.27",
- "socket2",
+ "rustls 0.23.29",
+ "socket2 0.5.10",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
@@ -5797,10 +5808,10 @@ dependencies = [
  "bytes",
  "getrandom 0.3.3",
  "lru-slab",
- "rand 0.9.1",
+ "rand 0.9.2",
  "ring",
  "rustc-hash 2.1.1",
- "rustls 0.23.27",
+ "rustls 0.23.29",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.12",
@@ -5811,14 +5822,14 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.12"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee4e529991f949c5e25755532370b8af5d114acae52326361d68d47af64aa842"
+checksum = "fcebb1209ee276352ef14ff8732e24cc2b02bbac986cd74a4c81bcb2f9881970"
 dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -5834,9 +5845,9 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "radium"
@@ -5857,9 +5868,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
@@ -5938,7 +5949,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rayon",
- "syn 2.0.101",
+ "syn 2.0.104",
  "uuid",
 ]
 
@@ -5952,7 +5963,7 @@ dependencies = [
  "ipnetwork",
  "libc",
  "nix 0.26.4",
- "socket2",
+ "socket2 0.5.10",
  "tokio",
 ]
 
@@ -6006,14 +6017,14 @@ version = "0.1.0"
 name = "recv_from"
 version = "0.1.0"
 dependencies = [
- "socket2",
+ "socket2 0.6.0",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.12"
+version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
  "bitflags 2.9.1",
 ]
@@ -6038,6 +6049,26 @@ dependencies = [
  "getrandom 0.2.16",
  "libredox",
  "thiserror 2.0.12",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a0ae411dbe946a674d89546582cea4ba2bb8defac896622d6496f14c23ba5cf"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -6098,31 +6129,28 @@ checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "reqwest"
-version = "0.12.18"
+version = "0.12.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e98ff6b0dbbe4d5a37318f433d4fc82babd21631f194d370409ceb2e40b2f0b5"
+checksum = "cbc931937e6ca3a06e3b6c0aa7841849b160a90351d6ab467a8b9b9959767531"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.10",
+ "h2 0.4.11",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.6.0",
- "hyper-rustls 0.27.6",
+ "hyper-rustls 0.27.7",
  "hyper-util",
- "ipnet",
  "js-sys",
  "log",
- "mime",
- "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.27",
+ "rustls 0.23.29",
  "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "serde",
@@ -6131,7 +6159,6 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls 0.26.2",
- "tokio-socks",
  "tower 0.5.2",
  "tower-http",
  "tower-service",
@@ -6208,7 +6235,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn 2.0.101",
+ "syn 2.0.104",
  "unicode-ident",
 ]
 
@@ -6253,9 +6280,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.24"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustc-hash"
@@ -6294,7 +6321,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
  "bitflags 2.9.1",
- "errno 0.3.12",
+ "errno 0.3.13",
  "libc",
  "linux-raw-sys 0.4.15",
  "windows-sys 0.59.0",
@@ -6302,15 +6329,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
  "bitflags 2.9.1",
- "errno 0.3.12",
+ "errno 0.3.13",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6327,16 +6354,16 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.27"
+version = "0.23.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "730944ca083c1c233a75c09f199e973ca499344a2b7ba9e755c457e86fb4a321"
+checksum = "2491382039b29b9b11ff08b76ff6c97cf287671dbb74f0be44bda389fffe9bd1"
 dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.3",
+ "rustls-webpki 0.103.4",
  "subtle",
  "zeroize",
 ]
@@ -6418,9 +6445,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.3"
+version = "0.103.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
+checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -6488,6 +6515,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82d20c4491bc164fa2f6c5d44565947a52ad80b9505d8e36f8d54c27c739fcd0"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "schemars_derive"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6496,7 +6547,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -6522,7 +6573,7 @@ checksum = "1783eabc414609e28a5ba76aee5ddd52199f7107a0b24c2e9746a1ecc34a683d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -6658,7 +6709,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -6669,14 +6720,14 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
 dependencies = [
  "itoa",
  "memchr",
@@ -6702,14 +6753,14 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
 ]
@@ -6728,15 +6779,17 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.12.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6b6f7f2fcb69f747921f79f3926bd1e203fce4fef62c268dd3abfb6d86029aa"
+checksum = "f2c45cd61fefa9db6f254525d46e392b852e0e61d9a1fd36e5bd183450a556d5"
 dependencies = [
  "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
+ "schemars 0.9.0",
+ "schemars 1.0.4",
  "serde",
  "serde_derive",
  "serde_json",
@@ -6749,7 +6802,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "itoa",
  "ryu",
  "serde",
@@ -6847,12 +6900,9 @@ checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "slab"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
-]
+checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
 
 [[package]]
 name = "slug"
@@ -6866,9 +6916,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "snafu"
@@ -6888,7 +6938,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -6899,6 +6949,16 @@ checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6964,9 +7024,9 @@ checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 
 [[package]]
 name = "strum"
-version = "0.27.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 
 [[package]]
 name = "strum_macros"
@@ -6978,20 +7038,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.27.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "rustversion",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -7034,9 +7093,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.101"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7060,7 +7119,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -7099,7 +7158,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
- "rustix 1.0.7",
+ "rustix 1.0.8",
  "windows-sys 0.59.0",
 ]
 
@@ -7142,7 +7201,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45c6481c4829e4cc63825e62c49186a34538b7b2750b73b266581ffb612fb5ed"
 dependencies = [
- "rustix 1.0.7",
+ "rustix 1.0.8",
  "windows-sys 0.59.0",
 ]
 
@@ -7190,12 +7249,12 @@ dependencies = [
  "mirrord-operator",
  "mirrord-tls-util",
  "pem",
- "rand 0.9.1",
+ "rand 0.9.2",
  "rcgen",
  "regex",
  "reqwest",
  "rstest",
- "rustls 0.23.27",
+ "rustls 0.23.29",
  "serde",
  "serde_json",
  "tempfile",
@@ -7211,7 +7270,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
 dependencies = [
  "unicode-linebreak",
- "unicode-width 0.2.0",
+ "unicode-width 0.2.1",
 ]
 
 [[package]]
@@ -7240,7 +7299,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -7251,17 +7310,16 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
- "once_cell",
 ]
 
 [[package]]
@@ -7331,20 +7389,22 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.45.1"
+version = "1.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
+checksum = "43864ed400b6043a4757a25c7a64a8efde741aed79a056a2fb348a406701bb35"
 dependencies = [
  "backtrace",
  "bytes",
+ "io-uring",
  "libc",
  "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "slab",
+ "socket2 0.6.0",
  "tokio-macros",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7355,7 +7415,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -7385,19 +7445,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
- "rustls 0.23.27",
- "tokio",
-]
-
-[[package]]
-name = "tokio-socks"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d4770b8024672c1101b3f6733eab95b18007dbe0847a8afe341fcf79e06043f"
-dependencies = [
- "either",
- "futures-util",
- "thiserror 1.0.69",
+ "rustls 0.23.29",
  "tokio",
 ]
 
@@ -7462,9 +7510,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.22"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ae329d1f08c4d17a59bed7ff5b5a769d062e64a62d34a3261b219e62cd5aae"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -7474,20 +7522,20 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.9"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.26"
+version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -7497,9 +7545,9 @@ dependencies = [
 
 [[package]]
 name = "toml_write"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfb942dfe1d8e29a7ee7fcbde5bd2b9a25fb89aa70caea2eba3bee836ff41076"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tonic"
@@ -7512,7 +7560,7 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "bytes",
- "h2 0.4.10",
+ "h2 0.4.11",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
@@ -7522,7 +7570,7 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost",
- "socket2",
+ "socket2 0.5.10",
  "tokio",
  "tokio-stream",
  "tower 0.4.13",
@@ -7542,7 +7590,7 @@ dependencies = [
  "prost-build",
  "prost-types",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -7584,9 +7632,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.4"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fdb0c213ca27a9f57ab69ddb290fd80d970922355b83ae380b395d3986b8a2e"
+checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
  "base64 0.22.1",
  "bitflags 2.9.1",
@@ -7629,20 +7677,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.28"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
  "valuable",
@@ -7730,7 +7778,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.8.5",
- "rustls 0.23.27",
+ "rustls 0.23.29",
  "rustls-native-certs 0.7.3",
  "rustls-pki-types",
  "sha1",
@@ -7749,7 +7797,7 @@ dependencies = [
  "http 1.3.1",
  "httparse",
  "log",
- "rand 0.9.1",
+ "rand 0.9.2",
  "sha1",
  "thiserror 2.0.12",
  "utf-8",
@@ -7773,9 +7821,9 @@ checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "typewit"
-version = "1.11.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb77c29baba9e4d3a6182d51fa75e3215c7fd1dab8f4ea9d107c716878e55fc0"
+checksum = "97e72ba082eeb9da9dc68ff5a2bf727ef6ce362556e8d29ec1aed3bd05e7d86a"
 dependencies = [
  "typewit_proc_macros",
 ]
@@ -7871,9 +7919,9 @@ checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
 
 [[package]]
 name = "unicode-xid"
@@ -8005,9 +8053,9 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
@@ -8046,7 +8094,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
  "wasm-bindgen-shared",
 ]
 
@@ -8081,7 +8129,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -8117,9 +8165,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2853738d1cc4f2da3a225c18ec6c3721abb31961096e9dbf5ab35fa88b19cfdb"
+checksum = "7e8983c3ab33d6fb807cfcdad2491c4ea8cbc8ed839181c7dfd9c67c83e261b2"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -8144,7 +8192,7 @@ checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
 dependencies = [
  "either",
  "env_home",
- "rustix 1.0.7",
+ "rustix 1.0.8",
  "winsafe",
 ]
 
@@ -8223,7 +8271,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -8234,14 +8282,14 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "windows-link"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-result"
@@ -8289,6 +8337,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.3",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8321,10 +8378,11 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.0"
+version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",
@@ -8475,9 +8533,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.10"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
+checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
 dependencies = [
  "memchr",
 ]
@@ -8500,9 +8558,9 @@ checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wintun-bindings"
-version = "0.7.31"
+version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "605f50b13e12e1f9f99dc5e93701d779dbe47282fec186cb8a079165368d3124"
+checksum = "b88303b411e20a1319b368dcd04db1480003ed46ac35193e139f542720b15fbf"
 dependencies = [
  "blocking",
  "c2rust-bitfields",
@@ -8510,7 +8568,7 @@ dependencies = [
  "libloading",
  "log",
  "thiserror 2.0.12",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8591,19 +8649,19 @@ dependencies = [
 
 [[package]]
 name = "xattr"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d65cbf2f12c15564212d48f4e3dfb87923d25d611f2aed18f4cb23f0413d89e"
+checksum = "af3a19837351dc82ba89f8a125e22a3c475f05aba604acc023d62b2739ae2909"
 dependencies = [
  "libc",
- "rustix 1.0.7",
+ "rustix 1.0.8",
 ]
 
 [[package]]
 name = "xml-rs"
-version = "0.8.26"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a62ce76d9b56901b19a74f19431b0d8b3bc7ca4ad685a746dfd78ca8f4fc6bda"
+checksum = "6fd8403733700263c6eb89f192880191f1b83e332f7a20371ddcf421c4a337c7"
 
 [[package]]
 name = "xmlparser"
@@ -8664,28 +8722,28 @@ checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -8705,7 +8763,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
  "synstructure",
 ]
 
@@ -8726,7 +8784,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -8759,7 +8817,7 @@ checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -8773,7 +8831,7 @@ dependencies = [
  "crossbeam-utils",
  "displaydoc",
  "flate2",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "memchr",
  "thiserror 2.0.12",
  "zopfli",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ resolver = "2"
 # latest commits on rustls suppress certificate verification
 [workspace.package]
 version = "3.153.0"
-edition = "2021"
+edition = "2024"
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/metalbear/mirrord"

--- a/mirrord/agent/src/steal/test.rs
+++ b/mirrord/agent/src/steal/test.rs
@@ -191,16 +191,16 @@ async fn tcp_stealing(#[values(false, true)] with_tls: bool, #[values(false, tru
         .await;
     tokio::join!(
         async {
-            let conn = if let Some(tls_setup) = &setup.tls {
+            let conn = match &setup.tls { Some(tls_setup) => {
                 let connector = tls_setup.connector(None);
                 let conn = connector
                     .connect(ServerName::try_from("server").unwrap(), conn)
                     .await
                     .unwrap();
                 MaybeTls::Tls(Box::new(TlsStream::Client(conn)))
-            } else {
+            } _ => {
                 MaybeTls::NoTls(conn)
-            };
+            }};
             TestTcpProtocol::Echo.run(conn, false).await;
         },
         async {
@@ -223,13 +223,13 @@ async fn tcp_stealing(#[values(false, true)] with_tls: bool, #[values(false, tru
                     .await;
             } else {
                 let (conn, _) = setup.original_server.accept().await.unwrap();
-                let conn = if let Some(tls_setup) = &setup.tls {
+                let conn = match &setup.tls { Some(tls_setup) => {
                     let acceptor = tls_setup.acceptor();
                     let conn = acceptor.accept(conn).await.unwrap();
                     MaybeTls::Tls(Box::new(TlsStream::Server(conn)))
-                } else {
+                } _ => {
                     MaybeTls::NoTls(conn)
-                };
+                }};
                 TestTcpProtocol::Echo.run(conn, true).await;
             }
         },

--- a/mirrord/agent/src/vpn.rs
+++ b/mirrord/agent/src/vpn.rs
@@ -329,11 +329,11 @@ impl VpnTask {
                     .map_err(|err| io::Error::new(io::ErrorKind::Other, err))?;
             }
             ClientVpn::Packet(packet) => {
-                if let Some(socket) = self.socket.as_mut() {
+                match self.socket.as_mut() { Some(socket) => {
                     socket.write(&packet).await?;
-                } else {
+                } _ => {
                     tracing::error!(?packet, "unable to send packet");
-                }
+                }}
             }
             ClientVpn::OpenSocket => {
                 self.socket.replace(create_raw_socket().await?);

--- a/mirrord/cli/src/external_proxy.rs
+++ b/mirrord/cli/src/external_proxy.rs
@@ -123,7 +123,7 @@ pub async fn proxy(config: LayerConfig, listen_port: u16, watch: drain::Watch) -
     loop {
         tokio::select! {
             conn = listener.accept() => {
-                if let Ok((stream, peer_addr)) = conn {
+                match conn { Ok((stream, peer_addr)) => {
                     tracing::debug!(?peer_addr, "new connection");
 
                     let tls_acceptor = tls_acceptor.clone();
@@ -161,9 +161,9 @@ pub async fn proxy(config: LayerConfig, listen_port: u16, watch: drain::Watch) -
                             tracing::debug!(?peer_addr, "final connection, closing listener");
                         }
                     });
-                } else {
+                } _ => {
                     break;
-                }
+                }}
             }
 
             message = own_agent_conn.agent_rx.recv() => {
@@ -261,15 +261,15 @@ async fn handle_connection(
                 }
             }
             daemon_message = agent_conn.agent_rx.recv() => {
-                if let Some(daemon_message) = daemon_message {
+                match daemon_message { Some(daemon_message) => {
                     if let Err(error) = stream.send(daemon_message).await {
                         tracing::error!(?peer_addr, %error, "unable to send message to intproxy");
 
                         break;
                     }
-                } else {
+                } _ => {
                     break;
-                }
+                }}
             }
             _ = cancellation_token.cancelled() => {
                 tracing::debug!(?peer_addr, "closing connection due to cancellation_token");

--- a/mirrord/cli/src/logging.rs
+++ b/mirrord/cli/src/logging.rs
@@ -155,7 +155,7 @@ pub fn init_extproxy_tracing_registry(config: &LayerConfig) -> Result<(), Extern
 pub async fn pipe_intproxy_sidecar_logs<'s, S>(
     config: &LayerConfig,
     stream: S,
-) -> Result<impl Future<Output = ()> + 's, InternalProxyError>
+) -> Result<impl Future<Output = ()> + 's + use<'s, S>, InternalProxyError>
 where
     S: Stream<Item = std::io::Result<String>> + 's,
 {

--- a/mirrord/cli/src/util.rs
+++ b/mirrord/cli/src/util.rs
@@ -18,23 +18,24 @@ pub(crate) fn remove_proxy_env() {
         if lower_key == "http_proxy" || lower_key == "https_proxy" {
             // we set instead of unset since this way extension
             // will be able to propogate it as well.
-            std::env::set_var(key, "")
+            // TODO: Audit that the environment access only happens in single-threaded code.
+            unsafe { std::env::set_var(key, "") }
         }
     }
 }
 
 /// Used to pipe std[in/out/err] to "/dev/null" to prevent any printing to prevent any unwanted
 /// side effects
-unsafe fn redirect_fd_to_dev_null(fd: libc::c_int) {
+unsafe fn redirect_fd_to_dev_null(fd: libc::c_int) { unsafe {
     let devnull_fd = libc::open(b"/dev/null\0" as *const [u8; 10] as _, libc::O_RDWR);
     libc::dup2(devnull_fd, fd);
     libc::close(devnull_fd);
-}
+}}
 
 /// Create a new session for the proxy process, detaching from the original terminal.
 /// This makes the process not to receive signals from the "mirrord" process or it's parent
 /// terminal fixes some side effects such as <https://github.com/metalbear-co/mirrord/issues/1232>
-pub(crate) unsafe fn detach_io() -> Result<(), nix::Error> {
+pub(crate) unsafe fn detach_io() -> Result<(), nix::Error> { unsafe {
     nix::unistd::setsid()?;
 
     // flush before redirection
@@ -46,7 +47,7 @@ pub(crate) unsafe fn detach_io() -> Result<(), nix::Error> {
         redirect_fd_to_dev_null(fd);
     }
     Ok(())
-}
+}}
 
 /// Creates a listening socket using socket2
 /// to control the backlog and manage scenarios where

--- a/mirrord/config/Cargo.toml
+++ b/mirrord/config/Cargo.toml
@@ -11,7 +11,8 @@ license.workspace = true
 keywords.workspace = true
 categories.workspace = true
 publish.workspace = true
-edition.workspace = true
+# edition.workspace = true
+edition = "2024"
 
 [lints]
 workspace = true

--- a/mirrord/config/Cargo.toml
+++ b/mirrord/config/Cargo.toml
@@ -11,8 +11,7 @@ license.workspace = true
 keywords.workspace = true
 categories.workspace = true
 publish.workspace = true
-# edition.workspace = true
-edition = "2024"
+edition.workspace = true
 
 [lints]
 workspace = true

--- a/mirrord/config/derive/src/config.rs
+++ b/mirrord/config/derive/src/config.rs
@@ -32,20 +32,20 @@ impl ConfigStruct {
 
         let flags = ConfigFlags::new(&attrs, ConfigFlagsType::Container)?;
 
-        let fields = if let Data::Struct(DataStruct {
+        let fields = match data
+        { Data::Struct(DataStruct {
             fields: Fields::Named(FieldsNamed { named, .. }),
             ..
-        }) = data
-        {
+        }) => {
             Ok(named
                 .into_iter()
                 .map(ConfigField::try_from)
                 .collect::<Result<_, _>>()?)
-        } else {
+        } _ => {
             Err(source
                 .span()
                 .error("Enums, Unions, and Unnamed Structs are not supported"))
-        }?;
+        }}?;
 
         let ident = flags
             .map_to

--- a/mirrord/config/derive/src/config/field.rs
+++ b/mirrord/config/derive/src/config/field.rs
@@ -25,11 +25,11 @@ pub struct ConfigField {
 impl ConfigField {
     /// Check if field is `Option<T>` and if so return type of `T`
     fn is_option(field: &Field) -> Option<Type> {
-        let seg = if let Type::Path(ty) = &field.ty {
+        let seg = match &field.ty { Type::Path(ty) => {
             ty.path.segments.first()
-        } else {
+        } _ => {
             None
-        }?;
+        }}?;
 
         (seg.ident == "Option").then(|| match &seg.arguments {
             PathArguments::AngleBracketed(generics) => match generics.args.first() {
@@ -72,7 +72,7 @@ impl ConfigField {
     /// #[serde(rename = "test2")]
     /// pub test: Option<String>
     /// ```
-    pub fn definition(&self) -> impl ToTokens {
+    pub fn definition(&self) -> impl ToTokens + use<> {
         let ConfigField {
             ident,
             vis,
@@ -124,7 +124,7 @@ impl ConfigField {
     ///           .source_value().transpose()?
     ///           .ok_or(crate::config::ConfigError::ValueNotProvided("MyConfig", "test", Some("TEST")))?
     /// ```
-    pub fn implmentation(&self, parent: &Ident) -> impl ToTokens {
+    pub fn implmentation(&self, parent: &Ident) -> impl ToTokens + use<> {
         let ConfigField {
             ident,
             option,
@@ -166,11 +166,11 @@ impl ConfigField {
             };
 
             // unwrap to default if exists
-            if let Some(default) = flags.default.as_ref() {
+            match flags.default.as_ref() { Some(default) => {
                 quote! {#default}
-            } else {
+            } _ => {
                 quote! { .ok_or(crate::config::ConfigError::ValueNotProvided(stringify!(#parent), stringify!(#ident), #env_override))? }
-            }
+            }}
         });
 
         let impls = impls

--- a/mirrord/config/src/feature/network/incoming.rs
+++ b/mirrord/config/src/feature/network/incoming.rs
@@ -524,11 +524,11 @@ impl IncomingConfig {
             }
         } else if self.ignore_ports.contains(&port) {
             false
-        } else if let Some(ports) = &self.ports {
+        } else { match &self.ports { Some(ports) => {
             ports.contains(&port)
-        } else {
+        } _ => {
             true
-        }
+        }}}
     }
 
     /// Update the [`HttpFilterConfig::ports`] with the health probes ports from the target and
@@ -553,11 +553,11 @@ impl IncomingConfig {
                 .filter(|port| self.ignore_ports.contains(port).not())
                 .filter(|port| {
                     // Avoid conflicts with `incoming.ports`.
-                    if let Some(ports) = &self.ports {
+                    match &self.ports { Some(ports) => {
                         ports.contains(port).not()
-                    } else {
+                    } _ => {
                         true
-                    }
+                    }}
                 })
                 .copied()
                 .collect::<HashSet<_>>();

--- a/mirrord/config/src/target.rs
+++ b/mirrord/config/src/target.rs
@@ -3,7 +3,7 @@ use std::{fmt, str::FromStr};
 use cron_job::CronJobTarget;
 use mirrord_analytics::CollectAnalytics;
 use replica_set::ReplicaSetTarget;
-use schemars::{gen::SchemaGenerator, schema::SchemaObject, JsonSchema};
+use schemars::{r#gen::SchemaGenerator, schema::SchemaObject, JsonSchema};
 use serde::{Deserialize, Serialize};
 use strum_macros::{EnumDiscriminants, EnumString};
 
@@ -51,10 +51,10 @@ pub enum TargetFileConfig {
     },
 }
 
-fn make_simple_target_custom_schema(gen: &mut SchemaGenerator) -> schemars::schema::Schema {
+fn make_simple_target_custom_schema(r#gen: &mut SchemaGenerator) -> schemars::schema::Schema {
     // generate the schema for the Option<Target> like usual, then just push a string type to the
     // any_of.
-    let mut schema: SchemaObject = <Option<Target>>::json_schema(gen).into();
+    let mut schema: SchemaObject = <Option<Target>>::json_schema(r#gen).into();
     let subschema = schema.subschemas();
 
     let mut any_ofs = subschema.any_of.clone().unwrap();

--- a/mirrord/intproxy/src/background_tasks.rs
+++ b/mirrord/intproxy/src/background_tasks.rs
@@ -166,11 +166,11 @@ where
                     {
                         ControlFlow::Break(err) => return Err(err),
                         ControlFlow::Continue(()) => {
-                            if let Err(err) = task.run(message_bus).await {
+                            match task.run(message_bus).await { Err(err) => {
                                 run_error = Some(err);
-                            } else {
+                            } _ => {
                                 return Ok(());
-                            }
+                            }}
                         }
                     }
                 }

--- a/mirrord/intproxy/src/failover_strategy.rs
+++ b/mirrord/intproxy/src/failover_strategy.rs
@@ -164,18 +164,18 @@ impl FailoverStrategy {
     }
 
     async fn send_error_to_layer(&self, layer_id: LayerId, message_id: MessageId) {
-        if let Some(layer) = self.layers.get(&layer_id) {
+        match self.layers.get(&layer_id) { Some(layer) => {
             layer
                 .send(LocalMessage {
                     message_id,
                     inner: ProxyToLayerMessage::ProxyFailed(self.fail_cause.to_string()),
                 })
                 .await;
-        } else {
+        } _ => {
             tracing::warn!(
                 "Layer {:?} not found, but it was waiting for proxy to respond!",
                 layer_id
             );
-        }
+        }}
     }
 }

--- a/mirrord/intproxy/src/proxies/incoming/http_gateway.rs
+++ b/mirrord/intproxy/src/proxies/incoming/http_gateway.rs
@@ -312,12 +312,12 @@ impl HttpGatewayTask {
             return Ok(());
         }
 
-        if let Some(on_upgrade) = on_upgrade {
+        match on_upgrade { Some(on_upgrade) => {
             message_bus.send(HttpOut::Upgraded(on_upgrade)).await;
-        } else {
+        } _ => {
             // If there was no upgrade and no error, the client can be reused.
             self.client_store.push_idle(client);
-        }
+        }}
 
         Ok(())
     }

--- a/mirrord/kube/src/api/kubernetes.rs
+++ b/mirrord/kube/src/api/kubernetes.rs
@@ -337,19 +337,19 @@ where
         ..Default::default()
     };
 
-    let mut config = if let Some(kubeconfig) = kubeconfig {
+    let mut config = match kubeconfig { Some(kubeconfig) => {
         let kubeconfig = shellexpand::full(&kubeconfig)
             .map_err(|e| KubeApiError::ConfigPathExpansionError(e.to_string()))?;
         let parsed_kube_config = Kubeconfig::read_from(kubeconfig.deref())?;
         Config::from_custom_kubeconfig(parsed_kube_config, &kube_config_opts).await?
-    } else if kube_config_opts.context.is_some() {
+    } _ => if kube_config_opts.context.is_some() {
         // if context is set, it's not in cluster so it has to be a kubeconfig.
         Config::from_kubeconfig(&kube_config_opts).await?
     } else {
         // if context isn't set and user doesn't specify a kubeconfig, we infer which tries local
         // kube or incluster configuration.
         Config::infer().await?
-    };
+    }};
 
     if let Some(accept_invalid_certificates) = accept_invalid_certificates {
         config.accept_invalid_certs = accept_invalid_certificates;

--- a/mirrord/kube/src/api/kubernetes/seeker.rs
+++ b/mirrord/kube/src/api/kubernetes/seeker.rs
@@ -252,7 +252,7 @@ impl KubeResourceSeeker<'_> {
     pub fn list_all_namespaced<R>(
         &self,
         field_selector: Option<&str>,
-    ) -> impl 'static + Stream<Item = kube::Result<R>> + Send
+    ) -> impl 'static + Stream<Item = kube::Result<R>> + Send + use<R>
     where
         R: 'static
             + Resource<DynamicType = (), Scope = NamespaceResourceScope>
@@ -301,7 +301,7 @@ impl KubeResourceSeeker<'_> {
     pub fn list_all_clusterwide<R>(
         &self,
         field_selector: Option<&str>,
-    ) -> impl 'static + Stream<Item = kube::Result<R>> + Send
+    ) -> impl 'static + Stream<Item = kube::Result<R>> + Send + use<R>
     where
         R: 'static
             + Resource<DynamicType = (), Scope = ClusterResourceScope>

--- a/mirrord/layer/Cargo.toml
+++ b/mirrord/layer/Cargo.toml
@@ -11,7 +11,8 @@ license.workspace = true
 keywords.workspace = true
 categories.workspace = true
 publish.workspace = true
-edition.workspace = true
+# edition.workspace = true
+edition = "2024"
 
 [lints]
 workspace = true

--- a/mirrord/layer/Cargo.toml
+++ b/mirrord/layer/Cargo.toml
@@ -11,8 +11,7 @@ license.workspace = true
 keywords.workspace = true
 categories.workspace = true
 publish.workspace = true
-# edition.workspace = true
-edition = "2024"
+edition.workspace = true
 
 [lints]
 workspace = true

--- a/mirrord/layer/src/detour.rs
+++ b/mirrord/layer/src/detour.rs
@@ -71,12 +71,12 @@ impl DetourGuard {
                 && *bypass
             {
                 None
-            } else if let Ok(mut bypass) = enabled.try_borrow_mut() {
+            } else { match enabled.try_borrow_mut() { Ok(mut bypass) => {
                 *bypass = true;
                 Some(Self)
-            } else {
+            } _ => {
                 None
-            }
+            }}}
         })
     }
 }

--- a/mirrord/layer/src/error.rs
+++ b/mirrord/layer/src/error.rs
@@ -224,7 +224,7 @@ impl From<HookError> for i64 {
             }
             HookError::ProxyError(ref err) => {
                 let reason = match err {
-                    &ProxyError::ProxyFailure(ref err) => {
+                    ProxyError::ProxyFailure(err) => {
                         format!("Proxy encountered an error: {err}")
                     }
                     err => format!("Proxy error, connectivity issue or a bug: {err}"),

--- a/mirrord/layer/src/error.rs
+++ b/mirrord/layer/src/error.rs
@@ -224,7 +224,7 @@ impl From<HookError> for i64 {
             }
             HookError::ProxyError(ref err) => {
                 let reason = match err {
-                    ProxyError::ProxyFailure(ref err) => {
+                    &ProxyError::ProxyFailure(ref err) => {
                         format!("Proxy encountered an error: {err}")
                     }
                     err => format!("Proxy error, connectivity issue or a bug: {err}"),

--- a/mirrord/layer/src/exec_hooks/hooks.rs
+++ b/mirrord/layer/src/exec_hooks/hooks.rs
@@ -119,7 +119,8 @@ pub(crate) unsafe extern "C" fn execve_detour(
     path: *const c_char,
     argv: *const *const c_char,
     envp: *const *const c_char,
-) -> c_int {
+) -> c_int {unsafe {
+
     match patch_sip_for_new_process(path, argv, envp) {
         Detour::Success((path, argv, envp)) => {
             match prepare_execve_envp(Detour::Success(envp.clone())) {
@@ -131,7 +132,7 @@ pub(crate) unsafe extern "C" fn execve_detour(
         }
         _ => FN_EXECVE(path, argv, envp),
     }
-}
+}}
 
 /// Enables `exec` hooks.
 pub(crate) unsafe fn enable_exec_hooks(hook_manager: &mut HookManager) { unsafe {

--- a/mirrord/layer/src/file/hooks.rs
+++ b/mirrord/layer/src/file/hooks.rs
@@ -72,6 +72,7 @@ fn update_ptr_from_bypass(ptr: *const c_char, bypass: &Bypass) -> *const c_char 
 /// We ignore mode in case we don't bypass the call.
 #[mirrord_layer_macro::instrument(level = "trace", ret)]
 unsafe fn open_logic(raw_path: *const c_char, open_flags: c_int, _mode: c_int) -> Detour<RawFd> {
+
     let path = raw_path.checked_into();
     let open_options = OpenOptionsInternalExt::from_flags(open_flags);
 
@@ -148,7 +149,8 @@ pub(super) unsafe extern "C" fn open_nocancel_detour(
 /// Opens the directory with `read` permission using the [`open_logic`] flow, then calls
 /// [`fdopendir`] to convert the [`RawFd`] into a `*DIR` stream (which we treat as `usize`).
 #[hook_guard_fn]
-pub(super) unsafe extern "C" fn opendir_detour(raw_filename: *const c_char) -> usize {
+pub(super) unsafe extern "C" fn opendir_detour(raw_filename: *const c_char) -> usize {unsafe {
+
     open_logic(raw_filename, O_RDONLY, O_DIRECTORY)
         .and_then(|fd| match fdopendir(fd) {
             Detour::Success(success) => Detour::Success(success),
@@ -166,11 +168,12 @@ pub(super) unsafe extern "C" fn opendir_detour(raw_filename: *const c_char) -> u
             let raw_filename = update_ptr_from_bypass(raw_filename, &bypass);
             opendir_bypass(raw_filename)
         })
-}
+}}
 
 /// see below, to have nice code we also implement it for other archs.
 #[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
 unsafe fn opendir_bypass(raw_filename: *const c_char) -> usize { unsafe {
+
     FN_OPENDIR(raw_filename)
 }}
 
@@ -178,7 +181,8 @@ unsafe fn opendir_bypass(raw_filename: *const c_char) -> usize { unsafe {
 /// so we implement our own bypass
 /// inspired by https://github.com/apple-oss-distributions/Libc/blob/c5a3293354e22262702a3add5b2dfc9bb0b93b85/gen/FreeBSD/opendir.c#L118
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
-unsafe fn opendir_bypass(raw_filename: *const c_char) -> usize {
+unsafe fn opendir_bypass(raw_filename: *const c_char) -> usize {unsafe {
+
     let fd = libc::open(raw_filename, O_RDONLY | O_DIRECTORY);
     if fd == -1 {
         // null
@@ -193,19 +197,21 @@ unsafe fn opendir_bypass(raw_filename: *const c_char) -> usize {
         return 0;
     }
     dir as usize
-}
+}}
 
 #[hook_guard_fn]
-pub(crate) unsafe extern "C" fn fdopendir_detour(fd: RawFd) -> usize {
+pub(crate) unsafe extern "C" fn fdopendir_detour(fd: RawFd) -> usize {unsafe {
+
     fdopendir(fd).unwrap_or_bypass_with(|_| FN_FDOPENDIR(fd))
-}
+}}
 
 #[hook_guard_fn]
 pub(crate) unsafe extern "C" fn readdir_r_detour(
     dirp: *mut DIR,
     entry: *mut dirent,
     result: *mut *mut dirent,
-) -> c_int {
+) -> c_int {unsafe {
+
     let Some(entry_ref) = entry.as_mut() else {
         return EINVAL;
     };
@@ -228,7 +234,7 @@ pub(crate) unsafe extern "C" fn readdir_r_detour(
             0
         })
         .unwrap_or_bypass_with(|_| FN_READDIR_R(dirp, entry, result))
-}
+}}
 
 #[cfg(target_os = "linux")]
 #[hook_guard_fn]
@@ -236,7 +242,8 @@ pub(crate) unsafe extern "C" fn readdir64_r_detour(
     dirp: *mut DIR,
     entry: *mut dirent64,
     result: *mut *mut dirent64,
-) -> c_int {
+) -> c_int {unsafe {
+
     let Some(entry_ref) = entry.as_mut() else {
         return EINVAL;
     };
@@ -259,11 +266,12 @@ pub(crate) unsafe extern "C" fn readdir64_r_detour(
             0
         })
         .unwrap_or_bypass_with(|_| FN_READDIR64_R(dirp, entry, result))
-}
+}}
 
 #[cfg(target_os = "linux")]
 #[hook_guard_fn]
-pub(crate) unsafe extern "C" fn readdir64_detour(dirp: *mut DIR) -> usize {
+pub(crate) unsafe extern "C" fn readdir64_detour(dirp: *mut DIR) -> usize {unsafe {
+
     match OPEN_DIRS.read64(dirp as usize) {
         Detour::Success(entry) => entry as usize,
         Detour::Bypass(..) => FN_READDIR64(dirp),
@@ -272,10 +280,11 @@ pub(crate) unsafe extern "C" fn readdir64_detour(dirp: *mut DIR) -> usize {
             std::ptr::null::<dirent64>() as usize
         }
     }
-}
+}}
 
 #[hook_guard_fn]
-pub(crate) unsafe extern "C" fn readdir_detour(dirp: *mut DIR) -> usize {
+pub(crate) unsafe extern "C" fn readdir_detour(dirp: *mut DIR) -> usize {unsafe {
+
     match OPEN_DIRS.read(dirp as usize) {
         Detour::Success(entry) => entry as usize,
         Detour::Bypass(..) => FN_READDIR(dirp),
@@ -284,21 +293,23 @@ pub(crate) unsafe extern "C" fn readdir_detour(dirp: *mut DIR) -> usize {
             std::ptr::null::<dirent>() as usize
         }
     }
-}
+}}
 
 #[hook_guard_fn]
-pub(crate) unsafe extern "C" fn closedir_detour(dirp: *mut DIR) -> c_int {
+pub(crate) unsafe extern "C" fn closedir_detour(dirp: *mut DIR) -> c_int {unsafe {
+
     OPEN_DIRS
         .close(dirp as usize)
         .unwrap_or_bypass_with(|_| FN_CLOSEDIR(dirp))
-}
+}}
 
 #[hook_guard_fn]
-pub(crate) unsafe extern "C" fn dirfd_detour(dirp: *mut DIR) -> c_int {
+pub(crate) unsafe extern "C" fn dirfd_detour(dirp: *mut DIR) -> c_int {unsafe {
+
     OPEN_DIRS
         .get_fd(dirp as usize)
         .unwrap_or_bypass_with(|_| FN_DIRFD(dirp))
-}
+}}
 
 /// Equivalent to `open_detour`, **except** when `raw_path` specifies a relative path.
 ///
@@ -337,28 +348,30 @@ pub(crate) unsafe extern "C" fn openat64_detour(
     fd: RawFd,
     raw_path: *const c_char,
     open_flags: c_int,
-) -> RawFd {
+) -> RawFd {unsafe {
+
     let open_options = OpenOptionsInternalExt::from_flags(open_flags);
 
     openat(fd, raw_path.checked_into(), open_options).unwrap_or_bypass_with(|bypass| {
         let raw_path = update_ptr_from_bypass(raw_path, &bypass);
         FN_OPENAT64(fd, raw_path, open_flags)
     })
-}
+}}
 
 #[hook_guard_fn]
 pub(crate) unsafe extern "C" fn _openat_nocancel_detour(
     fd: RawFd,
     raw_path: *const c_char,
     open_flags: c_int,
-) -> RawFd {
+) -> RawFd {unsafe {
+
     let open_options = OpenOptionsInternalExt::from_flags(open_flags);
 
     openat(fd, raw_path.checked_into(), open_options).unwrap_or_bypass_with(|bypass| {
         let raw_path = update_ptr_from_bypass(raw_path, &bypass);
         FN__OPENAT_NOCANCEL(fd, raw_path, open_flags)
     })
-}
+}}
 
 /// Hook for getdents64, for Go's `os.ReadDir` on Linux.
 #[cfg(target_os = "linux")]
@@ -367,7 +380,8 @@ pub(crate) unsafe extern "C" fn getdents64_detour(
     fd: RawFd,
     dirent_buf: *mut c_void,
     buf_size: c_size_t,
-) -> c_ssize_t {
+) -> c_ssize_t {unsafe {
+
     match getdents64(fd, buf_size as u64) {
         Detour::Success(res) => {
             let mut next = dirent_buf as *mut dirent;
@@ -430,7 +444,7 @@ pub(crate) unsafe extern "C" fn getdents64_detour(
             -1
         }
     }
-}
+}}
 
 /// Hook for `libc::read`.
 ///
@@ -440,7 +454,8 @@ pub(crate) unsafe extern "C" fn read_detour(
     fd: RawFd,
     out_buffer: *mut c_void,
     count: size_t,
-) -> ssize_t {
+) -> ssize_t {unsafe {
+
     read(fd, count as u64)
         .map(|read_file| {
             let ReadFileResponse { bytes, read_amount } = read_file;
@@ -458,14 +473,15 @@ pub(crate) unsafe extern "C" fn read_detour(
             ssize_t::try_from(read_amount).unwrap()
         })
         .unwrap_or_bypass_with(|_| FN_READ(fd, out_buffer, count))
-}
+}}
 
 #[hook_guard_fn]
 pub(crate) unsafe extern "C" fn _read_nocancel_detour(
     fd: RawFd,
     out_buffer: *mut c_void,
     count: size_t,
-) -> ssize_t {
+) -> ssize_t {unsafe {
+
     read(fd, count as u64)
         .map(|read_file| {
             let ReadFileResponse { bytes, read_amount } = read_file;
@@ -483,14 +499,15 @@ pub(crate) unsafe extern "C" fn _read_nocancel_detour(
             ssize_t::try_from(read_amount).unwrap()
         })
         .unwrap_or_bypass_with(|_| FN__READ_NOCANCEL(fd, out_buffer, count))
-}
+}}
 
 #[hook_guard_fn]
 pub(crate) unsafe extern "C" fn read_nocancel_detour(
     fd: RawFd,
     out_buffer: *mut c_void,
     count: size_t,
-) -> ssize_t {
+) -> ssize_t {unsafe {
+
     read(fd, count as u64)
         .map(|read_file| {
             let ReadFileResponse { bytes, read_amount } = read_file;
@@ -508,7 +525,7 @@ pub(crate) unsafe extern "C" fn read_nocancel_detour(
             ssize_t::try_from(read_amount).unwrap()
         })
         .unwrap_or_bypass_with(|_| FN_READ_NOCANCEL(fd, out_buffer, count))
-}
+}}
 
 #[hook_guard_fn]
 pub(crate) unsafe extern "C" fn pread_detour(
@@ -516,7 +533,8 @@ pub(crate) unsafe extern "C" fn pread_detour(
     out_buffer: *mut c_void,
     amount_to_read: size_t,
     offset: off_t,
-) -> ssize_t {
+) -> ssize_t {unsafe {
+
     pread(fd, amount_to_read as u64, offset as u64)
         .map(|read_file| {
             let ReadFileResponse { bytes, read_amount } = read_file;
@@ -536,7 +554,7 @@ pub(crate) unsafe extern "C" fn pread_detour(
             fixed_read as ssize_t
         })
         .unwrap_or_bypass_with(|_| FN_PREAD(fd, out_buffer, amount_to_read, offset))
-}
+}}
 
 #[hook_guard_fn]
 pub(crate) unsafe extern "C" fn _pread_nocancel_detour(
@@ -544,7 +562,8 @@ pub(crate) unsafe extern "C" fn _pread_nocancel_detour(
     out_buffer: *mut c_void,
     amount_to_read: size_t,
     offset: off_t,
-) -> ssize_t {
+) -> ssize_t {unsafe {
+
     pread(fd, amount_to_read as u64, offset as u64)
         .map(|read_file| {
             let ReadFileResponse { bytes, read_amount } = read_file;
@@ -564,7 +583,7 @@ pub(crate) unsafe extern "C" fn _pread_nocancel_detour(
             fixed_read as ssize_t
         })
         .unwrap_or_bypass_with(|_| FN__PREAD_NOCANCEL(fd, out_buffer, amount_to_read, offset))
-}
+}}
 
 /// Common code between the `pwrite` detours.
 ///
@@ -595,10 +614,11 @@ pub(crate) unsafe extern "C" fn pwrite_detour(
     in_buffer: *const c_void,
     amount_to_write: size_t,
     offset: off_t,
-) -> ssize_t {
+) -> ssize_t {unsafe {
+
     pwrite_logic(fd, in_buffer, amount_to_write, offset)
         .unwrap_or_bypass_with(|_| FN_PWRITE(fd, in_buffer, amount_to_write, offset))
-}
+}}
 
 #[hook_guard_fn]
 pub(crate) unsafe extern "C" fn _pwrite_nocancel_detour(
@@ -606,20 +626,22 @@ pub(crate) unsafe extern "C" fn _pwrite_nocancel_detour(
     in_buffer: *const c_void,
     amount_to_write: size_t,
     offset: off_t,
-) -> ssize_t {
+) -> ssize_t {unsafe {
+
     pwrite_logic(fd, in_buffer, amount_to_write, offset)
         .unwrap_or_bypass_with(|_| FN__PWRITE_NOCANCEL(fd, in_buffer, amount_to_write, offset))
-}
+}}
 
 /// Hook for `libc::lseek`.
 ///
 /// **Bypassed** by `fd`s that are not managed by us (not found in `OPEN_FILES`).
 #[hook_guard_fn]
-pub(crate) unsafe extern "C" fn lseek_detour(fd: RawFd, offset: off_t, whence: c_int) -> off_t {
+pub(crate) unsafe extern "C" fn lseek_detour(fd: RawFd, offset: off_t, whence: c_int) -> off_t {unsafe {
+
     lseek(fd, offset, whence)
         .map(|offset| i64::try_from(offset).unwrap())
         .unwrap_or_bypass_with(|_| FN_LSEEK(fd, offset, whence))
-}
+}}
 
 /// Implementation of write_detour, used in  write_detour
 pub(crate) unsafe extern "C" fn write_logic(
@@ -643,23 +665,25 @@ pub(crate) unsafe extern "C" fn write_detour(
     fd: RawFd,
     buffer: *const c_void,
     count: size_t,
-) -> ssize_t {
+) -> ssize_t {unsafe {
+
     write_logic(fd, buffer, count)
-}
+}}
 
 #[hook_guard_fn]
 pub(crate) unsafe extern "C" fn _write_nocancel_detour(
     fd: RawFd,
     buffer: *const c_void,
     count: size_t,
-) -> ssize_t {
+) -> ssize_t {unsafe {
+
     // WARN: Be veeery careful here, you cannot construct the `Vec` directly, as the buffer
     // allocation is handled on the C side.
     let write_bytes =
         (!buffer.is_null()).then(|| slice::from_raw_parts(buffer as *const u8, count).to_vec());
 
     write(fd, write_bytes).unwrap_or_bypass_with(|_| FN__WRITE_NOCANCEL(fd, buffer, count))
-}
+}}
 
 /// Implementation of access_detour, used in access_detour and faccessat_detour
 unsafe fn access_logic(raw_path: *const c_char, mode: c_int) -> c_int { unsafe {
@@ -671,9 +695,10 @@ unsafe fn access_logic(raw_path: *const c_char, mode: c_int) -> c_int { unsafe {
 
 /// Hook for `libc::access`.
 #[hook_guard_fn]
-pub(crate) unsafe extern "C" fn access_detour(raw_path: *const c_char, mode: c_int) -> c_int {
+pub(crate) unsafe extern "C" fn access_detour(raw_path: *const c_char, mode: c_int) -> c_int {unsafe {
+
     access_logic(raw_path, mode)
-}
+}}
 
 /// Hook for `libc::faccessat`.
 #[hook_guard_fn]
@@ -682,25 +707,28 @@ pub(crate) unsafe extern "C" fn faccessat_detour(
     pathname: *const c_char,
     mode: c_int,
     flags: c_int,
-) -> c_int {
+) -> c_int {unsafe {
+
     if dirfd == AT_FDCWD && (flags == AT_EACCESS || flags == 0) {
         access_logic(pathname, mode)
     } else {
         FN_FACCESSAT(dirfd, pathname, mode, flags)
     }
-}
+}}
 
 /// Hook for `libc::fsync`.
 #[hook_guard_fn]
-pub(crate) unsafe extern "C" fn fsync_detour(fd: RawFd) -> c_int {
+pub(crate) unsafe extern "C" fn fsync_detour(fd: RawFd) -> c_int {unsafe {
+
     fsync(fd).unwrap_or_bypass_with(|_| FN_FSYNC(fd))
-}
+}}
 
 /// Hook for `libc::fdatasync`.
 #[hook_guard_fn]
-pub(crate) unsafe extern "C" fn fdatasync_detour(fd: RawFd) -> c_int {
+pub(crate) unsafe extern "C" fn fdatasync_detour(fd: RawFd) -> c_int {unsafe {
+
     fsync(fd).unwrap_or_bypass_with(|_| FN_FDATASYNC(fd))
-}
+}}
 
 /// Tries to convert input to type O, if it fails it returns the max value of O.
 /// For example, if you put u32::MAX into a u8, it will return u8::MAX.
@@ -804,32 +832,35 @@ fn stat_logic<const FOLLOW_SYMLINK: bool>(
 
 /// Hook for `libc::lstat`.
 #[hook_guard_fn]
-unsafe extern "C" fn lstat_detour(raw_path: *const c_char, out_stat: *mut stat) -> c_int {
+unsafe extern "C" fn lstat_detour(raw_path: *const c_char, out_stat: *mut stat) -> c_int {unsafe {
+
     stat_logic::<false>(0, None, Some(raw_path), out_stat as *mut _).unwrap_or_bypass_with(
         |bypass| {
             let raw_path = update_ptr_from_bypass(raw_path, &bypass);
             FN_LSTAT(raw_path, out_stat)
         },
     )
-}
+}}
 
 /// Hook for `libc::fstat`.
 #[hook_guard_fn]
-pub(crate) unsafe extern "C" fn fstat_detour(fd: RawFd, out_stat: *mut stat) -> c_int {
+pub(crate) unsafe extern "C" fn fstat_detour(fd: RawFd, out_stat: *mut stat) -> c_int {unsafe {
+
     stat_logic::<true>(0, Some(fd), None, out_stat as *mut _)
         .unwrap_or_bypass_with(|_| FN_FSTAT(fd, out_stat))
-}
+}}
 
 /// Hook for `libc::stat`.
 #[hook_guard_fn]
-unsafe extern "C" fn stat_detour(raw_path: *const c_char, out_stat: *mut stat) -> c_int {
+unsafe extern "C" fn stat_detour(raw_path: *const c_char, out_stat: *mut stat) -> c_int {unsafe {
+
     stat_logic::<true>(0, None, Some(raw_path), out_stat as *mut _).unwrap_or_bypass_with(
         |bypass| {
             let raw_path = update_ptr_from_bypass(raw_path, &bypass);
             FN_STAT(raw_path, out_stat)
         },
     )
-}
+}}
 
 /// Hook for `libc::statx`.
 #[cfg(target_os = "linux")]
@@ -840,12 +871,13 @@ unsafe extern "C" fn statx_detour(
     flags: c_int,
     mask: c_int,
     statx_buf: *mut statx,
-) -> c_int {
+) -> c_int {unsafe {
+
     statx_logic(dir_fd, path_name, flags, mask, statx_buf).unwrap_or_bypass_with(|bypass| {
         let path_name = update_ptr_from_bypass(path_name, &bypass);
         FN_STATX(dir_fd, path_name, flags, mask, statx_buf)
     })
-}
+}}
 
 /// Hook for libc's stat syscall wrapper.
 #[hook_guard_fn]
@@ -853,14 +885,15 @@ pub(crate) unsafe extern "C" fn __xstat_detour(
     ver: c_int,
     raw_path: *const c_char,
     out_stat: *mut stat,
-) -> c_int {
+) -> c_int {unsafe {
+
     stat_logic::<true>(ver, None, Some(raw_path), out_stat as *mut _).unwrap_or_bypass_with(
         |bypass| {
             let raw_path = update_ptr_from_bypass(raw_path, &bypass);
             FN___XSTAT(ver, raw_path, out_stat)
         },
     )
-}
+}}
 
 /// Hook for libc's stat syscall wrapper.
 #[hook_guard_fn]
@@ -868,14 +901,15 @@ pub(crate) unsafe extern "C" fn __lxstat_detour(
     ver: c_int,
     raw_path: *const c_char,
     out_stat: *mut stat,
-) -> c_int {
+) -> c_int {unsafe {
+
     stat_logic::<true>(ver, None, Some(raw_path), out_stat as *mut _).unwrap_or_bypass_with(
         |bypass| {
             let raw_path = update_ptr_from_bypass(raw_path, &bypass);
             FN___LXSTAT(ver, raw_path, out_stat)
         },
     )
-}
+}}
 
 /// Hook for libc's stat syscall wrapper.
 #[hook_guard_fn]
@@ -883,12 +917,13 @@ pub(crate) unsafe extern "C" fn __xstat64_detour(
     ver: c_int,
     raw_path: *const c_char,
     out_stat: *mut stat64,
-) -> c_int {
+) -> c_int {unsafe {
+
     stat_logic::<true>(ver, None, Some(raw_path), out_stat).unwrap_or_bypass_with(|bypass| {
         let raw_path = update_ptr_from_bypass(raw_path, &bypass);
         FN___XSTAT64(ver, raw_path, out_stat)
     })
-}
+}}
 
 /// Hook for libc's stat syscall wrapper.
 #[hook_guard_fn]
@@ -896,12 +931,13 @@ pub(crate) unsafe extern "C" fn __lxstat64_detour(
     ver: c_int,
     raw_path: *const c_char,
     out_stat: *mut stat64,
-) -> c_int {
+) -> c_int {unsafe {
+
     stat_logic::<true>(ver, None, Some(raw_path), out_stat).unwrap_or_bypass_with(|bypass| {
         let raw_path = update_ptr_from_bypass(raw_path, &bypass);
         FN___LXSTAT64(ver, raw_path, out_stat)
     })
-}
+}}
 
 /// Separated out logic for `fstatat` so that it can be used by go to match on the xstat result.
 pub(crate) unsafe fn fstatat_logic(
@@ -929,16 +965,18 @@ unsafe extern "C" fn fstatat_detour(
     raw_path: *const c_char,
     out_stat: *mut stat,
     flag: c_int,
-) -> c_int {
+) -> c_int {unsafe {
+
     fstatat_logic(fd, raw_path, out_stat, flag).unwrap_or_bypass_with(|bypass| {
         let raw_path = update_ptr_from_bypass(raw_path, &bypass);
         FN_FSTATAT(fd, raw_path, out_stat, flag)
     })
-}
+}}
 
 /// Hook for `libc::fstatfs`.
 #[hook_guard_fn]
-unsafe extern "C" fn fstatfs_detour(fd: c_int, out_stat: *mut statfs) -> c_int {
+unsafe extern "C" fn fstatfs_detour(fd: c_int, out_stat: *mut statfs) -> c_int {unsafe {
+
     if out_stat.is_null() {
         return HookError::BadPointer.into();
     }
@@ -950,7 +988,7 @@ unsafe extern "C" fn fstatfs_detour(fd: c_int, out_stat: *mut statfs) -> c_int {
             0
         })
         .unwrap_or_bypass_with(|_| crate::file::hooks::FN_FSTATFS(fd, out_stat))
-}
+}}
 
 /// Hook for `libc::fstatfs64`.
 #[cfg(target_os = "linux")]
@@ -958,7 +996,8 @@ unsafe extern "C" fn fstatfs_detour(fd: c_int, out_stat: *mut statfs) -> c_int {
 pub(crate) unsafe extern "C" fn fstatfs64_detour(
     fd: c_int,
     out_stat: *mut libc::statfs64,
-) -> c_int {
+) -> c_int {unsafe {
+
     if out_stat.is_null() {
         return HookError::BadPointer.into();
     }
@@ -970,11 +1009,12 @@ pub(crate) unsafe extern "C" fn fstatfs64_detour(
             0
         })
         .unwrap_or_bypass_with(|_| FN_FSTATFS64(fd, out_stat))
-}
+}}
 
 /// Hook for `libc::statfs`.
 #[hook_guard_fn]
-unsafe extern "C" fn statfs_detour(raw_path: *const c_char, out_stat: *mut statfs) -> c_int {
+unsafe extern "C" fn statfs_detour(raw_path: *const c_char, out_stat: *mut statfs) -> c_int {unsafe {
+
     if out_stat.is_null() {
         return HookError::BadPointer.into();
     }
@@ -986,7 +1026,7 @@ unsafe extern "C" fn statfs_detour(raw_path: *const c_char, out_stat: *mut statf
             0
         })
         .unwrap_or_bypass_with(|_| FN_STATFS(raw_path, out_stat))
-}
+}}
 
 /// Hook for `libc::statfs`.
 #[cfg(target_os = "linux")]
@@ -994,7 +1034,8 @@ unsafe extern "C" fn statfs_detour(raw_path: *const c_char, out_stat: *mut statf
 pub(crate) unsafe extern "C" fn statfs64_detour(
     raw_path: *const c_char,
     out_stat: *mut libc::statfs64,
-) -> c_int {
+) -> c_int {unsafe {
+
     if out_stat.is_null() {
         return HookError::BadPointer.into();
     }
@@ -1006,7 +1047,7 @@ pub(crate) unsafe extern "C" fn statfs64_detour(
             0
         })
         .unwrap_or_bypass_with(|_| crate::file::hooks::FN_STATFS64(raw_path, out_stat))
-}
+}}
 
 unsafe fn realpath_logic(
     source_path: *const c_char,
@@ -1039,23 +1080,25 @@ unsafe fn realpath_logic(
 unsafe extern "C" fn realpath_detour(
     source_path: *const c_char,
     output_path: *mut c_char,
-) -> *mut c_char {
+) -> *mut c_char {unsafe {
+
     realpath_logic(source_path, output_path).unwrap_or_bypass_with(|bypass| {
         let source_path = update_ptr_from_bypass(source_path, &bypass);
         FN_REALPATH(source_path, output_path)
     })
-}
+}}
 
 #[hook_guard_fn]
 unsafe extern "C" fn realpath_darwin_extsn_detour(
     source_path: *const c_char,
     output_path: *mut c_char,
-) -> *mut c_char {
+) -> *mut c_char {unsafe {
+
     realpath_logic(source_path, output_path).unwrap_or_bypass_with(|bypass| {
         let source_path = update_ptr_from_bypass(source_path, &bypass);
         FN_REALPATH_DARWIN_EXTSN(source_path, output_path)
     })
-}
+}}
 
 fn vec_to_iovec(bytes: &[u8], iovecs: &[iovec]) {
     let mut copied = 0;
@@ -1079,7 +1122,8 @@ pub(crate) unsafe extern "C" fn readv_detour(
     fd: RawFd,
     iovecs: *const iovec,
     iovec_count: c_int,
-) -> ssize_t {
+) -> ssize_t {unsafe {
+
     if iovec_count < 0 {
         return FN_READV(fd, iovecs, iovec_count);
     }
@@ -1097,7 +1141,7 @@ pub(crate) unsafe extern "C" fn readv_detour(
             ssize_t::try_from(bytes.len()).unwrap()
         })
         .unwrap_or_bypass_with(|_| FN_READV(fd, iovecs, iovec_count))
-}
+}}
 
 /// Hook for `libc::readv`.
 #[hook_guard_fn]
@@ -1106,7 +1150,8 @@ pub(crate) unsafe extern "C" fn preadv_detour(
     iovecs: *const iovec,
     iovec_count: c_int,
     offset: off_t,
-) -> ssize_t {
+) -> ssize_t {unsafe {
+
     if iovec_count < 0 {
         return FN_PREADV(fd, iovecs, iovec_count, offset);
     }
@@ -1125,7 +1170,7 @@ pub(crate) unsafe extern "C" fn preadv_detour(
             ssize_t::try_from(bytes.len()).unwrap()
         })
         .unwrap_or_bypass_with(|_| FN_PREADV(fd, iovecs, iovec_count, offset))
-}
+}}
 
 /// Hook for [`libc::readlink`].
 #[hook_guard_fn]
@@ -1133,7 +1178,8 @@ pub(crate) unsafe extern "C" fn readlink_detour(
     raw_path: *const c_char,
     out_buffer: *mut c_char,
     buffer_size: size_t,
-) -> ssize_t {
+) -> ssize_t {unsafe {
+
     read_link(raw_path.checked_into())
         .map(|ReadLinkFileResponse { path }| {
             let path_bytes = path.as_os_str().as_bytes();
@@ -1149,18 +1195,19 @@ pub(crate) unsafe extern "C" fn readlink_detour(
             let raw_path = update_ptr_from_bypass(raw_path, &bypass);
             FN_READLINK(raw_path, out_buffer, buffer_size)
         })
-}
+}}
 
 /// Hook for `libc::mkdir`.
 #[hook_guard_fn]
-pub(crate) unsafe extern "C" fn mkdir_detour(pathname: *const c_char, mode: u32) -> c_int {
+pub(crate) unsafe extern "C" fn mkdir_detour(pathname: *const c_char, mode: u32) -> c_int {unsafe {
+
     mkdir(pathname.checked_into(), mode)
         .map(|()| 0)
         .unwrap_or_bypass_with(|bypass| {
             let raw_path = update_ptr_from_bypass(pathname, &bypass);
             FN_MKDIR(raw_path, mode)
         })
-}
+}}
 
 /// Hook for `libc::mkdirat`.
 #[hook_guard_fn]
@@ -1168,36 +1215,39 @@ pub(crate) unsafe extern "C" fn mkdirat_detour(
     dirfd: c_int,
     pathname: *const c_char,
     mode: u32,
-) -> c_int {
+) -> c_int {unsafe {
+
     mkdirat(dirfd, pathname.checked_into(), mode)
         .map(|()| 0)
         .unwrap_or_bypass_with(|bypass| {
             let raw_path = update_ptr_from_bypass(pathname, &bypass);
             FN_MKDIRAT(dirfd, raw_path, mode)
         })
-}
+}}
 
 /// Hook for `libc::rmdir`.
 #[hook_guard_fn]
-pub(crate) unsafe extern "C" fn rmdir_detour(pathname: *const c_char) -> c_int {
+pub(crate) unsafe extern "C" fn rmdir_detour(pathname: *const c_char) -> c_int {unsafe {
+
     rmdir(pathname.checked_into())
         .map(|()| 0)
         .unwrap_or_bypass_with(|bypass| {
             let raw_path = update_ptr_from_bypass(pathname, &bypass);
             FN_RMDIR(raw_path)
         })
-}
+}}
 
 /// Hook for `libc::unlink`.
 #[hook_guard_fn]
-pub(crate) unsafe extern "C" fn unlink_detour(pathname: *const c_char) -> c_int {
+pub(crate) unsafe extern "C" fn unlink_detour(pathname: *const c_char) -> c_int {unsafe {
+
     unlink(pathname.checked_into())
         .map(|()| 0)
         .unwrap_or_bypass_with(|bypass| {
             let raw_path = update_ptr_from_bypass(pathname, &bypass);
             FN_UNLINK(raw_path)
         })
-}
+}}
 
 /// Hook for `libc::unlinkat`.
 #[hook_guard_fn]
@@ -1205,14 +1255,15 @@ pub(crate) unsafe extern "C" fn unlinkat_detour(
     dirfd: c_int,
     pathname: *const c_char,
     flags: u32,
-) -> c_int {
+) -> c_int {unsafe {
+
     unlinkat(dirfd, pathname.checked_into(), flags)
         .map(|()| 0)
         .unwrap_or_bypass_with(|bypass| {
             let raw_path = update_ptr_from_bypass(pathname, &bypass);
             FN_UNLINKAT(dirfd, raw_path, flags)
         })
-}
+}}
 
 /// Convenience function to setup file hooks (`x_detour`) with `frida_gum`.
 pub(crate) unsafe fn enable_file_hooks(hook_manager: &mut HookManager) { unsafe {

--- a/mirrord/layer/src/go/mod.rs
+++ b/mirrord/layer/src/go/mod.rs
@@ -19,7 +19,7 @@ pub(crate) mod go_hooks;
 
 /// Syscall & Syscall6 handler - supports upto 6 params, mainly used for
 /// accept4 Note: Depending on success/failure Syscall may or may not call this handler
-#[no_mangle]
+#[unsafe(no_mangle)]
 unsafe extern "C" fn c_abi_syscall6_handler(
     syscall: i64,
     param1: i64,
@@ -28,7 +28,7 @@ unsafe extern "C" fn c_abi_syscall6_handler(
     param4: i64,
     param5: i64,
     param6: i64,
-) -> i64 {
+) -> i64 { unsafe {
     trace!(
         "c_abi_syscall6_handler: syscall={} param1={} param2={} param3={} param4={} param5={} param6={}",
         syscall, param1, param2, param3, param4, param5, param6
@@ -168,4 +168,4 @@ unsafe extern "C" fn c_abi_syscall6_handler(
     } else {
         syscall_result
     }
-}
+}}

--- a/mirrord/layer/src/macros.rs
+++ b/mirrord/layer/src/macros.rs
@@ -42,7 +42,7 @@
 /// ```
 #[macro_export]
 macro_rules! replace {
-    ($hook_manager:expr, $func:expr, $detour_function:expr, $detour_type:ty, $hook_fn:expr) => {{
+    ($hook_manager:expr_2021, $func:expr_2021, $detour_function:expr_2021, $detour_type:ty, $hook_fn:expr_2021) => {{
         let intercept = |hook_manager: &mut $crate::hooks::HookManager,
                          symbol_name,
                          detour: $detour_type|
@@ -100,7 +100,7 @@ macro_rules! replace {
 /// ```
 #[macro_export]
 macro_rules! replace_with_fallback {
-    ($hook_manager:expr, $func:expr, $detour_function:expr, $detour_type:ty, $hook_fn:expr, $fallback_fn:expr) => {{
+    ($hook_manager:expr_2021, $func:expr_2021, $detour_function:expr_2021, $detour_type:ty, $hook_fn:expr_2021, $fallback_fn:expr_2021) => {{
         let intercept = |hook_manager: &mut $crate::hooks::HookManager,
                          symbol_name,
                          detour: $detour_type|
@@ -149,7 +149,7 @@ macro_rules! replace_with_fallback {
     any(target_arch = "x86_64", target_arch = "aarch64")
 ))]
 macro_rules! hook_symbol {
-    ($hook_manager:expr, $func:expr, $detour_name:expr) => {
+    ($hook_manager:expr_2021, $func:expr_2021, $detour_name:expr_2021) => {
         match $hook_manager.hook_symbol_main_module($func, $detour_name as *mut libc::c_void) {
             Ok(_) => {
                 trace!("hooked {:?} in main module", $func);

--- a/mirrord/layer/src/proxy_connection.rs
+++ b/mirrord/layer/src/proxy_connection.rs
@@ -105,11 +105,11 @@ impl ProxyConnection {
 
     pub fn receive(&self, response_id: u64) -> Result<ProxyToLayerMessage> {
         let response = self.responses.lock()?.receive(response_id)?;
-        if let ProxyToLayerMessage::ProxyFailed(error_msg) = response {
+        match response { ProxyToLayerMessage::ProxyFailed(error_msg) => {
             Err(ProxyError::ProxyFailure(error_msg))
-        } else {
+        } _ => {
             Ok(response)
-        }
+        }}
     }
 
     #[mirrord_layer_macro::instrument(level = "trace", skip(self), ret)]

--- a/mirrord/layer/src/socket/hooks.rs
+++ b/mirrord/layer/src/socket/hooks.rs
@@ -191,7 +191,7 @@ pub(super) unsafe extern "C" fn _accept_nocancel_detour(
 
 /// <https://github.com/metalbear-co/mirrord/issues/184>
 #[hook_fn]
-pub(crate) unsafe extern "C" fn fcntl_detour(fd: c_int, cmd: c_int, mut arg: ...) -> c_int {
+pub(crate) unsafe extern "C" fn fcntl_detour(fd: c_int, cmd: c_int, mut arg: ...) -> c_int { unsafe {
     let arg = arg.arg::<usize>();
     let fcntl_result = FN_FCNTL(fd, cmd, arg);
     let guard = DetourGuard::new();
@@ -207,7 +207,7 @@ pub(crate) unsafe extern "C" fn fcntl_detour(fd: c_int, cmd: c_int, mut arg: ...
             Err(e) => e.into(),
         }
     }
-}
+}}
 
 #[hook_guard_fn]
 pub(super) unsafe extern "C" fn dup_detour(fd: c_int) -> c_int {
@@ -499,7 +499,7 @@ pub(crate) unsafe fn enable_socket_hooks(
     hook_manager: &mut HookManager,
     enabled_remote_dns: bool,
     experimental: &ExperimentalConfig,
-) {
+) { unsafe {
     replace!(hook_manager, "socket", socket_detour, FnSocket, FN_SOCKET);
 
     replace!(
@@ -669,4 +669,4 @@ pub(crate) unsafe fn enable_socket_hooks(
             FN_GETIFADDRS
         );
     }
-}
+}}

--- a/mirrord/layer/tests/apps/issue1776/src/main.rs
+++ b/mirrord/layer/tests/apps/issue1776/src/main.rs
@@ -11,7 +11,7 @@ use socket2::SockAddr;
 unsafe fn address_from_raw(
     raw_address: *const libc::sockaddr,
     address_length: libc::socklen_t,
-) -> Option<SocketAddr> {
+) -> Option<SocketAddr> { unsafe {
     SockAddr::try_init(|storage, len| {
         storage.copy_from_nonoverlapping(raw_address.cast(), 1);
         len.copy_from_nonoverlapping(&address_length, 1);
@@ -20,7 +20,7 @@ unsafe fn address_from_raw(
     })
     .ok()
     .and_then(|((), address)| address.as_socket())
-}
+}}
 
 /// Test that C# `mongodb+srv` protocol can resolve DNS with udp `sendmsg` and `recvmsg`.
 fn main() {

--- a/mirrord/layer/tests/apps/issue1776portnot53/src/main.rs
+++ b/mirrord/layer/tests/apps/issue1776portnot53/src/main.rs
@@ -11,7 +11,7 @@ use socket2::SockAddr;
 unsafe fn address_from_raw(
     raw_address: *const libc::sockaddr,
     address_length: libc::socklen_t,
-) -> Option<SocketAddr> {
+) -> Option<SocketAddr> { unsafe {
     SockAddr::try_init(|storage, len| {
         storage.copy_from_nonoverlapping(raw_address.cast(), 1);
         len.copy_from_nonoverlapping(&address_length, 1);
@@ -20,7 +20,7 @@ unsafe fn address_from_raw(
     })
     .ok()
     .and_then(|((), address)| address.as_socket())
-}
+}}
 
 fn main() {
     println!("test issue 1776 port not 53: START");

--- a/mirrord/operator/src/client/conn_wrapper.rs
+++ b/mirrord/operator/src/client/conn_wrapper.rs
@@ -96,16 +96,16 @@ where
                 client_message = self.client_rx.recv() => {
                     match client_message {
                         Some(ClientMessage::SwitchProtocolVersion(version)) => {
-                            if let Some(operator_protocol_version) = self.protocol_version.as_ref() {
+                            match self.protocol_version.as_ref() { Some(operator_protocol_version) => {
                                 self.handle_client_message(ClientMessage::SwitchProtocolVersion(operator_protocol_version.min(&version).clone())).await?;
-                            } else {
+                            } _ => {
                                 self.daemon_tx
                                     .send(DaemonMessage::SwitchProtocolVersionResponse(
                                         "1.2.1".parse().expect("Bad static version"),
                                     ))
                                     .await
                                     .map_err(|_| ConnectionWrapperError::ChannelClosed)?;
-                            }
+                            }}
                         }
                         Some(client_message) => self.handle_client_message(client_message).await?,
                         None => break,

--- a/mirrord/vpn/src/socket.rs
+++ b/mirrord/vpn/src/socket.rs
@@ -6,7 +6,7 @@ use crate::packet::patch_packet_checksum;
 
 pub fn create_vpn_socket(
     network: &NetworkConfiguration,
-) -> impl Stream<Item = io::Result<Vec<u8>>> + Sink<Vec<u8>, Error = io::Error> {
+) -> impl Stream<Item = io::Result<Vec<u8>>> + Sink<Vec<u8>, Error = io::Error> + use<> {
     let mut config = tun2::Configuration::default();
     config
         .address(network.ip)

--- a/tests/src/utils/process.rs
+++ b/tests/src/utils/process.rs
@@ -240,11 +240,11 @@ impl TestProcess {
     }
 
     pub async fn write_to_stdin(&mut self, data: &[u8]) {
-        if let Some(ref mut stdin) = self.child.stdin {
+        match self.child.stdin { Some(ref mut stdin) => {
             stdin.write(data).await.unwrap();
-        } else {
+        } _ => {
             panic!("Can't write to test app's stdin!");
-        }
+        }}
     }
 
     /// Waits for process to end and stdout/err to be read. - returns final exit status


### PR DESCRIPTION
- Issue: https://github.com/metalbear-co/private/issues/547

I tried to keep the most annoying crates as separate commits, before running `cargo fix --edition` on the others.

- Will run `cargo fmt` as late as possible, since it changes a lot of files (226 to be precise), which would make this pretty much un-reviewable.