### PR TITLE
Hide `mirrord_progress::Progress` implementations behind a crate feature

### DIFF
--- a/changelog.d/+hide-progress-implementations.internal.md
+++ b/changelog.d/+hide-progress-implementations.internal.md
@@ -1,0 +1,1 @@
+`mirrord_progress::Progress` implementations are now hidden behind the `implementations` feature.

--- a/mirrord/cli/Cargo.toml
+++ b/mirrord/cli/Cargo.toml
@@ -25,7 +25,7 @@ mirrord-operator = { path = "../operator", features = [
     "setup",
 ] }
 mirrord-intproxy-protocol = { path = "../intproxy/protocol" }
-mirrord-progress = { path = "../progress" }
+mirrord-progress = { path = "../progress", features = ["implementations"] }
 mirrord-kube = { path = "../kube", features = ["portforward"] }
 mirrord-config = { path = "../config" }
 mirrord-protocol = { path = "../protocol" }

--- a/mirrord/progress/Cargo.toml
+++ b/mirrord/progress/Cargo.toml
@@ -16,8 +16,15 @@ edition.workspace = true
 [lints]
 workspace = true
 
+[features]
+implementations = [
+    "dep:indicatif",
+    "dep:serde",
+    "dep:enum_dispatch",
+]
+
 [dependencies]
-indicatif = "0.17"
-serde.workspace = true
+indicatif = { version = "0.17", optional = true }
+serde = { workspace = true, optional = true }
 serde_json.workspace = true
-enum_dispatch.workspace = true
+enum_dispatch = { workspace = true, optional = true }

--- a/mirrord/progress/src/implementations.rs
+++ b/mirrord/progress/src/implementations.rs
@@ -1,0 +1,359 @@
+use std::{collections::HashSet, time::Duration};
+
+use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
+use serde::Serialize;
+use serde_json::Value;
+
+use crate::Progress;
+
+#[derive(Debug)]
+pub struct JsonProgress {
+    parent: Option<String>,
+    name: String,
+    done: bool,
+    fail_on_drop: bool,
+}
+
+impl JsonProgress {
+    pub fn new(text: &str) -> JsonProgress {
+        let progress = JsonProgress {
+            parent: None,
+            name: text.to_string(),
+            done: false,
+            fail_on_drop: true,
+        };
+        progress.print_new_task();
+        progress
+    }
+
+    fn print_new_task(&self) {
+        let message = ProgressMessage::NewTask(NewTaskMessage {
+            name: self.name.clone(),
+            parent: self.parent.clone(),
+        });
+        message.print();
+    }
+
+    fn print_finished_task(&self, success: bool, msg: Option<&str>) {
+        let message = ProgressMessage::FinishedTask(FinishedTaskMessage {
+            name: self.name.clone(),
+            message: msg.map(|s| s.to_string()),
+            success,
+        });
+        message.print();
+    }
+}
+
+impl Progress for JsonProgress {
+    fn subtask(&self, text: &str) -> JsonProgress {
+        let task = JsonProgress {
+            parent: Some(self.name.clone()),
+            name: text.to_string(),
+            done: false,
+            fail_on_drop: true,
+        };
+        task.print_new_task();
+        task
+    }
+
+    fn success(&mut self, msg: Option<&str>) {
+        self.done = true;
+        self.print_finished_task(true, msg)
+    }
+
+    fn failure(&mut self, msg: Option<&str>) {
+        self.done = true;
+        self.print_finished_task(false, msg)
+    }
+
+    fn warning(&self, msg: &str) {
+        let message = ProgressMessage::Warning(WarningMessage {
+            message: msg.to_string(),
+        });
+        message.print();
+    }
+
+    fn info(&self, msg: &str) {
+        let message = ProgressMessage::Info {
+            message: msg.to_string(),
+        };
+        message.print();
+    }
+
+    fn ide(&self, value: serde_json::Value) {
+        if std::env::var("MIRRORD_PROGRESS_SUPPORT_IDE")
+            .ok()
+            .and_then(|ide_support_enabled| ide_support_enabled.parse().ok())
+            .unwrap_or(false)
+        {
+            let message = ProgressMessage::IdeMessage { message: value };
+            message.print();
+        }
+    }
+
+    fn set_fail_on_drop(&mut self, fail: bool) {
+        self.fail_on_drop = fail;
+    }
+}
+
+impl Drop for JsonProgress {
+    fn drop(&mut self) {
+        if !self.done {
+            if self.fail_on_drop {
+                self.failure(None);
+            } else {
+                self.success(None);
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct SimpleProgress;
+
+impl SimpleProgress {
+    pub fn new(text: &str) -> SimpleProgress {
+        println!("{text}");
+        SimpleProgress {}
+    }
+}
+
+impl Progress for SimpleProgress {
+    fn subtask(&self, text: &str) -> SimpleProgress {
+        println!("{text}");
+        SimpleProgress {}
+    }
+
+    fn success(&mut self, msg: Option<&str>) {
+        println!("{msg:?}");
+    }
+
+    fn failure(&mut self, msg: Option<&str>) {
+        println!("{msg:?}");
+    }
+
+    fn warning(&self, msg: &str) {
+        println!("{msg}");
+    }
+
+    fn info(&self, msg: &str) {
+        println!("{msg}");
+    }
+
+    fn print(&self, text: &str) {
+        println!("{text}");
+    }
+}
+
+fn spinner_template(indent: usize) -> String {
+    format!("{indent}{{spinner}} {{msg}}", indent = "  ".repeat(indent))
+}
+
+fn spinner(indent: usize) -> ProgressBar {
+    ProgressBar::hidden().with_style(
+        ProgressStyle::default_spinner()
+            .template(&spinner_template(indent))
+            .unwrap(),
+    )
+}
+
+#[derive(Debug)]
+pub struct SpinnerProgress {
+    done: bool,
+    fail_on_drop: bool,
+    root_progress: MultiProgress,
+    progress: ProgressBar,
+    indent: usize,
+    message_buffer: Vec<String>,
+}
+
+impl SpinnerProgress {
+    pub fn new(text: &str) -> SpinnerProgress {
+        let root_progress = MultiProgress::new();
+        let progress = spinner(0);
+        progress.set_message(text.to_string());
+        root_progress.add(progress.clone());
+        progress.enable_steady_tick(Duration::from_millis(60));
+
+        SpinnerProgress {
+            done: false,
+            fail_on_drop: true,
+            indent: 0,
+            root_progress,
+            progress,
+            message_buffer: vec![],
+        }
+    }
+}
+
+impl Progress for SpinnerProgress {
+    fn subtask(&self, text: &str) -> SpinnerProgress {
+        let indent = self.indent + 1;
+        let progress = spinner(indent);
+        progress.set_message(text.to_string());
+        self.root_progress.add(progress.clone());
+        progress.enable_steady_tick(Duration::from_millis(60));
+        SpinnerProgress {
+            done: false,
+            fail_on_drop: true,
+            root_progress: self.root_progress.clone(),
+            indent,
+            progress,
+            message_buffer: vec![],
+        }
+    }
+
+    fn success(&mut self, msg: Option<&str>) {
+        self.done = true;
+        if let Some(msg) = msg {
+            self.progress.finish_with_message(format!("✓ {msg}"));
+        } else {
+            self.progress
+                .finish_with_message(format!("✓ {}", self.progress.message()));
+        }
+        self.message_buffer.iter().for_each(|msg| println!("{msg}"));
+    }
+
+    fn failure(&mut self, msg: Option<&str>) {
+        self.done = true;
+        if let Some(msg) = msg {
+            self.progress.abandon_with_message(format!("x {msg}"));
+        } else {
+            self.progress
+                .abandon_with_message(format!("x {}", self.progress.message()));
+        }
+    }
+
+    fn warning(&self, msg: &str) {
+        let formatted_message = format!("! {msg}");
+        self.print(&formatted_message);
+        self.progress.set_message(formatted_message);
+    }
+
+    fn info(&self, msg: &str) {
+        let formatted_message = format!("* {msg}");
+        self.print(&formatted_message);
+        self.progress.set_message(formatted_message);
+    }
+
+    fn print(&self, msg: &str) {
+        let _ = self.root_progress.println(msg);
+    }
+
+    fn add_to_print_buffer(&mut self, msg: &str) {
+        self.message_buffer.push(msg.to_string())
+    }
+
+    fn set_fail_on_drop(&mut self, fail: bool) {
+        self.fail_on_drop = fail;
+    }
+
+    fn suspend<F: FnOnce() -> R, R>(&self, f: F) -> R {
+        self.progress.suspend(f)
+    }
+}
+
+impl Drop for SpinnerProgress {
+    fn drop(&mut self) {
+        if !self.done {
+            if self.fail_on_drop {
+                self.failure(None);
+            } else {
+                self.success(None);
+            }
+        }
+    }
+}
+
+/// Message sent when a new task is created using subtask/new
+#[derive(Serialize, Debug, Clone, Default)]
+struct NewTaskMessage {
+    /// Task name (identifier)
+    name: String,
+    /// Parent task name, if subtask.
+    parent: Option<String>,
+}
+
+/// Message sent when a task is finished.
+#[derive(Serialize, Debug, Clone, Default)]
+struct FinishedTaskMessage {
+    /// Finished task name
+    name: String,
+    /// Was the task successful?
+    success: bool,
+    /// Finish message
+    message: Option<String>,
+}
+
+/// Message sent when a task is finished.
+#[derive(Serialize, Debug, Clone, Default)]
+struct WarningMessage {
+    /// Warning message
+    message: String,
+}
+
+/// Indicates what type of notification should appear in the IDEs.
+#[derive(Serialize, Debug, Clone, Default)]
+pub enum NotificationLevel {
+    /// Normal info box.
+    #[default]
+    Info,
+
+    /// Warning box.
+    Warning,
+}
+
+/// Action/button type that appears in the pop-up notifications.
+#[derive(Serialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[serde(tag = "kind")]
+pub enum IdeAction {
+    /// A link action, where `label` is the text, and `link` is the _href_.
+    Link { label: String, link: String },
+}
+
+/// Messages sent to the IDEs with full context.
+#[derive(Serialize, Debug, Clone, Default)]
+pub struct IdeMessage {
+    /// Allows us to identify this message and map it to something meaningful in the IDEs.
+    ///
+    /// Not shown to the user.
+    ///
+    /// In vscode, this should map to a `configEntry` defined in `package.json`.
+    pub id: String,
+
+    /// The level of the notification, the type of pop-up it'll be displayed in the IDEs.
+    pub level: NotificationLevel,
+
+    /// Message content.
+    pub text: String,
+
+    /// Actions/buttons that appears in the pop-up notification.
+    pub actions: HashSet<IdeAction>,
+}
+
+/// The message types that we report on [`Progress`].
+///
+/// These are used by the extensions (vscode and intellij) to show nice notifications.
+#[derive(Serialize, Debug, Clone)]
+#[serde(tag = "type")]
+enum ProgressMessage {
+    NewTask(NewTaskMessage),
+    Warning(WarningMessage),
+    FinishedTask(FinishedTaskMessage),
+    Info {
+        message: String,
+    },
+    /// Messages that are passed to the IDE and shown to the user in notification boxes.
+    IdeMessage {
+        /// It's a generic json [`Value`].
+        ///
+        /// Should be an [`IdeMessage`] converted to [`Value`].
+        message: Value,
+    },
+}
+
+impl ProgressMessage {
+    pub(crate) fn print(&self) {
+        println!("{}", serde_json::to_string(self).unwrap());
+    }
+}

--- a/mirrord/progress/src/lib.rs
+++ b/mirrord/progress/src/lib.rs
@@ -1,13 +1,11 @@
 #![deny(unused_crate_dependencies)]
 
-use std::{collections::HashSet, time::Duration};
-
-use enum_dispatch::enum_dispatch;
-use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
-use serde::Serialize;
-use serde_json::{Value, to_string};
-
+#[cfg(feature = "implementations")]
+pub mod implementations;
 pub mod messages;
+
+#[cfg(feature = "implementations")]
+pub use implementations::*;
 
 /// The environment variable name that is used
 /// to determine the mode of progress reporting
@@ -19,7 +17,7 @@ pub const MIRRORD_PROGRESS_ENV: &str = "MIRRORD_PROGRESS_MODE";
 /// mix it (e.g. calling `progress.info`) with regular [`println!`], as the IDE may fail to parse
 /// the [`ProgressMessage`] (intellij will fail with `"failed to parse a message from mirrord
 /// binary"`), and we end up displaying an error instead.
-#[enum_dispatch]
+#[cfg_attr(feature = "implementations", enum_dispatch::enum_dispatch)]
 pub trait Progress: Sized + Send + Sync {
     /// Create a subtask report from this task.
     fn subtask(&self, text: &str) -> Self;
@@ -61,9 +59,19 @@ pub trait Progress: Sized + Send + Sync {
     }
 }
 
-/// `ProgressTracker` determines the way progress is reported.
 #[derive(Debug)]
-#[enum_dispatch(Progress)]
+pub struct NullProgress;
+
+impl Progress for NullProgress {
+    fn subtask(&self, _: &str) -> NullProgress {
+        NullProgress
+    }
+}
+
+/// [`ProgressTracker`] determines the way progress is reported.
+#[cfg(feature = "implementations")]
+#[derive(Debug)]
+#[enum_dispatch::enum_dispatch(Progress)]
 pub enum ProgressTracker {
     /// Display dynamic progress with spinners.
     SpinnerProgress(SpinnerProgress),
@@ -78,274 +86,7 @@ pub enum ProgressTracker {
     NullProgress(NullProgress),
 }
 
-#[derive(Debug)]
-pub struct NullProgress;
-
-impl Progress for NullProgress {
-    fn subtask(&self, _: &str) -> NullProgress {
-        NullProgress
-    }
-}
-
-#[derive(Debug)]
-pub struct JsonProgress {
-    parent: Option<String>,
-    name: String,
-    done: bool,
-    fail_on_drop: bool,
-}
-
-impl JsonProgress {
-    pub fn new(text: &str) -> JsonProgress {
-        let progress = JsonProgress {
-            parent: None,
-            name: text.to_string(),
-            done: false,
-            fail_on_drop: true,
-        };
-        progress.print_new_task();
-        progress
-    }
-
-    fn print_new_task(&self) {
-        let message = ProgressMessage::NewTask(NewTaskMessage {
-            name: self.name.clone(),
-            parent: self.parent.clone(),
-        });
-        message.print();
-    }
-
-    fn print_finished_task(&self, success: bool, msg: Option<&str>) {
-        let message = ProgressMessage::FinishedTask(FinishedTaskMessage {
-            name: self.name.clone(),
-            message: msg.map(|s| s.to_string()),
-            success,
-        });
-        message.print();
-    }
-}
-
-impl Progress for JsonProgress {
-    fn subtask(&self, text: &str) -> JsonProgress {
-        let task = JsonProgress {
-            parent: Some(self.name.clone()),
-            name: text.to_string(),
-            done: false,
-            fail_on_drop: true,
-        };
-        task.print_new_task();
-        task
-    }
-
-    fn success(&mut self, msg: Option<&str>) {
-        self.done = true;
-        self.print_finished_task(true, msg)
-    }
-
-    fn failure(&mut self, msg: Option<&str>) {
-        self.done = true;
-        self.print_finished_task(false, msg)
-    }
-
-    fn warning(&self, msg: &str) {
-        let message = ProgressMessage::Warning(WarningMessage {
-            message: msg.to_string(),
-        });
-        message.print();
-    }
-
-    fn info(&self, msg: &str) {
-        let message = ProgressMessage::Info {
-            message: msg.to_string(),
-        };
-        message.print();
-    }
-
-    fn ide(&self, value: serde_json::Value) {
-        if std::env::var("MIRRORD_PROGRESS_SUPPORT_IDE")
-            .ok()
-            .and_then(|ide_support_enabled| ide_support_enabled.parse().ok())
-            .unwrap_or(false)
-        {
-            let message = ProgressMessage::IdeMessage { message: value };
-            message.print();
-        }
-    }
-
-    fn set_fail_on_drop(&mut self, fail: bool) {
-        self.fail_on_drop = fail;
-    }
-}
-
-impl Drop for JsonProgress {
-    fn drop(&mut self) {
-        if !self.done {
-            if self.fail_on_drop {
-                self.failure(None);
-            } else {
-                self.success(None);
-            }
-        }
-    }
-}
-
-#[derive(Debug)]
-pub struct SimpleProgress;
-
-impl SimpleProgress {
-    fn new(text: &str) -> SimpleProgress {
-        println!("{text}");
-        SimpleProgress {}
-    }
-}
-
-impl Progress for SimpleProgress {
-    fn subtask(&self, text: &str) -> SimpleProgress {
-        println!("{text}");
-        SimpleProgress {}
-    }
-
-    fn success(&mut self, msg: Option<&str>) {
-        println!("{msg:?}");
-    }
-
-    fn failure(&mut self, msg: Option<&str>) {
-        println!("{msg:?}");
-    }
-
-    fn warning(&self, msg: &str) {
-        println!("{msg}");
-    }
-
-    fn info(&self, msg: &str) {
-        println!("{msg}");
-    }
-
-    fn print(&self, text: &str) {
-        println!("{text}");
-    }
-}
-
-fn spinner_template(indent: usize) -> String {
-    format!("{indent}{{spinner}} {{msg}}", indent = "  ".repeat(indent))
-}
-
-fn spinner(indent: usize) -> ProgressBar {
-    ProgressBar::hidden().with_style(
-        ProgressStyle::default_spinner()
-            .template(&spinner_template(indent))
-            .unwrap(),
-    )
-}
-
-#[derive(Debug)]
-pub struct SpinnerProgress {
-    done: bool,
-    fail_on_drop: bool,
-    root_progress: MultiProgress,
-    progress: ProgressBar,
-    indent: usize,
-    message_buffer: Vec<String>,
-}
-
-impl SpinnerProgress {
-    fn new(text: &str) -> SpinnerProgress {
-        let root_progress = MultiProgress::new();
-        let progress = spinner(0);
-        progress.set_message(text.to_string());
-        root_progress.add(progress.clone());
-        progress.enable_steady_tick(Duration::from_millis(60));
-
-        SpinnerProgress {
-            done: false,
-            fail_on_drop: true,
-            indent: 0,
-            root_progress,
-            progress,
-            message_buffer: vec![],
-        }
-    }
-}
-
-impl Progress for SpinnerProgress {
-    fn subtask(&self, text: &str) -> SpinnerProgress {
-        let indent = self.indent + 1;
-        let progress = spinner(indent);
-        progress.set_message(text.to_string());
-        self.root_progress.add(progress.clone());
-        progress.enable_steady_tick(Duration::from_millis(60));
-        SpinnerProgress {
-            done: false,
-            fail_on_drop: true,
-            root_progress: self.root_progress.clone(),
-            indent,
-            progress,
-            message_buffer: vec![],
-        }
-    }
-
-    fn success(&mut self, msg: Option<&str>) {
-        self.done = true;
-        if let Some(msg) = msg {
-            self.progress.finish_with_message(format!("✓ {msg}"));
-        } else {
-            self.progress
-                .finish_with_message(format!("✓ {}", self.progress.message()));
-        }
-        self.message_buffer.iter().for_each(|msg| println!("{msg}"));
-    }
-
-    fn failure(&mut self, msg: Option<&str>) {
-        self.done = true;
-        if let Some(msg) = msg {
-            self.progress.abandon_with_message(format!("x {msg}"));
-        } else {
-            self.progress
-                .abandon_with_message(format!("x {}", self.progress.message()));
-        }
-    }
-
-    fn warning(&self, msg: &str) {
-        let formatted_message = format!("! {msg}");
-        self.print(&formatted_message);
-        self.progress.set_message(formatted_message);
-    }
-
-    fn info(&self, msg: &str) {
-        let formatted_message = format!("* {msg}");
-        self.print(&formatted_message);
-        self.progress.set_message(formatted_message);
-    }
-
-    fn print(&self, msg: &str) {
-        let _ = self.root_progress.println(msg);
-    }
-
-    fn add_to_print_buffer(&mut self, msg: &str) {
-        self.message_buffer.push(msg.to_string())
-    }
-
-    fn set_fail_on_drop(&mut self, fail: bool) {
-        self.fail_on_drop = fail;
-    }
-
-    fn suspend<F: FnOnce() -> R, R>(&self, f: F) -> R {
-        self.progress.suspend(f)
-    }
-}
-
-impl Drop for SpinnerProgress {
-    fn drop(&mut self) {
-        if !self.done {
-            if self.fail_on_drop {
-                self.failure(None);
-            } else {
-                self.success(None);
-            }
-        }
-    }
-}
-
+#[cfg(feature = "implementations")]
 impl ProgressTracker {
     /// Get the progress tracker from environment or return a default ([`SpinnerProgress`]).
     pub fn from_env(text: &str) -> Self {
@@ -363,98 +104,5 @@ impl ProgressTracker {
         };
 
         Some(progress)
-    }
-}
-
-/// Message sent when a new task is created using subtask/new
-#[derive(Serialize, Debug, Clone, Default)]
-struct NewTaskMessage {
-    /// Task name (identifier)
-    name: String,
-    /// Parent task name, if subtask.
-    parent: Option<String>,
-}
-
-/// Message sent when a task is finished.
-#[derive(Serialize, Debug, Clone, Default)]
-struct FinishedTaskMessage {
-    /// Finished task name
-    name: String,
-    /// Was the task successful?
-    success: bool,
-    /// Finish message
-    message: Option<String>,
-}
-
-/// Message sent when a task is finished.
-#[derive(Serialize, Debug, Clone, Default)]
-struct WarningMessage {
-    /// Warning message
-    message: String,
-}
-
-/// Indicates what type of notification should appear in the IDEs.
-#[derive(Serialize, Debug, Clone, Default)]
-pub enum NotificationLevel {
-    /// Normal info box.
-    #[default]
-    Info,
-
-    /// Warning box.
-    Warning,
-}
-
-/// Action/button type that appears in the pop-up notifications.
-#[derive(Serialize, Debug, Clone, PartialEq, Eq, Hash)]
-#[serde(tag = "kind")]
-pub enum IdeAction {
-    /// A link action, where `label` is the text, and `link` is the _href_.
-    Link { label: String, link: String },
-}
-
-/// Messages sent to the IDEs with full context.
-#[derive(Serialize, Debug, Clone, Default)]
-pub struct IdeMessage {
-    /// Allows us to identify this message and map it to something meaningful in the IDEs.
-    ///
-    /// Not shown to the user.
-    ///
-    /// In vscode, this should map to a `configEntry` defined in `package.json`.
-    pub id: String,
-
-    /// The level of the notification, the type of pop-up it'll be displayed in the IDEs.
-    pub level: NotificationLevel,
-
-    /// Message content.
-    pub text: String,
-
-    /// Actions/buttons that appears in the pop-up notification.
-    pub actions: HashSet<IdeAction>,
-}
-
-/// The message types that we report on [`Progress`].
-///
-/// These are used by the extensions (vscode and intellij) to show nice notifications.
-#[derive(Serialize, Debug, Clone)]
-#[serde(tag = "type")]
-enum ProgressMessage {
-    NewTask(NewTaskMessage),
-    Warning(WarningMessage),
-    FinishedTask(FinishedTaskMessage),
-    Info {
-        message: String,
-    },
-    /// Messages that are passed to the IDE and shown to the user in notification boxes.
-    IdeMessage {
-        /// It's a generic json [`Value`].
-        ///
-        /// Should be an [`IdeMessage`] converted to [`Value`].
-        message: Value,
-    },
-}
-
-impl ProgressMessage {
-    pub(crate) fn print(&self) {
-        println!("{}", to_string(self).unwrap());
     }
 }

--- a/mirrord/progress/src/lib.rs
+++ b/mirrord/progress/src/lib.rs
@@ -15,7 +15,7 @@ pub const MIRRORD_PROGRESS_ENV: &str = "MIRRORD_PROGRESS_MODE";
 ///
 /// This is our IDE friendly way of sending notification messages from the cli, be careful not to
 /// mix it (e.g. calling `progress.info`) with regular [`println!`], as the IDE may fail to parse
-/// the [`ProgressMessage`] (intellij will fail with `"failed to parse a message from mirrord
+/// the output (intellij will fail with `"failed to parse a message from mirrord
 /// binary"`), and we end up displaying an error instead.
 #[cfg_attr(feature = "implementations", enum_dispatch::enum_dispatch)]
 pub trait Progress: Sized + Send + Sync {


### PR DESCRIPTION
Right now dependents unnecessarily pull in `indicatif`, `enum_dispatch` and `serde`

(changed loc come from the fact that code from `lib.rs` was moved to a separate file)