### PR TITLE
feat: support glob patterns for target

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4789,6 +4789,7 @@ version = "3.179.0"
 dependencies = [
  "async-stream",
  "futures",
+ "glob",
  "http 1.4.0",
  "itertools 0.14.0",
  "k8s-openapi",

--- a/changelog.d/3731.added.md
+++ b/changelog.d/3731.added.md
@@ -1,0 +1,1 @@
+Added support of glob patterns for targets 

--- a/mirrord/kube/Cargo.toml
+++ b/mirrord/kube/Cargo.toml
@@ -46,6 +46,7 @@ tokio-retry = { workspace = true, optional = true }
 tower = { workspace = true, features = ["retry"] }
 http.workspace = true
 itertools.workspace = true
+glob = "0.3"
 
 [dev-dependencies]
 rstest.workspace = true

--- a/mirrord/kube/src/api.rs
+++ b/mirrord/kube/src/api.rs
@@ -1,3 +1,4 @@
 pub mod container;
+mod ext;
 pub mod kubernetes;
 pub mod runtime;

--- a/mirrord/kube/src/api/ext.rs
+++ b/mirrord/kube/src/api/ext.rs
@@ -1,0 +1,64 @@
+use std::fmt::Debug;
+
+use kube::{Api, Resource, api::ListParams, core::ErrorResponse};
+use serde::de::DeserializeOwned;
+
+use crate::error::Result;
+
+const DEFAULT_LIST_LIMIT: u32 = 25;
+
+/// Extensions trait for [`kube::Api`].
+pub(super) trait ApiExt<K: Resource> {
+    /// Searches for the first match of the `name` or `generated_name` fields against
+    /// the provided glob pattern. Returns `Ok(None)` if nothing found.
+    ///
+    /// See pattern details [`here`](https://docs.rs/glob/latest/glob/struct.Pattern.html)
+    async fn search_one_opt(&self, pattern: impl AsRef<str>) -> Result<Option<K>>;
+
+    /// Similar to [`Self::search_one_opt`] but it returns error if no items have found.
+    async fn search_one(&self, pattern: impl AsRef<str>) -> Result<K> {
+        Ok(self
+            .search_one_opt(pattern.as_ref())
+            .await?
+            .ok_or_else(|| {
+                kube::Error::Api(ErrorResponse {
+                    status: "Failure".to_owned(),
+                    message: format!("resource not found for pattern '{}'", pattern.as_ref()),
+                    reason: "NotFound".to_owned(),
+                    code: 404,
+                })
+            })?)
+    }
+}
+
+impl<K> ApiExt<K> for Api<K>
+where
+    K: Resource + Clone + DeserializeOwned + Debug,
+{
+    async fn search_one_opt(&self, pattern: impl AsRef<str>) -> Result<Option<K>> {
+        let pattern = glob::Pattern::new(pattern.as_ref())?;
+        let mut params = ListParams::default().limit(DEFAULT_LIST_LIMIT);
+        loop {
+            let list = self.list_metadata(&params).await?;
+            for item in &list {
+                let Some(name) = item
+                    .meta()
+                    .name
+                    .as_ref()
+                    .or(item.meta().generate_name.as_ref())
+                else {
+                    continue;
+                };
+                if pattern.matches(name) {
+                    return Ok(Some(self.get(name).await?));
+                }
+            }
+            match list.metadata.continue_ {
+                Some(continue_token) => {
+                    params.continue_token = Some(continue_token);
+                }
+                None => return Ok(None),
+            };
+        }
+    }
+}

--- a/mirrord/kube/src/api/runtime/pod.rs
+++ b/mirrord/kube/src/api/runtime/pod.rs
@@ -3,12 +3,18 @@ use kube::{Api, Client};
 use mirrord_config::target::pod::PodTarget;
 
 use super::{RuntimeData, RuntimeDataProvider};
-use crate::{api::kubernetes::get_k8s_resource_api, error::Result};
+use crate::{
+    api::{ext::ApiExt, kubernetes::get_k8s_resource_api},
+    error::Result,
+};
 
 impl RuntimeDataProvider for PodTarget {
     async fn runtime_data(&self, client: &Client, namespace: Option<&str>) -> Result<RuntimeData> {
         let pod_api: Api<Pod> = get_k8s_resource_api(client, namespace);
-        let pod = pod_api.get(&self.pod).await?;
+        let pod = match pod_api.get_opt(&self.pod).await? {
+            Some(pod) => pod,
+            None => pod_api.search_one(&self.pod).await?,
+        };
 
         RuntimeData::from_pod(&pod, self.container.as_deref())
     }

--- a/mirrord/kube/src/error.rs
+++ b/mirrord/kube/src/error.rs
@@ -84,6 +84,10 @@ pub enum KubeApiError {
     /// Spawned agent pod was deleted during startup.
     #[error("Agent pod was unexpectedly deleted")]
     AgentPodDeleted,
+
+    /// Attempted to build glob pattern from provided target but it failed to parse.
+    #[error("Failed to parse target search pattern: {0}")]
+    InvalidTargetPattern(#[from] glob::PatternError),
 }
 
 impl KubeApiError {

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -12,6 +12,7 @@ mod http;
 mod issue1317;
 #[cfg(any(feature = "cli", feature = "operator"))]
 mod ls;
+mod target;
 mod targetless;
 mod traffic;
 

--- a/tests/src/target.rs
+++ b/tests/src/target.rs
@@ -1,0 +1,54 @@
+#![cfg(test)]
+
+use std::time::Duration;
+
+use rstest::*;
+
+use crate::utils::{
+    application::env::EnvApp, kube_service::KubeService, run_command::run_exec_with_target,
+    services::basic_service,
+};
+
+/// Verifies that the pod target argument can be a glob pattern.
+#[cfg_attr(target_os = "windows", ignore)]
+#[rstest]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[timeout(Duration::from_secs(240))]
+#[cfg_attr(not(feature = "ephemeral"), ignore)]
+async fn glob_pattern_in_pod_target(#[future] basic_service: KubeService) {
+    let service = basic_service.await;
+
+    let application = EnvApp::Bash;
+    let mut process = run_exec_with_target(
+        application.command(),
+        &format!("pod/{}*", &service.pod_name[..service.pod_name.len() - 4]),
+        Some(&service.namespace),
+        application.mirrord_args(),
+        Some(vec![("MIRRORD_EPHEMERAL_CONTAINER", "true")]),
+    )
+    .await;
+    let res = process.wait().await;
+    assert!(res.success());
+}
+
+/// Verifies that the deployment target argument can be a glob pattern.
+#[cfg_attr(target_os = "windows", ignore)]
+#[rstest]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[timeout(Duration::from_secs(240))]
+#[cfg_attr(not(feature = "ephemeral"), ignore)]
+async fn glob_pattern_in_deployment_target(#[future] basic_service: KubeService) {
+    let service = basic_service.await;
+
+    let application = EnvApp::Bash;
+    let mut process = run_exec_with_target(
+        application.command(),
+        &format!("deployment/{}*", &service.name[..service.name.len() - 4]),
+        Some(&service.namespace),
+        application.mirrord_args(),
+        Some(vec![("MIRRORD_EPHEMERAL_CONTAINER", "true")]),
+    )
+    .await;
+    let res = process.wait().await;
+    assert!(res.success());
+}


### PR DESCRIPTION
Added support for glob pattern for targets, for example, `--target deployment/myService-*`. It will pick the first matching entry, or return an error if nothing is found.

Fixes #3731 