### PR TITLE
Use the file name in the identifier of the new signed file when patching for SIP

### DIFF
--- a/changelog.d/+codesign-filename.changed.md
+++ b/changelog.d/+codesign-filename.changed.md
@@ -1,0 +1,1 @@
+In SIP-patched binaries, set the identifier to start with the original filename, like the codesign binary does.

--- a/mirrord/sip/src/lib.rs
+++ b/mirrord/sip/src/lib.rs
@@ -1145,10 +1145,13 @@ mod main {
                 SipStatus::SipBinary(_),
             ));
             assert!(matches!(
-                get_sip_status(signed_temp_file_path, SipPatchOptions {
-                    patch: &[],
-                    skip: &[signed_temp_file_path.to_string()],
-                })
+                get_sip_status(
+                    signed_temp_file_path,
+                    SipPatchOptions {
+                        patch: &[],
+                        skip: &[signed_temp_file_path.to_string()],
+                    }
+                )
                 .unwrap(),
                 SipStatus::NoSip,
             ));

--- a/mirrord/sip/src/lib.rs
+++ b/mirrord/sip/src/lib.rs
@@ -366,7 +366,7 @@ mod main {
         }
 
         let signed_temp_file = tempfile::NamedTempFile::new()?;
-        codesign::sign(&temp_binary, &signed_temp_file)?;
+        codesign::sign(&temp_binary, &signed_temp_file, path)?;
 
         // Give the new file the same permissions as the old file.
         // This needs to happen after the sign because it might change the permissions.
@@ -1145,13 +1145,10 @@ mod main {
                 SipStatus::SipBinary(_),
             ));
             assert!(matches!(
-                get_sip_status(
-                    signed_temp_file_path,
-                    SipPatchOptions {
-                        patch: &[],
-                        skip: &[signed_temp_file_path.to_string()],
-                    }
-                )
+                get_sip_status(signed_temp_file_path, SipPatchOptions {
+                    patch: &[],
+                    skip: &[signed_temp_file_path.to_string()],
+                })
                 .unwrap(),
                 SipStatus::NoSip,
             ));


### PR DESCRIPTION
Hopeful try for MBE-1366

Before, the identifier looked like `mirrord-patched-bin-2f0bf90efc71519a0a52884873ce877cbde13bca`, now it looks like `zsh-e9b62e761b8f7382dd4baf7eeb7f7f5a480128bd`, which is kind of what the identifier looks like when signed with `codesign`, only we do random hex and maybe for codesign it's some checksum or hash, idk.

https://linear.app/metalbear/issue/MBE-1366/sip-issue-manual-patch-works-mirrord-patch-fails