### PR TITLE
Fixed incoming HTTP connection shutdown (mirrord-agent)

### DIFF
--- a/changelog.d/+agent-hanging.fixed.md
+++ b/changelog.d/+agent-hanging.fixed.md
@@ -1,0 +1,1 @@
+Fixed an issue where the mirrord-agent would sometimes hang and linger in the cluster.

--- a/mirrord/agent/src/incoming/task.rs
+++ b/mirrord/agent/src/incoming/task.rs
@@ -218,19 +218,19 @@ where
         let token = port_state.http_shutdown.clone();
         let mut requests = ExtractedRequests::new(TokioIo::new(conn.stream), http_version);
         tokio::spawn(async move {
-            let mut token_cancelled = false;
+            let mut shutting_down = false;
             loop {
                 let result = tokio::select! {
                     result = requests.next() => result,
-                    _ = token.cancelled(), if token_cancelled.not() => {
+                    _ = token.cancelled(), if shutting_down.not() => {
                         tracing::debug!(
                             connection = ?conn.info,
                             "Gracefully shutting down a redirected HTTP connection",
                         );
-                        token_cancelled = true;
                         // After starting the graceful shutdown,
                         // `requests` iterator will eventually finish on its own.
                         requests.graceful_shutdown();
+                        shutting_down = true;
                         continue;
                     },
                 };


### PR DESCRIPTION
Just saw 35MB of "Gracefully shutting down a redirected HTTP connection" logs :skull: 

`CancellationToken::cancelled` immediately returns `Poll::Ready` when the token has already been cancelled, so the task was never returning control to the runtime