### PR TITLE
sip: exit when SIP patch fails due to hitting FD limit

### DIFF
--- a/changelog.d/+fail-on-sip-fd-error.fixed.md
+++ b/changelog.d/+fail-on-sip-fd-error.fixed.md
@@ -1,0 +1,2 @@
+mirrord will now fail (panic) if SIP patching encounters the `"Too many open files"` error. To fix this, the user can
+try increasing the file limit using `ulimit`.

--- a/mirrord/cli/src/execution.rs
+++ b/mirrord/cli/src/execution.rs
@@ -15,7 +15,7 @@ use mirrord_intproxy::agent_conn::AgentConnectInfo;
 use mirrord_progress::Progress;
 use mirrord_protocol::{ClientMessage, DaemonMessage, EnvVars, GetEnvVarsRequest, LogLevel};
 #[cfg(target_os = "macos")]
-use mirrord_sip::{SipPatchOptions, sip_patch};
+use mirrord_sip::{SipError, SipPatchOptions, sip_patch};
 use mirrord_tls_util::SecureChannelSetup;
 use semver::Version;
 use serde::Serialize;
@@ -376,7 +376,13 @@ impl MirrordExecution {
                 .transpose() // We transpose twice to propagate a possible error out of this
                 // closure.
             })
-            .transpose()?;
+            .transpose()
+            .inspect_err(|sip_error| {
+                // we can't recover from hitting the fd limit, so we have to exit fully
+                if let SipError::TooManyFilesOpen(..) = sip_error {
+                    panic!("mirrord failed to patch SIP with: {}", sip_error);
+                }
+            })?;
 
         #[cfg(not(target_os = "macos"))]
         let patched_path = None;


### PR DESCRIPTION
Issue: https://linear.app/metalbear/issue/COR-181/sip-failure-doesnt-crashprovide-enough-information-for-user