### PR TITLE
Add a PR checklist to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,18 +1,19 @@
 <!-- Thank you for contributing to mirrord! -->
 <!-- Please use the checklist below as a guide for docs, tests and admin tasks for your PR -->
+<!-- Feel free to ~strikethrough~ any items that you don't think apply -->
 
 ### Quality Checklist:
 
 - [ ] I have documented new code sufficiently
-- [ ] I have checked and updated the relevant existing docs in code
-- [ ] I have written user-facing website docs for new features
+- [ ] I have checked and updated the relevant existing docs in code, including removing outdated material
+- [ ] I have written user-facing website docs for new features, or opened a (sub)issue to do so
 - [ ] I have checked and updated existing website docs for changed features
-- [ ] I have tested this change locally and know it succeeds and fails as expected
-- [ ] I have written unit tests where possible
-- [ ] I have written e2e tests if needed
-- [ ] I have explained what this PR introduces and why, and linked to relevant context where possible (e.g. linear
-  issues, related PRs, documentation)
-- [ ] I have added a changelog entry that is well formatted and clear for
-  users ([changelog help](../CONTRIBUTING.md#submitting-a-pull-request))
+- [ ] I have tested this change and know it succeeds and fails as expected
+- [ ] I have written unit tests or purposefully omitted them
+- [ ] I have written e2e tests or purposefully omitted them
+- [ ] I have explained what this PR introduces and why, and linked to relevant context (e.g. linear issues, related PRs,
+  documentation)
+- [ ] I have introduced a short, clear and well-formatted changelog entry
 
+<!-- need help with the changelog? see ../CONTRIBUTING.md#submitting-a-pull-request -->
 <!-- Add more details of your changes below if needed -->

--- a/changelog.d/+pr-template.internal.md
+++ b/changelog.d/+pr-template.internal.md
@@ -1,0 +1,1 @@
+Added a checklist to the PR template for important tasks.


### PR DESCRIPTION
Following on from the addition of the review guide, I think we could benefit from a PR checklist to remind the PR owner of extra tasks that are important before merging code. I don't want to suggest anything that would block CI if it _wasn't_ checked, and I don't want anything so long that people would be tempted to skip reading it. This is purely an exercise in reminding the PR owner of things they may have forgotten (like checking existing documentation is up to date!!!).

I think it also functions as a neat list of extras for the reviewer to check for for, when reviewing the changes. All together, I'm hoping that we can merge higher quality changes which will have a positive effect on product stability in the long run.

Please leave feedback (some of the wording is a bit clumsy) and thoughts :)