### PR TITLE
Verify correct Prometheus metrics in SQS E2E tests

### DIFF
--- a/changelog.d/+sqs-prometheus-e2e-test.internal.md
+++ b/changelog.d/+sqs-prometheus-e2e-test.internal.md
@@ -1,0 +1,1 @@
+Verify correct Prometheus metrics in SQS E2E tests.

--- a/tests/src/operator/queue_splitting.rs
+++ b/tests/src/operator/queue_splitting.rs
@@ -389,6 +389,10 @@ pub async fn two_users(
         is invalid, and `count_temp_queues` might need to be updated."
     );
 
+    println!("Verifying correct Prometheus metrics.");
+    sqs_test_resources.verify_prometheus_metrics().await;
+    println!("Prometheus metrics verified.");
+
     // TODO: verify queue tags.
 
     println!("Killing test clients (local mirrord runs).");


### PR DESCRIPTION
Closes https://linear.app/metalbear/issue/INT-201/test-sqs-prometheus-metrics-in-e2e


https://github.com/metalbear-co/operator/pull/1063 has to be merged first, so that if the operator is updated to a new mirrord crate version, CI doesn't fail.

And I also want to verify the test passes on CI before merging. Testing in this manual workflow with a test branch https://github.com/metalbear-co/operator/actions/runs/17865079044