### PR TITLE
Add session monitor React frontend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1115,6 +1115,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
 dependencies = [
  "axum-core 0.5.6",
+ "base64",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -1133,8 +1134,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1",
  "sync_wrapper",
  "tokio",
+ "tokio-tungstenite 0.28.0",
  "tower 0.5.3",
  "tower-layer",
  "tower-service",
@@ -2860,6 +2863,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "fsio"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3822,6 +3834,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
 
 [[package]]
+name = "inotify"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd168d97690d0b8c412d6b6c10360277f4d7ee495c5d0d5d5fe0854923255cc"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3829,6 +3861,15 @@ checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "block-padding",
  "generic-array",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -4203,6 +4244,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4b1eb7788f3824c629b1116a7a9060d6e898c358ebff59070093d51103dcc3c"
 dependencies = [
  "typewit",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
 ]
 
 [[package]]
@@ -4713,6 +4774,7 @@ dependencies = [
  "mirrord-tls-util",
  "mirrord-vpn",
  "nix 0.29.0",
+ "notify",
  "opener",
  "prettytable-rs",
  "rand 0.9.2",
@@ -4720,6 +4782,7 @@ dependencies = [
  "regex",
  "reqwest 0.13.2",
  "rstest",
+ "rust-embed",
  "rustls 0.23.37",
  "semver 1.0.27",
  "serde",
@@ -5495,6 +5558,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf23ab2b905654b4cb177e30b629937b3868311d4e1cba859f899c041046e69b"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "notify"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c533b4c39709f9ba5005d8002048266593c1cfaf3c5f0739d5b8ab0c6c504009"
+dependencies = [
+ "bitflags 2.11.0",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "notify-types"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585d3cb5e12e01aed9e8a1f70d5c6b5e86fe2a6e48fc8cd0b3e0b8df6f6eb174"
+dependencies = [
+ "instant",
 ]
 
 [[package]]
@@ -6314,7 +6405,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.5+spec-1.1.0",
+ "toml_edit 0.25.6+spec-1.1.0",
 ]
 
 [[package]]
@@ -6983,6 +7074,40 @@ name = "rust-e2e-fileops"
 version = "3.194.0"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "rust-embed"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04113cb9355a377d83f06ef1f0a45b8ab8cd7d8b1288160717d66df5c7988d27"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0902e4c7c8e997159ab384e6d0fc91c221375f6894346ae107f47dd0f3ccaa"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "syn 2.0.117",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
+dependencies = [
+ "sha2",
+ "walkdir",
 ]
 
 [[package]]
@@ -8331,6 +8456,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.28.0",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8376,9 +8513,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.0.1+spec-1.1.0"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b320e741db58cac564e26c607d3cc1fdc4a88fd36c879568c07856ed83ff3e9"
+checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
 dependencies = [
  "serde_core",
 ]
@@ -8399,21 +8536,21 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.5+spec-1.1.0"
+version = "0.25.6+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca1a40644a28bce036923f6a431df0b34236949d111cc07cb6dca830c9ef2e1"
+checksum = "0db3bae107c9522f86d361697dee1d7386a2ddcf659d5aea5159819a21a3c4a7"
 dependencies = [
  "indexmap 2.13.0",
- "toml_datetime 1.0.1+spec-1.1.0",
+ "toml_datetime 1.1.0+spec-1.1.0",
  "toml_parser",
  "winnow 1.0.0",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.10+spec-1.1.0"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df25b4befd31c4816df190124375d5a20c6b6921e2cad937316de3fccd63420"
+checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
 dependencies = [
  "winnow 1.0.0",
 ]
@@ -8711,6 +8848,23 @@ name = "tungstenite"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http 1.4.0",
+ "httparse",
+ "log",
+ "rand 0.9.2",
+ "sha1",
+ "thiserror 2.0.18",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
 dependencies = [
  "bytes",
  "data-encoding",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4941,8 +4941,10 @@ dependencies = [
 name = "mirrord-intproxy"
 version = "3.194.0"
 dependencies = [
+ "axum 0.8.8",
  "bytes",
  "futures",
+ "home",
  "http-body-util",
  "hyper 1.8.1",
  "hyper-util",
@@ -4961,6 +4963,7 @@ dependencies = [
  "rustls 0.23.37",
  "semver 1.0.27",
  "serde",
+ "serde_json",
  "strum 0.27.2",
  "strum_macros 0.27.2",
  "thiserror 2.0.18",

--- a/mirrord/cli/Cargo.toml
+++ b/mirrord/cli/Cargo.toml
@@ -72,13 +72,18 @@ tower = { workspace = true, features = ["retry"] }
 ci_info.workspace = true
 opener = "0.8.3"
 tempfile = { workspace = true, optional = true }
-axum = { version = "0.8.4", optional = true }
+axum = { version = "0.8.4", features = ["ws"] }
 tower-http = { version = "0.6.6", features = ["fs", "set-header"], optional = true }
 tar = { workspace = true, optional = true }
 flate2 = { workspace = true, optional = true }
 itertools = { workspace = true, optional = true }
 yamlpatch.workspace = true
 yamlpath.workspace = true
+rust-embed = "8"
+notify = { version = "7", features = ["macos_fsevent"] }
+hyper = { workspace = true, features = ["full"] }
+hyper-util = { workspace = true, features = ["client-legacy", "tokio"] }
+http-body-util.workspace = true
 
 [target.'cfg(unix)'.dependencies]
 rand.workspace = true
@@ -113,4 +118,4 @@ tempfile.workspace = true
 
 [features]
 windows_build = []
-wizard = ["dep:axum", "dep:tower-http", "dep:tar", "dep:flate2", "dep:tempfile", "dep:itertools"]
+wizard = ["dep:tower-http", "dep:tar", "dep:flate2", "dep:tempfile", "dep:itertools"]

--- a/mirrord/cli/build.rs
+++ b/mirrord/cli/build.rs
@@ -94,6 +94,13 @@ fn main() {
         if !std::fs::exists(&frontend_path).unwrap_or(false) {
             std::fs::write(frontend_path, "").unwrap();
         };
+
+        // Ensure monitor-frontend/dist exists for rust-embed during clippy
+        let monitor_dist = std::path::Path::new("../../monitor-frontend/dist");
+        if !monitor_dist.exists() {
+            std::fs::create_dir_all(monitor_dist).ok();
+        }
+
         return;
     }
     // Make sure `MIRRORD_LAYER_FILE` is provided either by user, or computed.
@@ -102,6 +109,14 @@ fn main() {
     // Build the wizard frontend
     #[cfg(feature = "wizard")]
     build_wizard_frontend();
+
+    // Ensure monitor-frontend/dist exists for rust-embed
+    {
+        let dist_dir = std::path::Path::new("../../monitor-frontend/dist");
+        if !dist_dir.exists() {
+            std::fs::create_dir_all(dist_dir).ok();
+        }
+    }
 
     // this check uses cargo env vars instead of conditional compilation due to cfg! not respecting
     // the target flag on a build

--- a/mirrord/cli/src/config.rs
+++ b/mirrord/cli/src/config.rs
@@ -209,6 +209,13 @@ pub(super) enum Commands {
 
     /// Fix issues related to mirrord.
     Fix(FixArgs),
+
+    /// Launch the session monitor UI.
+    ///
+    /// Watches active mirrord sessions and displays a web dashboard showing
+    /// real-time events (file operations, DNS queries, HTTP requests, etc.)
+    /// from all running mirrord sessions.
+    Ui(UiArgs),
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum, Debug)]
@@ -1413,6 +1420,22 @@ impl PreviewStopArgs {
 
         envs
     }
+}
+
+/// Arguments for the `mirrord ui` command.
+#[derive(Args, Debug)]
+pub struct UiArgs {
+    /// Port to serve the UI on.
+    #[arg(short = 'p', long, default_value_t = 59281)]
+    pub port: u16,
+
+    /// Dev mode: skip serving static files, use Vite dev server instead.
+    #[arg(long)]
+    pub dev: bool,
+
+    /// Do not open the browser automatically.
+    #[arg(long)]
+    pub no_open: bool,
 }
 
 #[cfg(test)]

--- a/mirrord/cli/src/error.rs
+++ b/mirrord/cli/src/error.rs
@@ -472,18 +472,6 @@ pub(crate) enum CliError {
     ))]
     AgentPodDeleted,
 
-    #[error(
-        "The target node `{node_name}` has no capacity for a new agent pod (currently running {pod_count} pods)"
-    )]
-    #[diagnostic(help(
-        "The Kubernetes node where the target pod runs has reached its pod limit. You can either:
-        1. Free up pod capacity on the node by deleting unused pods.
-        2. Use ephemeral containers instead, which do not count toward the node's pod limit.
-           Set `\"agent\": {{ \"ephemeral\": true }}` in your mirrord config file,
-           or set the environment variable MIRRORD_EPHEMERAL_CONTAINER=true.{GENERAL_HELP}"
-    ))]
-    NodeOutOfPods { node_name: String, pod_count: usize },
-
     #[error("Detected mirrord being run within mirrord")]
     #[diagnostic(help(
         "Running mirrord within mirrord is likely to fail or introduce severe slowness. \
@@ -575,8 +563,7 @@ pub(crate) enum CliError {
 
     #[error("A preview environment with key \"{key}\" already exists for target \"{target}\"")]
     #[diagnostic(help(
-        "Use `--force` to replace the existing session, \
-         `mirrord preview stop` to stop it first, \
+        "Use `mirrord preview stop` to stop the existing session first, \
          or choose a different key with `--key`."
     ))]
     PreviewDuplicateSession { key: String, target: String },
@@ -595,6 +582,17 @@ pub(crate) enum CliError {
         Please check that the target exists and has running pods.{GENERAL_HELP}"
     ))]
     RuntimeDataResolution(KubeApiError),
+
+    #[error("Invalid image reference: {0}")]
+    #[diagnostic(help(
+        "Image must be a valid OCI image reference (e.g. 'myregistry.io/myimage:tag')."
+    ))]
+    PreviewInvalidImage(String),
+
+    /// Errors produced by the `mirrord ui` command.
+    #[error("Session monitor UI error: {0}")]
+    #[diagnostic(help("Check that no other process is using the port and try again."))]
+    UiError(String),
 }
 
 impl CliError {
@@ -621,13 +619,6 @@ impl CliError {
                 Self::InvalidCertificate(error)
             }
             KubeApiError::AgentPodDeleted => Self::AgentPodDeleted,
-            KubeApiError::NodeOutOfPods {
-                node_name,
-                pod_count,
-            } => Self::NodeOutOfPods {
-                node_name,
-                pod_count,
-            },
             error => fallback(error),
         }
     }

--- a/mirrord/cli/src/error.rs
+++ b/mirrord/cli/src/error.rs
@@ -472,6 +472,18 @@ pub(crate) enum CliError {
     ))]
     AgentPodDeleted,
 
+    #[error(
+        "The target node `{node_name}` has no capacity for a new agent pod (currently running {pod_count} pods)"
+    )]
+    #[diagnostic(help(
+        "The Kubernetes node where the target pod runs has reached its pod limit. You can either:
+        1. Free up pod capacity on the node by deleting unused pods.
+        2. Use ephemeral containers instead, which do not count toward the node's pod limit.
+           Set `\"agent\": {{ \"ephemeral\": true }}` in your mirrord config file,
+           or set the environment variable MIRRORD_EPHEMERAL_CONTAINER=true.{GENERAL_HELP}"
+    ))]
+    NodeOutOfPods { node_name: String, pod_count: usize },
+
     #[error("Detected mirrord being run within mirrord")]
     #[diagnostic(help(
         "Running mirrord within mirrord is likely to fail or introduce severe slowness. \
@@ -563,7 +575,8 @@ pub(crate) enum CliError {
 
     #[error("A preview environment with key \"{key}\" already exists for target \"{target}\"")]
     #[diagnostic(help(
-        "Use `mirrord preview stop` to stop the existing session first, \
+        "Use `--force` to replace the existing session, \
+         `mirrord preview stop` to stop it first, \
          or choose a different key with `--key`."
     ))]
     PreviewDuplicateSession { key: String, target: String },
@@ -582,12 +595,6 @@ pub(crate) enum CliError {
         Please check that the target exists and has running pods.{GENERAL_HELP}"
     ))]
     RuntimeDataResolution(KubeApiError),
-
-    #[error("Invalid image reference: {0}")]
-    #[diagnostic(help(
-        "Image must be a valid OCI image reference (e.g. 'myregistry.io/myimage:tag')."
-    ))]
-    PreviewInvalidImage(String),
 
     /// Errors produced by the `mirrord ui` command.
     #[error("Session monitor UI error: {0}")]
@@ -619,6 +626,13 @@ impl CliError {
                 Self::InvalidCertificate(error)
             }
             KubeApiError::AgentPodDeleted => Self::AgentPodDeleted,
+            KubeApiError::NodeOutOfPods {
+                node_name,
+                pod_count,
+            } => Self::NodeOutOfPods {
+                node_name,
+                pod_count,
+            },
             error => fallback(error),
         }
     }

--- a/mirrord/cli/src/internal_proxy.rs
+++ b/mirrord/cli/src/internal_proxy.rs
@@ -23,11 +23,14 @@ use mirrord_config::LayerConfig;
 use mirrord_intproxy::{
     IntProxy,
     agent_conn::{AgentConnectInfo, AgentConnection},
+    session_monitor::MonitorTx,
 };
 use mirrord_protocol::{ClientMessage, DaemonMessage, LogLevel, LogMessage};
 #[cfg(not(target_os = "windows"))]
 use nix::sys::resource::{Resource, setrlimit};
 use tokio::net::TcpListener;
+#[cfg(unix)]
+use tokio_util::sync::CancellationToken;
 use tracing::Level;
 #[cfg(not(target_os = "windows"))]
 use tracing::warn;
@@ -132,6 +135,59 @@ pub(crate) async fn proxy(
     let process_logging_interval =
         Duration::from_secs(config.internal_proxy.process_logging_interval);
 
+    #[cfg(unix)]
+    let monitor_tx = if config.api {
+        let (tx, _rx) =
+            tokio::sync::broadcast::channel::<mirrord_intproxy::session_monitor::MonitorEvent>(256);
+        let proxy_monitor_tx = MonitorTx::from_sender(tx.clone());
+        let api_monitor_tx = MonitorTx::from_sender(tx);
+
+        let session_id =
+            env::var("MIRRORD_SESSION_ID").unwrap_or_else(|_| uuid::Uuid::new_v4().to_string());
+
+        let target_name = config
+            .target
+            .path
+            .as_ref()
+            .map(|t| t.to_string())
+            .unwrap_or_else(|| "unknown".to_owned());
+
+        let config_value = serde_json::to_value(&config).unwrap_or(serde_json::Value::Null);
+
+        let session_info = mirrord_intproxy::session_monitor::api::SessionInfo {
+            session_id: session_id.clone(),
+            target: target_name,
+            started_at: humantime::format_rfc3339(std::time::SystemTime::now()).to_string(),
+            mirrord_version: env!("CARGO_PKG_VERSION").to_owned(),
+            is_operator: config.operator.unwrap_or(false),
+            processes: Vec::new(),
+            config: config_value,
+            filter: None,
+        };
+
+        let shutdown = CancellationToken::new();
+
+        tokio::spawn(async move {
+            if let Err(error) = mirrord_intproxy::session_monitor::api::start_api_server(
+                session_info.session_id.clone(),
+                session_info,
+                api_monitor_tx,
+                shutdown,
+            )
+            .await
+            {
+                tracing::warn!(%error, "Session monitor API server failed");
+            }
+        });
+
+        proxy_monitor_tx
+    } else {
+        MonitorTx::disabled()
+    };
+
+    #[cfg(not(unix))]
+    let monitor_tx = MonitorTx::disabled();
+
     IntProxy::new_with_connection(
         agent_conn,
         listener,
@@ -145,7 +201,7 @@ pub(crate) async fn proxy(
             .unwrap_or_default(),
         process_logging_interval,
         &config.experimental,
-        mirrord_intproxy::session_monitor::MonitorTx::disabled(),
+        monitor_tx,
     )
     .run(first_connection_timeout, consecutive_connection_timeout)
     .await

--- a/mirrord/cli/src/internal_proxy.rs
+++ b/mirrord/cli/src/internal_proxy.rs
@@ -145,6 +145,7 @@ pub(crate) async fn proxy(
             .unwrap_or_default(),
         process_logging_interval,
         &config.experimental,
+        mirrord_intproxy::session_monitor::MonitorTx::disabled(),
     )
     .run(first_connection_timeout, consecutive_connection_timeout)
     .await

--- a/mirrord/cli/src/main.rs
+++ b/mirrord/cli/src/main.rs
@@ -325,6 +325,8 @@ mod wizard;
 
 mod fix;
 
+mod ui;
+
 pub(crate) use error::{CliError, CliResult};
 #[cfg(target_os = "windows")]
 use mirrord_layer_lib::process::windows::{console, execution::LayerManagedProcess};
@@ -1061,6 +1063,7 @@ fn main() -> miette::Result<()> {
                 .await?
             }
             Commands::Fix(args) => fix::fix_command(args).await?,
+            Commands::Ui(args) => ui::ui_command(args).await?,
         };
 
         Ok(())

--- a/mirrord/cli/src/port_forward.rs
+++ b/mirrord/cli/src/port_forward.rs
@@ -11,6 +11,7 @@ use mirrord_intproxy::{
     background_tasks::{BackgroundTasks, TaskError, TaskSender, TaskUpdate},
     main_tasks::{ProxyMessage, ToLayer},
     proxies::incoming::{IncomingProxy, IncomingProxyError, IncomingProxyMessage},
+    session_monitor::MonitorTx,
 };
 use mirrord_intproxy_protocol::{
     IncomingRequest, IncomingResponse, LayerId, PortSubscribe, PortSubscription,
@@ -499,6 +500,7 @@ impl ReversePortForwarder {
                     .clone()
                     .or_else(|| network_config.https_delivery.clone())
                     .unwrap_or_default(),
+                MonitorTx::disabled(),
             ),
             (),
             512,

--- a/mirrord/cli/src/ui.rs
+++ b/mirrord/cli/src/ui.rs
@@ -1,0 +1,608 @@
+//! # mirrord UI (Session Monitor)
+//!
+//! The `mirrord ui` command launches a web-based session monitor that aggregates events from all
+//! active mirrord sessions. It watches `~/.mirrord/sessions/` for Unix socket files, connects
+//! to each session's HTTP API, and serves a React frontend plus REST/SSE/WebSocket endpoints on
+//! localhost.
+//!
+//! This replaces the Node.js aggregator that was previously in `monitor-frontend/server.ts`.
+
+use std::{
+    collections::HashMap,
+    convert::Infallible,
+    net::{Ipv4Addr, SocketAddr},
+    path::PathBuf,
+    sync::Arc,
+    time::Duration,
+};
+
+use axum::{
+    Router,
+    extract::{
+        Path, State,
+        ws::{Message, WebSocket, WebSocketUpgrade},
+    },
+    http::{StatusCode, header},
+    response::{IntoResponse, Response, sse},
+    routing::{get, post},
+};
+use http_body_util::{BodyExt, Full};
+use hyper::body::Bytes;
+use hyper_util::rt::TokioIo;
+use mirrord_intproxy::session_monitor::api::SessionInfo;
+use notify::{EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use rust_embed::Embed;
+use serde::Serialize;
+use tokio::{
+    net::UnixStream,
+    sync::{RwLock, broadcast, mpsc},
+};
+use tokio_stream::wrappers::ReceiverStream;
+use tracing::{debug, error, info, warn};
+
+use crate::{config::UiArgs, error::CliError};
+
+/// Embedded frontend assets from the monitor-frontend dist directory.
+#[derive(Embed)]
+#[folder = "../../monitor-frontend/dist/"]
+struct FrontendAssets;
+
+/// Notification broadcast when sessions are added or removed.
+#[derive(Clone, Debug, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum SessionNotification {
+    SessionAdded { session: TrackedSession },
+    SessionRemoved { session_id: String },
+}
+
+/// A tracked session with its info and buffered events.
+#[derive(Clone, Debug)]
+struct TrackedSession {
+    session_id: String,
+    socket_path: PathBuf,
+    info: SessionInfo,
+    events: Vec<serde_json::Value>,
+}
+
+impl Serialize for TrackedSession {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.info.serialize(serializer)
+    }
+}
+
+/// Shared application state for the UI server.
+struct AppState {
+    sessions: RwLock<HashMap<String, TrackedSession>>,
+    notify_tx: broadcast::Sender<SessionNotification>,
+}
+
+/// Makes an HTTP request to a Unix socket and returns the response body as bytes.
+async fn unix_http_request(
+    socket_path: &std::path::Path,
+    method: &str,
+    path: &str,
+) -> Result<(StatusCode, Bytes), Box<dyn std::error::Error + Send + Sync>> {
+    let stream = UnixStream::connect(socket_path).await?;
+    let io = TokioIo::new(stream);
+
+    let (mut sender, conn) = hyper::client::conn::http1::handshake(io).await?;
+    tokio::spawn(async move {
+        if let Err(err) = conn.await {
+            debug!(?err, "Unix socket connection finished");
+        }
+    });
+
+    let req = hyper::Request::builder()
+        .method(method)
+        .uri(path)
+        .header("host", "localhost")
+        .body(Full::<Bytes>::new(Bytes::new()))?;
+
+    let resp = sender.send_request(req).await?;
+    let status = resp.status();
+    let body = resp.into_body().collect().await?.to_bytes();
+    Ok((status, body))
+}
+
+/// Fetches SessionInfo from a session's Unix socket.
+async fn fetch_session_info(
+    socket_path: &std::path::Path,
+) -> Result<SessionInfo, Box<dyn std::error::Error + Send + Sync>> {
+    let (_status, body) = unix_http_request(socket_path, "GET", "/info").await?;
+    let info: SessionInfo = serde_json::from_slice(&body)?;
+    Ok(info)
+}
+
+/// Connects to a session's SSE /events endpoint and buffers events into the shared state.
+async fn stream_session_events(session_id: String, socket_path: PathBuf, state: Arc<AppState>) {
+    let stream = match UnixStream::connect(&socket_path).await {
+        Ok(s) => s,
+        Err(err) => {
+            warn!(%session_id, ?err, "Failed to connect for SSE streaming");
+            return;
+        }
+    };
+    let io = TokioIo::new(stream);
+
+    let (mut sender, conn) = match hyper::client::conn::http1::handshake(io).await {
+        Ok(pair) => pair,
+        Err(err) => {
+            warn!(%session_id, ?err, "Handshake failed for SSE");
+            return;
+        }
+    };
+    tokio::spawn(async move {
+        if let Err(err) = conn.await {
+            debug!(?err, "SSE connection finished");
+        }
+    });
+
+    let req = match hyper::Request::builder()
+        .method("GET")
+        .uri("/events")
+        .header("host", "localhost")
+        .header("accept", "text/event-stream")
+        .body(Full::<Bytes>::new(Bytes::new()))
+    {
+        Ok(r) => r,
+        Err(err) => {
+            warn!(%session_id, ?err, "Failed to build SSE request");
+            return;
+        }
+    };
+
+    let resp = match sender.send_request(req).await {
+        Ok(r) => r,
+        Err(err) => {
+            warn!(%session_id, ?err, "SSE request failed");
+            return;
+        }
+    };
+
+    let mut body = resp.into_body();
+    let mut leftover = String::new();
+
+    loop {
+        match body.frame().await {
+            Some(Ok(frame)) => {
+                if let Ok(data) = frame.into_data() {
+                    leftover.push_str(&String::from_utf8_lossy(&data));
+                    while let Some(pos) = leftover.find("\n\n") {
+                        let chunk = leftover[..pos].to_owned();
+                        leftover = leftover[pos + 2..].to_owned();
+                        for line in chunk.lines() {
+                            if let Some(json_str) = line.strip_prefix("data:") {
+                                let json_str = json_str.trim();
+                                if let Ok(val) = serde_json::from_str::<serde_json::Value>(json_str)
+                                {
+                                    let mut sessions = state.sessions.write().await;
+                                    if let Some(session) = sessions.get_mut(&session_id) {
+                                        session.events.push(val);
+                                        if session.events.len() > 500 {
+                                            session.events.drain(..session.events.len() - 500);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            Some(Err(err)) => {
+                debug!(%session_id, ?err, "SSE stream error");
+                break;
+            }
+            None => {
+                debug!(%session_id, "SSE stream ended");
+                break;
+            }
+        }
+    }
+
+    // Session ended, clean up
+    info!(%session_id, "Session stream disconnected, removing");
+    let _ = std::fs::remove_file(&socket_path);
+    remove_session(&session_id, &state).await;
+}
+
+/// Scans for existing socket files and adds them as sessions.
+async fn scan_existing_sessions(sessions_dir: &std::path::Path, state: &Arc<AppState>) {
+    let entries = match std::fs::read_dir(sessions_dir) {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) == Some("sock") {
+            if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
+                let session_id = stem.to_owned();
+                add_session(session_id, path, state.clone()).await;
+            }
+        }
+    }
+}
+
+/// Adds a new session: fetches info, starts event streaming, and broadcasts notification.
+async fn add_session(session_id: String, socket_path: PathBuf, state: Arc<AppState>) {
+    {
+        let sessions = state.sessions.read().await;
+        if sessions.contains_key(&session_id) {
+            return;
+        }
+    }
+
+    let info = match fetch_session_info(&socket_path).await {
+        Ok(i) => i,
+        Err(err) => {
+            debug!(%session_id, ?err, "Could not fetch session info, removing stale socket");
+            let _ = std::fs::remove_file(&socket_path);
+            return;
+        }
+    };
+
+    let tracked = TrackedSession {
+        session_id: session_id.clone(),
+        socket_path: socket_path.clone(),
+        info,
+        events: Vec::new(),
+    };
+
+    let notification = SessionNotification::SessionAdded {
+        session: tracked.clone(),
+    };
+
+    {
+        let mut sessions = state.sessions.write().await;
+        sessions.insert(session_id.clone(), tracked);
+    }
+
+    let _ = state.notify_tx.send(notification);
+    info!(%session_id, "Session added");
+
+    tokio::spawn(stream_session_events(session_id, socket_path, state));
+}
+
+/// Removes a session and broadcasts a notification.
+async fn remove_session(session_id: &str, state: &Arc<AppState>) {
+    let removed = {
+        let mut sessions = state.sessions.write().await;
+        sessions.remove(session_id)
+    };
+
+    if removed.is_some() {
+        let _ = state.notify_tx.send(SessionNotification::SessionRemoved {
+            session_id: session_id.to_owned(),
+        });
+        info!(%session_id, "Session removed");
+    }
+}
+
+/// Helper to build a JSON value for a session, including session_id at the top level.
+fn session_to_json(session: &TrackedSession) -> serde_json::Value {
+    let mut val = serde_json::to_value(&session.info).unwrap_or_default();
+    if let Some(obj) = val.as_object_mut() {
+        obj.insert(
+            "session_id".to_owned(),
+            serde_json::Value::String(session.session_id.clone()),
+        );
+    }
+    val
+}
+
+// --- HTTP Handlers ---
+
+/// GET /api/sessions
+async fn list_sessions(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    let sessions = state.sessions.read().await;
+    let list: Vec<serde_json::Value> = sessions.values().map(session_to_json).collect();
+    axum::Json(list)
+}
+
+/// GET /api/sessions/:id
+async fn get_session(State(state): State<Arc<AppState>>, Path(id): Path<String>) -> Response {
+    let sessions = state.sessions.read().await;
+    match sessions.get(&id) {
+        Some(session) => axum::Json(session_to_json(session)).into_response(),
+        None => StatusCode::NOT_FOUND.into_response(),
+    }
+}
+
+/// GET /api/sessions/:id/events - SSE proxy. Flushes buffered events first, then streams live.
+async fn session_events_sse(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+) -> Response {
+    let (buffered_events, socket_path) = {
+        let sessions = state.sessions.read().await;
+        match sessions.get(&id) {
+            Some(session) => (session.events.clone(), session.socket_path.clone()),
+            None => return StatusCode::NOT_FOUND.into_response(),
+        }
+    };
+
+    let (tx, rx) = mpsc::channel::<Result<sse::Event, Infallible>>(256);
+
+    tokio::spawn(async move {
+        // Flush buffered events
+        for event in buffered_events {
+            let data = serde_json::to_string(&event).unwrap_or_default();
+            if tx.send(Ok(sse::Event::default().data(data))).await.is_err() {
+                return;
+            }
+        }
+
+        // Open live SSE connection to the session socket
+        let stream = match UnixStream::connect(&socket_path).await {
+            Ok(s) => s,
+            Err(err) => {
+                warn!(?err, "Failed to connect to session socket for SSE proxy");
+                return;
+            }
+        };
+        let io = TokioIo::new(stream);
+
+        let (mut sender, conn) = match hyper::client::conn::http1::handshake(io).await {
+            Ok(pair) => pair,
+            Err(err) => {
+                warn!(?err, "Handshake failed for SSE proxy");
+                return;
+            }
+        };
+        tokio::spawn(async move {
+            let _ = conn.await;
+        });
+
+        let req = match hyper::Request::builder()
+            .method("GET")
+            .uri("/events")
+            .header("host", "localhost")
+            .header("accept", "text/event-stream")
+            .body(Full::<Bytes>::new(Bytes::new()))
+        {
+            Ok(r) => r,
+            Err(_) => return,
+        };
+
+        let resp = match sender.send_request(req).await {
+            Ok(r) => r,
+            Err(_) => return,
+        };
+
+        let mut body = resp.into_body();
+        let mut leftover = String::new();
+
+        loop {
+            match body.frame().await {
+                Some(Ok(frame)) => {
+                    if let Ok(data) = frame.into_data() {
+                        leftover.push_str(&String::from_utf8_lossy(&data));
+                        while let Some(pos) = leftover.find("\n\n") {
+                            let chunk = leftover[..pos].to_owned();
+                            leftover = leftover[pos + 2..].to_owned();
+                            for line in chunk.lines() {
+                                if let Some(json_str) = line.strip_prefix("data:") {
+                                    let json_str = json_str.trim();
+                                    if tx
+                                        .send(Ok(sse::Event::default().data(json_str.to_owned())))
+                                        .await
+                                        .is_err()
+                                    {
+                                        return;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                Some(Err(_)) | None => break,
+            }
+        }
+    });
+
+    sse::Sse::new(ReceiverStream::new(rx))
+        .keep_alive(
+            sse::KeepAlive::new()
+                .interval(Duration::from_secs(15))
+                .text("ping"),
+        )
+        .into_response()
+}
+
+/// POST /api/sessions/:id/kill
+async fn kill_session(State(state): State<Arc<AppState>>, Path(id): Path<String>) -> Response {
+    let socket_path = {
+        let sessions = state.sessions.read().await;
+        match sessions.get(&id) {
+            Some(session) => session.socket_path.clone(),
+            None => return StatusCode::NOT_FOUND.into_response(),
+        }
+    };
+
+    match unix_http_request(&socket_path, "POST", "/kill").await {
+        Ok((_status, body)) => {
+            let val: serde_json::Value =
+                serde_json::from_slice(&body).unwrap_or(serde_json::json!({"status": "ok"}));
+            axum::Json(val).into_response()
+        }
+        Err(err) => {
+            error!(?err, "Failed to proxy kill request");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                axum::Json(serde_json::json!({"error": err.to_string()})),
+            )
+                .into_response()
+        }
+    }
+}
+
+/// WebSocket handler: sends all current sessions on connect, then forwards notifications.
+async fn ws_handler(ws: WebSocketUpgrade, State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    ws.on_upgrade(|socket| ws_connection(socket, state))
+}
+
+async fn ws_connection(mut socket: WebSocket, state: Arc<AppState>) {
+    {
+        let sessions = state.sessions.read().await;
+        for session in sessions.values() {
+            let notification = SessionNotification::SessionAdded {
+                session: session.clone(),
+            };
+            let msg = serde_json::to_string(&notification).unwrap_or_default();
+            if socket.send(Message::Text(msg.into())).await.is_err() {
+                return;
+            }
+        }
+    }
+
+    let mut rx = state.notify_tx.subscribe();
+    loop {
+        match rx.recv().await {
+            Ok(notification) => {
+                let msg = serde_json::to_string(&notification).unwrap_or_default();
+                if socket.send(Message::Text(msg.into())).await.is_err() {
+                    break;
+                }
+            }
+            Err(broadcast::error::RecvError::Lagged(n)) => {
+                warn!(n, "WebSocket client lagged, dropped messages");
+            }
+            Err(broadcast::error::RecvError::Closed) => break,
+        }
+    }
+}
+
+/// Returns the MIME type for a file path based on its extension.
+fn guess_mime(path: &str) -> &'static str {
+    match path.rsplit('.').next() {
+        Some("html") => "text/html",
+        Some("js") | Some("mjs") => "application/javascript",
+        Some("css") => "text/css",
+        Some("json") => "application/json",
+        Some("png") => "image/png",
+        Some("svg") => "image/svg+xml",
+        Some("ico") => "image/x-icon",
+        Some("woff") => "font/woff",
+        Some("woff2") => "font/woff2",
+        Some("ttf") => "font/ttf",
+        Some("map") => "application/json",
+        _ => "application/octet-stream",
+    }
+}
+
+/// Serves embedded static files with SPA fallback to index.html.
+async fn static_handler(uri: axum::http::Uri) -> impl IntoResponse {
+    let path = uri.path().trim_start_matches('/');
+
+    if let Some(file) = FrontendAssets::get(path) {
+        let mime = guess_mime(path);
+        return ([(header::CONTENT_TYPE, mime)], file.data.to_vec()).into_response();
+    }
+
+    // SPA fallback
+    match FrontendAssets::get("index.html") {
+        Some(file) => ([(header::CONTENT_TYPE, "text/html")], file.data.to_vec()).into_response(),
+        None => StatusCode::NOT_FOUND.into_response(),
+    }
+}
+
+/// Entrypoint for the `mirrord ui` command.
+pub async fn ui_command(args: UiArgs) -> Result<(), CliError> {
+    let sessions_dir = home::home_dir()
+        .ok_or_else(|| CliError::UiError("could not determine home directory".to_owned()))?
+        .join(".mirrord")
+        .join("sessions");
+
+    std::fs::create_dir_all(&sessions_dir)
+        .map_err(|e| CliError::UiError(format!("failed to create sessions directory: {e}")))?;
+
+    let (notify_tx, _) = broadcast::channel::<SessionNotification>(256);
+
+    let state = Arc::new(AppState {
+        sessions: RwLock::new(HashMap::new()),
+        notify_tx,
+    });
+
+    scan_existing_sessions(&sessions_dir, &state).await;
+
+    // Set up filesystem watcher
+    let watcher_state = state.clone();
+    let (watcher_tx, mut watcher_rx) = mpsc::channel::<notify::Event>(100);
+
+    let mut watcher: RecommendedWatcher =
+        notify::recommended_watcher(move |res: Result<notify::Event, notify::Error>| {
+            if let Ok(event) = res {
+                let _ = watcher_tx.blocking_send(event);
+            }
+        })
+        .map_err(|e| CliError::UiError(format!("failed to create file watcher: {e}")))?;
+
+    watcher
+        .watch(&sessions_dir, RecursiveMode::NonRecursive)
+        .map_err(|e| CliError::UiError(format!("failed to watch sessions directory: {e}")))?;
+
+    tokio::spawn(async move {
+        let _watcher = watcher;
+        while let Some(event) = watcher_rx.recv().await {
+            for path in &event.paths {
+                if path.extension().and_then(|e| e.to_str()) != Some("sock") {
+                    continue;
+                }
+
+                let session_id = match path.file_stem().and_then(|s| s.to_str()) {
+                    Some(s) => s.to_owned(),
+                    None => continue,
+                };
+
+                match event.kind {
+                    EventKind::Create(_) => {
+                        tokio::time::sleep(Duration::from_millis(100)).await;
+                        add_session(session_id, path.clone(), watcher_state.clone()).await;
+                    }
+                    EventKind::Remove(_) => {
+                        remove_session(&session_id, &watcher_state).await;
+                    }
+                    _ => {}
+                }
+            }
+        }
+    });
+
+    let api_routes = Router::new()
+        .route("/sessions", get(list_sessions))
+        .route("/sessions/{id}", get(get_session))
+        .route("/sessions/{id}/events", get(session_events_sse))
+        .route("/sessions/{id}/kill", post(kill_session));
+
+    let mut app = Router::new()
+        .nest("/api", api_routes)
+        .route("/ws", get(ws_handler))
+        .with_state(state.clone());
+
+    if args.dev {
+        println!("Dev mode: not serving static files.");
+        println!("Run `npm run dev` in monitor-frontend/ for the frontend.");
+    } else {
+        app = app.fallback(static_handler);
+    }
+
+    let addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), args.port);
+    let listener = tokio::net::TcpListener::bind(&addr)
+        .await
+        .map_err(|e| CliError::UiError(format!("failed to bind to {addr}: {e}")))?;
+
+    let url = format!("http://127.0.0.1:{}", args.port);
+    println!("mirrord session monitor: {url}");
+
+    if !args.no_open && !args.dev {
+        if let Err(err) = opener::open(&url) {
+            warn!(?err, "Failed to open browser");
+        }
+    }
+
+    axum::serve(listener, app)
+        .await
+        .map_err(|e| CliError::UiError(format!("server error: {e}")))?;
+
+    Ok(())
+}

--- a/mirrord/config/src/lib.rs
+++ b/mirrord/config/src/lib.rs
@@ -274,6 +274,17 @@ pub struct LayerConfig {
     #[config(env = "MIRRORD_OPERATOR_ENABLE")]
     pub operator: Option<bool>,
 
+    /// ## api {#root-api}
+    ///
+    /// Enables the local session monitor API server.
+    ///
+    /// When enabled, mirrord exposes a Unix socket at `~/.mirrord/sessions/<session-id>.sock`
+    /// with HTTP endpoints for observing session activity in real time.
+    ///
+    /// Defaults to `true`.
+    #[config(default = true, env = "MIRRORD_API")]
+    pub api: bool,
+
     /// ## profile {#root-profile}
     ///
     /// Name of the mirrord profile to use.

--- a/mirrord/intproxy/Cargo.toml
+++ b/mirrord/intproxy/Cargo.toml
@@ -48,6 +48,11 @@ tokio-retry.workspace = true
 tokio-rustls.workspace = true
 tokio-util.workspace = true
 
+[target.'cfg(unix)'.dependencies]
+axum = "0.8.4"
+serde_json.workspace = true
+home.workspace = true
+
 [dev-dependencies]
 rcgen.workspace = true
 rstest.workspace = true

--- a/mirrord/intproxy/src/lib.rs
+++ b/mirrord/intproxy/src/lib.rs
@@ -43,6 +43,7 @@ use crate::{
     error::{ProxyRuntimeError, ProxyStartupError},
     failover_strategy::FailoverStrategy,
     main_tasks::{ConnectionRefresh, LayerClosed},
+    session_monitor::MonitorTx,
 };
 
 pub mod agent_conn;
@@ -56,6 +57,7 @@ pub mod ping_pong;
 pub mod proxies;
 mod remote_resources;
 mod request_queue;
+pub mod session_monitor;
 
 /// [`TaskSender`]s for main background tasks. See [`MainTaskId`].
 struct TaskTxs {
@@ -102,6 +104,9 @@ pub struct IntProxy {
 
     /// Send handle for the agent connection
     agent_tx: TxHandle<Client>,
+
+    /// Session monitor event sender
+    monitor_tx: MonitorTx,
 }
 
 impl IntProxy {
@@ -125,6 +130,7 @@ impl IntProxy {
         https_delivery: LocalTlsDelivery,
         process_logging_interval: Duration,
         experimental: &ExperimentalConfig,
+        monitor_tx: MonitorTx,
     ) -> Self {
         let mut background_tasks: BackgroundTasks<MainTaskId, ProxyMessage, ProxyRuntimeError> =
             BackgroundTasks::new(agent_conn.connection.tx_handle());
@@ -218,6 +224,7 @@ impl IntProxy {
             connected_layers: HashMap::new(),
             process_logging_interval,
             agent_tx,
+            monitor_tx,
         }
     }
 
@@ -764,7 +771,7 @@ mod test {
     };
 
     use crate::{
-        IntProxy,
+        IntProxy, MonitorTx,
         agent_conn::{
             AgentConnectInfo, AgentConnectInfoDiscriminants, AgentConnection, ReconnectFlow,
         },
@@ -799,6 +806,7 @@ mod test {
             &ExperimentalFileConfig::default()
                 .generate_config(&mut Default::default())
                 .unwrap(),
+            MonitorTx::disabled(),
         );
         let proxy_handle = tokio::spawn(proxy.run(Duration::from_secs(60), Duration::ZERO));
 
@@ -917,6 +925,7 @@ mod test {
             &ExperimentalFileConfig::default()
                 .generate_config(&mut Default::default())
                 .unwrap(),
+            MonitorTx::disabled(),
         );
         let proxy_handle = tokio::spawn(proxy.run(Duration::from_secs(60), Duration::ZERO));
 
@@ -1010,6 +1019,7 @@ mod test {
             &ExperimentalFileConfig::default()
                 .generate_config(&mut Default::default())
                 .unwrap(),
+            MonitorTx::disabled(),
         );
         tokio::time::timeout(
             Duration::from_millis(200),
@@ -1081,6 +1091,7 @@ mod test {
             &ExperimentalFileConfig::default()
                 .generate_config(&mut Default::default())
                 .unwrap(),
+            MonitorTx::disabled(),
         );
         tokio::spawn(proxy.run(Duration::from_millis(100), Duration::ZERO));
 

--- a/mirrord/intproxy/src/lib.rs
+++ b/mirrord/intproxy/src/lib.rs
@@ -17,7 +17,8 @@ use mirrord_config::{
     experimental::ExperimentalConfig, feature::network::incoming::tls_delivery::LocalTlsDelivery,
 };
 use mirrord_intproxy_protocol::{
-    IncomingRequest, LayerId, LayerToProxyMessage, LocalMessage, MessageId, ProcessInfo,
+    IncomingRequest, LayerId, LayerToProxyMessage, LocalMessage, MessageId, OutgoingRequest,
+    ProcessInfo,
 };
 use mirrord_protocol::{
     CLIENT_READY_FOR_LOGS, ClientMessage, DaemonMessage, FileRequest, LogLevel,
@@ -43,7 +44,7 @@ use crate::{
     error::{ProxyRuntimeError, ProxyStartupError},
     failover_strategy::FailoverStrategy,
     main_tasks::{ConnectionRefresh, LayerClosed},
-    session_monitor::MonitorTx,
+    session_monitor::{MonitorEvent, MonitorTx},
 };
 
 pub mod agent_conn;
@@ -58,6 +59,52 @@ pub mod proxies;
 mod remote_resources;
 mod request_queue;
 pub mod session_monitor;
+
+/// Returns a short string describing the type of file operation.
+fn file_request_operation_name(req: &FileRequest) -> &'static str {
+    match req {
+        FileRequest::Open(..) | FileRequest::OpenRelative(..) => "open",
+        FileRequest::Read(..) | FileRequest::ReadLimited(..) => "read",
+        FileRequest::Seek(..) => "seek",
+        FileRequest::Write(..) | FileRequest::WriteLimited(..) => "write",
+        FileRequest::Close(..) => "close",
+        FileRequest::Access(..) => "access",
+        FileRequest::Xstat(..) | FileRequest::XstatFs(..) | FileRequest::XstatFsV2(..) => "stat",
+        FileRequest::FdOpenDir(..) => "opendir",
+        FileRequest::ReadDir(..) | FileRequest::ReadDirBatch(..) => "readdir",
+        FileRequest::CloseDir(..) => "closedir",
+        FileRequest::GetDEnts64(..) => "getdents64",
+        FileRequest::ReadLink(..) => "readlink",
+        FileRequest::MakeDir(..) | FileRequest::MakeDirAt(..) => "mkdir",
+        FileRequest::RemoveDir(..) => "rmdir",
+        FileRequest::Unlink(..) | FileRequest::UnlinkAt(..) => "unlink",
+        FileRequest::StatFs(..) | FileRequest::StatFsV2(..) => "statfs",
+        FileRequest::Rename(..) => "rename",
+        FileRequest::Ftruncate(..) => "ftruncate",
+        FileRequest::Futimens(..) => "futimens",
+        FileRequest::Fchown(..) => "fchown",
+        FileRequest::Fchmod(..) => "fchmod",
+    }
+}
+
+fn file_request_path(req: &FileRequest) -> Option<String> {
+    match req {
+        FileRequest::Open(r) => Some(r.path.to_string_lossy().into_owned()),
+        FileRequest::OpenRelative(r) => Some(r.path.to_string_lossy().into_owned()),
+        FileRequest::Access(r) => Some(r.pathname.to_string_lossy().into_owned()),
+        FileRequest::Xstat(r) => r.path.as_ref().map(|p| p.to_string_lossy().into_owned()),
+        FileRequest::ReadLink(r) => Some(r.path.to_string_lossy().into_owned()),
+        FileRequest::MakeDir(r) => Some(r.pathname.to_string_lossy().into_owned()),
+        FileRequest::MakeDirAt(r) => Some(r.pathname.to_string_lossy().into_owned()),
+        FileRequest::RemoveDir(r) => Some(r.pathname.to_string_lossy().into_owned()),
+        FileRequest::Unlink(r) => Some(r.pathname.to_string_lossy().into_owned()),
+        FileRequest::UnlinkAt(r) => Some(r.pathname.to_string_lossy().into_owned()),
+        FileRequest::StatFs(r) => Some(r.path.to_string_lossy().into_owned()),
+        FileRequest::StatFsV2(r) => Some(r.path.to_string_lossy().into_owned()),
+        FileRequest::Rename(r) => Some(r.old_path.to_string_lossy().into_owned()),
+        _ => None,
+    }
+}
 
 /// [`TaskSender`]s for main background tasks. See [`MainTaskId`].
 struct TaskTxs {
@@ -171,6 +218,7 @@ impl IntProxy {
                 experimental.non_blocking_tcp_connect.unwrap_or_default(),
                 experimental.latency.receive_delay,
                 experimental.latency.transmit_delay,
+                monitor_tx.clone(),
             ),
             MainTaskId::OutgoingProxy,
             Self::CHANNEL_SIZE,
@@ -179,6 +227,7 @@ impl IntProxy {
             IncomingProxy::new(
                 Duration::from_millis(experimental.idle_local_http_connection_timeout),
                 https_delivery,
+                monitor_tx.clone(),
             ),
             MainTaskId::IncomingProxy,
             Self::CHANNEL_SIZE,
@@ -349,6 +398,9 @@ impl IntProxy {
             ProxyMessage::NewLayer(new_layer) => {
                 self.any_connection_accepted = true;
 
+                self.monitor_tx.emit(MonitorEvent::LayerConnected {
+                    pid: new_layer.process_info.pid as u32,
+                });
                 self.connected_layers
                     .insert(new_layer.id, new_layer.process_info);
                 let tx = self.background_tasks.register(
@@ -426,6 +478,8 @@ impl IntProxy {
                         tracing::error!(layer_id = id, %error, "Layer connection failed");
                     }
                 }
+
+                self.monitor_tx.emit(MonitorEvent::LayerDisconnected);
 
                 let msg = LayerClosed { id: LayerId(id) };
 
@@ -610,24 +664,44 @@ impl IntProxy {
 
         match message {
             LayerToProxyMessage::File(req) => {
+                self.monitor_tx.emit(MonitorEvent::FileOp {
+                    path: file_request_path(&req),
+                    operation: file_request_operation_name(&req).to_owned(),
+                });
                 self.task_txs
                     .files
                     .send(FilesProxyMessage::FileReq(message_id, layer_id, req))
                     .await;
             }
             LayerToProxyMessage::GetAddrInfo(req) => {
+                self.monitor_tx.emit(MonitorEvent::DnsQuery {
+                    host: req.node.clone(),
+                });
                 self.task_txs
                     .simple
                     .send(SimpleProxyMessage::AddrInfoReq(message_id, layer_id, req))
                     .await
             }
             LayerToProxyMessage::Outgoing(req) => {
+                if let OutgoingRequest::Connect(ref connect_req) = req {
+                    let port = connect_req.remote_address.get_port().unwrap_or(0);
+                    self.monitor_tx.emit(MonitorEvent::OutgoingConnection {
+                        address: format!("{}", connect_req.remote_address),
+                        port,
+                    });
+                }
                 self.task_txs
                     .outgoing
                     .send(OutgoingProxyMessage::Layer(req, message_id, layer_id))
                     .await
             }
             LayerToProxyMessage::Incoming(req) => {
+                if let IncomingRequest::PortSubscribe(ref sub) = req {
+                    self.monitor_tx.emit(MonitorEvent::PortSubscription {
+                        port: sub.listening_on.port(),
+                        mode: format!("{:?}", sub.subscription),
+                    });
+                }
                 self.task_txs
                     .incoming
                     .send(IncomingProxyMessage::LayerRequest(
@@ -636,6 +710,14 @@ impl IntProxy {
                     .await
             }
             LayerToProxyMessage::GetEnv(req) => {
+                self.monitor_tx.emit(MonitorEvent::EnvVar {
+                    vars: req
+                        .env_vars_select
+                        .iter()
+                        .chain(req.env_vars_filter.iter())
+                        .cloned()
+                        .collect(),
+                });
                 self.task_txs
                     .simple
                     .send(SimpleProxyMessage::GetEnvReq(message_id, layer_id, req))

--- a/mirrord/intproxy/src/proxies/incoming.rs
+++ b/mirrord/intproxy/src/proxies/incoming.rs
@@ -7,7 +7,7 @@
 //! 2. HttpSender -
 
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     io,
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
     ops::Not,
@@ -49,7 +49,22 @@ use crate::{
         BackgroundTask, BackgroundTasks, MessageBus, TaskError, TaskSender, TaskUpdate,
     },
     main_tasks::{ConnectionRefresh, LayerClosed, LayerForked, ToLayer},
+    session_monitor::{MonitorEvent, MonitorTx, try_parse_http_request},
 };
+
+/// Extracts method, path, and host from an [`InternalHttpRequest`] and emits
+/// a [`MonitorEvent::IncomingRequest`].
+fn emit_incoming_request_event<B>(monitor_tx: &MonitorTx, req: &InternalHttpRequest<B>) {
+    let method = req.method.to_string();
+    let path = req.uri.path().to_owned();
+    let host = req
+        .headers
+        .get("host")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("")
+        .to_owned();
+    monitor_tx.emit(MonitorEvent::IncomingRequest { method, path, host });
+}
 
 mod bound_socket;
 pub mod http;
@@ -205,6 +220,12 @@ pub struct IncomingProxy {
     protocol_version: Option<Version>,
 
     restore_subscriptions_on_protocol_version_switch: bool,
+
+    /// Session monitor event sender.
+    monitor_tx: MonitorTx,
+
+    /// Connection IDs whose first data chunk we haven't sniffed yet for HTTP.
+    http_sniff_pending: HashSet<ConnectionId>,
 }
 
 impl IncomingProxy {
@@ -214,6 +235,7 @@ impl IncomingProxy {
     pub fn new(
         idle_local_http_connection_timeout: Duration,
         https_delivery: LocalTlsDelivery,
+        monitor_tx: MonitorTx,
     ) -> Self {
         let tls_setup = LocalTlsSetup::from_config(https_delivery);
         Self {
@@ -230,6 +252,8 @@ impl IncomingProxy {
             tasks: None,
             protocol_version: None,
             restore_subscriptions_on_protocol_version_switch: false,
+            monitor_tx,
+            http_sniff_pending: Default::default(),
         }
     }
 
@@ -421,6 +445,7 @@ impl IncomingProxy {
     ) {
         match request {
             ChunkedRequest::StartV1(request) => {
+                emit_incoming_request_event(&self.monitor_tx, &request.internal_request);
                 let (body_tx, body_rx) = mpsc::channel(128);
                 let request = request.map_body(|frames| StreamingBody::new(body_rx, frames));
                 self.start_http_gateway(
@@ -434,6 +459,8 @@ impl IncomingProxy {
             }
 
             ChunkedRequest::StartV2(request) => {
+                emit_incoming_request_event(&self.monitor_tx, &request.request);
+
                 let (body, body_tx) = if request.request.body.is_last {
                     (StreamingBody::from(request.request.body.frames), None)
                 } else {
@@ -575,6 +602,14 @@ impl IncomingProxy {
             }
 
             DaemonTcp::Data(data) => {
+                // Sniff first data chunk of each new connection for HTTP.
+                if self.http_sniff_pending.remove(&data.connection_id)
+                    && let Some((method, path, host)) = try_parse_http_request(&data.bytes)
+                {
+                    self.monitor_tx
+                        .emit(MonitorEvent::IncomingRequest { method, path, host });
+                }
+
                 let tx = self.tcp_proxies.get(is_steal).get(&data.connection_id);
 
                 if let Some(tx) = tx {
@@ -590,6 +625,7 @@ impl IncomingProxy {
             }
 
             DaemonTcp::HttpRequest(request) => {
+                emit_incoming_request_event(&self.monitor_tx, &request.internal_request);
                 self.start_http_gateway(
                     request.map_body(From::from),
                     None,
@@ -601,6 +637,7 @@ impl IncomingProxy {
             }
 
             DaemonTcp::HttpRequestFramed(request) => {
+                emit_incoming_request_event(&self.monitor_tx, &request.internal_request);
                 self.start_http_gateway(
                     request.map_body(From::from),
                     None,
@@ -617,6 +654,7 @@ impl IncomingProxy {
             }
 
             DaemonTcp::NewConnectionV1(connection) => {
+                self.http_sniff_pending.insert(connection.connection_id);
                 self.handle_new_connection(
                     NewTcpConnectionV2 {
                         connection,
@@ -629,6 +667,8 @@ impl IncomingProxy {
             }
 
             DaemonTcp::NewConnectionV2(connection) => {
+                self.http_sniff_pending
+                    .insert(connection.connection.connection_id);
                 self.handle_new_connection(connection, is_steal, message_bus)
                     .await?;
             }

--- a/mirrord/intproxy/src/proxies/incoming/tests.rs
+++ b/mirrord/intproxy/src/proxies/incoming/tests.rs
@@ -62,7 +62,11 @@ async fn http_request_terminates_on_remote_close(#[case] steal_type: StealType) 
     let local_addr = local_listener.local_addr().unwrap();
 
     let (conn, _, out) = Connection::dummy();
-    let proxy = IncomingProxy::new(Duration::from_secs(3), Default::default());
+    let proxy = IncomingProxy::new(
+        Duration::from_secs(3),
+        Default::default(),
+        crate::session_monitor::MonitorTx::disabled(),
+    );
     let mut background_tasks: BackgroundTasks<(), ProxyMessage, IncomingProxyError> =
         BackgroundTasks::new(conn.tx_handle());
 

--- a/mirrord/intproxy/src/proxies/outgoing.rs
+++ b/mirrord/intproxy/src/proxies/outgoing.rs
@@ -36,6 +36,7 @@ use crate::{
     proxies::outgoing::net_protocol_ext::{NetProtocolExt, PreparedSocket},
     remote_resources::RemoteResources,
     request_queue::RequestQueue,
+    session_monitor::{MonitorEvent, MonitorTx, try_parse_http_request},
 };
 
 mod interceptor;
@@ -209,6 +210,13 @@ pub struct OutgoingProxy {
     connections_in_layers: RemoteResources<u128>,
     /// Maps outgoing connection local IDs to local addresses of corresponding agent sockets.
     agent_local_addresses: HashMap<u128, SocketAddr>,
+
+    /// Session monitor event sender.
+    monitor_tx: MonitorTx,
+    /// TCP connections that have not yet sent their first bytes to the agent.
+    /// Used to sniff HTTP requests from the first data chunk.
+    /// Stores the remote address so we can report the port in the event.
+    http_sniff_pending: HashMap<InterceptorId, SocketAddress>,
 }
 
 impl OutgoingProxy {
@@ -226,6 +234,7 @@ impl OutgoingProxy {
         non_blocking_tcp_connect: bool,
         receive_delay_ms: u64,
         transmit_delay_ms: u64,
+        monitor_tx: MonitorTx,
     ) -> Self {
         Self {
             datagrams_reqs: Default::default(),
@@ -239,6 +248,8 @@ impl OutgoingProxy {
             transmit_delay_ms,
             connections_in_layers: Default::default(),
             agent_local_addresses: Default::default(),
+            monitor_tx,
+            http_sniff_pending: Default::default(),
         }
     }
 
@@ -409,6 +420,12 @@ impl OutgoingProxy {
             Self::CHANNEL_SIZE,
         );
         self.txs.insert(id, interceptor);
+
+        // Register for HTTP sniffing on TCP connections.
+        if protocol == NetProtocol::Stream {
+            self.http_sniff_pending
+                .insert(id, in_progress.remote_address);
+        }
 
         Ok(())
     }
@@ -680,6 +697,24 @@ impl BackgroundTask for OutgoingProxy {
                             tokio::time::sleep(std::time::Duration::from_millis(self.transmit_delay_ms)).await;
                         }
 
+                        // On the first non-empty data chunk from a TCP connection, try to
+                        // detect an HTTP/1.x request and emit a monitor event.
+                        if !bytes.is_empty()
+                            && let Some(remote_addr) = self.http_sniff_pending.remove(&id)
+                            && let Some((method, path, host)) = try_parse_http_request(&bytes)
+                        {
+                            let port = match &remote_addr {
+                                SocketAddress::Ip(addr) => addr.port(),
+                                _ => 0,
+                            };
+                            self.monitor_tx.emit(MonitorEvent::HttpRequest {
+                                method,
+                                path,
+                                host,
+                                port,
+                            });
+                        }
+
                         let msg = id.protocol.wrap_agent_write(id.connection_id, bytes);
                         message_bus.send_agent(msg).await;
                     }
@@ -693,6 +728,8 @@ impl BackgroundTask for OutgoingProxy {
                                 tracing::error!(%id, "Interceptor panicked");
                             }
                         }
+
+                        self.http_sniff_pending.remove(&id);
 
                         if self.txs.remove(&id).is_some() {
                             tracing::trace!(%id, "Local connection closed, notifying the agent");
@@ -725,6 +762,7 @@ mod test {
     use mirrord_protocol_io::Connection;
 
     use crate::{
+        MonitorTx,
         background_tasks::{BackgroundTasks, TaskUpdate},
         main_tasks::{ConnectionRefresh, ProxyMessage, ToLayer},
         proxies::outgoing::{OutgoingProxy, OutgoingProxyError, OutgoingProxyMessage},
@@ -739,7 +777,11 @@ mod test {
 
         let mut background_tasks: BackgroundTasks<(), ProxyMessage, OutgoingProxyError> =
             BackgroundTasks::new(connection.tx_handle());
-        let outgoing = background_tasks.register(OutgoingProxy::new(false, 0, 0), (), 8);
+        let outgoing = background_tasks.register(
+            OutgoingProxy::new(false, 0, 0, MonitorTx::disabled()),
+            (),
+            8,
+        );
 
         for i in 0..=1 {
             // Layer wants to make an outgoing connection.

--- a/mirrord/intproxy/src/session_monitor/api.rs
+++ b/mirrord/intproxy/src/session_monitor/api.rs
@@ -1,0 +1,144 @@
+use std::{
+    convert::Infallible, fs, os::unix::fs::PermissionsExt, path::PathBuf, sync::Arc, time::Duration,
+};
+
+use axum::{
+    Json, Router,
+    extract::State,
+    response::{
+        IntoResponse,
+        sse::{Event, Sse},
+    },
+    routing::{get, post},
+};
+use serde::{Deserialize, Serialize};
+use tokio::net::UnixListener;
+use tokio_stream::{StreamExt, wrappers::BroadcastStream};
+use tokio_util::sync::CancellationToken;
+
+use super::MonitorTx;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ProcessInfo {
+    pub pid: u32,
+    pub process_name: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SessionInfo {
+    pub session_id: String,
+    pub target: String,
+    pub started_at: String,
+    pub mirrord_version: String,
+    pub is_operator: bool,
+    pub processes: Vec<ProcessInfo>,
+    pub config: serde_json::Value,
+    pub filter: Option<String>,
+}
+
+struct AppState {
+    session_info: SessionInfo,
+    monitor_tx: MonitorTx,
+    shutdown: CancellationToken,
+}
+
+/// Drop guard that removes the socket file on cleanup.
+struct SocketCleanup {
+    path: PathBuf,
+}
+
+impl Drop for SocketCleanup {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.path);
+    }
+}
+
+async fn health() -> impl IntoResponse {
+    Json(serde_json::json!({"status": "ok"}))
+}
+
+async fn info(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    Json(state.session_info.clone())
+}
+
+async fn events(
+    State(state): State<Arc<AppState>>,
+) -> Sse<impl tokio_stream::Stream<Item = Result<Event, Infallible>>> {
+    let rx = state
+        .monitor_tx
+        .subscribe()
+        .expect("monitor_tx should be enabled when API server is running");
+
+    let stream = BroadcastStream::new(rx).filter_map(|result| match result {
+        Ok(event) => {
+            let data = serde_json::to_string(&event).unwrap_or_default();
+            Some(Ok(Event::default().data(data)))
+        }
+        Err(_) => None,
+    });
+
+    Sse::new(stream).keep_alive(
+        axum::response::sse::KeepAlive::new()
+            .interval(Duration::from_secs(15))
+            .text("ping"),
+    )
+}
+
+async fn kill(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    state.shutdown.cancel();
+    Json(serde_json::json!({"status": "shutting_down"}))
+}
+
+/// Starts the session monitor API server on a Unix socket.
+///
+/// The socket is created at `~/.mirrord/sessions/<session_id>.sock`.
+/// On exit (normal or panic), the socket file is cleaned up via a drop guard.
+pub async fn start_api_server(
+    session_id: String,
+    session_info: SessionInfo,
+    monitor_tx: MonitorTx,
+    shutdown: CancellationToken,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let sessions_dir = home::home_dir()
+        .ok_or("could not determine home directory")?
+        .join(".mirrord")
+        .join("sessions");
+
+    fs::create_dir_all(&sessions_dir)?;
+    fs::set_permissions(&sessions_dir, fs::Permissions::from_mode(0o700))?;
+
+    let socket_path = sessions_dir.join(format!("{session_id}.sock"));
+
+    // Remove stale socket if it exists
+    let _ = fs::remove_file(&socket_path);
+
+    let listener = UnixListener::bind(&socket_path)?;
+    fs::set_permissions(&socket_path, fs::Permissions::from_mode(0o600))?;
+
+    let _cleanup = SocketCleanup {
+        path: socket_path.clone(),
+    };
+
+    let state = Arc::new(AppState {
+        session_info,
+        monitor_tx,
+        shutdown: shutdown.clone(),
+    });
+
+    let app = Router::new()
+        .route("/health", get(health))
+        .route("/info", get(info))
+        .route("/events", get(events))
+        .route("/kill", post(kill))
+        .with_state(state);
+
+    tracing::info!(?socket_path, "Session monitor API server starting");
+
+    axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown.cancelled_owned())
+        .await?;
+
+    tracing::info!("Session monitor API server stopped");
+
+    Ok(())
+}

--- a/mirrord/intproxy/src/session_monitor/mod.rs
+++ b/mirrord/intproxy/src/session_monitor/mod.rs
@@ -1,0 +1,106 @@
+use serde::Serialize;
+use tokio::sync::broadcast;
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum MonitorEvent {
+    FileOp {
+        path: Option<String>,
+        operation: String,
+    },
+    DnsQuery {
+        host: String,
+    },
+    HttpRequest {
+        method: String,
+        path: String,
+        host: String,
+        port: u16,
+    },
+    IncomingRequest {
+        method: String,
+        path: String,
+        host: String,
+    },
+    OutgoingConnection {
+        address: String,
+        port: u16,
+    },
+    PortSubscription {
+        port: u16,
+        mode: String,
+    },
+    EnvVar {
+        vars: Vec<String>,
+    },
+    LayerConnected {
+        pid: u32,
+    },
+    LayerDisconnected,
+}
+
+/// Wrapper around an optional broadcast sender for session monitor events.
+///
+/// When the session monitor is disabled, this wraps `None` and all emit calls are no-ops.
+#[derive(Clone)]
+pub struct MonitorTx {
+    inner: Option<broadcast::Sender<MonitorEvent>>,
+}
+
+impl MonitorTx {
+    /// Creates a disabled monitor sender that discards all events.
+    pub fn disabled() -> Self {
+        Self { inner: None }
+    }
+
+    /// Emits an event to all subscribers. Does nothing if disabled or if there are no receivers.
+    pub fn emit(&self, event: MonitorEvent) {
+        if let Some(tx) = &self.inner {
+            let _ = tx.send(event);
+        }
+    }
+
+    /// Creates an enabled monitor sender from an existing broadcast sender.
+    pub fn from_sender(tx: broadcast::Sender<MonitorEvent>) -> Self {
+        Self { inner: Some(tx) }
+    }
+
+    /// Returns a new receiver if the monitor is enabled.
+    pub fn subscribe(&self) -> Option<broadcast::Receiver<MonitorEvent>> {
+        self.inner.as_ref().map(|tx| tx.subscribe())
+    }
+}
+
+/// Tries to parse an HTTP/1.x request from raw bytes.
+/// Returns `(method, path, host)` on success.
+pub fn try_parse_http_request(bytes: &[u8]) -> Option<(String, String, String)> {
+    const HTTP_METHODS: &[&str] = &[
+        "GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS", "PATCH", "CONNECT", "TRACE",
+    ];
+
+    let s = std::str::from_utf8(bytes).ok()?;
+    let first_line_end = s.find("\r\n")?;
+    let first_line = &s[..first_line_end];
+
+    let mut parts = first_line.splitn(3, ' ');
+    let method = parts.next()?;
+    let path = parts.next()?;
+    let version = parts.next()?;
+
+    if !HTTP_METHODS.contains(&method) {
+        return None;
+    }
+    if !version.starts_with("HTTP/") {
+        return None;
+    }
+
+    let host_line = s[first_line_end + 2..]
+        .lines()
+        .find(|l| l.len() > 5 && l[..5].eq_ignore_ascii_case("host:"))?;
+    let host = host_line[5..].trim();
+
+    Some((method.to_owned(), path.to_owned(), host.to_owned()))
+}
+
+#[cfg(unix)]
+pub mod api;

--- a/mirrord/layer-tests/src/intproxy.rs
+++ b/mirrord/layer-tests/src/intproxy.rs
@@ -65,6 +65,7 @@ impl TestIntProxy {
                 Default::default(),
                 Duration::from_secs(60),
                 &experimental_config,
+                mirrord_intproxy::session_monitor::MonitorTx::disabled(),
             );
             intproxy
                 .run(Duration::from_secs(15), Duration::from_secs(5))

--- a/monitor-frontend/.gitignore
+++ b/monitor-frontend/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+.vite/
+.playwright-cli/

--- a/monitor-frontend/TESTING.md
+++ b/monitor-frontend/TESTING.md
@@ -1,0 +1,53 @@
+# Session Monitor Testing
+
+Test checklist for the combined session monitor feature. Run these before updating the combined PR.
+
+## Rust
+
+### Compile checks
+- [ ] `cargo check -p mirrord-intproxy --keep-going`
+- [ ] `MIRRORD_LAYER_FILE_MACOS_ARM64=/dev/null cargo check -p mirrord --keep-going`
+
+### Tests
+- [ ] `cargo test -p mirrord-intproxy` (37+ tests)
+
+### Lint
+- [ ] `cargo clippy -p mirrord-intproxy` (0 warnings)
+- [ ] `cargo fmt -- --check` (no diff)
+
+## Frontend
+
+### Build
+- [ ] `cd monitor-frontend && npm ci && npm run build`
+
+### Type check
+- [ ] `cd monitor-frontend && npx tsc --noEmit`
+
+## Integration (manual)
+
+### API server lifecycle
+- [ ] Run `mirrord exec` with `api: true`, verify socket appears at `~/.mirrord/sessions/<id>.sock`
+- [ ] `curl --unix-socket ~/.mirrord/sessions/<id>.sock http://localhost/health` returns `{"status":"ok"}`
+- [ ] `curl --unix-socket ~/.mirrord/sessions/<id>.sock http://localhost/info` returns session info JSON
+- [ ] Socket is cleaned up after mirrord process exits
+
+### Event emission
+- [ ] SSE stream (`/events`) emits FileOp events when target app does file operations
+- [ ] SSE stream emits DnsQuery events on DNS lookups
+- [ ] SSE stream emits IncomingRequest events on HTTP traffic (steal/mirror mode)
+- [ ] SSE stream emits OutgoingConnection events on outgoing TCP
+- [ ] SSE stream emits LayerConnected on session start
+
+### mirrord ui command
+- [ ] `mirrord ui` starts and opens browser to localhost:59281
+- [ ] Dashboard shows active sessions
+- [ ] Events stream in real time per session
+- [ ] `mirrord ui --no-open` starts without opening browser
+- [ ] `mirrord ui --dev` proxies to Vite dev server (port 5173)
+- [ ] Stale sockets are cleaned on startup
+
+### Edge cases
+- [ ] `api: false` in config disables the API server (no socket created)
+- [ ] Multiple concurrent mirrord sessions each get their own socket
+- [ ] API server crash does not affect intproxy (session continues working)
+- [ ] No SSE clients connected: events are silently dropped, no memory growth

--- a/monitor-frontend/http-echo.js
+++ b/monitor-frontend/http-echo.js
@@ -1,0 +1,58 @@
+const http = require('http');
+const fs = require('fs');
+const dns = require('dns');
+
+function log(type, msg) {
+  console.log(`[${new Date().toISOString()}] [${type}] ${msg}`);
+}
+
+const server = http.createServer((req, res) => {
+  log('HTTP', `${req.method} ${req.url} from ${req.headers.host || 'unknown'}`);
+
+  // Log headers
+  const interesting = ['user-agent', 'referer', 'content-type', 'authorization'];
+  for (const h of interesting) {
+    if (req.headers[h]) {
+      log('HTTP', `  ${h}: ${req.headers[h].substring(0, 100)}`);
+    }
+  }
+
+  // Read some remote files to generate file events
+  try {
+    const hostname = fs.readFileSync('/etc/hostname', 'utf-8').trim();
+    log('FILE', `read /etc/hostname: ${hostname}`);
+  } catch {}
+
+  // Resolve DNS
+  dns.resolve4('kubernetes.default.svc.cluster.local', (err, addrs) => {
+    if (!err) log('DNS', `kubernetes.default -> ${addrs.join(', ')}`);
+  });
+
+  res.writeHead(200, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify({
+    message: 'mirrord session monitor echo',
+    method: req.method,
+    url: req.url,
+    timestamp: new Date().toISOString(),
+  }));
+});
+
+server.listen(4000, '0.0.0.0', () => {
+  log('INFO', 'Echo server listening on 0.0.0.0:4000');
+  log('INFO', `PID: ${process.pid}`);
+
+  // Log environment
+  const envKeys = Object.keys(process.env)
+    .filter(k => !k.startsWith('_') && !k.startsWith('npm') && !k.startsWith('HOME'))
+    .filter(k => k.includes('METALBEAR') || k.includes('KUBERNETES') || k.includes('APP_'))
+    .slice(0, 10);
+  if (envKeys.length > 0) {
+    log('ENV', `remote env vars: ${envKeys.join(', ')}`);
+  }
+});
+
+process.on('SIGINT', () => {
+  log('INFO', 'Shutting down');
+  server.close();
+  process.exit(0);
+});

--- a/monitor-frontend/index.html
+++ b/monitor-frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>mirrord Session Monitor</title>
+  </head>
+  <body class="bg-background text-foreground">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/monitor-frontend/mock-sessions.ts
+++ b/monitor-frontend/mock-sessions.ts
@@ -1,0 +1,185 @@
+import * as http from 'node:http'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import * as os from 'node:os'
+import type { SessionInfo, SessionEvent } from './types.js'
+
+const SESSIONS_DIR = path.join(os.homedir(), '.mirrord', 'sessions')
+
+const sessions: SessionInfo[] = [
+  {
+    session_id: 'sess-a1b2c3',
+    target: 'deploy/checkout-svc',
+    mode: 'steal',
+    pid: 12001,
+    process_name: 'node',
+    started_at: new Date(Date.now() - 300_000).toISOString(),
+    ports: [8080, 3000],
+    mirrord_version: '3.142.0',
+  },
+  {
+    session_id: 'sess-d4e5f6',
+    target: 'deploy/payments-svc',
+    mode: 'mirror',
+    pid: 12002,
+    process_name: 'python',
+    started_at: new Date(Date.now() - 120_000).toISOString(),
+    ports: [5000],
+    mirrord_version: '3.142.0',
+  },
+  {
+    session_id: 'sess-g7h8i9',
+    target: 'deploy/auth-svc',
+    mode: 'steal',
+    pid: 12003,
+    process_name: 'java',
+    started_at: new Date(Date.now() - 600_000).toISOString(),
+    ports: [8443, 9090],
+    mirrord_version: '3.141.0',
+  },
+]
+
+function randomEvent(): SessionEvent {
+  const types: SessionEvent['type'][] = ['file_op', 'dns_query', 'http_request', 'connection', 'env_var']
+  const t = types[Math.floor(Math.random() * types.length)]
+  const base = { type: t, timestamp: Date.now() }
+
+  switch (t) {
+    case 'file_op':
+      return {
+        ...base,
+        data: {
+          op: ['read', 'write', 'open'][Math.floor(Math.random() * 3)],
+          path: ['/etc/config.yaml', '/tmp/cache.json', '/var/log/app.log'][Math.floor(Math.random() * 3)],
+          bytes: Math.floor(Math.random() * 4096),
+        },
+      }
+    case 'dns_query':
+      return {
+        ...base,
+        data: {
+          name: ['api.internal.svc', 'redis.default.svc', 'postgres.db.svc'][Math.floor(Math.random() * 3)],
+          record_type: 'A',
+          resolved: `10.0.${Math.floor(Math.random() * 255)}.${Math.floor(Math.random() * 255)}`,
+        },
+      }
+    case 'http_request':
+      return {
+        ...base,
+        data: {
+          method: ['GET', 'POST', 'PUT', 'DELETE'][Math.floor(Math.random() * 4)],
+          path: ['/api/orders', '/api/users', '/health', '/api/payments'][Math.floor(Math.random() * 4)],
+          status: [200, 201, 404, 500][Math.floor(Math.random() * 4)],
+          duration_ms: Math.floor(Math.random() * 500),
+        },
+      }
+    case 'connection':
+      return {
+        ...base,
+        data: {
+          remote: `10.0.${Math.floor(Math.random() * 255)}.${Math.floor(Math.random() * 255)}:${3000 + Math.floor(Math.random() * 5000)}`,
+          direction: Math.random() > 0.5 ? 'incoming' : 'outgoing',
+          protocol: Math.random() > 0.3 ? 'TCP' : 'UDP',
+        },
+      }
+    case 'env_var':
+      return {
+        ...base,
+        data: {
+          name: ['DATABASE_URL', 'REDIS_HOST', 'API_KEY', 'LOG_LEVEL'][Math.floor(Math.random() * 4)],
+          action: 'read',
+        },
+      }
+  }
+}
+
+function createSessionServer(session: SessionInfo): http.Server {
+  const server = http.createServer((req, res) => {
+    if (req.method === 'GET' && req.url === '/health') {
+      res.writeHead(200, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ status: 'ok' }))
+      return
+    }
+
+    if (req.method === 'GET' && req.url === '/info') {
+      res.writeHead(200, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify(session))
+      return
+    }
+
+    if (req.method === 'GET' && req.url === '/events') {
+      res.writeHead(200, {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+        Connection: 'keep-alive',
+      })
+
+      const interval = setInterval(() => {
+        const event = randomEvent()
+        res.write(`data: ${JSON.stringify(event)}\n\n`)
+      }, 2000)
+
+      req.on('close', () => clearInterval(interval))
+      return
+    }
+
+    if (req.method === 'POST' && req.url === '/kill') {
+      res.writeHead(200, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ status: 'killed', session_id: session.session_id }))
+
+      const socketPath = path.join(SESSIONS_DIR, `${session.session_id}.sock`)
+      setTimeout(() => {
+        server.close()
+        try { fs.unlinkSync(socketPath) } catch {}
+        console.log(`[mock] Session ${session.session_id} killed, socket removed`)
+      }, 100)
+      return
+    }
+
+    res.writeHead(404)
+    res.end('Not found')
+  })
+
+  return server
+}
+
+// Ensure sessions directory exists
+fs.mkdirSync(SESSIONS_DIR, { recursive: true })
+
+const servers: http.Server[] = []
+
+for (const session of sessions) {
+  const socketPath = path.join(SESSIONS_DIR, `${session.session_id}.sock`)
+
+  // Clean up stale socket
+  try { fs.unlinkSync(socketPath) } catch {}
+
+  const server = createSessionServer(session)
+  server.listen(socketPath, () => {
+    console.log(`[mock] Session ${session.session_id} (${session.target}) listening on ${socketPath}`)
+  })
+  servers.push(server)
+}
+
+function cleanup() {
+  console.log('\n[mock] Cleaning up sockets...')
+  for (const session of sessions) {
+    const socketPath = path.join(SESSIONS_DIR, `${session.session_id}.sock`)
+    try { fs.unlinkSync(socketPath) } catch {}
+  }
+  for (const server of servers) {
+    server.close()
+  }
+  process.exit(0)
+}
+
+process.on('SIGINT', cleanup)
+process.on('SIGTERM', cleanup)
+process.on('exit', () => {
+  for (const session of sessions) {
+    const socketPath = path.join(SESSIONS_DIR, `${session.session_id}.sock`)
+    try { fs.unlinkSync(socketPath) } catch {}
+  }
+})
+
+console.log(`[mock] ${sessions.length} mock sessions running. Press Ctrl+C to stop.`)

--- a/monitor-frontend/package-server.json
+++ b/monitor-frontend/package-server.json
@@ -1,0 +1,24 @@
+{
+  "name": "session-monitor-server",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "mock": "tsx mock-sessions.ts",
+    "server": "tsx server.ts",
+    "real": "tsx real-session.ts",
+    "start": "tsx mock-sessions.ts & tsx server.ts"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^4.21.0",
+    "ws": "^8.18.0"
+  },
+  "devDependencies": {
+    "@types/cors": "^2.8.17",
+    "@types/express": "^4.17.21",
+    "@types/node": "^22.10.0",
+    "@types/ws": "^8.5.13",
+    "tsx": "^4.19.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/monitor-frontend/package.json
+++ b/monitor-frontend/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "session-monitor-frontend",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@metalbear/ui": "^0.1.5",
+    "class-variance-authority": "^0.7.1",
+    "lucide-react": "^0.577.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
+    "@vitejs/plugin-react": "^4.3.4",
+    "autoprefixer": "^10.4.20",
+    "postcss": "^8.4.49",
+    "tailwindcss": "^3.4.16",
+    "typescript": "^5.7.0",
+    "vite": "^6.0.0"
+  }
+}

--- a/monitor-frontend/postcss.config.js
+++ b/monitor-frontend/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/monitor-frontend/real-session.ts
+++ b/monitor-frontend/real-session.ts
@@ -1,0 +1,225 @@
+import http from 'node:http'
+import net from 'node:net'
+import fs from 'node:fs'
+import path from 'node:path'
+import { spawn, ChildProcess } from 'node:child_process'
+import crypto from 'node:crypto'
+import type { SessionInfo, SessionEvent } from './types'
+
+const SESSIONS_DIR = path.join(process.env.HOME || '~', '.mirrord', 'sessions')
+const SESSION_ID = `sess-${crypto.randomBytes(4).toString('hex')}`
+const SOCKET_PATH = path.join(SESSIONS_DIR, `${SESSION_ID}.sock`)
+
+// Parse args: supports two forms:
+//   tsx real-session.ts <target> [cmd args...]
+//   tsx real-session.ts --config-file <path> [cmd args...]
+let CONFIG_FILE: string | undefined
+let TARGET: string
+let rawCmdArgs: string[]
+
+if (process.argv[2] === '--config-file') {
+  CONFIG_FILE = process.argv[3]
+  // Read target from config file
+  try {
+    const cfg = JSON.parse(fs.readFileSync(CONFIG_FILE, 'utf-8'))
+    TARGET = cfg.target?.path || cfg.target || 'unknown'
+  } catch {
+    TARGET = 'unknown'
+  }
+  rawCmdArgs = process.argv.slice(4)
+} else {
+  TARGET = process.argv[2] || 'deployment/app-metalbear-co'
+  rawCmdArgs = process.argv.slice(3)
+}
+const MODE = 'mirror'
+
+const sessionInfo: SessionInfo = {
+  session_id: SESSION_ID,
+  target: TARGET,
+  mode: MODE as 'steal' | 'mirror',
+  pid: 0, // will be set when mirrord starts
+  process_name: 'sleep',
+  started_at: new Date().toISOString(),
+  ports: [],
+  mirrord_version: '',
+}
+
+// Get mirrord version
+try {
+  const { execSync } = require('node:child_process')
+  const version = execSync('mirrord --version 2>/dev/null').toString().trim()
+  sessionInfo.mirrord_version = version.replace('mirrord ', '')
+} catch {
+  sessionInfo.mirrord_version = 'unknown'
+}
+
+// Create sessions directory
+fs.mkdirSync(SESSIONS_DIR, { recursive: true, mode: 0o700 })
+
+// Clean up stale socket
+if (fs.existsSync(SOCKET_PATH)) fs.unlinkSync(SOCKET_PATH)
+
+// Track events from mirrord output
+const events: SessionEvent[] = []
+function addEvent(type: SessionEvent['type'], data: Record<string, unknown>) {
+  const event: SessionEvent = { type, timestamp: Date.now(), data }
+  events.push(event)
+  if (events.length > 200) events.shift()
+}
+
+// Start the Unix socket HTTP server
+const server = http.createServer((req, res) => {
+  res.setHeader('Content-Type', 'application/json')
+
+  if (req.method === 'GET' && req.url === '/health') {
+    res.end(JSON.stringify({ status: 'ok' }))
+    return
+  }
+
+  if (req.method === 'GET' && req.url === '/info') {
+    res.end(JSON.stringify(sessionInfo))
+    return
+  }
+
+  if (req.method === 'GET' && req.url === '/events') {
+    res.writeHead(200, {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive',
+    })
+
+    // Send existing events
+    for (const event of events) {
+      res.write(`data: ${JSON.stringify(event)}\n\n`)
+    }
+
+    // Only send NEW events (track cursor)
+    let sentCount = events.length
+    const interval = setInterval(() => {
+      if (events.length > sentCount) {
+        const newEvents = events.slice(sentCount)
+        for (const event of newEvents) {
+          res.write(`data: ${JSON.stringify(event)}\n\n`)
+        }
+        sentCount = events.length
+      }
+    }, 1000)
+
+    req.on('close', () => clearInterval(interval))
+    return
+  }
+
+  if (req.method === 'POST' && req.url === '/kill') {
+    res.end(JSON.stringify({ status: 'killing' }))
+    cleanup()
+    return
+  }
+
+  res.writeHead(404)
+  res.end(JSON.stringify({ error: 'not found' }))
+})
+
+server.listen(SOCKET_PATH, () => {
+  fs.chmodSync(SOCKET_PATH, 0o600)
+  console.log(`[real] Socket server listening on ${SOCKET_PATH}`)
+})
+
+const CMD = rawCmdArgs[0] || 'node'
+const CMD_ARGS = rawCmdArgs.length > 1 ? rawCmdArgs.slice(1) : (rawCmdArgs[0] ? [] : [path.join(__dirname, 'traffic-generator.js')])
+
+const mirrordArgs = CONFIG_FILE
+  ? ['exec', '--config-file', CONFIG_FILE, '--', CMD, ...CMD_ARGS]
+  : ['exec', '--target', TARGET, '--', CMD, ...CMD_ARGS]
+
+console.log(`[real] Starting mirrord ${mirrordArgs.join(' ')} ...`)
+
+const mirrordProcess: ChildProcess = spawn('mirrord', mirrordArgs, {
+  env: {
+    ...process.env,
+    MIRRORD_AGENT_RUST_LOG: 'info',
+    RUST_LOG: 'mirrord=info',
+  },
+  stdio: ['pipe', 'pipe', 'pipe'],
+})
+
+sessionInfo.process_name = CMD
+
+sessionInfo.pid = mirrordProcess.pid || 0
+
+addEvent('connection', {
+  message: `mirrord session started targeting ${TARGET}`,
+  mode: MODE,
+})
+
+mirrordProcess.stdout?.on('data', (data: Buffer) => {
+  const lines = data.toString().trim().split('\n')
+  for (const line of lines) {
+    if (!line.trim()) continue
+    console.log(`[mirrord stdout] ${line}`)
+
+    // Parse structured lines from traffic-generator: [timestamp] [TYPE] message
+    const typeMatch = line.match(/\[[\dT:.Z-]+\]\s+\[(FILE|DNS|HTTP|ENV|INFO)\]\s+(.+)/)
+    if (typeMatch) {
+      const [, type, message] = typeMatch
+      const eventType = {
+        FILE: 'file_op',
+        DNS: 'dns_query',
+        HTTP: 'http_request',
+        ENV: 'env_var',
+        INFO: 'connection',
+      }[type] || 'connection'
+      addEvent(eventType, { message, source: 'app' })
+    } else {
+      addEvent('connection', { message: line, source: 'stdout' })
+    }
+  }
+})
+
+mirrordProcess.stderr?.on('data', (data: Buffer) => {
+  const lines = data.toString().trim().split('\n')
+  for (const line of lines) {
+    if (!line) continue
+    console.log(`[mirrord stderr] ${line}`)
+
+    // Parse interesting events from mirrord output
+    if (line.includes('file') || line.includes('open')) {
+      addEvent('file_op', { message: line, operation: 'read' })
+    } else if (line.includes('dns') || line.includes('DNS') || line.includes('resolve')) {
+      addEvent('dns_query', { message: line })
+    } else if (line.includes('connect') || line.includes('port') || line.includes('traffic')) {
+      addEvent('connection', { message: line })
+    } else if (line.includes('env')) {
+      addEvent('env_var', { message: line })
+    } else {
+      addEvent('connection', { message: line, source: 'stderr' })
+    }
+  }
+})
+
+mirrordProcess.on('exit', (code) => {
+  console.log(`[real] mirrord process exited with code ${code}`)
+  addEvent('connection', { message: `mirrord exited with code ${code}` })
+})
+
+mirrordProcess.on('error', (err) => {
+  console.error(`[real] mirrord process error:`, err.message)
+  addEvent('connection', { message: `error: ${err.message}` })
+})
+
+// Cleanup
+function cleanup() {
+  console.log('[real] Cleaning up...')
+  try { mirrordProcess.kill() } catch {}
+  try { fs.unlinkSync(SOCKET_PATH) } catch {}
+  try { server.close() } catch {}
+  process.exit(0)
+}
+
+process.on('SIGINT', cleanup)
+process.on('SIGTERM', cleanup)
+process.on('exit', () => {
+  try { fs.unlinkSync(SOCKET_PATH) } catch {}
+})
+
+console.log(`[real] Session ${SESSION_ID} running. Target: ${TARGET}, Mode: ${MODE}`)
+console.log(`[real] Press Ctrl+C to stop.`)

--- a/monitor-frontend/server.ts
+++ b/monitor-frontend/server.ts
@@ -1,0 +1,221 @@
+import * as http from 'node:http'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import * as os from 'node:os'
+import express from 'express'
+import cors from 'cors'
+import { WebSocketServer, WebSocket } from 'ws'
+import type { SessionInfo, WsMessage } from './types.js'
+
+const SESSIONS_DIR = path.join(os.homedir(), '.mirrord', 'sessions')
+const PORT = 59281
+
+// Track known sessions
+const knownSessions = new Map<string, SessionInfo>()
+
+function sessionIdFromSocket(filename: string): string {
+  return filename.replace('.sock', '')
+}
+
+/** Make an HTTP request over a Unix socket */
+function requestOverSocket(
+  socketPath: string,
+  method: string,
+  reqPath: string,
+): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        socketPath,
+        path: reqPath,
+        method,
+        headers: { 'Content-Type': 'application/json' },
+      },
+      (res) => {
+        let body = ''
+        res.on('data', (chunk) => (body += chunk))
+        res.on('end', () => resolve({ status: res.statusCode ?? 500, body }))
+      },
+    )
+    req.on('error', reject)
+    req.setTimeout(3000, () => {
+      req.destroy(new Error('timeout'))
+    })
+    req.end()
+  })
+}
+
+/** Fetch session info from a socket */
+async function fetchSessionInfo(socketPath: string): Promise<SessionInfo | null> {
+  try {
+    const { status, body } = await requestOverSocket(socketPath, 'GET', '/info')
+    if (status === 200) return JSON.parse(body)
+  } catch {
+    // Socket not ready or dead
+  }
+  return null
+}
+
+/** Discover all .sock files and fetch their info */
+async function discoverSessions(): Promise<void> {
+  let files: string[] = []
+  try {
+    files = fs.readdirSync(SESSIONS_DIR).filter((f) => f.endsWith('.sock'))
+  } catch {
+    return
+  }
+
+  const currentIds = new Set(files.map(sessionIdFromSocket))
+
+  // Remove sessions whose sockets are gone
+  for (const id of knownSessions.keys()) {
+    if (!currentIds.has(id)) {
+      knownSessions.delete(id)
+      broadcast({ type: 'session_removed', session_id: id })
+      console.log(`[server] Session removed: ${id}`)
+    }
+  }
+
+  // Add new sessions
+  for (const file of files) {
+    const id = sessionIdFromSocket(file)
+    if (!knownSessions.has(id)) {
+      const socketPath = path.join(SESSIONS_DIR, file)
+      const info = await fetchSessionInfo(socketPath)
+      if (info) {
+        knownSessions.set(id, info)
+        broadcast({ type: 'session_added', session_id: id, info })
+        console.log(`[server] Session discovered: ${id} (${info.target})`)
+      }
+    }
+  }
+}
+
+// WebSocket clients
+const wsClients = new Set<WebSocket>()
+
+function broadcast(msg: WsMessage) {
+  const data = JSON.stringify(msg)
+  for (const client of wsClients) {
+    if (client.readyState === WebSocket.OPEN) {
+      client.send(data)
+    }
+  }
+}
+
+// Express app
+const app = express()
+app.use(cors())
+app.use(express.json())
+
+app.get('/api/health', (_req, res) => {
+  res.json({ status: 'ok', sessions: knownSessions.size })
+})
+
+app.get('/api/sessions', (_req, res) => {
+  res.json(Array.from(knownSessions.values()))
+})
+
+app.get('/api/sessions/:id', (req, res) => {
+  const info = knownSessions.get(req.params.id)
+  if (!info) return res.status(404).json({ error: 'Session not found' })
+  res.json(info)
+})
+
+app.post('/api/sessions/:id/kill', async (req, res) => {
+  const id = req.params.id
+  if (!knownSessions.has(id)) return res.status(404).json({ error: 'Session not found' })
+
+  const socketPath = path.join(SESSIONS_DIR, `${id}.sock`)
+  try {
+    const { status, body } = await requestOverSocket(socketPath, 'POST', '/kill')
+    knownSessions.delete(id)
+    broadcast({ type: 'session_removed', session_id: id })
+    res.status(status).json(JSON.parse(body))
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to kill session' })
+  }
+})
+
+app.get('/api/sessions/:id/events', (req, res) => {
+  const id = req.params.id
+  if (!knownSessions.has(id)) return res.status(404).json({ error: 'Session not found' })
+
+  const socketPath = path.join(SESSIONS_DIR, `${id}.sock`)
+
+  // Proxy SSE stream from the session socket
+  const proxyReq = http.request(
+    { socketPath, path: '/events', method: 'GET' },
+    (proxyRes) => {
+      res.writeHead(200, {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+        Connection: 'keep-alive',
+      })
+      proxyRes.pipe(res)
+    },
+  )
+
+  proxyReq.on('error', () => {
+    if (!res.headersSent) {
+      res.status(502).json({ error: 'Failed to connect to session' })
+    }
+  })
+
+  req.on('close', () => proxyReq.destroy())
+  proxyReq.end()
+})
+
+// Serve static frontend files
+const frontendDist = path.join(__dirname || process.cwd(), 'frontend', 'dist')
+app.use(express.static(frontendDist))
+app.get('*', (req, res, next) => {
+  if (req.path.startsWith('/api') || req.path.startsWith('/ws')) return next()
+  const indexPath = path.join(frontendDist, 'index.html')
+  if (fs.existsSync(indexPath)) {
+    res.sendFile(indexPath)
+  } else {
+    next()
+  }
+})
+
+// Create HTTP server and attach WebSocket
+const server = http.createServer(app)
+const wss = new WebSocketServer({ server, path: '/ws' })
+
+wss.on('connection', (ws) => {
+  wsClients.add(ws)
+  console.log(`[server] WebSocket client connected (${wsClients.size} total)`)
+
+  // Send current sessions on connect
+  for (const info of knownSessions.values()) {
+    ws.send(JSON.stringify({ type: 'session_added', session_id: info.session_id, info }))
+  }
+
+  ws.on('close', () => {
+    wsClients.delete(ws)
+    console.log(`[server] WebSocket client disconnected (${wsClients.size} total)`)
+  })
+})
+
+// Watch sessions directory for changes
+fs.mkdirSync(SESSIONS_DIR, { recursive: true })
+
+let debounceTimer: ReturnType<typeof setTimeout> | null = null
+fs.watch(SESSIONS_DIR, () => {
+  if (debounceTimer) clearTimeout(debounceTimer)
+  debounceTimer = setTimeout(() => discoverSessions(), 500)
+})
+
+// Initial discovery + start
+async function main() {
+  await discoverSessions()
+
+  server.listen(PORT, () => {
+    console.log(`[server] Aggregator running on http://localhost:${PORT}`)
+    console.log(`[server] WebSocket at ws://localhost:${PORT}/ws`)
+    console.log(`[server] Watching ${SESSIONS_DIR} for session sockets`)
+  })
+}
+
+main()

--- a/monitor-frontend/src/App.tsx
+++ b/monitor-frontend/src/App.tsx
@@ -1,0 +1,281 @@
+import { useState, useEffect, useCallback, useRef } from 'react'
+import { MirrordIcon } from '@metalbear/ui'
+import { Badge, Separator, Loader, cn } from '@metalbear/ui'
+import { Activity, Sun, Moon, PanelLeftClose, PanelLeftOpen } from 'lucide-react'
+import type { SessionInfo, WsMessage } from './types'
+import SessionCard from './SessionCard'
+import EventStream from './EventStream'
+
+const SIDEBAR_MIN = 240
+const SIDEBAR_MAX = 600
+const SIDEBAR_DEFAULT = 320
+const SIDEBAR_STORAGE_KEY = 'session-monitor-sidebar-width'
+const SIDEBAR_HIDDEN_KEY = 'session-monitor-sidebar-hidden'
+
+function getSavedSidebarWidth(): number {
+  try {
+    const saved = localStorage.getItem(SIDEBAR_STORAGE_KEY)
+    if (saved) {
+      const val = parseInt(saved, 10)
+      if (val >= SIDEBAR_MIN && val <= SIDEBAR_MAX) return val
+    }
+  } catch {}
+  return SIDEBAR_DEFAULT
+}
+
+function getSavedSidebarHidden(): boolean {
+  try {
+    return localStorage.getItem(SIDEBAR_HIDDEN_KEY) === 'true'
+  } catch {}
+  return false
+}
+
+export default function App() {
+  const [sessions, setSessions] = useState<SessionInfo[]>([])
+  const [selectedId, setSelectedId] = useState<string | null>(null)
+  const [connected, setConnected] = useState(false)
+  const [loading, setLoading] = useState(true)
+  const [sidebarWidth, setSidebarWidth] = useState(getSavedSidebarWidth)
+  const [sidebarHidden, setSidebarHidden] = useState(getSavedSidebarHidden)
+  const [isDragging, setIsDragging] = useState(false)
+  const sidebarRef = useRef<HTMLDivElement>(null)
+  const [isDarkMode, setIsDarkMode] = useState(() => {
+    if (typeof window !== 'undefined') {
+      const saved = localStorage.getItem('session-monitor-theme')
+      if (saved) return saved === 'dark'
+      return window.matchMedia('(prefers-color-scheme: dark)').matches
+    }
+    return true
+  })
+
+  useEffect(() => {
+    document.documentElement.classList.toggle('dark', isDarkMode)
+    localStorage.setItem('session-monitor-theme', isDarkMode ? 'dark' : 'light')
+  }, [isDarkMode])
+
+  // Sidebar drag resize
+  useEffect(() => {
+    if (!isDragging) return
+
+    const handleMouseMove = (e: MouseEvent) => {
+      e.preventDefault()
+      const newWidth = Math.min(SIDEBAR_MAX, Math.max(SIDEBAR_MIN, e.clientX))
+      setSidebarWidth(newWidth)
+    }
+
+    const handleMouseUp = () => {
+      setIsDragging(false)
+      document.body.style.cursor = ''
+      document.body.style.userSelect = ''
+      localStorage.setItem(SIDEBAR_STORAGE_KEY, String(sidebarWidth))
+    }
+
+    document.body.style.cursor = 'col-resize'
+    document.body.style.userSelect = 'none'
+    window.addEventListener('mousemove', handleMouseMove)
+    window.addEventListener('mouseup', handleMouseUp)
+
+    return () => {
+      window.removeEventListener('mousemove', handleMouseMove)
+      window.removeEventListener('mouseup', handleMouseUp)
+      document.body.style.cursor = ''
+      document.body.style.userSelect = ''
+    }
+  }, [isDragging, sidebarWidth])
+
+  // Save width to localStorage on change (debounced by mouseup above)
+  useEffect(() => {
+    localStorage.setItem(SIDEBAR_STORAGE_KEY, String(sidebarWidth))
+  }, [sidebarWidth])
+
+  // Initial fetch
+  useEffect(() => {
+    fetch('/api/sessions')
+      .then((r) => r.json())
+      .then((data: SessionInfo[]) => {
+        setSessions(data)
+        setLoading(false)
+      })
+      .catch((err) => {
+        console.error(err)
+        setLoading(false)
+      })
+  }, [])
+
+  // WebSocket for live updates
+  useEffect(() => {
+    const wsUrl = import.meta.env.DEV
+      ? 'ws://localhost:59281/ws'
+      : `${window.location.protocol === 'https:' ? 'wss:' : 'ws:'}//${window.location.host}/ws`
+    const ws = new WebSocket(wsUrl)
+
+    ws.onopen = () => setConnected(true)
+    ws.onclose = () => {
+      setConnected(false)
+    }
+
+    ws.onmessage = (e) => {
+      const msg: WsMessage = JSON.parse(e.data)
+      if (msg.type === 'session_added' && msg.info) {
+        setSessions((prev) => {
+          if (prev.find((s) => s.session_id === msg.session_id)) return prev
+          return [...prev, msg.info!]
+        })
+      } else if (msg.type === 'session_removed') {
+        setSessions((prev) => prev.filter((s) => s.session_id !== msg.session_id))
+        setSelectedId((prev) => (prev === msg.session_id ? null : prev))
+      }
+    }
+
+    return () => ws.close()
+  }, [])
+
+  const handleKill = useCallback(async (id: string) => {
+    await fetch(`/api/sessions/${id}/kill`, { method: 'POST' })
+  }, [])
+
+  const selected = sessions.find((s) => s.session_id === selectedId)
+
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      {/* Header */}
+      <header className={`relative ${isDarkMode ? 'bg-[#232141]' : 'bg-white/80 backdrop-blur-sm border-b border-[#E5E5E5]'}`}>
+        <div className="absolute bottom-0 left-0 right-0 h-[2px] bg-gradient-to-r from-transparent via-[#756DF3] to-transparent opacity-40" />
+        <div className="px-6">
+          <div className={`flex items-center justify-between h-14 ${isDarkMode ? 'text-white' : 'text-[#232141]'}`}>
+            <div className="flex items-center gap-3">
+              <img
+                src={MirrordIcon}
+                alt="mirrord"
+                className={`w-8 h-8 ${isDarkMode ? 'invert' : ''}`}
+              />
+              <span className="font-semibold text-lg">mirrord</span>
+              <span className={isDarkMode ? 'text-white/30' : 'text-[#232141]/30'}>|</span>
+              <span className={`text-sm font-medium ${isDarkMode ? 'text-white/80' : 'text-[#232141]/70'}`}>
+                Session Monitor
+              </span>
+            </div>
+            <div className="flex items-center gap-3">
+              <div className="flex items-center gap-2">
+                <div
+                  className={cn(
+                    'h-2 w-2 rounded-full',
+                    connected ? 'bg-green-500' : 'bg-red-500'
+                  )}
+                />
+                <span className={`text-sm ${isDarkMode ? 'text-white/60' : 'text-[#232141]/60'}`}>
+                  {connected ? 'Connected' : 'Disconnected'}
+                </span>
+              </div>
+              <span className={isDarkMode ? 'text-white/20' : 'text-[#232141]/20'}>|</span>
+              <div className={`flex items-center gap-1.5 text-sm ${isDarkMode ? 'text-white/60' : 'text-[#232141]/60'}`}>
+                <Activity className="h-3.5 w-3.5" />
+                <span>
+                  {sessions.length} session{sessions.length !== 1 ? 's' : ''}
+                </span>
+              </div>
+              <span className={isDarkMode ? 'text-white/20' : 'text-[#232141]/20'}>|</span>
+              <button
+                onClick={() => setIsDarkMode(!isDarkMode)}
+                className={`p-1.5 rounded-md transition-colors ${isDarkMode ? 'hover:bg-white/10 text-white/60 hover:text-white' : 'hover:bg-[#232141]/10 text-[#232141]/60 hover:text-[#232141]'}`}
+                title={isDarkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+              >
+                {isDarkMode ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
+              </button>
+            </div>
+          </div>
+        </div>
+      </header>
+
+      <div className="flex h-[calc(100vh-57px)]">
+        {/* Session list sidebar */}
+        {!sidebarHidden && (
+        <>
+        <div
+          ref={sidebarRef}
+          className="border-r border-border overflow-y-auto p-3 space-y-2 shrink-0 relative"
+          style={{ width: sidebarWidth }}
+        >
+          <div className="flex justify-end mb-1">
+            <button
+              onClick={() => {
+                setSidebarHidden(true)
+                localStorage.setItem(SIDEBAR_HIDDEN_KEY, 'true')
+              }}
+              className="p-1.5 rounded-md hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
+              title="Hide sidebar"
+            >
+              <PanelLeftClose className="h-4 w-4" />
+            </button>
+          </div>
+          {loading ? (
+            <div className="flex items-center justify-center py-12">
+              <Loader size="lg" />
+            </div>
+          ) : sessions.length === 0 ? (
+            <div className="text-center text-muted-foreground py-12">
+              <Activity className="h-10 w-10 mx-auto mb-3 opacity-30" />
+              <p className="text-base mb-1">No active sessions</p>
+              <p className="text-sm opacity-70">Start mirrord to see sessions here</p>
+            </div>
+          ) : (
+            sessions.map((s) => (
+              <SessionCard
+                key={s.session_id}
+                session={s}
+                selected={s.session_id === selectedId}
+                onSelect={() => setSelectedId(s.session_id === selectedId ? null : s.session_id)}
+                onKill={() => handleKill(s.session_id)}
+              />
+            ))
+          )}
+        </div>
+
+        {/* Drag handle */}
+        <div
+          className={cn(
+            'w-1 shrink-0 cursor-col-resize transition-colors relative group',
+            isDragging ? 'bg-[#756DF3]' : 'bg-transparent hover:bg-[#756DF3]/50'
+          )}
+          onMouseDown={(e) => {
+            e.preventDefault()
+            setIsDragging(true)
+          }}
+        >
+          <div className={cn(
+            'absolute inset-y-0 -left-1 -right-1',
+            'cursor-col-resize'
+          )} />
+        </div>
+        </>
+        )}
+
+        {/* Show sidebar button when hidden */}
+        {sidebarHidden && (
+          <button
+            onClick={() => {
+              setSidebarHidden(false)
+              localStorage.setItem(SIDEBAR_HIDDEN_KEY, 'false')
+            }}
+            className="shrink-0 w-8 border-r border-border flex items-center justify-center hover:bg-muted transition-colors text-muted-foreground hover:text-foreground"
+            title="Show sidebar"
+          >
+            <PanelLeftOpen className="h-4 w-4" />
+          </button>
+        )}
+
+        {/* Detail / event stream */}
+        <div className="flex-1 overflow-hidden">
+          {selected ? (
+            <EventStream session={selected} />
+          ) : (
+            <div className="flex flex-col items-center justify-center h-full text-muted-foreground gap-2">
+              <Activity className="h-8 w-8 opacity-30" />
+              <p>Select a session to view live events</p>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/monitor-frontend/src/EventStream.tsx
+++ b/monitor-frontend/src/EventStream.tsx
@@ -1,0 +1,416 @@
+import React, { useState, useEffect, useRef } from 'react'
+import { Badge, Separator, cn } from '@metalbear/ui'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@metalbear/ui'
+import { FileText, Globe, Zap, Activity, Server, Info, AlertTriangle, Bug, Settings, ExternalLink, Trash2, Search, X } from 'lucide-react'
+import type { SessionInfo, SessionEvent } from './types'
+
+const EVENT_TYPE_CONFIG: Record<string, {
+  variant: 'default' | 'destructive' | 'outline' | 'secondary'
+  label: string
+  className: string
+  icon: typeof Activity
+}> = {
+  file_op: { variant: 'outline', label: 'File', className: 'border-amber-500/50 text-amber-400 bg-amber-500/10', icon: FileText },
+  dns_query: { variant: 'outline', label: 'DNS', className: 'border-blue-500/50 text-blue-400 bg-blue-500/10', icon: Globe },
+  http_request: { variant: 'outline', label: 'HTTP', className: 'border-green-500/50 text-green-400 bg-green-500/10', icon: Zap },
+  connection: { variant: 'outline', label: 'Event', className: 'border-purple-500/50 text-purple-400 bg-purple-500/10', icon: Server },
+  env_var: { variant: 'outline', label: 'Env', className: 'border-pink-500/50 text-pink-400 bg-pink-500/10', icon: Settings },
+  info: { variant: 'outline', label: 'Info', className: 'border-sky-500/50 text-sky-400 bg-sky-500/10', icon: Info },
+  warning: { variant: 'outline', label: 'Warn', className: 'border-yellow-500/50 text-yellow-400 bg-yellow-500/10', icon: AlertTriangle },
+  error: { variant: 'outline', label: 'Error', className: 'border-red-500/50 text-red-400 bg-red-500/10', icon: Bug },
+}
+
+interface ParsedEvent {
+  type: string
+  summary: string
+  rawData?: string
+  skip: boolean
+}
+
+function parseEvent(event: SessionEvent): ParsedEvent {
+  switch (event.type) {
+    case 'file_op': {
+      const op = (event.operation as string) || 'op'
+      const path = (event.path as string | null) ?? null
+      const summary = path ? `${op} ${path}` : `${op} (fd-based)`
+      return { type: 'file_op', summary, skip: false }
+    }
+    case 'dns_query': {
+      const host = (event.host as string) || '?'
+      return { type: 'dns_query', summary: `DNS lookup: ${host}`, skip: false }
+    }
+    case 'outgoing_connection': {
+      const addr = (event.address as string) || '?'
+      const port = (event.port as number) ?? ''
+      return { type: 'connection', summary: `Connect to ${addr}:${port}`, skip: false }
+    }
+    case 'port_subscription': {
+      const port = (event.port as number) ?? '?'
+      const mode = (event.mode as string) || ''
+      return { type: 'connection', summary: `Port ${port} subscribed (${mode})`, skip: false }
+    }
+    case 'env_var': {
+      const vars = (event.vars as string[]) ?? []
+      const summary =
+        vars.length === 0
+          ? 'Env vars requested'
+          : `Env vars: ${vars.slice(0, 5).join(', ')}${vars.length > 5 ? ` +${vars.length - 5} more` : ''}`
+      return { type: 'env_var', summary, skip: false }
+    }
+    case 'layer_connected': {
+      const pid = (event.pid as number) ?? '?'
+      return { type: 'info', summary: `Process connected (PID ${pid})`, skip: false }
+    }
+    case 'layer_disconnected': {
+      return { type: 'info', summary: 'Process disconnected', skip: false }
+    }
+    default:
+      return { type: 'info', summary: `${event.type}`, skip: false }
+  }
+}
+
+/** Format time as 24-hour HH:MM:SS */
+function formatTime24(timestamp: string): string {
+  const d = new Date(timestamp)
+  return d.toLocaleTimeString('en-GB', { hour12: false })
+}
+
+/** Try to pretty-format raw data (JSON or Rust struct) */
+function formatRawData(raw: string): { formatted: string; isStructured: boolean } {
+  // Try JSON parse first
+  try {
+    const parsed = JSON.parse(raw)
+    return { formatted: JSON.stringify(parsed, null, 2), isStructured: true }
+  } catch {}
+
+  // Try to detect if it looks like a JSON-ish structure that just needs cleanup
+  const jsonLike = raw.trim()
+  if (jsonLike.startsWith('{') || jsonLike.startsWith('[')) {
+    try {
+      // Sometimes raw data has trailing commas or other minor issues
+      const cleaned = jsonLike.replace(/,\s*([}\]])/g, '$1')
+      const parsed = JSON.parse(cleaned)
+      return { formatted: JSON.stringify(parsed, null, 2), isStructured: true }
+    } catch {}
+  }
+
+  // Rust struct formatting: indent based on braces/parens
+  if (raw.includes('{') && (raw.includes('::') || raw.includes('Some(') || raw.includes('None'))) {
+    let indent = 0
+    let result = ''
+    let i = 0
+    while (i < raw.length) {
+      const ch = raw[i]
+      if (ch === '{' || ch === '(') {
+        result += ch + '\n'
+        indent += 2
+        result += ' '.repeat(indent)
+        // Skip whitespace after opening brace
+        i++
+        while (i < raw.length && (raw[i] === ' ' || raw[i] === '\n')) i++
+        continue
+      } else if (ch === '}' || ch === ')') {
+        indent = Math.max(0, indent - 2)
+        result += '\n' + ' '.repeat(indent) + ch
+      } else if (ch === ',') {
+        result += ',\n' + ' '.repeat(indent)
+        // Skip whitespace after comma
+        i++
+        while (i < raw.length && (raw[i] === ' ' || raw[i] === '\n')) i++
+        continue
+      } else {
+        result += ch
+      }
+      i++
+    }
+    return { formatted: result, isStructured: true }
+  }
+
+  // If it's already multi-line or has some structure, mark it as structured
+  if (raw.includes('\n') && raw.split('\n').length > 3) {
+    return { formatted: raw, isStructured: true }
+  }
+
+  return { formatted: raw, isStructured: false }
+}
+
+/** Simple syntax colorizer for config lines */
+function colorizeConfigLine(line: string): React.ReactNode {
+  // Color key: value patterns
+  const kvMatch = line.match(/^(\s*)([\w_]+):\s*(.+)$/)
+  if (kvMatch) {
+    const [, indent, key, value] = kvMatch
+    let valueColor = '#a6e3a1' // green for strings
+    if (value === 'true' || value === 'false') valueColor = '#fab387' // orange for booleans
+    else if (value === 'None' || value === 'null') valueColor = '#585b70' // dim for null
+    else if (/^\d+/.test(value)) valueColor = '#f9e2af' // yellow for numbers
+    else if (value.startsWith('"')) valueColor = '#a6e3a1' // green for strings
+    return (
+      <>
+        {indent}
+        <span style={{ color: '#89b4fa' }}>{key}</span>
+        <span style={{ color: '#585b70' }}>: </span>
+        <span style={{ color: valueColor }}>{value}</span>
+      </>
+    )
+  }
+  // Braces/brackets
+  if (/^\s*[{}()\[\]],?\s*$/.test(line)) {
+    return <span style={{ color: '#585b70' }}>{line}</span>
+  }
+  // Struct names like "LayerConfig {" or "FeatureConfig {"
+  const structMatch = line.match(/^(\s*)(\w+)\s*(\{.*)$/)
+  if (structMatch) {
+    const [, indent, name, rest] = structMatch
+    return (
+      <>
+        {indent}
+        <span style={{ color: '#cba6f7' }}>{name}</span>
+        <span style={{ color: '#585b70' }}>{rest}</span>
+      </>
+    )
+  }
+  return line
+}
+
+interface Props {
+  session: SessionInfo
+}
+
+export default function EventStream({ session }: Props) {
+  const [events, setEvents] = useState<SessionEvent[]>([])
+  const [streaming, setStreaming] = useState(false)
+  const [detailEvent, setDetailEvent] = useState<{ summary: string; raw: string } | null>(null)
+  const [searchQuery, setSearchQuery] = useState('')
+  const [showSearch, setShowSearch] = useState(false)
+  const logRef = useRef<HTMLDivElement>(null)
+  const searchRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    setEvents([])
+    setStreaming(true)
+
+    const baseUrl = import.meta.env.DEV ? 'http://localhost:59281' : ''
+    const eventSource = new EventSource(`${baseUrl}/api/sessions/${session.session_id}/events`)
+
+    eventSource.onmessage = (e) => {
+      const raw = JSON.parse(e.data)
+      const event: SessionEvent = { ...raw, received_at: Date.now() }
+      setEvents((prev) => [...prev.slice(-200), event])
+    }
+
+    eventSource.onerror = () => {
+      setStreaming(false)
+      eventSource.close()
+    }
+
+    return () => {
+      eventSource.close()
+      setStreaming(false)
+    }
+  }, [session.session_id])
+
+  // Auto-scroll only if user is already near the bottom
+  const isNearBottom = useRef(true)
+  useEffect(() => {
+    const el = logRef.current
+    if (!el) return
+    const handleScroll = () => {
+      isNearBottom.current = el.scrollHeight - el.scrollTop - el.clientHeight < 50
+    }
+    el.addEventListener('scroll', handleScroll)
+    return () => el.removeEventListener('scroll', handleScroll)
+  }, [])
+
+  useEffect(() => {
+    if (logRef.current && isNearBottom.current) {
+      logRef.current.scrollTop = logRef.current.scrollHeight
+    }
+  }, [events])
+
+  // Parse, filter, and dedup
+  const processedEvents = events
+    .map((event) => ({ event, parsed: parseEvent(event) }))
+    .filter(({ parsed }) => !parsed.skip)
+
+  // Dedup: only dedup info/connection startup messages, not traffic events
+  const TRAFFIC_TYPES = new Set(['file_op', 'dns_query', 'http_request', 'env_var'])
+  const seenSummaries = new Set<string>()
+  const dedupedEvents = processedEvents.filter(({ parsed }) => {
+    // Never dedup traffic events (file, dns, http, env) - they should all show
+    if (TRAFFIC_TYPES.has(parsed.type)) return true
+    // Dedup info/connection/warning startup messages
+    if (seenSummaries.has(parsed.summary)) return false
+    seenSummaries.add(parsed.summary)
+    return true
+  })
+
+  // Search filter
+  const filteredEvents = searchQuery
+    ? dedupedEvents.filter(({ parsed }) =>
+        parsed.summary.toLowerCase().includes(searchQuery.toLowerCase())
+      )
+    : dedupedEvents
+
+  // Format detail event raw data for dialog
+  const detailFormatted = detailEvent ? formatRawData(detailEvent.raw) : null
+
+  return (
+    <div className="h-full flex flex-col">
+      {/* Session detail header */}
+      <div className="border-b border-border px-6 py-3 bg-card/50">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <Server className="h-4 w-4 text-muted-foreground" />
+            <span className="font-mono font-semibold text-foreground">
+              {session.target}
+            </span>
+            <Separator orientation="vertical" className="h-4" />
+            <span className="text-muted-foreground text-sm font-mono">
+              {session.session_id}
+            </span>
+          </div>
+          <div className="flex items-center gap-2">
+            <div className="flex items-center gap-1.5">
+              <div
+                className={cn(
+                  'h-2 w-2 rounded-full',
+                  streaming ? 'bg-green-500 animate-pulse' : 'bg-destructive'
+                )}
+              />
+              <span className="text-xs text-muted-foreground">
+                {streaming ? 'Streaming' : 'Disconnected'}
+              </span>
+            </div>
+            <Separator orientation="vertical" className="h-3" />
+            <span className="text-xs text-muted-foreground">
+              {filteredEvents.length} events
+            </span>
+            <Separator orientation="vertical" className="h-3" />
+            <button
+              onClick={() => {
+                setShowSearch(!showSearch)
+                if (!showSearch) setTimeout(() => searchRef.current?.focus(), 100)
+                else setSearchQuery('')
+              }}
+              className={cn(
+                'p-1 rounded hover:bg-muted transition-colors',
+                showSearch ? 'text-primary' : 'text-muted-foreground hover:text-foreground'
+              )}
+              title="Search events"
+            >
+              <Search className="h-3.5 w-3.5" />
+            </button>
+            <button
+              onClick={() => setEvents([])}
+              className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
+              title="Clear events"
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* Search bar */}
+      {showSearch && (
+        <div className="border-b border-border px-4 py-2 flex items-center gap-2 bg-card/30">
+          <Search className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+          <input
+            ref={searchRef}
+            type="text"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            placeholder="Filter events..."
+            className="flex-1 bg-transparent text-sm text-foreground placeholder:text-muted-foreground/50 outline-none"
+          />
+          {searchQuery && (
+            <button onClick={() => setSearchQuery('')} className="text-muted-foreground hover:text-foreground">
+              <X className="h-3.5 w-3.5" />
+            </button>
+          )}
+          <span className="text-xs text-muted-foreground">
+            {filteredEvents.length}/{dedupedEvents.length}
+          </span>
+        </div>
+      )}
+
+      {/* Event log */}
+      <div ref={logRef} className="flex-1 overflow-y-auto p-4 text-sm">
+        {filteredEvents.length === 0 && streaming && (
+          <div className="text-muted-foreground text-center py-8 flex flex-col items-center gap-2">
+            <Activity className="h-6 w-6 opacity-30 animate-pulse" />
+            <span>Waiting for events...</span>
+          </div>
+        )}
+        {filteredEvents.map(({ event, parsed }, i) => {
+          const config = EVENT_TYPE_CONFIG[parsed.type] ?? EVENT_TYPE_CONFIG['connection']!
+          const time = formatTime24(new Date(event.received_at).toISOString())
+          const Icon = config.icon
+          const hasDetail = !!parsed.rawData
+
+          return (
+            <div
+              key={`${event.timestamp}-${i}`}
+              className={cn(
+                'flex items-start gap-2.5 py-1 px-3 rounded-md transition-colors event-row-animate',
+                hasDetail ? 'hover:bg-muted/50 cursor-pointer group' : 'hover:bg-muted/30',
+                i % 2 === 0 ? 'bg-muted/10' : ''
+              )}
+              onClick={hasDetail ? () => setDetailEvent({ summary: parsed.summary, raw: parsed.rawData! }) : undefined}
+            >
+              <span className="text-muted-foreground text-xs shrink-0 mt-0.5 w-[64px] tabular-nums font-mono">
+                {time}
+              </span>
+              <Badge
+                variant={config.variant}
+                className={cn('shrink-0 w-[52px] justify-center text-[10px] font-semibold px-1 py-0 gap-0.5', config.className)}
+              >
+                <Icon className="h-2.5 w-2.5" />
+                {config.label}
+              </Badge>
+              <span className={cn(
+                'leading-snug flex-1',
+                hasDetail ? 'text-foreground/90 underline decoration-dotted decoration-muted-foreground/30 underline-offset-2' : 'text-foreground/90'
+              )}>
+                {parsed.summary}
+              </span>
+              {hasDetail && (
+                <ExternalLink className="h-3 w-3 text-primary/60 shrink-0 mt-0.5" />
+              )}
+            </div>
+          )
+        })}
+      </div>
+
+      {/* Detail dialog */}
+      <Dialog open={!!detailEvent} onOpenChange={() => setDetailEvent(null)}>
+        <DialogContent className="max-w-4xl max-h-[85vh]">
+          <DialogHeader>
+            <DialogTitle className="text-sm font-medium text-foreground">
+              {detailEvent?.summary}
+            </DialogTitle>
+          </DialogHeader>
+          <div className="relative overflow-auto max-h-[70vh] rounded-lg border border-border bg-[#1e1e2e] text-[#cdd6f4]">
+            <div className="overflow-x-auto">
+              <table className="w-full border-collapse text-xs font-mono">
+                <tbody>
+                  {detailFormatted?.formatted.split('\n').map((line, lineIdx) => (
+                    <tr key={lineIdx} className="hover:bg-white/5">
+                      <td className="select-none text-right pr-4 pl-4 py-[2px] text-[#585b70] border-r border-[#313244] w-[1%] whitespace-nowrap">
+                        {lineIdx + 1}
+                      </td>
+                      <td className="pl-4 pr-4 py-[2px] whitespace-pre-wrap break-all">
+                        {colorizeConfigLine(line)}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}

--- a/monitor-frontend/src/SessionCard.tsx
+++ b/monitor-frontend/src/SessionCard.tsx
@@ -1,0 +1,97 @@
+import { Card, CardContent, Badge, Button, cn } from '@metalbear/ui'
+import { Cpu, Clock, Server, Trash2, ShieldCheck } from 'lucide-react'
+import type { SessionInfo } from './types'
+
+function formatUptime(startedAt: string): string {
+  const diff = Date.now() - new Date(startedAt).getTime()
+  const seconds = Math.floor(diff / 1000)
+  const minutes = Math.floor(seconds / 60)
+  const hours = Math.floor(minutes / 60)
+
+  if (hours > 0) return `${hours}h ${minutes % 60}m`
+  if (minutes > 0) return `${minutes}m ${seconds % 60}s`
+  return `${seconds}s`
+}
+
+interface Props {
+  session: SessionInfo
+  selected: boolean
+  onSelect: () => void
+  onKill: () => void
+}
+
+export default function SessionCard({ session, selected, onSelect, onKill }: Props) {
+  const firstProcess = session.processes[0]
+
+  return (
+    <Card
+      className={cn(
+        'cursor-pointer transition-all duration-150 hover:border-primary/50',
+        selected && 'border-l-4 border-l-[#756DF3] border-primary/60 bg-primary/5'
+      )}
+      onClick={onSelect}
+    >
+      <CardContent className="p-3 space-y-2">
+        {/* Target + operator badge */}
+        <div className="flex items-center justify-between gap-2">
+          <div className="flex items-center gap-1.5 min-w-0">
+            <Server className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+            <span className="font-mono text-sm font-semibold text-foreground truncate">
+              {session.target}
+            </span>
+          </div>
+          {session.is_operator && (
+            <Badge
+              variant="secondary"
+              className="shrink-0 uppercase text-[10px] tracking-wider"
+            >
+              <ShieldCheck className="h-3 w-3 mr-0.5" />
+              Operator
+            </Badge>
+          )}
+        </div>
+
+        {/* Details row */}
+        <div className="flex items-center gap-3 text-xs text-muted-foreground">
+          {firstProcess ? (
+            <>
+              <span className="flex items-center gap-1" title="Process">
+                <Cpu className="h-3 w-3" />
+                {firstProcess.process_name}
+              </span>
+              <span title="PID">PID {firstProcess.pid}</span>
+            </>
+          ) : (
+            <span className="flex items-center gap-1 italic" title="No layers connected yet">
+              <Cpu className="h-3 w-3" />
+              connecting...
+            </span>
+          )}
+          <span className="flex items-center gap-1" title="Uptime">
+            <Clock className="h-3 w-3" />
+            {formatUptime(session.started_at)}
+          </span>
+          <span title="mirrord version" className="ml-auto font-mono">
+            v{session.mirrord_version}
+          </span>
+        </div>
+
+        {/* Kill button */}
+        <div className="flex items-center">
+          <Button
+            variant="destructive"
+            size="sm"
+            className="ml-auto h-6 px-2 text-xs"
+            onClick={(e) => {
+              e.stopPropagation()
+              onKill()
+            }}
+          >
+            <Trash2 className="h-3 w-3 mr-1" />
+            Kill
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/monitor-frontend/src/index.css
+++ b/monitor-frontend/src/index.css
@@ -1,0 +1,77 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  margin: 0;
+  -webkit-font-smoothing: antialiased;
+}
+
+/* Custom scrollbar for dark theme */
+::-webkit-scrollbar {
+  width: 6px;
+}
+::-webkit-scrollbar-track {
+  background: hsl(var(--background));
+}
+::-webkit-scrollbar-thumb {
+  background: hsl(var(--primary));
+  border-radius: 3px;
+}
+
+/* Event row fade-in animation */
+@keyframes eventFadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.event-row-animate {
+  animation: eventFadeIn 0.2s ease-out;
+}
+
+/* Code block styling for detail dialog */
+.code-block-detail {
+  background: hsl(var(--muted) / 0.5);
+  counter-reset: line;
+}
+
+.code-line {
+  display: flex;
+  line-height: 1.6;
+}
+
+.code-line:hover {
+  background: hsl(var(--muted) / 0.8);
+}
+
+.code-line-number {
+  display: inline-block;
+  width: 3em;
+  padding: 0 0.75em 0 0.5em;
+  text-align: right;
+  color: hsl(var(--muted-foreground) / 0.4);
+  user-select: none;
+  flex-shrink: 0;
+  border-right: 1px solid hsl(var(--border));
+}
+
+.code-line-content {
+  padding-left: 1em;
+  flex: 1;
+  /* Syntax-like coloring for keys and values */
+}
+
+/* Simple syntax highlighting for structured data */
+.dark .code-line-content {
+  color: #e2e8f0;
+}
+
+.code-line-content {
+  color: #1e293b;
+}

--- a/monitor-frontend/src/main.tsx
+++ b/monitor-frontend/src/main.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App'
+import '@metalbear/ui/styles.css'
+import './index.css'
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+)

--- a/monitor-frontend/src/types.ts
+++ b/monitor-frontend/src/types.ts
@@ -1,0 +1,28 @@
+export interface ProcessInfo {
+  pid: number
+  process_name: string
+}
+
+export interface SessionInfo {
+  session_id: string
+  target: string
+  started_at: string
+  mirrord_version: string
+  is_operator: boolean
+  processes: ProcessInfo[]
+  config: Record<string, unknown>
+  filter: string | null
+}
+
+/** A raw event from the backend SSE stream, enriched with a local receive timestamp. */
+export interface SessionEvent {
+  type: string
+  received_at: number
+  [key: string]: unknown
+}
+
+export interface WsMessage {
+  type: 'session_added' | 'session_removed'
+  session_id: string
+  info?: SessionInfo
+}

--- a/monitor-frontend/src/vite-env.d.ts
+++ b/monitor-frontend/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/monitor-frontend/tailwind.config.js
+++ b/monitor-frontend/tailwind.config.js
@@ -1,0 +1,41 @@
+import {
+  brandColors,
+  darkModeColors,
+  DARK_BORDER,
+  FONT_FAMILY_SANS,
+  FONT_FAMILY_CODE,
+} from '@metalbear/ui';
+
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: [
+    './index.html',
+    './src/**/*.{js,ts,jsx,tsx}',
+    './node_modules/@metalbear/ui/**/*.{js,ts,jsx,tsx}',
+  ],
+  darkMode: 'class',
+  theme: {
+    extend: {
+      fontFamily: {
+        sans: FONT_FAMILY_SANS.split(', '),
+        code: FONT_FAMILY_CODE.split(', '),
+      },
+      colors: {
+        brand: brandColors,
+        primary: {
+          DEFAULT: brandColors.purple,
+          light: brandColors.purpleMedium,
+          dark: brandColors.purpleDark,
+        },
+        dark: {
+          background: darkModeColors.background,
+          foreground: darkModeColors.foreground,
+          card: darkModeColors.card,
+          muted: darkModeColors.muted,
+          border: DARK_BORDER,
+        },
+      },
+    },
+  },
+  plugins: [],
+}

--- a/monitor-frontend/traffic-generator.js
+++ b/monitor-frontend/traffic-generator.js
@@ -1,0 +1,128 @@
+// This script runs under mirrord and generates real traffic events
+// by reading remote files, resolving DNS, and making HTTP requests
+// that go through the mirrord layer
+
+const fs = require('fs');
+const dns = require('dns');
+const http = require('http');
+const https = require('https');
+
+const INTERVAL = 3000; // every 3 seconds
+
+function log(type, msg) {
+  const ts = new Date().toISOString();
+  console.log(`[${ts}] [${type}] ${msg}`);
+}
+
+async function readRemoteFile(path) {
+  try {
+    const content = fs.readFileSync(path, 'utf-8');
+    log('FILE', `read ${path} (${content.length} bytes)`);
+    return content;
+  } catch (e) {
+    log('FILE', `failed to read ${path}: ${e.message}`);
+    return null;
+  }
+}
+
+function resolveDns(hostname) {
+  return new Promise((resolve) => {
+    dns.resolve4(hostname, (err, addresses) => {
+      if (err) {
+        log('DNS', `resolve ${hostname} failed: ${err.message}`);
+        resolve(null);
+      } else {
+        log('DNS', `resolve ${hostname} -> ${addresses.join(', ')}`);
+        resolve(addresses);
+      }
+    });
+  });
+}
+
+function httpGet(url) {
+  return new Promise((resolve) => {
+    const client = url.startsWith('https') ? https : http;
+    const req = client.get(url, { timeout: 5000 }, (res) => {
+      let data = '';
+      res.on('data', (chunk) => data += chunk);
+      res.on('end', () => {
+        log('HTTP', `GET ${url} -> ${res.statusCode} (${data.length} bytes)`);
+        resolve({ status: res.statusCode, size: data.length });
+      });
+    });
+    req.on('error', (e) => {
+      log('HTTP', `GET ${url} failed: ${e.message}`);
+      resolve(null);
+    });
+    req.on('timeout', () => {
+      log('HTTP', `GET ${url} timeout`);
+      req.destroy();
+      resolve(null);
+    });
+  });
+}
+
+// Files to try reading (these exist on most K8s pods)
+const FILES = [
+  '/etc/hostname',
+  '/etc/resolv.conf',
+  '/etc/hosts',
+  '/etc/os-release',
+  '/proc/1/status',
+  '/etc/passwd',
+];
+
+// Hostnames to resolve (cluster-internal DNS)
+const HOSTNAMES = [
+  'kubernetes.default.svc.cluster.local',
+  'kube-dns.kube-system.svc.cluster.local',
+  'app-metalbear-co.default.svc.cluster.local',
+  'crm.default.svc.cluster.local',
+];
+
+// URLs to fetch
+const URLS = [
+  'http://localhost:4000/api/v1/frontegg',
+  'http://kubernetes.default.svc.cluster.local:443',
+];
+
+let iteration = 0;
+
+async function tick() {
+  iteration++;
+  log('INFO', `--- iteration ${iteration} ---`);
+
+  // Rotate through different activities
+  const fileIdx = iteration % FILES.length;
+  const hostIdx = iteration % HOSTNAMES.length;
+
+  await readRemoteFile(FILES[fileIdx]);
+  await resolveDns(HOSTNAMES[hostIdx]);
+
+  if (iteration % 3 === 0) {
+    const urlIdx = (iteration / 3) % URLS.length;
+    await httpGet(URLS[Math.floor(urlIdx)]);
+  }
+
+  // Read env vars (mirrord injects remote env)
+  if (iteration % 5 === 0) {
+    const envKeys = Object.keys(process.env).filter(k =>
+      !k.startsWith('_') && !k.startsWith('npm') && !k.startsWith('HOME')
+    ).slice(0, 5);
+    log('ENV', `remote env vars: ${envKeys.join(', ')}`);
+  }
+}
+
+log('INFO', 'Traffic generator started. Generating events every 3s...');
+log('INFO', `PID: ${process.pid}`);
+
+// Initial burst
+tick().then(() => {
+  setInterval(tick, INTERVAL);
+});
+
+// Keep alive
+process.on('SIGINT', () => {
+  log('INFO', 'Shutting down');
+  process.exit(0);
+});

--- a/monitor-frontend/tsconfig.json
+++ b/monitor-frontend/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"]
+}

--- a/monitor-frontend/tsconfig.tsbuildinfo
+++ b/monitor-frontend/tsconfig.tsbuildinfo
@@ -1,0 +1,1 @@
+{"root":["./src/app.tsx","./src/eventstream.tsx","./src/sessioncard.tsx","./src/main.tsx","./src/types.ts","./src/vite-env.d.ts"],"version":"5.9.3"}

--- a/monitor-frontend/types.ts
+++ b/monitor-frontend/types.ts
@@ -1,0 +1,28 @@
+export interface ProcessInfo {
+  pid: number
+  process_name: string
+}
+
+export interface SessionInfo {
+  session_id: string
+  target: string
+  started_at: string
+  mirrord_version: string
+  is_operator: boolean
+  processes: ProcessInfo[]
+  config: Record<string, unknown>
+  filter: string | null
+}
+
+/** A raw event from the backend SSE stream, enriched with a local receive timestamp. */
+export interface SessionEvent {
+  type: string
+  received_at: number
+  [key: string]: unknown
+}
+
+export interface WsMessage {
+  type: 'session_added' | 'session_removed'
+  session_id: string
+  info?: SessionInfo
+}

--- a/monitor-frontend/vite.config.ts
+++ b/monitor-frontend/vite.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    proxy: {
+      '/api': 'http://localhost:59281',
+      '/ws': {
+        target: 'ws://localhost:59281',
+        ws: true,
+      },
+    },
+  },
+})


### PR DESCRIPTION
## Summary
React frontend for the session monitor, served by `mirrord ui`.

Related: [RFC 0004](https://github.com/metalbear-co/rfcs/pull/20), depends on [#4039](https://github.com/metalbear-co/mirrord/pull/4039) (backend)

## What it does
- React frontend with @metalbear/ui components
- Parses structured monitor events: file ops, DNS, HTTP in/out, outgoing connections, port subscriptions, env vars
- Real-time SSE event streaming per session
- Session sidebar with live discovery via WebSocket
- Dark/light mode, search/filter, event detail modal
- Embedded in mirrord binary via `rust-embed` (built with `npm run build`)

## How to use
Production (single command):
```
cd monitor-frontend && npm run build && cd ..
cargo build -p mirrord --features ui
mirrord ui
```

Development:
```
mirrord ui --dev          # Terminal 1: Rust API server
cd monitor-frontend && npm run dev  # Terminal 2: Vite with HMR
```

## Test plan
- [x] Tested live against playground cluster services
- [x] Works with both Node.js aggregator and Rust `mirrord ui` server
- [ ] Full CI pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)