### PR TITLE
Use IPv4 when checking BusyTcpListener support

### DIFF
--- a/changelog.d/+busy-tcp-listener-check-ipv4.internal.md
+++ b/changelog.d/+busy-tcp-listener-check-ipv4.internal.md
@@ -1,0 +1,1 @@
+Changed incoming proxy's `BusyTcpListener` check to use IPv4 instead of IPv6.

--- a/mirrord/intproxy/src/proxies/outgoing/busy_tcp_listener.rs
+++ b/mirrord/intproxy/src/proxies/outgoing/busy_tcp_listener.rs
@@ -78,7 +78,7 @@ impl BusyListenerMethod {
     ///
     /// If the method fails the check, returns [`Err`].
     async fn check_if_works(self) -> io::Result<()> {
-        let prepared = self.prepare_socket(false).await?;
+        let prepared = self.prepare_socket(true).await?;
         let addr = prepared.local_addr()?;
 
         let mut conn_fut = Box::pin(TcpStream::connect(addr));


### PR DESCRIPTION
It shouldn't really matter, but IPv4 seems more correct, since mirrord by default handles only IPv4 traffic