### PR TITLE
mark new release as latest GH release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -845,7 +845,7 @@ jobs:
           # Get complete history
           fetch-depth: 0
 
-      - name: Update major version and latest tags
+      - name: Update major version and latest tags in git
         uses: metalbear-co/release-tracker-action@main
         env:
           # GitHub token to enable pushing tags
@@ -855,3 +855,8 @@ jobs:
           update-latest: true
           # Don't update the vX.Y tags
           update-minor: false
+
+      - name: Update latest release on GitHub (not latest git tag).
+        run: gh release edit "${{ github.ref_name }}" --latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/changelog.d/+set-latest-gh-release.internal.md
+++ b/changelog.d/+set-latest-gh-release.internal.md
@@ -1,0 +1,1 @@
+After a release is done and everything is published, set it to be the latest release on GitHub.


### PR DESCRIPTION
Right now we automatically set the `latest` tag in git, but we don't automatically mark the GitHub release object as `latest`.
A GitHub release could be marked as latest on creation - but to my understanding we don't want that, because then we would have a `latest` release that doesn't have any assets until the release workflow finishes.
