### PR TITLE
Tiny refactor to make a struct field name not be a lie

### DIFF
--- a/changelog.d/+enpty-target-final.internal.md
+++ b/changelog.d/+enpty-target-final.internal.md
@@ -1,0 +1,1 @@
+Small refactor to make a struct member name make sense.

--- a/mirrord/cli/src/verify_config.rs
+++ b/mirrord/cli/src/verify_config.rs
@@ -2,6 +2,9 @@
 //! [`VerifyConfig`](crate::Commands::VerifyConfig) enum after checking the config file passed in
 //! `path`. It's used by the IDE plugins to display errors/warnings quickly, without having to start
 //! mirrord-layer.
+
+use std::ops::Not;
+
 use error::CliResult;
 use futures::TryFutureExt;
 use mirrord_config::{
@@ -165,7 +168,7 @@ pub(super) async fn verify_config(
     VerifyConfigArgs { ide, path }: VerifyConfigArgs,
 ) -> CliResult<()> {
     let mut config_context = ConfigContext::default()
-        .empty_target_final(ide)
+        .empty_target_final(ide.not())
         .override_env(LayerConfig::FILE_PATH_ENV, path);
 
     let layer_config =

--- a/mirrord/config/src/config/context.rs
+++ b/mirrord/config/src/config/context.rs
@@ -12,6 +12,7 @@ use std::{
 /// See:
 /// 1. [`LayerConfig::verify`](crate::LayerConfig::verify)
 /// 2. [`MirrordConfig::generate_config`](crate::config::MirrordConfig::generate_config)
+#[derive(Default)]
 pub struct ConfigContext {
     /// Whether an empty [TargetConfig::path](crate::target::TargetConfig::path) should be
     /// considered final.
@@ -144,16 +145,5 @@ impl ConfigContext {
     /// Returns whether this context stores any warnings.
     pub fn has_warnings(&self) -> bool {
         self.warnings.is_empty().not()
-    }
-}
-
-impl Default for ConfigContext {
-    fn default() -> Self {
-        Self {
-            empty_target_final: true,
-            env_override: Default::default(),
-            strict_env: false,
-            warnings: Default::default(),
-        }
     }
 }

--- a/mirrord/config/src/lib.rs
+++ b/mirrord/config/src/lib.rs
@@ -23,7 +23,7 @@ pub mod retry;
 pub mod target;
 pub mod util;
 
-use std::{collections::HashMap, ffi::OsStr, ops::Not, path::Path};
+use std::{collections::HashMap, ffi::OsStr, path::Path};
 
 use base64::prelude::*;
 use config::{ConfigContext, ConfigError, MirrordConfig};
@@ -613,7 +613,7 @@ impl LayerConfig {
 
         let is_targetless = match self.target.path.as_ref() {
             Some(Target::Targetless) => true,
-            None => context.is_empty_target_final().not(),
+            None => context.is_empty_target_final(),
             _ => false,
         };
 


### PR DESCRIPTION
The field `empty_target_final` of the `ConfigContext` struct was holding exactly the opposite value of what its name suggest. It was `true` when the target **wasn't** final and `false` when it was.

I just changed all its usages to hold the value that its name says it holds. I changed both the writing to and the reading from that value, so there is no change in behaviour or functionality.