### PR TITLE
layer: Don't call `fcntl` through `FN_FCNTL` on `SOCKETS` initialization

### DIFF
--- a/changelog.d/+374.fixed.md
+++ b/changelog.d/+374.fixed.md
@@ -1,0 +1,1 @@
+Fixed a rare layer crash in `exec`


### PR DESCRIPTION
Fixes https://github.com/metalbear-co/mirrord-intellij/issues/374