### PR TITLE
config, cli: Allow overlap in incoming.ports and http_filter.ports

### DIFF
--- a/changelog.d/+allow-ports-to-overlap-with-filter-ports.changed.md
+++ b/changelog.d/+allow-ports-to-overlap-with-filter-ports.changed.md
@@ -1,0 +1,1 @@
+Allow an overlap in the configuration for `incoming.ports` and `incoming.http_filter.ports`.

--- a/mirrord/cli/src/main.rs
+++ b/mirrord/cli/src/main.rs
@@ -243,7 +243,12 @@
 #![cfg_attr(all(windows, feature = "windows_build"), feature(windows_change_time))]
 #![cfg_attr(all(windows, feature = "windows_build"), feature(windows_by_handle))]
 
-use std::{collections::HashMap, env::vars, net::SocketAddr, time::Duration};
+use std::{
+    collections::{HashMap, HashSet},
+    env::vars,
+    net::SocketAddr,
+    time::Duration,
+};
 #[cfg(not(target_os = "windows"))]
 use std::{ffi::CString, os::unix::ffi::OsStrExt};
 #[cfg(target_os = "macos")]
@@ -662,20 +667,24 @@ pub(crate) fn print_config<P>(
     if config.feature.network.incoming.is_steal()
         && config.feature.network.incoming.http_filter.is_filter_set()
     {
-        let filtered_ports_str = config
+        let filtered_ports = config
             .feature
             .network
             .incoming
             .http_filter
             .get_filtered_ports()
-            .and_then(|filtered_ports| match filtered_ports.len() {
-                0 => None,
-                1 => Some(format!(
-                    "port {} (filtered)",
-                    filtered_ports.first().unwrap()
-                )),
-                _ => Some(format!("ports {filtered_ports:?} (filtered)")),
-            });
+            .unwrap_or_default();
+        let filtered_ports_str = match filtered_ports.len() {
+            0 => None,
+            1 => Some(format!(
+                "port {} (filtered)",
+                filtered_ports.first().unwrap()
+            )),
+            _ => Some(format!("ports {filtered_ports:?} (filtered)")),
+        };
+
+        // since filter ports and `incoming.ports` are not required to be disjoint, let
+        // `unfiltered_ports_str` contain `incoming.ports` - filter ports
         let unfiltered_ports_str =
             config
                 .feature
@@ -683,21 +692,22 @@ pub(crate) fn print_config<P>(
                 .incoming
                 .ports
                 .as_ref()
-                .and_then(|ports| match ports.len() {
-                    0 => None,
-                    1 => Some(format!(
-                        "port {} (unfiltered)",
-                        ports.iter().next().unwrap()
-                    )),
-                    _ => Some(format!(
-                        "ports [{}] (unfiltered)",
-                        ports
-                            .iter()
-                            .copied()
-                            .map(|n| n.to_string())
-                            .collect::<Vec<String>>()
-                            .join(", ")
-                    )),
+                .and_then(|ports| {
+                    let filtered = filtered_ports.iter().copied().collect::<HashSet<_>>();
+                    let ports: Vec<&u16> = ports.difference(&filtered).collect();
+                    match ports.len() {
+                        0 => None,
+                        1 => Some(format!("port {} (unfiltered)", ports.first().unwrap())),
+                        _ => Some(format!(
+                            "ports [{}] (unfiltered)",
+                            ports
+                                .iter()
+                                .copied()
+                                .map(|n| n.to_string())
+                                .collect::<Vec<String>>()
+                                .join(", ")
+                        )),
+                    }
                 });
         let and = if filtered_ports_str.is_some() && unfiltered_ports_str.is_some() {
             " and "

--- a/mirrord/config/src/lib.rs
+++ b/mirrord/config/src/lib.rs
@@ -504,31 +504,6 @@ impl LayerConfig {
             ))?
         }
 
-        if let (Some(unfiltered_ports), Some(filtered_ports)) = (
-            self.feature.network.incoming.ports.as_ref(),
-            self.feature
-                .network
-                .incoming
-                .http_filter
-                .get_filtered_ports(),
-        ) {
-            let intersection = filtered_ports
-                .iter()
-                .copied()
-                .filter(|port| unfiltered_ports.contains(port))
-                .collect::<Vec<_>>();
-            if intersection.is_empty().not() {
-                Err(ConfigError::Conflict(format!(
-                    "Ports {intersection:?} are present in both `feature.network.incoming.ports` and \
-                    `feature.network.incoming.http_filter.ports`. These lists must remain disjoint. \
-                    If you want traffic to a port to be filtered, \
-                    include it only in `feature.network.incoming.http_filter.ports`. \
-                    To steal all the traffic from that port without filtering, \
-                    include it only in `feature.network.incoming.ports`."
-                )))?
-            }
-        }
-
         match (
             &self.feature.network.incoming.https_delivery,
             &self.feature.network.incoming.tls_delivery,


### PR DESCRIPTION
Reverts some of https://github.com/metalbear-co/mirrord/pull/2486 to allow ports in `incoming.ports` and `incoming.http_filter.ports` to overlap. If the port is present in both, the port is filtered according to `http_filter` filters.
