### PR TITLE
Env unset for skipped process

### DIFF
--- a/changelog.d/+env-unset-sip-only.fixed.md
+++ b/changelog.d/+env-unset-sip-only.fixed.md
@@ -1,0 +1,1 @@
+`mirrord` now unsets env from process even if the process is skipped on macOS.

--- a/mirrord/layer/src/lib.rs
+++ b/mirrord/layer/src/lib.rs
@@ -597,6 +597,15 @@ fn sip_only_layer_start(
     SETUP.set(layer_setup).expect("SETUP set failed");
 
     unsafe { file::hooks::enable_file_hooks(&mut hook_manager, setup()) };
+
+    if let Some(unset) = setup().env_config().unset.as_ref() {
+        let unset = unset.iter().map(|s| s.to_lowercase()).collect::<Vec<_>>();
+        std::env::vars().for_each(|(key, _)| {
+            if unset.contains(&key.to_lowercase()) {
+                unsafe { std::env::remove_var(&key) };
+            }
+        });
+    }
 }
 
 /// Prepares the [`HookManager`] and [`replace!`]s [`libc`] calls with our hooks, according to what


### PR DESCRIPTION
This PR adds env unset logic to skipped process on macOS. When go app debug build is ran by delve (debugging tool), using env unset removes env from the go app process, but it doesn't shrink the size of `envp` leaving additional null pointers after `envp`. This makes go runtime fails to read apple vector. Thus, cause error when `os.Executable()` is called from the go app. The issue is resolved if the same envs are removed from the delve process.

Before this change, debugging a go app with `env.unset: ["USER"]` in VSCode results in:
```
2026-01-14T04:22:53.574838Z  INFO ThreadId(01) mirrord_layer: Initializing mirrord-layer!
2026-01-14T04:22:53.575174Z  INFO ThreadId(01) mirrord_layer::exec_utils: skipped 78 envs from envp
2026-01-14T04:22:53.575179Z  INFO ThreadId(01) mirrord_layer: Finished reading Apple variables count=0
```

After this change:
```
2026-01-14T04:24:20.424959Z  INFO ThreadId(01) mirrord_layer: Initializing mirrord-layer!
2026-01-14T04:24:20.425499Z  INFO ThreadId(01) mirrord_layer::exec_utils: skipped 78 envs from envp
2026-01-14T04:24:20.425511Z  INFO ThreadId(01) mirrord_layer: applev[0]: executable_path=/Users/yuanl/code/go-is-hell/__debug_bin3326495358
2026-01-14T04:24:20.425517Z  INFO ThreadId(01) mirrord_layer: applev[1]: 
2026-01-14T04:24:20.425520Z  INFO ThreadId(01) mirrord_layer: applev[2]: 
2026-01-14T04:24:20.425524Z  INFO ThreadId(01) mirrord_layer: applev[3]: 
2026-01-14T04:24:20.425526Z  INFO ThreadId(01) mirrord_layer: applev[4]: ptr_munge=
2026-01-14T04:24:20.425529Z  INFO ThreadId(01) mirrord_layer: applev[5]: main_stack=
2026-01-14T04:24:20.425532Z  INFO ThreadId(01) mirrord_layer: applev[6]: executable_file=0x1a01000011,0x3071ec5
2026-01-14T04:24:20.425535Z  INFO ThreadId(01) mirrord_layer: applev[7]: dyld_file=0x1a01000011,0xfffffff000a6e8d
2026-01-14T04:24:20.425539Z  INFO ThreadId(01) mirrord_layer: applev[8]: executable_cdhash=16f493b6785aa8b66858c7074a20cf8f7311fa57
2026-01-14T04:24:20.425542Z  INFO ThreadId(01) mirrord_layer: applev[9]: executable_boothash=b5cdcf7572794a6908111cefa001ae81a61c3564
2026-01-14T04:24:20.425546Z  INFO ThreadId(01) mirrord_layer: applev[10]: arm64e_abi=os
2026-01-14T04:24:20.425549Z  INFO ThreadId(01) mirrord_layer: applev[11]: th_port=
2026-01-14T04:24:20.425552Z  INFO ThreadId(01) mirrord_layer: applev[12]: security_config=0x0
2026-01-14T04:24:20.425568Z  INFO ThreadId(01) mirrord_layer: Finished reading Apple variables count=13
```