### PR TITLE
Add session monitor event system and wire events across intproxy (Part 1/3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4941,8 +4941,10 @@ dependencies = [
 name = "mirrord-intproxy"
 version = "3.194.0"
 dependencies = [
+ "axum 0.8.8",
  "bytes",
  "futures",
+ "home",
  "http-body-util",
  "hyper 1.8.1",
  "hyper-util",
@@ -4961,6 +4963,7 @@ dependencies = [
  "rustls 0.23.37",
  "semver 1.0.27",
  "serde",
+ "serde_json",
  "strum 0.27.2",
  "strum_macros 0.27.2",
  "thiserror 2.0.18",

--- a/mirrord/cli/src/error.rs
+++ b/mirrord/cli/src/error.rs
@@ -472,18 +472,6 @@ pub(crate) enum CliError {
     ))]
     AgentPodDeleted,
 
-    #[error(
-        "The target node `{node_name}` has no capacity for a new agent pod (currently running {pod_count} pods)"
-    )]
-    #[diagnostic(help(
-        "The Kubernetes node where the target pod runs has reached its pod limit. You can either:
-        1. Free up pod capacity on the node by deleting unused pods.
-        2. Use ephemeral containers instead, which do not count toward the node's pod limit.
-           Set `\"agent\": {{ \"ephemeral\": true }}` in your mirrord config file,
-           or set the environment variable MIRRORD_EPHEMERAL_CONTAINER=true.{GENERAL_HELP}"
-    ))]
-    NodeOutOfPods { node_name: String, pod_count: usize },
-
     #[error("Detected mirrord being run within mirrord")]
     #[diagnostic(help(
         "Running mirrord within mirrord is likely to fail or introduce severe slowness. \
@@ -575,8 +563,7 @@ pub(crate) enum CliError {
 
     #[error("A preview environment with key \"{key}\" already exists for target \"{target}\"")]
     #[diagnostic(help(
-        "Use `--force` to replace the existing session, \
-         `mirrord preview stop` to stop it first, \
+        "Use `mirrord preview stop` to stop the existing session first, \
          or choose a different key with `--key`."
     ))]
     PreviewDuplicateSession { key: String, target: String },
@@ -595,6 +582,17 @@ pub(crate) enum CliError {
         Please check that the target exists and has running pods.{GENERAL_HELP}"
     ))]
     RuntimeDataResolution(KubeApiError),
+
+    #[error("Invalid image reference: {0}")]
+    #[diagnostic(help(
+        "Image must be a valid OCI image reference (e.g. 'myregistry.io/myimage:tag')."
+    ))]
+    PreviewInvalidImage(String),
+
+    /// Errors produced by the `mirrord ui` command.
+    #[error("Session monitor UI error: {0}")]
+    #[diagnostic(help("Check that no other process is using the port and try again."))]
+    UiError(String),
 }
 
 impl CliError {
@@ -621,13 +619,6 @@ impl CliError {
                 Self::InvalidCertificate(error)
             }
             KubeApiError::AgentPodDeleted => Self::AgentPodDeleted,
-            KubeApiError::NodeOutOfPods {
-                node_name,
-                pod_count,
-            } => Self::NodeOutOfPods {
-                node_name,
-                pod_count,
-            },
             error => fallback(error),
         }
     }

--- a/mirrord/cli/src/error.rs
+++ b/mirrord/cli/src/error.rs
@@ -472,6 +472,18 @@ pub(crate) enum CliError {
     ))]
     AgentPodDeleted,
 
+    #[error(
+        "The target node `{node_name}` has no capacity for a new agent pod (currently running {pod_count} pods)"
+    )]
+    #[diagnostic(help(
+        "The Kubernetes node where the target pod runs has reached its pod limit. You can either:
+        1. Free up pod capacity on the node by deleting unused pods.
+        2. Use ephemeral containers instead, which do not count toward the node's pod limit.
+           Set `\"agent\": {{ \"ephemeral\": true }}` in your mirrord config file,
+           or set the environment variable MIRRORD_EPHEMERAL_CONTAINER=true.{GENERAL_HELP}"
+    ))]
+    NodeOutOfPods { node_name: String, pod_count: usize },
+
     #[error("Detected mirrord being run within mirrord")]
     #[diagnostic(help(
         "Running mirrord within mirrord is likely to fail or introduce severe slowness. \
@@ -563,7 +575,8 @@ pub(crate) enum CliError {
 
     #[error("A preview environment with key \"{key}\" already exists for target \"{target}\"")]
     #[diagnostic(help(
-        "Use `mirrord preview stop` to stop the existing session first, \
+        "Use `--force` to replace the existing session, \
+         `mirrord preview stop` to stop it first, \
          or choose a different key with `--key`."
     ))]
     PreviewDuplicateSession { key: String, target: String },
@@ -582,12 +595,6 @@ pub(crate) enum CliError {
         Please check that the target exists and has running pods.{GENERAL_HELP}"
     ))]
     RuntimeDataResolution(KubeApiError),
-
-    #[error("Invalid image reference: {0}")]
-    #[diagnostic(help(
-        "Image must be a valid OCI image reference (e.g. 'myregistry.io/myimage:tag')."
-    ))]
-    PreviewInvalidImage(String),
 
     /// Errors produced by the `mirrord ui` command.
     #[error("Session monitor UI error: {0}")]
@@ -619,6 +626,13 @@ impl CliError {
                 Self::InvalidCertificate(error)
             }
             KubeApiError::AgentPodDeleted => Self::AgentPodDeleted,
+            KubeApiError::NodeOutOfPods {
+                node_name,
+                pod_count,
+            } => Self::NodeOutOfPods {
+                node_name,
+                pod_count,
+            },
             error => fallback(error),
         }
     }

--- a/mirrord/cli/src/internal_proxy.rs
+++ b/mirrord/cli/src/internal_proxy.rs
@@ -23,11 +23,14 @@ use mirrord_config::LayerConfig;
 use mirrord_intproxy::{
     IntProxy,
     agent_conn::{AgentConnectInfo, AgentConnection},
+    session_monitor::MonitorTx,
 };
 use mirrord_protocol::{ClientMessage, DaemonMessage, LogLevel, LogMessage};
 #[cfg(not(target_os = "windows"))]
 use nix::sys::resource::{Resource, setrlimit};
 use tokio::net::TcpListener;
+#[cfg(unix)]
+use tokio_util::sync::CancellationToken;
 use tracing::Level;
 #[cfg(not(target_os = "windows"))]
 use tracing::warn;
@@ -132,6 +135,59 @@ pub(crate) async fn proxy(
     let process_logging_interval =
         Duration::from_secs(config.internal_proxy.process_logging_interval);
 
+    #[cfg(unix)]
+    let monitor_tx = if config.api {
+        let (tx, _rx) =
+            tokio::sync::broadcast::channel::<mirrord_intproxy::session_monitor::MonitorEvent>(256);
+        let proxy_monitor_tx = MonitorTx::from_sender(tx.clone());
+        let api_monitor_tx = MonitorTx::from_sender(tx);
+
+        let session_id =
+            env::var("MIRRORD_SESSION_ID").unwrap_or_else(|_| uuid::Uuid::new_v4().to_string());
+
+        let target_name = config
+            .target
+            .path
+            .as_ref()
+            .map(|t| t.to_string())
+            .unwrap_or_else(|| "unknown".to_owned());
+
+        let config_value = serde_json::to_value(&config).unwrap_or(serde_json::Value::Null);
+
+        let session_info = mirrord_intproxy::session_monitor::api::SessionInfo {
+            session_id: session_id.clone(),
+            target: target_name,
+            started_at: humantime::format_rfc3339(std::time::SystemTime::now()).to_string(),
+            mirrord_version: env!("CARGO_PKG_VERSION").to_owned(),
+            is_operator: config.operator.unwrap_or(false),
+            processes: Vec::new(),
+            config: config_value,
+            filter: None,
+        };
+
+        let shutdown = CancellationToken::new();
+
+        tokio::spawn(async move {
+            if let Err(error) = mirrord_intproxy::session_monitor::api::start_api_server(
+                session_info.session_id.clone(),
+                session_info,
+                api_monitor_tx,
+                shutdown,
+            )
+            .await
+            {
+                tracing::warn!(%error, "Session monitor API server failed");
+            }
+        });
+
+        proxy_monitor_tx
+    } else {
+        MonitorTx::disabled()
+    };
+
+    #[cfg(not(unix))]
+    let monitor_tx = MonitorTx::disabled();
+
     IntProxy::new_with_connection(
         agent_conn,
         listener,
@@ -145,7 +201,7 @@ pub(crate) async fn proxy(
             .unwrap_or_default(),
         process_logging_interval,
         &config.experimental,
-        mirrord_intproxy::session_monitor::MonitorTx::disabled(),
+        monitor_tx,
     )
     .run(first_connection_timeout, consecutive_connection_timeout)
     .await

--- a/mirrord/cli/src/internal_proxy.rs
+++ b/mirrord/cli/src/internal_proxy.rs
@@ -145,6 +145,7 @@ pub(crate) async fn proxy(
             .unwrap_or_default(),
         process_logging_interval,
         &config.experimental,
+        mirrord_intproxy::session_monitor::MonitorTx::disabled(),
     )
     .run(first_connection_timeout, consecutive_connection_timeout)
     .await

--- a/mirrord/cli/src/port_forward.rs
+++ b/mirrord/cli/src/port_forward.rs
@@ -11,6 +11,7 @@ use mirrord_intproxy::{
     background_tasks::{BackgroundTasks, TaskError, TaskSender, TaskUpdate},
     main_tasks::{ProxyMessage, ToLayer},
     proxies::incoming::{IncomingProxy, IncomingProxyError, IncomingProxyMessage},
+    session_monitor::MonitorTx,
 };
 use mirrord_intproxy_protocol::{
     IncomingRequest, IncomingResponse, LayerId, PortSubscribe, PortSubscription,
@@ -499,6 +500,7 @@ impl ReversePortForwarder {
                     .clone()
                     .or_else(|| network_config.https_delivery.clone())
                     .unwrap_or_default(),
+                MonitorTx::disabled(),
             ),
             (),
             512,

--- a/mirrord/config/src/lib.rs
+++ b/mirrord/config/src/lib.rs
@@ -274,6 +274,17 @@ pub struct LayerConfig {
     #[config(env = "MIRRORD_OPERATOR_ENABLE")]
     pub operator: Option<bool>,
 
+    /// ## api {#root-api}
+    ///
+    /// Enables the local session monitor API server.
+    ///
+    /// When enabled, mirrord exposes a Unix socket at `~/.mirrord/sessions/<session-id>.sock`
+    /// with HTTP endpoints for observing session activity in real time.
+    ///
+    /// Defaults to `true`.
+    #[config(default = true, env = "MIRRORD_API")]
+    pub api: bool,
+
     /// ## profile {#root-profile}
     ///
     /// Name of the mirrord profile to use.

--- a/mirrord/intproxy/Cargo.toml
+++ b/mirrord/intproxy/Cargo.toml
@@ -48,6 +48,11 @@ tokio-retry.workspace = true
 tokio-rustls.workspace = true
 tokio-util.workspace = true
 
+[target.'cfg(unix)'.dependencies]
+axum = "0.8.4"
+serde_json.workspace = true
+home.workspace = true
+
 [dev-dependencies]
 rcgen.workspace = true
 rstest.workspace = true

--- a/mirrord/intproxy/src/lib.rs
+++ b/mirrord/intproxy/src/lib.rs
@@ -43,6 +43,7 @@ use crate::{
     error::{ProxyRuntimeError, ProxyStartupError},
     failover_strategy::FailoverStrategy,
     main_tasks::{ConnectionRefresh, LayerClosed},
+    session_monitor::MonitorTx,
 };
 
 pub mod agent_conn;
@@ -56,6 +57,7 @@ pub mod ping_pong;
 pub mod proxies;
 mod remote_resources;
 mod request_queue;
+pub mod session_monitor;
 
 /// [`TaskSender`]s for main background tasks. See [`MainTaskId`].
 struct TaskTxs {
@@ -102,6 +104,9 @@ pub struct IntProxy {
 
     /// Send handle for the agent connection
     agent_tx: TxHandle<Client>,
+
+    /// Session monitor event sender
+    monitor_tx: MonitorTx,
 }
 
 impl IntProxy {
@@ -125,6 +130,7 @@ impl IntProxy {
         https_delivery: LocalTlsDelivery,
         process_logging_interval: Duration,
         experimental: &ExperimentalConfig,
+        monitor_tx: MonitorTx,
     ) -> Self {
         let mut background_tasks: BackgroundTasks<MainTaskId, ProxyMessage, ProxyRuntimeError> =
             BackgroundTasks::new(agent_conn.connection.tx_handle());
@@ -218,6 +224,7 @@ impl IntProxy {
             connected_layers: HashMap::new(),
             process_logging_interval,
             agent_tx,
+            monitor_tx,
         }
     }
 
@@ -764,7 +771,7 @@ mod test {
     };
 
     use crate::{
-        IntProxy,
+        IntProxy, MonitorTx,
         agent_conn::{
             AgentConnectInfo, AgentConnectInfoDiscriminants, AgentConnection, ReconnectFlow,
         },
@@ -799,6 +806,7 @@ mod test {
             &ExperimentalFileConfig::default()
                 .generate_config(&mut Default::default())
                 .unwrap(),
+            MonitorTx::disabled(),
         );
         let proxy_handle = tokio::spawn(proxy.run(Duration::from_secs(60), Duration::ZERO));
 
@@ -917,6 +925,7 @@ mod test {
             &ExperimentalFileConfig::default()
                 .generate_config(&mut Default::default())
                 .unwrap(),
+            MonitorTx::disabled(),
         );
         let proxy_handle = tokio::spawn(proxy.run(Duration::from_secs(60), Duration::ZERO));
 
@@ -1010,6 +1019,7 @@ mod test {
             &ExperimentalFileConfig::default()
                 .generate_config(&mut Default::default())
                 .unwrap(),
+            MonitorTx::disabled(),
         );
         tokio::time::timeout(
             Duration::from_millis(200),
@@ -1081,6 +1091,7 @@ mod test {
             &ExperimentalFileConfig::default()
                 .generate_config(&mut Default::default())
                 .unwrap(),
+            MonitorTx::disabled(),
         );
         tokio::spawn(proxy.run(Duration::from_millis(100), Duration::ZERO));
 

--- a/mirrord/intproxy/src/lib.rs
+++ b/mirrord/intproxy/src/lib.rs
@@ -17,7 +17,8 @@ use mirrord_config::{
     experimental::ExperimentalConfig, feature::network::incoming::tls_delivery::LocalTlsDelivery,
 };
 use mirrord_intproxy_protocol::{
-    IncomingRequest, LayerId, LayerToProxyMessage, LocalMessage, MessageId, ProcessInfo,
+    IncomingRequest, LayerId, LayerToProxyMessage, LocalMessage, MessageId, OutgoingRequest,
+    ProcessInfo,
 };
 use mirrord_protocol::{
     CLIENT_READY_FOR_LOGS, ClientMessage, DaemonMessage, FileRequest, LogLevel,
@@ -43,7 +44,7 @@ use crate::{
     error::{ProxyRuntimeError, ProxyStartupError},
     failover_strategy::FailoverStrategy,
     main_tasks::{ConnectionRefresh, LayerClosed},
-    session_monitor::MonitorTx,
+    session_monitor::{MonitorEvent, MonitorTx},
 };
 
 pub mod agent_conn;
@@ -58,6 +59,52 @@ pub mod proxies;
 mod remote_resources;
 mod request_queue;
 pub mod session_monitor;
+
+/// Returns a short string describing the type of file operation.
+fn file_request_operation_name(req: &FileRequest) -> &'static str {
+    match req {
+        FileRequest::Open(..) | FileRequest::OpenRelative(..) => "open",
+        FileRequest::Read(..) | FileRequest::ReadLimited(..) => "read",
+        FileRequest::Seek(..) => "seek",
+        FileRequest::Write(..) | FileRequest::WriteLimited(..) => "write",
+        FileRequest::Close(..) => "close",
+        FileRequest::Access(..) => "access",
+        FileRequest::Xstat(..) | FileRequest::XstatFs(..) | FileRequest::XstatFsV2(..) => "stat",
+        FileRequest::FdOpenDir(..) => "opendir",
+        FileRequest::ReadDir(..) | FileRequest::ReadDirBatch(..) => "readdir",
+        FileRequest::CloseDir(..) => "closedir",
+        FileRequest::GetDEnts64(..) => "getdents64",
+        FileRequest::ReadLink(..) => "readlink",
+        FileRequest::MakeDir(..) | FileRequest::MakeDirAt(..) => "mkdir",
+        FileRequest::RemoveDir(..) => "rmdir",
+        FileRequest::Unlink(..) | FileRequest::UnlinkAt(..) => "unlink",
+        FileRequest::StatFs(..) | FileRequest::StatFsV2(..) => "statfs",
+        FileRequest::Rename(..) => "rename",
+        FileRequest::Ftruncate(..) => "ftruncate",
+        FileRequest::Futimens(..) => "futimens",
+        FileRequest::Fchown(..) => "fchown",
+        FileRequest::Fchmod(..) => "fchmod",
+    }
+}
+
+fn file_request_path(req: &FileRequest) -> Option<String> {
+    match req {
+        FileRequest::Open(r) => Some(r.path.to_string_lossy().into_owned()),
+        FileRequest::OpenRelative(r) => Some(r.path.to_string_lossy().into_owned()),
+        FileRequest::Access(r) => Some(r.pathname.to_string_lossy().into_owned()),
+        FileRequest::Xstat(r) => r.path.as_ref().map(|p| p.to_string_lossy().into_owned()),
+        FileRequest::ReadLink(r) => Some(r.path.to_string_lossy().into_owned()),
+        FileRequest::MakeDir(r) => Some(r.pathname.to_string_lossy().into_owned()),
+        FileRequest::MakeDirAt(r) => Some(r.pathname.to_string_lossy().into_owned()),
+        FileRequest::RemoveDir(r) => Some(r.pathname.to_string_lossy().into_owned()),
+        FileRequest::Unlink(r) => Some(r.pathname.to_string_lossy().into_owned()),
+        FileRequest::UnlinkAt(r) => Some(r.pathname.to_string_lossy().into_owned()),
+        FileRequest::StatFs(r) => Some(r.path.to_string_lossy().into_owned()),
+        FileRequest::StatFsV2(r) => Some(r.path.to_string_lossy().into_owned()),
+        FileRequest::Rename(r) => Some(r.old_path.to_string_lossy().into_owned()),
+        _ => None,
+    }
+}
 
 /// [`TaskSender`]s for main background tasks. See [`MainTaskId`].
 struct TaskTxs {
@@ -171,6 +218,7 @@ impl IntProxy {
                 experimental.non_blocking_tcp_connect.unwrap_or_default(),
                 experimental.latency.receive_delay,
                 experimental.latency.transmit_delay,
+                monitor_tx.clone(),
             ),
             MainTaskId::OutgoingProxy,
             Self::CHANNEL_SIZE,
@@ -179,6 +227,7 @@ impl IntProxy {
             IncomingProxy::new(
                 Duration::from_millis(experimental.idle_local_http_connection_timeout),
                 https_delivery,
+                monitor_tx.clone(),
             ),
             MainTaskId::IncomingProxy,
             Self::CHANNEL_SIZE,
@@ -349,6 +398,9 @@ impl IntProxy {
             ProxyMessage::NewLayer(new_layer) => {
                 self.any_connection_accepted = true;
 
+                self.monitor_tx.emit(MonitorEvent::LayerConnected {
+                    pid: new_layer.process_info.pid as u32,
+                });
                 self.connected_layers
                     .insert(new_layer.id, new_layer.process_info);
                 let tx = self.background_tasks.register(
@@ -426,6 +478,8 @@ impl IntProxy {
                         tracing::error!(layer_id = id, %error, "Layer connection failed");
                     }
                 }
+
+                self.monitor_tx.emit(MonitorEvent::LayerDisconnected);
 
                 let msg = LayerClosed { id: LayerId(id) };
 
@@ -610,24 +664,44 @@ impl IntProxy {
 
         match message {
             LayerToProxyMessage::File(req) => {
+                self.monitor_tx.emit(MonitorEvent::FileOp {
+                    path: file_request_path(&req),
+                    operation: file_request_operation_name(&req).to_owned(),
+                });
                 self.task_txs
                     .files
                     .send(FilesProxyMessage::FileReq(message_id, layer_id, req))
                     .await;
             }
             LayerToProxyMessage::GetAddrInfo(req) => {
+                self.monitor_tx.emit(MonitorEvent::DnsQuery {
+                    host: req.node.clone(),
+                });
                 self.task_txs
                     .simple
                     .send(SimpleProxyMessage::AddrInfoReq(message_id, layer_id, req))
                     .await
             }
             LayerToProxyMessage::Outgoing(req) => {
+                if let OutgoingRequest::Connect(ref connect_req) = req {
+                    let port = connect_req.remote_address.get_port().unwrap_or(0);
+                    self.monitor_tx.emit(MonitorEvent::OutgoingConnection {
+                        address: format!("{}", connect_req.remote_address),
+                        port,
+                    });
+                }
                 self.task_txs
                     .outgoing
                     .send(OutgoingProxyMessage::Layer(req, message_id, layer_id))
                     .await
             }
             LayerToProxyMessage::Incoming(req) => {
+                if let IncomingRequest::PortSubscribe(ref sub) = req {
+                    self.monitor_tx.emit(MonitorEvent::PortSubscription {
+                        port: sub.listening_on.port(),
+                        mode: format!("{:?}", sub.subscription),
+                    });
+                }
                 self.task_txs
                     .incoming
                     .send(IncomingProxyMessage::LayerRequest(
@@ -636,6 +710,14 @@ impl IntProxy {
                     .await
             }
             LayerToProxyMessage::GetEnv(req) => {
+                self.monitor_tx.emit(MonitorEvent::EnvVar {
+                    vars: req
+                        .env_vars_select
+                        .iter()
+                        .chain(req.env_vars_filter.iter())
+                        .cloned()
+                        .collect(),
+                });
                 self.task_txs
                     .simple
                     .send(SimpleProxyMessage::GetEnvReq(message_id, layer_id, req))

--- a/mirrord/intproxy/src/proxies/incoming.rs
+++ b/mirrord/intproxy/src/proxies/incoming.rs
@@ -7,7 +7,7 @@
 //! 2. HttpSender -
 
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     io,
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
     ops::Not,
@@ -49,7 +49,22 @@ use crate::{
         BackgroundTask, BackgroundTasks, MessageBus, TaskError, TaskSender, TaskUpdate,
     },
     main_tasks::{ConnectionRefresh, LayerClosed, LayerForked, ToLayer},
+    session_monitor::{MonitorEvent, MonitorTx, try_parse_http_request},
 };
+
+/// Extracts method, path, and host from an [`InternalHttpRequest`] and emits
+/// a [`MonitorEvent::IncomingRequest`].
+fn emit_incoming_request_event<B>(monitor_tx: &MonitorTx, req: &InternalHttpRequest<B>) {
+    let method = req.method.to_string();
+    let path = req.uri.path().to_owned();
+    let host = req
+        .headers
+        .get("host")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("")
+        .to_owned();
+    monitor_tx.emit(MonitorEvent::IncomingRequest { method, path, host });
+}
 
 mod bound_socket;
 pub mod http;
@@ -205,6 +220,12 @@ pub struct IncomingProxy {
     protocol_version: Option<Version>,
 
     restore_subscriptions_on_protocol_version_switch: bool,
+
+    /// Session monitor event sender.
+    monitor_tx: MonitorTx,
+
+    /// Connection IDs whose first data chunk we haven't sniffed yet for HTTP.
+    http_sniff_pending: HashSet<ConnectionId>,
 }
 
 impl IncomingProxy {
@@ -214,6 +235,7 @@ impl IncomingProxy {
     pub fn new(
         idle_local_http_connection_timeout: Duration,
         https_delivery: LocalTlsDelivery,
+        monitor_tx: MonitorTx,
     ) -> Self {
         let tls_setup = LocalTlsSetup::from_config(https_delivery);
         Self {
@@ -230,6 +252,8 @@ impl IncomingProxy {
             tasks: None,
             protocol_version: None,
             restore_subscriptions_on_protocol_version_switch: false,
+            monitor_tx,
+            http_sniff_pending: Default::default(),
         }
     }
 
@@ -421,6 +445,7 @@ impl IncomingProxy {
     ) {
         match request {
             ChunkedRequest::StartV1(request) => {
+                emit_incoming_request_event(&self.monitor_tx, &request.internal_request);
                 let (body_tx, body_rx) = mpsc::channel(128);
                 let request = request.map_body(|frames| StreamingBody::new(body_rx, frames));
                 self.start_http_gateway(
@@ -434,6 +459,8 @@ impl IncomingProxy {
             }
 
             ChunkedRequest::StartV2(request) => {
+                emit_incoming_request_event(&self.monitor_tx, &request.request);
+
                 let (body, body_tx) = if request.request.body.is_last {
                     (StreamingBody::from(request.request.body.frames), None)
                 } else {
@@ -575,6 +602,14 @@ impl IncomingProxy {
             }
 
             DaemonTcp::Data(data) => {
+                // Sniff first data chunk of each new connection for HTTP.
+                if self.http_sniff_pending.remove(&data.connection_id)
+                    && let Some((method, path, host)) = try_parse_http_request(&data.bytes)
+                {
+                    self.monitor_tx
+                        .emit(MonitorEvent::IncomingRequest { method, path, host });
+                }
+
                 let tx = self.tcp_proxies.get(is_steal).get(&data.connection_id);
 
                 if let Some(tx) = tx {
@@ -590,6 +625,7 @@ impl IncomingProxy {
             }
 
             DaemonTcp::HttpRequest(request) => {
+                emit_incoming_request_event(&self.monitor_tx, &request.internal_request);
                 self.start_http_gateway(
                     request.map_body(From::from),
                     None,
@@ -601,6 +637,7 @@ impl IncomingProxy {
             }
 
             DaemonTcp::HttpRequestFramed(request) => {
+                emit_incoming_request_event(&self.monitor_tx, &request.internal_request);
                 self.start_http_gateway(
                     request.map_body(From::from),
                     None,
@@ -617,6 +654,7 @@ impl IncomingProxy {
             }
 
             DaemonTcp::NewConnectionV1(connection) => {
+                self.http_sniff_pending.insert(connection.connection_id);
                 self.handle_new_connection(
                     NewTcpConnectionV2 {
                         connection,
@@ -629,6 +667,8 @@ impl IncomingProxy {
             }
 
             DaemonTcp::NewConnectionV2(connection) => {
+                self.http_sniff_pending
+                    .insert(connection.connection.connection_id);
                 self.handle_new_connection(connection, is_steal, message_bus)
                     .await?;
             }

--- a/mirrord/intproxy/src/proxies/incoming/tests.rs
+++ b/mirrord/intproxy/src/proxies/incoming/tests.rs
@@ -62,7 +62,11 @@ async fn http_request_terminates_on_remote_close(#[case] steal_type: StealType) 
     let local_addr = local_listener.local_addr().unwrap();
 
     let (conn, _, out) = Connection::dummy();
-    let proxy = IncomingProxy::new(Duration::from_secs(3), Default::default());
+    let proxy = IncomingProxy::new(
+        Duration::from_secs(3),
+        Default::default(),
+        crate::session_monitor::MonitorTx::disabled(),
+    );
     let mut background_tasks: BackgroundTasks<(), ProxyMessage, IncomingProxyError> =
         BackgroundTasks::new(conn.tx_handle());
 

--- a/mirrord/intproxy/src/proxies/outgoing.rs
+++ b/mirrord/intproxy/src/proxies/outgoing.rs
@@ -36,6 +36,7 @@ use crate::{
     proxies::outgoing::net_protocol_ext::{NetProtocolExt, PreparedSocket},
     remote_resources::RemoteResources,
     request_queue::RequestQueue,
+    session_monitor::{MonitorEvent, MonitorTx, try_parse_http_request},
 };
 
 mod interceptor;
@@ -209,6 +210,13 @@ pub struct OutgoingProxy {
     connections_in_layers: RemoteResources<u128>,
     /// Maps outgoing connection local IDs to local addresses of corresponding agent sockets.
     agent_local_addresses: HashMap<u128, SocketAddr>,
+
+    /// Session monitor event sender.
+    monitor_tx: MonitorTx,
+    /// TCP connections that have not yet sent their first bytes to the agent.
+    /// Used to sniff HTTP requests from the first data chunk.
+    /// Stores the remote address so we can report the port in the event.
+    http_sniff_pending: HashMap<InterceptorId, SocketAddress>,
 }
 
 impl OutgoingProxy {
@@ -226,6 +234,7 @@ impl OutgoingProxy {
         non_blocking_tcp_connect: bool,
         receive_delay_ms: u64,
         transmit_delay_ms: u64,
+        monitor_tx: MonitorTx,
     ) -> Self {
         Self {
             datagrams_reqs: Default::default(),
@@ -239,6 +248,8 @@ impl OutgoingProxy {
             transmit_delay_ms,
             connections_in_layers: Default::default(),
             agent_local_addresses: Default::default(),
+            monitor_tx,
+            http_sniff_pending: Default::default(),
         }
     }
 
@@ -409,6 +420,12 @@ impl OutgoingProxy {
             Self::CHANNEL_SIZE,
         );
         self.txs.insert(id, interceptor);
+
+        // Register for HTTP sniffing on TCP connections.
+        if protocol == NetProtocol::Stream {
+            self.http_sniff_pending
+                .insert(id, in_progress.remote_address);
+        }
 
         Ok(())
     }
@@ -680,6 +697,24 @@ impl BackgroundTask for OutgoingProxy {
                             tokio::time::sleep(std::time::Duration::from_millis(self.transmit_delay_ms)).await;
                         }
 
+                        // On the first non-empty data chunk from a TCP connection, try to
+                        // detect an HTTP/1.x request and emit a monitor event.
+                        if !bytes.is_empty()
+                            && let Some(remote_addr) = self.http_sniff_pending.remove(&id)
+                            && let Some((method, path, host)) = try_parse_http_request(&bytes)
+                        {
+                            let port = match &remote_addr {
+                                SocketAddress::Ip(addr) => addr.port(),
+                                _ => 0,
+                            };
+                            self.monitor_tx.emit(MonitorEvent::HttpRequest {
+                                method,
+                                path,
+                                host,
+                                port,
+                            });
+                        }
+
                         let msg = id.protocol.wrap_agent_write(id.connection_id, bytes);
                         message_bus.send_agent(msg).await;
                     }
@@ -693,6 +728,8 @@ impl BackgroundTask for OutgoingProxy {
                                 tracing::error!(%id, "Interceptor panicked");
                             }
                         }
+
+                        self.http_sniff_pending.remove(&id);
 
                         if self.txs.remove(&id).is_some() {
                             tracing::trace!(%id, "Local connection closed, notifying the agent");
@@ -725,6 +762,7 @@ mod test {
     use mirrord_protocol_io::Connection;
 
     use crate::{
+        MonitorTx,
         background_tasks::{BackgroundTasks, TaskUpdate},
         main_tasks::{ConnectionRefresh, ProxyMessage, ToLayer},
         proxies::outgoing::{OutgoingProxy, OutgoingProxyError, OutgoingProxyMessage},
@@ -739,7 +777,11 @@ mod test {
 
         let mut background_tasks: BackgroundTasks<(), ProxyMessage, OutgoingProxyError> =
             BackgroundTasks::new(connection.tx_handle());
-        let outgoing = background_tasks.register(OutgoingProxy::new(false, 0, 0), (), 8);
+        let outgoing = background_tasks.register(
+            OutgoingProxy::new(false, 0, 0, MonitorTx::disabled()),
+            (),
+            8,
+        );
 
         for i in 0..=1 {
             // Layer wants to make an outgoing connection.

--- a/mirrord/intproxy/src/session_monitor/api.rs
+++ b/mirrord/intproxy/src/session_monitor/api.rs
@@ -1,0 +1,144 @@
+use std::{
+    convert::Infallible, fs, os::unix::fs::PermissionsExt, path::PathBuf, sync::Arc, time::Duration,
+};
+
+use axum::{
+    Json, Router,
+    extract::State,
+    response::{
+        IntoResponse,
+        sse::{Event, Sse},
+    },
+    routing::{get, post},
+};
+use serde::{Deserialize, Serialize};
+use tokio::net::UnixListener;
+use tokio_stream::{StreamExt, wrappers::BroadcastStream};
+use tokio_util::sync::CancellationToken;
+
+use super::MonitorTx;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ProcessInfo {
+    pub pid: u32,
+    pub process_name: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SessionInfo {
+    pub session_id: String,
+    pub target: String,
+    pub started_at: String,
+    pub mirrord_version: String,
+    pub is_operator: bool,
+    pub processes: Vec<ProcessInfo>,
+    pub config: serde_json::Value,
+    pub filter: Option<String>,
+}
+
+struct AppState {
+    session_info: SessionInfo,
+    monitor_tx: MonitorTx,
+    shutdown: CancellationToken,
+}
+
+/// Drop guard that removes the socket file on cleanup.
+struct SocketCleanup {
+    path: PathBuf,
+}
+
+impl Drop for SocketCleanup {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.path);
+    }
+}
+
+async fn health() -> impl IntoResponse {
+    Json(serde_json::json!({"status": "ok"}))
+}
+
+async fn info(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    Json(state.session_info.clone())
+}
+
+async fn events(
+    State(state): State<Arc<AppState>>,
+) -> Sse<impl tokio_stream::Stream<Item = Result<Event, Infallible>>> {
+    let rx = state
+        .monitor_tx
+        .subscribe()
+        .expect("monitor_tx should be enabled when API server is running");
+
+    let stream = BroadcastStream::new(rx).filter_map(|result| match result {
+        Ok(event) => {
+            let data = serde_json::to_string(&event).unwrap_or_default();
+            Some(Ok(Event::default().data(data)))
+        }
+        Err(_) => None,
+    });
+
+    Sse::new(stream).keep_alive(
+        axum::response::sse::KeepAlive::new()
+            .interval(Duration::from_secs(15))
+            .text("ping"),
+    )
+}
+
+async fn kill(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    state.shutdown.cancel();
+    Json(serde_json::json!({"status": "shutting_down"}))
+}
+
+/// Starts the session monitor API server on a Unix socket.
+///
+/// The socket is created at `~/.mirrord/sessions/<session_id>.sock`.
+/// On exit (normal or panic), the socket file is cleaned up via a drop guard.
+pub async fn start_api_server(
+    session_id: String,
+    session_info: SessionInfo,
+    monitor_tx: MonitorTx,
+    shutdown: CancellationToken,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let sessions_dir = home::home_dir()
+        .ok_or("could not determine home directory")?
+        .join(".mirrord")
+        .join("sessions");
+
+    fs::create_dir_all(&sessions_dir)?;
+    fs::set_permissions(&sessions_dir, fs::Permissions::from_mode(0o700))?;
+
+    let socket_path = sessions_dir.join(format!("{session_id}.sock"));
+
+    // Remove stale socket if it exists
+    let _ = fs::remove_file(&socket_path);
+
+    let listener = UnixListener::bind(&socket_path)?;
+    fs::set_permissions(&socket_path, fs::Permissions::from_mode(0o600))?;
+
+    let _cleanup = SocketCleanup {
+        path: socket_path.clone(),
+    };
+
+    let state = Arc::new(AppState {
+        session_info,
+        monitor_tx,
+        shutdown: shutdown.clone(),
+    });
+
+    let app = Router::new()
+        .route("/health", get(health))
+        .route("/info", get(info))
+        .route("/events", get(events))
+        .route("/kill", post(kill))
+        .with_state(state);
+
+    tracing::info!(?socket_path, "Session monitor API server starting");
+
+    axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown.cancelled_owned())
+        .await?;
+
+    tracing::info!("Session monitor API server stopped");
+
+    Ok(())
+}

--- a/mirrord/intproxy/src/session_monitor/mod.rs
+++ b/mirrord/intproxy/src/session_monitor/mod.rs
@@ -1,0 +1,106 @@
+use serde::Serialize;
+use tokio::sync::broadcast;
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum MonitorEvent {
+    FileOp {
+        path: Option<String>,
+        operation: String,
+    },
+    DnsQuery {
+        host: String,
+    },
+    HttpRequest {
+        method: String,
+        path: String,
+        host: String,
+        port: u16,
+    },
+    IncomingRequest {
+        method: String,
+        path: String,
+        host: String,
+    },
+    OutgoingConnection {
+        address: String,
+        port: u16,
+    },
+    PortSubscription {
+        port: u16,
+        mode: String,
+    },
+    EnvVar {
+        vars: Vec<String>,
+    },
+    LayerConnected {
+        pid: u32,
+    },
+    LayerDisconnected,
+}
+
+/// Wrapper around an optional broadcast sender for session monitor events.
+///
+/// When the session monitor is disabled, this wraps `None` and all emit calls are no-ops.
+#[derive(Clone)]
+pub struct MonitorTx {
+    inner: Option<broadcast::Sender<MonitorEvent>>,
+}
+
+impl MonitorTx {
+    /// Creates a disabled monitor sender that discards all events.
+    pub fn disabled() -> Self {
+        Self { inner: None }
+    }
+
+    /// Emits an event to all subscribers. Does nothing if disabled or if there are no receivers.
+    pub fn emit(&self, event: MonitorEvent) {
+        if let Some(tx) = &self.inner {
+            let _ = tx.send(event);
+        }
+    }
+
+    /// Creates an enabled monitor sender from an existing broadcast sender.
+    pub fn from_sender(tx: broadcast::Sender<MonitorEvent>) -> Self {
+        Self { inner: Some(tx) }
+    }
+
+    /// Returns a new receiver if the monitor is enabled.
+    pub fn subscribe(&self) -> Option<broadcast::Receiver<MonitorEvent>> {
+        self.inner.as_ref().map(|tx| tx.subscribe())
+    }
+}
+
+/// Tries to parse an HTTP/1.x request from raw bytes.
+/// Returns `(method, path, host)` on success.
+pub fn try_parse_http_request(bytes: &[u8]) -> Option<(String, String, String)> {
+    const HTTP_METHODS: &[&str] = &[
+        "GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS", "PATCH", "CONNECT", "TRACE",
+    ];
+
+    let s = std::str::from_utf8(bytes).ok()?;
+    let first_line_end = s.find("\r\n")?;
+    let first_line = &s[..first_line_end];
+
+    let mut parts = first_line.splitn(3, ' ');
+    let method = parts.next()?;
+    let path = parts.next()?;
+    let version = parts.next()?;
+
+    if !HTTP_METHODS.contains(&method) {
+        return None;
+    }
+    if !version.starts_with("HTTP/") {
+        return None;
+    }
+
+    let host_line = s[first_line_end + 2..]
+        .lines()
+        .find(|l| l.len() > 5 && l[..5].eq_ignore_ascii_case("host:"))?;
+    let host = host_line[5..].trim();
+
+    Some((method.to_owned(), path.to_owned(), host.to_owned()))
+}
+
+#[cfg(unix)]
+pub mod api;

--- a/mirrord/layer-tests/src/intproxy.rs
+++ b/mirrord/layer-tests/src/intproxy.rs
@@ -65,6 +65,7 @@ impl TestIntProxy {
                 Default::default(),
                 Duration::from_secs(60),
                 &experimental_config,
+                mirrord_intproxy::session_monitor::MonitorTx::disabled(),
             );
             intproxy
                 .run(Duration::from_secs(15), Duration::from_secs(5))


### PR DESCRIPTION
## Summary

Introduce the session monitor event system and wire up event emission across the intproxy.

### Event system (session_monitor/)
- `MonitorTx` broadcast channel wrapper with fire-and-forget `emit()`, zero-cost when disabled
- `MonitorEvent` enum with 9 typed variants (FileOp, DnsQuery, HttpRequest, IncomingRequest, OutgoingConnection, PortSubscription, EnvVar, LayerConnected, LayerDisconnected)
- `try_parse_http_request()` for detecting HTTP/1.x from raw TCP bytes
- Unix socket HTTP API server at `~/.mirrord/sessions/<id>.sock` with `/health`, `/info`, `/events` (SSE), `/kill`
- Socket cleanup via Drop guard, `0600` permissions
- New `api` config field (default: `true`, env: `MIRRORD_API`)

### Event wiring (lib.rs, incoming.rs, outgoing.rs)
- Emit MonitorEvents from `handle_layer_message()` for file ops, DNS, outgoing connections, port subscriptions, env vars
- Emit LayerConnected/LayerDisconnected on layer connect/close
- HTTP sniffing on outgoing TCP (first data chunk per connection)
- HTTP sniffing on incoming TCP mirror mode
- `emit_incoming_request_event()` helper deduplicates 4 identical extraction blocks

### API server startup (internal_proxy.rs)
- Creates broadcast channel, spawns API server task when `config.api` is true
- Generates `MIRRORD_SESSION_ID` UUID in execution.rs

Related: [RFC 0004](https://github.com/metalbear-co/rfcs/pull/20) | [PRO-73](https://linear.app/metalbear/issue/PRO-73)

## Test plan

- [x] `cargo test -p mirrord-intproxy` passes (37 tests)
- [x] `cargo clippy -p mirrord-intproxy` clean (0 warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)