### PR TITLE
cli+operator/crd: show remaining TTL in `preview status`

### DIFF
--- a/changelog.d/+preview-env-show-ttl.added.md
+++ b/changelog.d/+preview-env-show-ttl.added.md
@@ -1,0 +1,1 @@
+The `mirrord preview status` command will now show the remaining TTL of each preview environment session.

--- a/mirrord/operator/src/crd/preview.rs
+++ b/mirrord/operator/src/crd/preview.rs
@@ -80,6 +80,14 @@ pub struct PreviewSessionStatus {
     /// Only set when `phase` is `Failed`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub failure_message: Option<String>,
+
+    /// Timestamp when the session's TTL expires.
+    ///
+    /// Set when the session enters the `Ready` phase. Computed as `now + ttl_secs` at the
+    /// moment the operator starts the TTL countdown. `None` during earlier phases or when
+    /// running against an older operator that does not set this field.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<MicroTime>,
 }
 
 /// Phase of a preview session's lifecycle.


### PR DESCRIPTION
<!-- Thank you for contributing to mirrord! -->
<!-- Please use the checklist below as a guide for docs, tests and admin tasks for your PR -->
<!-- Feel free to ~strikethrough~ any items that you don't think apply -->

### Quality Checklist:

- [x] I have documented new code sufficiently
- [x] I have checked and updated the relevant existing docs in code, including removing outdated material
- ~[ ] I have written user-facing website docs for new features, or opened a (sub)issue to do so~
- ~[ ] I have checked and updated existing website docs for changed features~
- [x] I have tested this change and know it succeeds and fails as expected
- [x] I have written unit tests or purposefully omitted them
- [x] I have written e2e tests or purposefully omitted them
- [x] I have explained what this PR introduces and why, and linked to relevant context (e.g. linear issues, related PRs,
  documentation)
- [x] I have introduced a short, clear and well-formatted changelog entry

<!-- need help with the changelog? see ../CONTRIBUTING.md#submitting-a-pull-request -->
<!-- Add more details of your changes below if needed -->

- Related PRs:
  - https://github.com/metalbear-co/operator/pull/1302
  - https://github.com/metalbear-co/charts/pull/344
