### PR TITLE
[bugfix] WIN-34 getaddrinfo missing port in result

### DIFF
--- a/mirrord/layer-win/src/hooks/socket/hostname.rs
+++ b/mirrord/layer-win/src/hooks/socket/hostname.rs
@@ -314,7 +314,9 @@ pub fn windows_getaddrinfo<T: WindowsAddrInfo>(
 
     let response = make_proxy_request_with_response(request)?;
     // Convert response back to Windows ADDRINFO structures using trait method
-    ManagedAddrInfo::<T>::try_from(response)
+    let mut managed = ManagedAddrInfo::<T>::try_from(response)?;
+    managed.apply_port(port);
+    Ok(managed)
 }
 
 /// Safely deallocates ADDRINFOA structures that were allocated by our getaddrinfo_detour.

--- a/mirrord/layer-win/src/hooks/socket/ops.rs
+++ b/mirrord/layer-win/src/hooks/socket/ops.rs
@@ -256,6 +256,11 @@ pub fn connect_through_proxy_with_layer_lib<F>(
 where
     F: FnOnce(SocketDescriptor, SockAddr) -> ConnectResult,
 {
+    tracing::debug!(
+        "connect_through_proxy_with_layer_lib -> attempting proxy connection for socket {} to address {:#?}",
+        socket,
+        remote_addr
+    );
     let raw_remote_addr = SockAddr::from(remote_addr);
     let optional_ip_address = raw_remote_addr.as_socket();
     if let Some(ip_address) = optional_ip_address


### PR DESCRIPTION
Thank you for contributing to mirrord!

Please make sure you added a CHANGELOG file in `changelog.d/` named `issue_number.category.md`.
For example, `1054.changed.md` or `+towncrier.added.md` (if no issue).