### PR TITLE
Make ports and target required for `mirrord dump`

### DIFF
--- a/changelog.d/+dump-ports.fixed.md
+++ b/changelog.d/+dump-ports.fixed.md
@@ -1,0 +1,2 @@
+The `mirrord dump` no longer hangs if the required `--ports` flag was not specified.
+Also, it no longer provides an inaccurate error when no target is specified.

--- a/mirrord/cli/src/config.rs
+++ b/mirrord/cli/src/config.rs
@@ -444,7 +444,7 @@ pub(super) struct DumpArgs {
 
     /// List of ports to dump data from.
     /// Can be specified multiple times.
-    #[arg(short = 'p', long)]
+    #[arg(short = 'p', long, required = true)]
     pub ports: Vec<u16>,
 }
 

--- a/mirrord/cli/src/error.rs
+++ b/mirrord/cli/src/error.rs
@@ -246,6 +246,9 @@ pub(crate) enum CliError {
     #[diagnostic(help(r#"Inspect your config file and arguments provided.{GENERAL_HELP}"#))]
     ConfigError(#[from] mirrord_config::config::ConfigError),
 
+    #[error("Failed to run command `{command}` due to missing argument `{arg}`")]
+    MissingArg { command: String, arg: String },
+
     #[error("Failed to access env file at `{0}`: {1}")]
     #[diagnostic(help(
         "Please check that the path is correct and that you have permissions to read it.{GENERAL_HELP}"


### PR DESCRIPTION
<!-- Thank you for contributing to mirrord! -->
<!-- Please use the checklist below as a guide for docs, tests and admin tasks for your PR -->
<!-- Feel free to ~strikethrough~ any items that you don't think apply -->

### Quality Checklist:

- [x] I have documented new code sufficiently
- [x] I have checked and updated the relevant existing docs in code, including removing outdated material
- [ ] ~I have written user-facing website docs for new features, or opened a (sub)issue to do so~
- [ ] ~I have checked and updated existing website docs for changed features~
- [x] I have tested this change and know it succeeds and fails as expected
- [x] I have written unit tests or purposefully omitted them
- [x] I have written e2e tests or purposefully omitted them
- [x] I have explained what this PR introduces and why, and linked to relevant context (e.g. linear issues, related PRs,
  documentation)
- [x] I have introduced a short, clear and well-formatted changelog entry

<!-- need help with the changelog? see ../CONTRIBUTING.md#submitting-a-pull-request -->
<!-- Add more details of your changes below if needed -->

### Info
- Added `required = true` to ports arg
- Since the target can be resolved from config or the `ExecArgs` we can't just add `required = true`, so it uses a check in `mirrord::dump::dump_command` instead