### PR TITLE
cli/preview: mark preview sessions with the operator's ownership label

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -553,6 +553,16 @@ kubectl logs <YOUR_POD_NAME> | less -R
 
 where you would replace `<YOUR_POD_NAME>` with the name of the pod.
 
+## Operator Isolation Marker
+
+When multiple operator instances share the same cluster, each uses an isolation marker to avoid
+reconciling resources created by the other. The marker is set via the `OPERATOR_ISOLATION_MARKER`
+environment variable and defaults to `mirrord-operator`. Its value is used as a special label on
+operator-managed resources (agents, copy-targets, preview sessions, etc.).
+
+The operator reads this env var at **compile time** (via `option_env!`), while the CLI reads it at
+**runtime** (via `std::env::var`).
+
 # New Hook Guidelines
 
 Adding a feature to mirrord that introduces a new hook (file system, network) can be tricky and there are a lot of edge cases we might need to cover.

--- a/changelog.d/+preview-env-isolation-label.internal.md
+++ b/changelog.d/+preview-env-isolation-label.internal.md
@@ -1,0 +1,1 @@
+Preview sessions are now marked with the operator's ownership label, allowing developers to create preview sessions when multiple operators are running concurrently.

--- a/mirrord/operator/src/types.rs
+++ b/mirrord/operator/src/types.rs
@@ -46,3 +46,13 @@ pub const RECONNECT_NOT_POSSIBLE_CODE: u16 = 410;
 /// Reason returned in error responses from the operator, when reconnecting to a session is no
 /// longer possible.
 pub const RECONNECT_NOT_POSSIBLE_REASON: &str = "ReconnectNotPossible";
+
+/// Kubernetes label key identifying resources owned by the mirrord operator.
+pub const OPERATOR_OWNERSHIP_LABEL: &str = "operator.metalbear.co/owner";
+
+/// Name of the environment variable that overrides the default operator isolation marker.
+pub const OPERATOR_ISOLATION_MARKER_ENV: &str = "OPERATOR_ISOLATION_MARKER";
+
+/// Default value for the [`OPERATOR_OWNERSHIP_LABEL`] when
+/// [`OPERATOR_ISOLATION_MARKER_ENV`] is not set.
+pub const DEFAULT_OPERATOR_ISOLATION_MARKER: &str = "mirrord-operator";


### PR DESCRIPTION
<!-- Thank you for contributing to mirrord! -->
<!-- Please use the checklist below as a guide for docs, tests and admin tasks for your PR -->
<!-- Feel free to ~strikethrough~ any items that you don't think apply -->

### Quality Checklist:

- ~~[ ] I have documented new code sufficiently~~
- ~~[ ] I have checked and updated the relevant existing docs in code, including removing outdated material~~
- ~~[ ] I have written user-facing website docs for new features, or opened a (sub)issue to do so~~
- ~~[ ] I have checked and updated existing website docs for changed features~~
- [x] I have tested this change and know it succeeds and fails as expected
- [x] I have written unit tests or purposefully omitted them
- [x] I have written e2e tests or purposefully omitted them
- [x] I have explained what this PR introduces and why, and linked to relevant context (e.g. linear issues, related PRs,
  documentation)
- [x] I have introduced a short, clear and well-formatted changelog entry

<!-- need help with the changelog? see ../CONTRIBUTING.md#submitting-a-pull-request -->
<!-- Add more details of your changes below if needed -->

This allows running a "local" operator with `OPERATOR_ISOLATION_MARKER`
without having it compete with the actual operator for reconciliation.

- Related PRs:
  - https://github.com/metalbear-co/operator/pull/1305
