### PR TITLE
Added config for specifying mirrord-tls.pem path when using mirrord container command.

### DIFF
--- a/changelog.d/3508.added.md
+++ b/changelog.d/3508.added.md
@@ -1,0 +1,1 @@
+Added config for specifying mirrord-tls.pem path when using mirrord container command.

--- a/mirrord-schema.json
+++ b/mirrord-schema.json
@@ -652,7 +652,7 @@
         },
         "container_tls_path": {
           "title": "container.container_tls_path {#container-container_tls_path}",
-          "description": "When using TLS with `mirrord container` (TLS is enabled by default), you can specify the path where the certificate `.pem` file will be created, in the container.\n\nDefaults to `\"/var/run/mirrord/mirrord-tls.pem\"`.",
+          "description": "When using TLS with `mirrord container` (TLS is enabled by default), you can specify the path where the certificate `.pem` file will be created, in the container.\n\nDefaults to `\"/mirrord/mirrord-tls.pem\"`.",
           "type": [
             "string",
             "null"

--- a/mirrord-schema.json
+++ b/mirrord-schema.json
@@ -652,7 +652,7 @@
         },
         "cli_tls_path": {
           "title": "container.cli_tls_path {#container-cli_tls_path}",
-          "description": "When using`mirrord container` with external_proxy TLS enabled (is enabled by default), you can specify the path where the certificate `.pem` file will be created, in the cli container.\n\nDefaults to `\"/mirrord/mirrord-tls.pem\"`.",
+          "description": "When using`mirrord container` with external_proxy TLS enabled (is enabled by default), you can specify the path where the certificate `.pem` file will be created, in the cli container.\n\nDefaults to `\"/opt/mirrord/tls/mirrord-tls.pem\"`.",
           "type": [
             "string",
             "null"

--- a/mirrord-schema.json
+++ b/mirrord-schema.json
@@ -650,9 +650,9 @@
             "null"
           ]
         },
-        "container_tls_path": {
-          "title": "container.container_tls_path {#container-container_tls_path}",
-          "description": "When using TLS with `mirrord container` (TLS is enabled by default), you can specify the path where the certificate `.pem` file will be created, in the container.\n\nDefaults to `\"/mirrord/mirrord-tls.pem\"`.",
+        "cli_tls_path": {
+          "title": "container.cli_tls_path {#container-container_tls_path}",
+          "description": "When using`mirrord container` with external_proxy TLS enabled (is enabled by default), you can specify the path where the certificate `.pem` file will be created, in the cli container.\n\nDefaults to `\"/mirrord/mirrord-tls.pem\"`.",
           "type": [
             "string",
             "null"

--- a/mirrord-schema.json
+++ b/mirrord-schema.json
@@ -651,7 +651,7 @@
           ]
         },
         "cli_tls_path": {
-          "title": "container.cli_tls_path {#container-container_tls_path}",
+          "title": "container.cli_tls_path {#container-cli_tls_path}",
           "description": "When using`mirrord container` with external_proxy TLS enabled (is enabled by default), you can specify the path where the certificate `.pem` file will be created, in the cli container.\n\nDefaults to `\"/mirrord/mirrord-tls.pem\"`.",
           "type": [
             "string",

--- a/mirrord-schema.json
+++ b/mirrord-schema.json
@@ -650,6 +650,14 @@
             "null"
           ]
         },
+        "container_tls_path": {
+          "title": "container.container_tls_path {#container-container_tls_path}",
+          "description": "When using TLS with `mirrord container` (TLS is enabled by default), you can specify the path where the certificate `.pem` file will be created, in the container.\n\nDefaults to `\"/var/run/mirrord/mirrord-tls.pem\"`.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "override_host_ip": {
           "title": "container.override_host_ip {#container-override_host_ip}",
           "description": "Allows to override the IP address for the internal proxy to use when connecting to the host machine from within the container.\n\n```json5 { \"container\": { \"override_host_ip\": \"172.17.0.1\" // usual resolution of value from `host.docker.internal` } } ```\n\nThis should be useful if your host machine is exposed with a different IP address than the one bound as host.\n\n- If you're running inside WSL, and encountering problems, try setting `external_proxy.host_ip` T `0.0.0.0`, and this to the internal container runtime address (for docker, this  would be what `host.docker.internal` resolved to, which by default is `192.168.65.254`). You can find this ip by resolving it from inside a running container, e.g. `docker run --rm -it {image-with-nslookup} nslookup host.docker.internal`",

--- a/mirrord/cli/src/container/sidecar.rs
+++ b/mirrord/cli/src/container/sidecar.rs
@@ -137,12 +137,12 @@ impl IntproxySidecar {
 
             sidecar_command.add_volume(
                 client_pem_path,
-                &config.container.container_tls_path.to_string_lossy(),
+                &config.container.cli_tls_path.to_string_lossy(),
                 true,
             );
             AgentConnectInfo::ExternalProxy {
                 proxy_addr: extproxy_addr,
-                tls_pem: Some(config.container.container_tls_path.clone()),
+                tls_pem: Some(config.container.cli_tls_path.clone()),
             }
         } else {
             AgentConnectInfo::ExternalProxy {

--- a/mirrord/cli/src/container/sidecar.rs
+++ b/mirrord/cli/src/container/sidecar.rs
@@ -134,11 +134,15 @@ impl IntproxySidecar {
             let client_pem_path = tls.client_pem().to_str().ok_or_else(|| {
                 IntproxySidecarError::NonUtf8Path(tls.client_pem().to_string_lossy().into_owned())
             })?;
-            let container_path = "/tmp/mirrord-tls.pem";
-            sidecar_command.add_volume(client_pem_path, container_path, true);
+
+            sidecar_command.add_volume(
+                client_pem_path,
+                &config.container.container_tls_path.to_string_lossy(),
+                true,
+            );
             AgentConnectInfo::ExternalProxy {
                 proxy_addr: extproxy_addr,
-                tls_pem: Some(PathBuf::from(container_path)),
+                tls_pem: Some(config.container.container_tls_path.clone()),
             }
         } else {
             AgentConnectInfo::ExternalProxy {

--- a/mirrord/cli/src/container/sidecar.rs
+++ b/mirrord/cli/src/container/sidecar.rs
@@ -1,4 +1,4 @@
-use std::{fmt, io, net::SocketAddr, ops::Not, path::PathBuf, process::Stdio, time::Duration};
+use std::{fmt, io, net::SocketAddr, ops::Not, process::Stdio, time::Duration};
 
 use futures::{FutureExt, Stream};
 use mirrord_analytics::ExecutionKind;

--- a/mirrord/config/configuration.md
+++ b/mirrord/config/configuration.md
@@ -518,7 +518,7 @@ Don't add `--rm` to sidecar command to prevent cleanup.
 When using TLS with `mirrord container` (TLS is enabled by default), you can specify the
 path where the certificate `.pem` file will be created, in the container.
 
-Defaults to `"/var/run/mirrord/mirrord-tls.pem"`.
+Defaults to `"/mirrord/mirrord-tls.pem"`.
 
 ### container.override_host_ip {#container-override_host_ip}
 

--- a/mirrord/config/configuration.md
+++ b/mirrord/config/configuration.md
@@ -511,7 +511,7 @@ Path of the mirrord-layer lib inside the specified mirrord-cli image.
 
 Don't add `--rm` to sidecar command to prevent cleanup.
 
-### container.cli_tls_path {#container-container_tls_path}
+### container.cli_tls_path {#container-cli_tls_path}
 
 When using`mirrord container` with external_proxy TLS enabled (is enabled by default), you
 can specify the path where the certificate `.pem` file will be created, in the cli

--- a/mirrord/config/configuration.md
+++ b/mirrord/config/configuration.md
@@ -511,10 +511,11 @@ Path of the mirrord-layer lib inside the specified mirrord-cli image.
 
 Don't add `--rm` to sidecar command to prevent cleanup.
 
-### container.container_tls_path {#container-container_tls_path}
+### container.cli_tls_path {#container-container_tls_path}
 
-When using TLS with `mirrord container` (TLS is enabled by default), you can specify the
-path where the certificate `.pem` file will be created, in the container.
+When using`mirrord container` with external_proxy TLS enabled (is enabled by default), you
+can specify the path where the certificate `.pem` file will be created, in the cli
+container.
 
 Defaults to `"/mirrord/mirrord-tls.pem"`.
 
@@ -590,6 +591,12 @@ Defaults to `false` in mfT.
 Enables exec hooks on Linux. Enable Linux hooks can fix issues when the application
 shares sockets with child commands (e.g Python web servers with reload),
 but the feature is not stable and may cause other issues.
+
+### _experimental_ force_hook_connect {#experimental-force_hook_connect}
+
+Forces hooking all instances of the connect function.
+In very niche cases the connect function has multiple exports and this flag
+makes us hook all of the instances. <https://linear.app/metalbear/issue/MBE-1385/mirrord-container-curl-doesnt-work-for-php-curl>
 
 ### _experimental_ hide_ipv6_interfaces {#experimental-hide_ipv6_interfaces}
 
@@ -734,7 +741,7 @@ on process execution, delaying the layer startup and connection to the external 
 Controls mirrord features.
 
 See the
-[technical reference, Technical Reference](https://metalbear.co/mirrord/docs/reference/)
+[technical reference, Technical Reference](https://metalbear.com/mirrord/docs/reference/)
 to learn more about what each feature does.
 
 The [`env`](#feature-env), [`fs`](#feature-fs) and [`network`](#feature-network) options
@@ -787,7 +794,7 @@ have support for a shortened version, that you can see [here](#root-shortened).
 ## feature.copy_target {#feature-copy_target}
 
 Creates a new copy of the target. mirrord will use this copy instead of the original target
-(e.g. intercept network traffic). This feature requires a [mirrord operator](https://metalbear.co/mirrord/docs/overview/teams/?utm_source=copytarget).
+(e.g. intercept network traffic). This feature requires a [mirrord operator](https://metalbear.com/mirrord/docs/overview/teams/?utm_source=copytarget).
 
 This feature is not compatible with rollout targets and running without a target
 (`targetless` mode).
@@ -828,7 +835,7 @@ Can be set to one of the options:
 Which environment variables to load from the remote pod are controlled by setting either
 [`include`](#feature-env-include) or [`exclude`](#feature-env-exclude).
 
-See the environment variables [reference](https://metalbear.co/mirrord/docs/reference/env/) for more details.
+See the environment variables [reference](https://metalbear.com/mirrord/docs/reference/env/) for more details.
 
 ```json
 {
@@ -980,7 +987,7 @@ The logic for choosing the behavior is as follows:
 4. If none of the above match, use the default behavior (mode).
 
 For more information, check the file operations
-[technical reference](https://metalbear.co/mirrord/docs/reference/fileops/).
+[technical reference](https://metalbear.com/mirrord/docs/reference/fileops/).
 
 ```json
 {
@@ -1063,7 +1070,7 @@ Should mirrord return the hostname of the target pod when calling `gethostname`
 
 Controls mirrord network operations.
 
-See the network traffic [reference](https://metalbear.co/mirrord/docs/reference/traffic/)
+See the network traffic [reference](https://metalbear.com/mirrord/docs/reference/traffic/)
 for more details.
 
 ```json
@@ -1175,7 +1182,7 @@ Valid values follow this pattern: `[name|address|subnet/mask][:port]`.
 
 Controls the incoming TCP traffic feature.
 
-See the incoming [reference](https://metalbear.co/mirrord/docs/reference/traffic/#incoming) for more
+See the incoming [reference](https://metalbear.com/mirrord/docs/reference/traffic/#incoming) for more
 details.
 
 Incoming traffic supports 3 [modes](#feature-network-incoming-mode) of operation:
@@ -1655,7 +1662,7 @@ or connects to other services over IPv6.
 
 Tunnel outgoing network operations through mirrord.
 
-See the outgoing [reference](https://metalbear.co/mirrord/docs/reference/traffic/#outgoing) for more
+See the outgoing [reference](https://metalbear.com/mirrord/docs/reference/traffic/#outgoing) for more
 details.
 
 You can use either the `remote` or `local` value to turn outgoing traffic tunneling on or off.

--- a/mirrord/config/configuration.md
+++ b/mirrord/config/configuration.md
@@ -517,7 +517,7 @@ When using`mirrord container` with external_proxy TLS enabled (is enabled by def
 can specify the path where the certificate `.pem` file will be created, in the cli
 container.
 
-Defaults to `"/mirrord/mirrord-tls.pem"`.
+Defaults to `"/opt/mirrord/tls/mirrord-tls.pem"`.
 
 ### container.override_host_ip {#container-override_host_ip}
 

--- a/mirrord/config/configuration.md
+++ b/mirrord/config/configuration.md
@@ -514,6 +514,13 @@ Defaults to `"/opt/mirrord/lib/libmirrord_layer.so"`.
 
 Don't add `--rm` to sidecar command to prevent cleanup.
 
+### container.container_tls_path {#container-container_tls_path}
+
+When using TLS with `mirrord container` (TLS is enabled by default), you can specify the
+path where the certificate `.pem` file will be created, in the container.
+
+Defaults to `"/var/run/mirrord/mirrord-tls.pem"`.
+
 ### container.override_host_ip {#container-override_host_ip}
 
 Allows to override the IP address for the internal proxy to use
@@ -1846,8 +1853,8 @@ Defaults to `mirrord=info,warn`.
 
 How often to log information about connected processes in seconds.
 
-This feature logs details about processes that are currently connected to the internal proxy,
-including their PID, process name, command line, and connection status.
+This feature logs details about processes that are currently connected to the internal
+proxy, including their PID, process name, command line, and connection status.
 
 ```json
 {
@@ -1856,8 +1863,6 @@ including their PID, process name, command line, and connection status.
   }
 }
 ```
-
-Defaults to 60 seconds.
 
 ### internal_proxy.start_idle_timeout {#internal_proxy-start_idle_timeout}
 

--- a/mirrord/config/src/container.rs
+++ b/mirrord/config/src/container.rs
@@ -77,6 +77,12 @@ pub struct ContainerConfig {
     ///   e.g. `docker run --rm -it {image-with-nslookup} nslookup host.docker.internal`
     pub override_host_ip: Option<IpAddr>,
 
+    /// ### container.container_tls_path {#container-container_tls_path}
+    ///
+    /// When using TLS with `mirrord container` (TLS is enabled by default), you can specify the
+    /// path where the certificate `.pem` file will be created, in the container.
+    ///
+    /// Defaults to `"/var/run/mirrord/mirrord-tls.pem"`.
     #[config(default = PathBuf::from(r"/var/run/mirrord/mirrord-tls.pem"))]
     pub container_tls_path: PathBuf,
 }

--- a/mirrord/config/src/container.rs
+++ b/mirrord/config/src/container.rs
@@ -82,7 +82,7 @@ pub struct ContainerConfig {
     /// When using TLS with `mirrord container` (TLS is enabled by default), you can specify the
     /// path where the certificate `.pem` file will be created, in the container.
     ///
-    /// Defaults to `"/var/run/mirrord/mirrord-tls.pem"`.
-    #[config(default = PathBuf::from(r"/var/run/mirrord/mirrord-tls.pem"))]
+    /// Defaults to `"/mirrord/mirrord-tls.pem"`.
+    #[config(default = PathBuf::from(r"/mirrord/mirrord-tls.pem"))]
     pub container_tls_path: PathBuf,
 }

--- a/mirrord/config/src/container.rs
+++ b/mirrord/config/src/container.rs
@@ -77,12 +77,12 @@ pub struct ContainerConfig {
     ///   e.g. `docker run --rm -it {image-with-nslookup} nslookup host.docker.internal`
     pub override_host_ip: Option<IpAddr>,
 
-    /// ### container.container_tls_path {#container-container_tls_path}
+    /// ### container.cli_tls_path {#container-container_tls_path}
     ///
-    /// When using TLS with `mirrord container` (TLS is enabled by default), you can specify the
-    /// path where the certificate `.pem` file will be created, in the container.
+    /// When using`mirrord container` with external_proxy TLS enabled (is enabled by default), you can specify the
+    /// path where the certificate `.pem` file will be created, in the cli container.
     ///
     /// Defaults to `"/mirrord/mirrord-tls.pem"`.
-    #[config(default = PathBuf::from(r"/mirrord/mirrord-tls.pem"))]
-    pub container_tls_path: PathBuf,
+    #[config(default = PathBuf::from(r"/opt/mirrord/tls/mirrord-tls.pem"))]
+    pub cli_tls_path: PathBuf,
 }

--- a/mirrord/config/src/container.rs
+++ b/mirrord/config/src/container.rs
@@ -80,7 +80,7 @@ pub struct ContainerConfig {
     /// can specify the path where the certificate `.pem` file will be created, in the cli
     /// container.
     ///
-    /// Defaults to `"/mirrord/mirrord-tls.pem"`.
+    /// Defaults to `"/opt/mirrord/tls/mirrord-tls.pem"`.
     #[config(default = PathBuf::from(r"/opt/mirrord/tls/mirrord-tls.pem"))]
     pub cli_tls_path: PathBuf,
 

--- a/mirrord/config/src/container.rs
+++ b/mirrord/config/src/container.rs
@@ -74,7 +74,7 @@ pub struct ContainerConfig {
     ///   e.g. `docker run --rm -it {image-with-nslookup} nslookup host.docker.internal`
     pub override_host_ip: Option<IpAddr>,
 
-    /// ### container.cli_tls_path {#container-container_tls_path}
+    /// ### container.cli_tls_path {#container-cli_tls_path}
     ///
     /// When using`mirrord container` with external_proxy TLS enabled (is enabled by default), you
     /// can specify the path where the certificate `.pem` file will be created, in the cli

--- a/mirrord/config/src/container.rs
+++ b/mirrord/config/src/container.rs
@@ -1,4 +1,4 @@
-use std::net::IpAddr;
+use std::{net::IpAddr, path::PathBuf};
 
 use mirrord_config_derive::MirrordConfig;
 use schemars::JsonSchema;
@@ -76,4 +76,7 @@ pub struct ContainerConfig {
     ///   `192.168.65.254`). You can find this ip by resolving it from inside a running container,
     ///   e.g. `docker run --rm -it {image-with-nslookup} nslookup host.docker.internal`
     pub override_host_ip: Option<IpAddr>,
+
+    #[config(default = PathBuf::from(r"/var/run/mirrord/mirrord-tls.pem"))]
+    pub container_tls_path: PathBuf,
 }


### PR DESCRIPTION
- Issue: https://github.com/metalbear-co/mirrord/issues/3508

Also changed the default path from `/tmp/mirrord-tls.pem` to `/mirrord/mirrord-tls.pem`.