### PR TITLE
Add a nix devshell

### DIFF
--- a/changelog.d/nix.internal.md
+++ b/changelog.d/nix.internal.md
@@ -1,0 +1,1 @@
+Added a nix devshell

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,100 @@
+{
+  "nodes": {
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1759560021,
+        "narHash": "sha256-J/rtMKVUAEqOFj0ogvcHKK8HbaKhw+tiNrDOpEM+ZDY=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "6ffcbf59c119b0c6384c7d98f18cea06a9af7e9c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1753939845,
+        "narHash": "sha256-K2ViRJfdVGE8tpJejs8Qpvvejks1+A4GQej/lBk5y7I=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "94def634a20494ee057c76998843c015909d6311",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "fenix": "fenix",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1759301569,
+        "narHash": "sha256-7StxDed3v2fAWLkl+Hse9FlpjT7Dk7Cn/4vxTFyEhIg=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "472037b789cf593172d6adf3b8d9f7a429f6cd9b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,80 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    fenix = {
+      url = "github:nix-community/fenix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    inputs:
+    inputs.flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import inputs.nixpkgs { inherit system; };
+
+        nightlyRustToolchain =
+          let
+            fenix = inputs.fenix.packages.${system};
+
+            toolchainDesc = {
+              name = (pkgs.lib.importTOML ./rust-toolchain.toml).toolchain.channel;
+              sha256 = "sha256-JE+aoEa897IBKa03oVUOOnW+sbyUgXGrhkwzWFzCnnI=";
+            };
+
+            toolchain = (fenix.fromToolchainName toolchainDesc).withComponents [
+              "cargo"
+              "clippy"
+              "rust-analyzer"
+              "rust-src"
+              "rustc"
+              "rustfmt"
+            ];
+          in
+          # On darwin we need both x86 and arm toolchains in order to compile universal binaries
+          if pkgs.stdenv.isDarwin then
+            let
+              # aarch64 -> x86_64
+              # x86_64 -> aarch64
+              crossTriplet =
+                if pkgs.stdenv.hostPlatform.isAarch then "x86_64-apple-darwin" else "aarch64-apple-darwin";
+
+              # Fewer components are required for the cross-compilation toolchain because we don't need IDE functionality
+              crossToolchain = (fenix.targets.${crossTriplet}.fromToolchainName toolchainDesc).withComponents [
+                "rustc"
+                "rust-src"
+              ];
+            in
+            fenix.combine [
+              toolchain
+              crossToolchain
+            ]
+          else
+            toolchain;
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          packages = with pkgs; [
+            nightlyRustToolchain
+
+            # Kubernetes
+            kubectl
+            minikube
+
+            # E2E testing
+            go
+            nodejs_24 # Needs express.js - install with `npm install express` after entering the devshell
+            (python3.withPackages (
+              py-pkgs: with py-pkgs; [
+                flask
+                fastapi
+                uvicorn
+              ]
+            ))
+          ];
+        };
+      }
+    );
+}


### PR DESCRIPTION
This adds a nix devshell containing all the required packages to run mirrord and the e2e tests.

Contains both aarc64 and x86_64 toolchains on darwin to build universal binaries
