### PR TITLE
Improve intproxy bg tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4579,6 +4579,7 @@ dependencies = [
  "tokio-retry",
  "tokio-rustls 0.26.2",
  "tokio-stream",
+ "tokio-util",
  "tracing",
 ]
 

--- a/changelog.d/+intproxy-bg-task-cancel.internal.md
+++ b/changelog.d/+intproxy-bg-task-cancel.internal.md
@@ -1,0 +1,1 @@
+Fixed cancellation of background tasks in the internal proxy.

--- a/mirrord/intproxy/Cargo.toml
+++ b/mirrord/intproxy/Cargo.toml
@@ -45,6 +45,7 @@ strum.workspace = true
 strum_macros.workspace = true
 tokio-retry.workspace = true
 tokio-rustls.workspace = true
+tokio-util.workspace = true
 
 [dev-dependencies]
 rcgen.workspace = true

--- a/mirrord/intproxy/src/proxies/incoming/http_gateway.rs
+++ b/mirrord/intproxy/src/proxies/incoming/http_gateway.rs
@@ -346,13 +346,24 @@ impl BackgroundTask for HttpGatewayTask {
             .max_delay(Duration::from_millis(500))
             .take(9);
 
-        let guard = message_bus.closed();
+        let closed_token = message_bus.closed_token().clone();
 
         let mut attempt = 0;
         let error = loop {
             attempt += 1;
             tracing::debug!(attempt, "Starting send attempt");
-            match guard.cancel_on_close(self.send_attempt(message_bus)).await {
+
+            let send_result = if self.response_mode.is_some() {
+                closed_token
+                    .run_until_cancelled(self.send_attempt(message_bus))
+                    .await
+            } else {
+                // If we're in mirror mode, we cannot cancel the request when the remote connection
+                // ends. The local application processes the request independently.
+                self.send_attempt(message_bus).await.into()
+            };
+
+            match send_result {
                 None | Some(Ok(())) => return Ok(()),
                 Some(Err(error)) => {
                     let backoff = error.can_retry().then(|| backoffs.next()).flatten();
@@ -375,8 +386,19 @@ impl BackgroundTask for HttpGatewayTask {
                         "Trying again after backoff",
                     );
 
-                    if guard.cancel_on_close(time::sleep(backoff)).await.is_none() {
-                        return Ok(());
+                    if self.response_mode.is_some() {
+                        if closed_token
+                            .run_until_cancelled(time::sleep(backoff))
+                            .await
+                            .is_none()
+                        {
+                            return Ok(());
+                        }
+                    } else {
+                        // If we're in mirror mode, we cannot cancel the request when the remote
+                        // connection ends. The local application processes
+                        // the request independently.
+                        time::sleep(backoff).await;
                     }
                 }
             }

--- a/mirrord/intproxy/src/proxies/incoming/tcp_proxy.rs
+++ b/mirrord/intproxy/src/proxies/incoming/tcp_proxy.rs
@@ -148,14 +148,7 @@ impl BackgroundTask for TcpProxyTask {
             .take()
             .expect("task should have a valid connection before run");
 
-        let Some((mut stream, read_buf)) = message_bus
-            .closed()
-            .cancel_on_close(connection.connect())
-            .await
-            .transpose()?
-        else {
-            return Ok(());
-        };
+        let (mut stream, read_buf) = connection.connect().await?;
 
         if self.discard_data.not() && read_buf.is_empty().not() {
             // We don't send empty data,


### PR DESCRIPTION
1. Tasks for delivering stolen HTTP messages are now properly cancelled when the connection is closed from the agent side.
2. Agent reconnect is cancelled when the intproxy is entering the failover state.
