### PR TITLE
tests: Use a unique connection id for each peer in `outgoing_udp`

### DIFF
--- a/changelog.d/+outgoing_udp-flake.internal.md
+++ b/changelog.d/+outgoing_udp-flake.internal.md
@@ -1,0 +1,1 @@
+Improvements to the `outgoing_udp` test to make it less flaky.


### PR DESCRIPTION
As an attempt to make this test less flaky
