### PR TITLE
Allow users to ignore containers and init containers in copy target config

### DIFF
--- a/changelog.d/+add-ignore-containers-config.added.md
+++ b/changelog.d/+add-ignore-containers-config.added.md
@@ -1,0 +1,1 @@
+Add configuration to ignore specified containers and init containers when `copy_target` is enabled.

--- a/mirrord-schema.json
+++ b/mirrord-schema.json
@@ -676,6 +676,24 @@
                 "null"
               ]
             },
+            "exclude_containers": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
+            },
+            "exclude_init_containers": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
+            },
             "scale_down": {
               "type": [
                 "boolean",

--- a/mirrord/config/configuration.md
+++ b/mirrord/config/configuration.md
@@ -749,14 +749,16 @@ Creates a new copy of the target. mirrord will use this copy instead of the orig
 This feature is not compatible with rollout targets and running without a target
 (`targetless` mode).
 
-Allows the user to target a pod created dynamically from the orignal [`target`](#target).
+Allows the user to target a pod created dynamically from the original [`target`](#target).
 The new pod inherits most of the original target's specification, e.g. labels.
 
 ```json
 {
   "feature": {
     "copy_target": {
-      "scale_down": true
+      "scale_down": true,
+      "exclude_containers": ["my-container"],
+      "exclude_init_containers": ["my-init-container"]
     }
   }
 }
@@ -769,6 +771,14 @@ The new pod inherits most of the original target's specification, e.g. labels.
   }
 }
 ```
+
+### feature.copy_target.exclude_containers {#feature-copy_target-exclude_containers}
+
+Set a list of containers to be ignored by copy_target
+
+### feature.copy_target.exclude_init_containers {#feature-copy_target-exclude_init_containers}
+
+Set a list of init containers to be ignored by copy_target
 
 ### feature.copy_target.scale_down {#feature-copy_target-scale_down}
 

--- a/mirrord/config/src/feature/copy_target.rs
+++ b/mirrord/config/src/feature/copy_target.rs
@@ -20,6 +20,8 @@ pub enum CopyTargetFileConfig {
     Advanced {
         enabled: Option<bool>,
         scale_down: Option<bool>,
+        exclude_containers: Option<Vec<String>>,
+        exclude_init_containers: Option<Vec<String>>,
     },
 }
 
@@ -37,13 +39,19 @@ impl MirrordConfig for CopyTargetFileConfig {
             Self::Simple(enabled) => Self::Generated {
                 enabled,
                 scale_down: false,
+                exclude_containers: vec![],
+                exclude_init_containers: vec![],
             },
             Self::Advanced {
                 enabled,
                 scale_down,
+                exclude_containers,
+                exclude_init_containers,
             } => Self::Generated {
                 enabled: enabled.unwrap_or(true),
                 scale_down: scale_down.unwrap_or_default(),
+                exclude_containers: exclude_containers.unwrap_or_default(),
+                exclude_init_containers: exclude_init_containers.unwrap_or_default(),
             },
         };
 
@@ -55,14 +63,16 @@ impl FromMirrordConfig for CopyTargetConfig {
     type Generator = CopyTargetFileConfig;
 }
 
-/// Allows the user to target a pod created dynamically from the orignal [`target`](#target).
+/// Allows the user to target a pod created dynamically from the original [`target`](#target).
 /// The new pod inherits most of the original target's specification, e.g. labels.
 ///
 /// ```json
 /// {
 ///   "feature": {
 ///     "copy_target": {
-///       "scale_down": true
+///       "scale_down": true,
+///       "exclude_containers": ["my-container"],
+///       "exclude_init_containers": ["my-init-container"]
 ///     }
 ///   }
 /// }
@@ -91,6 +101,16 @@ pub struct CopyTargetConfig {
     ///     }
     /// ```
     pub scale_down: bool,
+
+    /// ### feature.copy_target.exclude_containers {#feature-copy_target-exclude_containers}
+    ///
+    /// Set a list of containers to be ignored by copy_target
+    pub exclude_containers: Vec<String>,
+
+    /// ### feature.copy_target.exclude_init_containers {#feature-copy_target-exclude_init_containers}
+    ///
+    /// Set a list of init containers to be ignored by copy_target
+    pub exclude_init_containers: Vec<String>,
 }
 
 impl CollectAnalytics for &CopyTargetConfig {

--- a/mirrord/operator/src/client.rs
+++ b/mirrord/operator/src/client.rs
@@ -874,6 +874,13 @@ impl OperatorApi<PreparedClientCert> {
             .is_set()
             .then(|| layer_config.feature.split_queues.clone());
 
+        let exclude_containers = layer_config.feature.copy_target.exclude_containers.clone();
+        let exclude_init_containers = layer_config
+            .feature
+            .copy_target
+            .exclude_init_containers
+            .clone();
+
         let copy_target_api: Api<CopyTargetCrd> = Api::namespaced(self.client.clone(), namespace);
         let copy_target_name = TargetCrd::urlfied_name(&target);
         let copy_target_spec = CopyTargetSpec {
@@ -881,6 +888,8 @@ impl OperatorApi<PreparedClientCert> {
             idle_ttl: Some(Self::COPIED_POD_IDLE_TTL),
             scale_down,
             split_queues,
+            exclude_containers,
+            exclude_init_containers,
         };
 
         let copied = copy_target_api
@@ -923,6 +932,13 @@ impl OperatorApi<PreparedClientCert> {
             .is_set()
             .then(|| layer_config.feature.split_queues.clone());
 
+        let exclude_containers = layer_config.feature.copy_target.exclude_containers.clone();
+        let exclude_init_containers = layer_config
+            .feature
+            .copy_target
+            .exclude_init_containers
+            .clone();
+
         let user_id = self.get_user_id_str();
 
         let copy_target_api: Api<CopyTargetCrd> = Api::namespaced(self.client.clone(), namespace);
@@ -931,6 +947,8 @@ impl OperatorApi<PreparedClientCert> {
             idle_ttl: Some(Self::COPIED_POD_IDLE_TTL),
             scale_down,
             split_queues,
+            exclude_containers,
+            exclude_init_containers,
         };
 
         let existing = copy_target_api

--- a/mirrord/operator/src/crd/copy_target.rs
+++ b/mirrord/operator/src/crd/copy_target.rs
@@ -27,6 +27,10 @@ pub struct CopyTargetSpec {
     pub scale_down: bool,
     /// Split queues client side configuration.
     pub split_queues: Option<SplitQueuesConfig>,
+    /// Containers that are ignored by copy target.
+    pub exclude_containers: Vec<String>,
+    /// Init containers that are ignored by copy target.
+    pub exclude_init_containers: Vec<String>,
 }
 
 /// This is the `status` field for [`CopyTargetCrd`].

--- a/mirrord/operator/src/crd/copy_target.rs
+++ b/mirrord/operator/src/crd/copy_target.rs
@@ -28,8 +28,10 @@ pub struct CopyTargetSpec {
     /// Split queues client side configuration.
     pub split_queues: Option<SplitQueuesConfig>,
     /// Containers that are ignored by copy target.
+    #[serde(default)]
     pub exclude_containers: Vec<String>,
     /// Init containers that are ignored by copy target.
+    #[serde(default)]
     pub exclude_init_containers: Vec<String>,
 }
 


### PR DESCRIPTION
Issue: https://linear.app/metalbear/issue/MBE-1330/allow-user-to-remove-init-containers-in-copy-target