### PR TITLE
fix towncrier config

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,7 +61,7 @@ jobs:
       - run: uv python install
       - run: uv venv
       - name: install towncrier
-        run: uv pip install towncrier==23.11.0
+        run: uv pip install towncrier==25.08.0
       - name: verify newsfragment exist
         run: uv run towncrier check
 

--- a/changelog.d/+towncrier-issue-pattern.internal.md
+++ b/changelog.d/+towncrier-issue-pattern.internal.md
@@ -1,0 +1,1 @@
+Set pattern for towncrier issue pattern to reduce bogus links.

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -6,6 +6,8 @@ underlines = ["", "", ""]
 template = "changelog.d/changelog_template.jinja"
 title_format = "## [{version}](https://github.com/metalbear-co/mirrord/tree/{version}) - {project_date}"
 issue_format = "[#{issue}](https://github.com/metalbear-co/mirrord/issues/{issue})"
+# We link to GitHub, and GitHub issues are made only out of digits.
+issue_pattern = "\\d+"
 wrap = true
 
 [[tool.towncrier.type]]


### PR DESCRIPTION
There are some cases that the previous config lead to a bogus link being created in the changelog. One example is when people create an issue with a name like +db-branching.env-from.added.md‎, env-from is treated like an issue identifier and a bogus link is created in the changelog.

This and some other cases that currently lead to a bogus issue link, will now either be created without a bogus link, or will be denied in the towncrier check step on CI.