### PR TITLE
Synchronize prints in python e2e apps

### DIFF
--- a/changelog.d/+python-e2e-apps-stdout.internal.md
+++ b/changelog.d/+python-e2e-apps-stdout.internal.md
@@ -1,0 +1,1 @@
+Fixed mangled output from some of the Python E2E apps.

--- a/tests/python-e2e/app_fastapi.py
+++ b/tests/python-e2e/app_fastapi.py
@@ -1,23 +1,29 @@
 from fastapi import FastAPI, Response
+from threading import Lock
 
+print_lock = Lock()
 app = FastAPI()
 
 @app.get("/")
 def get():
-    print("GET: Request completed")
+    with print_lock:
+        print("GET: Request completed")
     return Response(content = "GET", media_type="text/plain")
 
 @app.post("/")
 def post():
-    print("POST: Request completed")
+    with print_lock:
+        print("POST: Request completed")
     return Response(content = "POST", media_type="text/plain")
 
 @app.put("/")
 def put():
-    print("PUT: Request completed")
+    with print_lock:
+        print("PUT: Request completed")
     return Response(content = "PUT", media_type="text/plain")
 
 @app.delete("/")
 def delete():
-    print("DELETE: Request completed")
+    with print_lock:
+        print("DELETE: Request completed")
     return Response(content = "DELETE", media_type="text/plain")

--- a/tests/python-e2e/app_flask.py
+++ b/tests/python-e2e/app_flask.py
@@ -1,6 +1,9 @@
 from flask import Flask
 import logging
 import sys
+from threading import Lock
+
+print_lock = Lock()
 
 log = logging.getLogger("werkzeug")
 log.disabled = True
@@ -15,25 +18,29 @@ TEXT = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod 
 
 @app.route("/", methods=["GET"])
 def get():
-    print("GET: Request completed")
+    with print_lock:
+        print("GET: Request completed")
     return "GET"
 
 
 @app.route("/", methods=["POST"])
 def post():
-    print("POST: Request completed")
+    with print_lock:
+        print("POST: Request completed")
     return "POST"
 
 
 @app.route("/", methods=["PUT"])
 def put():
-    print("PUT: Request completed")
+    with print_lock:
+        print("PUT: Request completed")
     return "PUT"
 
 
 @app.route("/", methods=["DELETE"])
 def delete():
-    print("DELETE: Request completed")
+    with print_lock:
+        print("DELETE: Request completed")
     return "DELETE"
 
 


### PR DESCRIPTION
I believe we read mangled output from Python E2E apps, see [this failure](https://github.com/metalbear-co/mirrord/actions/runs/16648023970/job/47113327516?pr=3465):

```
Making HTTP connection 1
Making HTTP request 1 in connection 1
Sending request
Received response 200 OK. BODY=Ok("Echo [remote]: GET 1:1"), HEADERS={"content-length": "22", "content-type": "text/plain; charset=utf-8", "date": "Thu, 31 Jul 2025 11:50:45 GMT"}
Making HTTP request 2 in connection 1
Sending request
Received response 200 OK. BODY=Ok("Echo [remote]: GET 1:2"), HEADERS={"content-length": "22", "content-type": "text/plain; charset=utf-8", "date": "Thu, 31 Jul 2025 11:50:45 GMT"}
Making HTTP connection 2
Making HTTP request 1 in connection 2
Sending request
stdout 11:50:45 33756: GET: Request completedGET: Request completed
stdout 11:50:45 33756: 
Received response 200 OK. BODY=Ok("Echo [remote]: GET 2:1"), HEADERS={"content-length": "22", "content-type": "text/plain; charset=utf-8", "date": "Thu, 31 Jul 2025 11:50:45 GMT"}
Making HTTP request 2 in connection 2
Sending request
Received response 200 OK. BODY=Ok("Echo [remote]: GET 2:2"), HEADERS={"content-length": "22", "content-type": "text/plain; charset=utf-8", "date": "Thu, 31 Jul 2025 11:50:45 GMT"}
stdout 11:50:45 33756: GET: Request completed
stdout 11:50:45 33756: GET: Request completedstdout 11:50:45 33756: 
```

Looks like we read `GET: Request completed` twice, and then two newlines. This breaks tests.