### PR TITLE
Update PingPong task reconnect attempts

### DIFF
--- a/changelog.d/+better-ping-pong-restart-error.changed.md
+++ b/changelog.d/+better-ping-pong-restart-error.changed.md
@@ -1,0 +1,1 @@
+Updated so if the PingPong will not attempt to request restart if not connected to operator.

--- a/mirrord/intproxy/src/agent_conn.rs
+++ b/mirrord/intproxy/src/agent_conn.rs
@@ -94,6 +94,12 @@ impl ReconnectFlow {
     }
 }
 
+impl ReconnectFlow {
+    const fn reconnectable(&self) -> bool {
+        matches!(self, ReconnectFlow::ConnectInfo { .. })
+    }
+}
+
 impl fmt::Debug for ReconnectFlow {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -211,6 +217,10 @@ impl AgentConnection {
             .send(msg)
             .await
             .map_err(|_| AgentConnectionTaskError::ChannelError(self.reconnect.kind()))
+    }
+
+    pub fn reconnectable(&self) -> bool {
+        self.reconnect.reconnectable()
     }
 }
 

--- a/mirrord/intproxy/src/lib.rs
+++ b/mirrord/intproxy/src/lib.rs
@@ -124,6 +124,8 @@ impl IntProxy {
         let mut background_tasks: BackgroundTasks<MainTaskId, ProxyMessage, ProxyRuntimeError> =
             Default::default();
 
+        let agent_conn_reconnectable = agent_conn.reconnectable();
+
         let agent = background_tasks.register_restartable(
             agent_conn,
             MainTaskId::AgentConnection,
@@ -141,7 +143,12 @@ impl IntProxy {
         // to requests that have a requirement on the mirrord-protocol version.
         background_tasks.suspend_messages(MainTaskId::LayerInitializer);
         let ping_pong = background_tasks.register_restartable(
-            PingPong::new(Self::PING_INTERVAL, Self::PING_PONG_MAX_RECONNECTS),
+            PingPong::new(
+                Self::PING_INTERVAL,
+                agent_conn_reconnectable
+                    .then_some(Self::PING_PONG_MAX_RECONNECTS)
+                    .unwrap_or(0),
+            ),
             MainTaskId::PingPong,
             Self::CHANNEL_SIZE,
         );


### PR DESCRIPTION
Updated so if the PingPong will not attempt to request restart if not connected to operator.