### PR TITLE
Add Ready message to port-forward cmd progress

### DIFF
--- a/changelog.d/+add-port-fwder-ready.fixed.md
+++ b/changelog.d/+add-port-fwder-ready.fixed.md
@@ -1,0 +1,1 @@
+Added "Ready!" message when `mirrord port-forward` command finishes setup.

--- a/mirrord/cli/src/main.rs
+++ b/mirrord/cli/src/main.rs
@@ -764,6 +764,7 @@ async fn port_forward(
         receiver: agent_conn.agent_rx,
     };
 
+    progress.success(Some("Ready!"));
     let _ = tokio::try_join!(
         async {
             if !args.port_mapping.is_empty() {


### PR DESCRIPTION
Issue: https://linear.app/metalbear/issue/MBE-1012/add-ready-progress-message-to-port-forwarding