### PR TITLE
Increase timeout for flaky layer test

### DIFF
--- a/changelog.d/+increased-timeout-for-flaky.internal.md
+++ b/changelog.d/+increased-timeout-for-flaky.internal.md
@@ -1,0 +1,1 @@
+Increased the timeout on the layer test `outgoing::outgoing_tcp_bound_socket` from 15 to 25 seconds to reduce chance of flakes on macOS.

--- a/mirrord/layer/tests/outgoing.rs
+++ b/mirrord/layer/tests/outgoing.rs
@@ -191,7 +191,7 @@ async fn outgoing_tcp_from_the_local_app_broken(
 /// application.
 #[rstest]
 #[tokio::test]
-#[timeout(Duration::from_secs(15))]
+#[timeout(Duration::from_secs(25))]
 async fn outgoing_tcp_bound_socket(dylib_path: &Path) {
     let (mut test_process, mut intproxy) = Application::RustIssue2438
         .start_process_with_layer(dylib_path, vec![], None)


### PR DESCRIPTION
Issue: https://linear.app/metalbear/issue/COR-167/possible-test-flake-outgoing-tcp-bound-socket-in-macos-tests-mirrord