### PR TITLE
Remove a leftover file

### DIFF
--- a/changelog.d/+tests.cleanup.internal.md
+++ b/changelog.d/+tests.cleanup.internal.md
@@ -1,0 +1,1 @@
+Remove a leftover file that is not used anywhere.

--- a/tests/src/operator.rs
+++ b/tests/src/operator.rs
@@ -1,9 +1,0 @@
-#![cfg(test)]
-
-mod concurrent_steal;
-mod copy_target;
-mod policies;
-mod profiles;
-mod queue_splitting;
-mod setup;
-mod steal_tls;


### PR DESCRIPTION
The whole `operator` folder is gone after https://github.com/metalbear-co/mirrord/pull/3619. This module is no longer needed, is it?