### PR TITLE
Improve UX when spawning the agent pod fails

### DIFF
--- a/changelog.d/3578.added.md
+++ b/changelog.d/3578.added.md
@@ -1,0 +1,1 @@
+Improved UX when spawning the agent pod fails or takes a long time

--- a/mirrord/kube/src/error.rs
+++ b/mirrord/kube/src/error.rs
@@ -79,6 +79,16 @@ pub enum KubeApiError {
 
     #[error(transparent)]
     InvalidBackoff(#[from] InvalidBackoff),
+
+    /// Failed to initialize the job agent's pod.
+    /// This will happen when the pod moves to the `"Failed"` stage while initializing.
+    #[error("Pod failed to spawn with reason `{0:?}` and message `{1:?}`.")]
+    PodFailedToInitialize(Option<String>, Option<String>),
+
+    /// The job agent's pod finished running all of it's containers without notifying us of the
+    /// `"Running"` stage. This is a bug and should never happen.
+    #[error("Pod terminated before running")]
+    PodTerminatedPrematurely,
 }
 
 impl KubeApiError {


### PR DESCRIPTION
Hello ＼(٥⁀▽⁀ )／! 

This fixes issue #3578.

I will now go through each of subtasks as described in the issue and explain where they are in this patch and why I did things the way I did,,,

> 1. Fail early if the agent pod moves to Failed phase. This can happen due to cluster conditions. We should extract status.reason and status.message and include them in the error message presented to the user.

This is one of the more straightforward changes, it corresponds to lines 104..=114 in the diff:
```rust
"Failed" => {
    pod_progress.failure(Some(&format!(
        "agent pod failed to initialize - '{}' ({})",
        status.message.as_deref().unwrap_or("<no message>"),
        status.reason.as_deref().unwrap_or("<unknown reason>")
    )));
    return Err(KubeApiError::PodFailedToInitialize(
        status.reason.clone(),
        status.message.clone(),
    ));
}
```
I decided to add a new error to `KubeApiError` to better describe what went wrong since I thought none of the existing errors quite captured this particular error path.

> 2. Fail early if the agent pod moves to Succeeded phase. This should never happen, and should be reported to the user as a bug.

This is handled right below the last step:
```rust
"Succeeded" => {
    pod_progress.failure(Some(
        "agent pod terminated prematurely - this is a bug, please report it!",
    ));
    return Err(KubeApiError::PodTerminatedPrematurely);
}
```
Again, decided to add a new error variant - these could be changed to the more generic `AgentPodNotRunning`. 

This branch also features a nice little message to the user.

Initially I implemented this with an `unreachable!` block, since this branch kinda implies that a logic bug somewhere else happened, but crashing mirrord in the middle of pod initialization seems scary so I decided against that.

> 3. Fail early if the agent pod is deleted while in Pending phase. This usually means that the user does not have sufficient permissions to spawn the agent pod in the cluster. The error message presented to the user should mention [Pod Security Admission](https://kubernetes.io/docs/concepts/security/pod-security-admission/) as a probable cause of the failure, and suggest trying out mirrord for Teams (similar to [this](https://github.com/metalbear-co/mirrord/blob/81e715586e3ff04307bf4ce50ea4d31e6a674a4e/mirrord/cli/src/error.rs#L317)).

For context, here's the impl:
```rust
Ok(None) | Ok(Some(Err(_))) => {
    if is_pending {
        pod_progress.failure(Some("agent pod unexpectedly closed, \
        this likely means that you don't have the required permissions to spawn it. \
        look into your namespace's Pod Security admission controllers and try mirrord for Teams if the issue persists."));
        return Err(KubeApiError::AgentPodNotRunning);
    } else {
        break;
    }
}
```

This one I have some questions about. I'm not sure how to detect that the pod is deleted. I interpreted either getting a `None` event or a `Some(Err(err))` as the way to detect that, but I'm not fully convinced of this. The declaration of `agent_pod` on lines 62..=66 does seem to reinforce this theory:
```rust
let agent_pod = stream
    .next()
    .await
    .ok_or(KubeApiError::AgentPodNotRunning)?
    .map_err(|_| KubeApiError::AgentPodNotRunning)?;
```
This statement is also why I chose to return `AgentPodNotRunning` in this case.

This shows how I decided to check whether the pod is in the "Pending" phase or not: a mutable variable declared outside the loop that gets set to `phase == "Pending"` when a new event is received.

> 4. For every 10s while the agent pod is stuck in the Pending phase, we should issue a Progress::warning. The warning should state that the agent pod startup takes longer than expected, and contain info about status.containerStatuses.[].state of the agent container. See [container states](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-states) for reference.

For this I added wrapped the `stream.next()` in a `tokio::time::timeout` call and shoved the whole thing into a `loop`:

```rust
loop {
    match timeout(Duration::from_secs(10), stream.next()).await {
    	// ...
    	
    	// Timeout elapsed
        Err(_) => {
            if is_pending {
                pod_progress.warning("agent pod initialization is taking longer than expected");
            }
        }
    }
}    
```
 
> and contain info about status.containerStatuses.[].state of the agent container

I didn't implement this part since I don't know which entry in the `containerStatuses` list belongs to the container that we care about.

It's also a bit annoying to implement because inside of this branch we don't have access to `status` so, much like `is_pending`, it'd have to be some sort of `Option<String>` declared outside of the loop that gets set to the appropriate status string when a new event arrives. This made the implementation a bit harder to read and I wasn't even sure that it was the right approach, so I ended up leaving it out for now, but do plan on adding it back as soon as I know which index to use for `containerStatuses`.

---------------------

Opened as a draft to share my progress, ask questions and get feedback on the current direction. Please let me know what you think :)

The biggest issue I faced while writing this was *testing* it. I don't really know how to consistently reach the error path in this case. I tried several things, but setting a breakpoint on where the pod gets created then pausing the `minikube` session with `minikube pause` and resuming from the breakpoint seemed to be the best strategy, even though it barely ever worked. When it did though I did manage to reach the timeout branch (yay) but I never got the `Ok(None) | Ok(Some(Err(_)))` branch, so I don't really know if that's *really* what happens when the pod closes.