### PR TITLE
Remove `MirrordOperatorUser`

### DIFF
--- a/changelog.d/+remove-mirrordoperatoruser.internal.md
+++ b/changelog.d/+remove-mirrordoperatoruser.internal.md
@@ -1,0 +1,1 @@
+Removed legacy `MirrordOperatorUser` CRD.

--- a/mirrord/operator/src/crd.rs
+++ b/mirrord/operator/src/crd.rs
@@ -3,7 +3,6 @@ use std::{
     fmt::{Display, Formatter},
 };
 
-use chrono::{DateTime, Utc};
 use kube::CustomResource;
 use kube_target::{KubeTarget, UnknownTargetType};
 pub use mirrord_config::feature::split_queues::QueueId;
@@ -727,32 +726,4 @@ pub struct MirrordSqsSessionSpec {
     // The Kubernetes API can't deal with 64 bit numbers (with most significant bit set)
     // so we save that field as a (HEX) string even though its source is a u64
     pub session_id: String,
-}
-
-/// Describes an operator user.
-#[derive(CustomResource, Clone, Debug, Deserialize, Serialize, JsonSchema)]
-#[kube(
-    group = "operator.metalbear.co",
-    version = "v1",
-    kind = "MirrordOperatorUser",
-    root = "MirrordOperatorUser"
-)]
-#[serde(rename_all = "camelCase")]
-pub struct MirrordOperatorUserSpec {
-    /// Unique ID.
-    pub user_id: String,
-    /// Last seen local username.
-    pub last_username: String,
-    /// Last seen hostname.
-    pub last_hostname: String,
-    /// Last seen Kubernetes username.
-    pub last_k8s_username: String,
-    /// Most recent session activity.
-    pub last_seen: DateTime<Utc>,
-    /// Total session count.
-    pub total_sessions_count: u64,
-    /// Total session duration.
-    pub total_sessions_duration_seconds: u64,
-    /// Last session's target.
-    pub last_target: String,
 }

--- a/mirrord/operator/src/setup.rs
+++ b/mirrord/operator/src/setup.rs
@@ -28,7 +28,7 @@ use kube::{CustomResourceExt, Resource};
 use thiserror::Error;
 
 use crate::crd::{
-    MirrordOperatorUser, MirrordSqsSession, MirrordWorkloadQueueRegistry, TargetCrd,
+    MirrordOperatorCrd, MirrordSqsSession, MirrordWorkloadQueueRegistry, TargetCrd,
     kafka::{MirrordKafkaClientConfig, MirrordKafkaEphemeralTopic, MirrordKafkaTopicsConsumer},
     mysql_branching::MysqlBranchDatabase,
     policy::{MirrordClusterPolicy, MirrordPolicy},
@@ -1051,7 +1051,7 @@ impl OperatorClusterUserRole {
                     "mirrordoperators".to_owned(),
                     "targets".to_owned(),
                     "targets/port-locks".to_owned(),
-                    MirrordOperatorUser::plural(&()).into_owned(),
+                    MirrordOperatorCrd::plural(&()).into_owned(),
                 ]),
                 verbs: vec!["get".to_owned(), "list".to_owned()],
                 ..Default::default()


### PR DESCRIPTION
It was a temporary solution, replaced with the license server