### PR TITLE
expose feature.env.load_from_process as env

### DIFF
--- a/changelog.d/+expose-env-load-from-process.added.md
+++ b/changelog.d/+expose-env-load-from-process.added.md
@@ -1,0 +1,1 @@
+expose feature.env.load_from_process as env MIRRORD_ENV_LOAD_FROM_PROCESS

--- a/mirrord/config/src/feature/env.rs
+++ b/mirrord/config/src/feature/env.rs
@@ -95,6 +95,7 @@ pub struct EnvConfig {
     ///
     /// This setting is meant to resolve issues when using mirrord via the IntelliJ plugin on WSL
     /// and the remote environment contains a lot of variables.
+    #[config(env = "MIRRORD_ENV_LOAD_FROM_PROCESS")]
     pub load_from_process: Option<bool>,
 
     /// #### feature.env.unset {#feature-env-unset}


### PR DESCRIPTION
expose feature.env.load_from_process as env `MIRRORD_ENV_LOAD_FROM_PROCESS