### PR TITLE
Prioritize using the fs filters on relative file ops

### DIFF
--- a/changelog.d/+681.changed.md
+++ b/changelog.d/+681.changed.md
@@ -1,0 +1,1 @@
+The `fs.not_found` filesystem filter is now checked *before* bypassing relative files, meaning you can now ignore relative files instead of always reading them locally

--- a/mirrord/layer/src/file/filter.rs
+++ b/mirrord/layer/src/file/filter.rs
@@ -150,6 +150,11 @@ impl FileFilter {
             FsModeConfig::Read => Detour::Success(()),
         }
     }
+
+    pub fn check_not_found(&self, path: &Path) -> bool {
+        let text = path.to_str().unwrap_or_default();
+        self.not_found.is_match(text) || self.default_not_found.is_match(text)
+    }
 }
 
 impl Default for FileFilter {


### PR DESCRIPTION
This will now run *all* fs filters before checking if path is relative, let me know if we only want to specifically run `fs.not_found`