### PR TITLE
Deny unknown config fields

### DIFF
--- a/.vale/styles/config/vocabularies/Metalbear/accept.txt
+++ b/.vale/styles/config/vocabularies/Metalbear/accept.txt
@@ -32,6 +32,10 @@ gcloud
 Tokio
 tokio
 serde
+serialize
+serialization
+deserialize
+deserialization
 reqwest
 rustls
 bincode
@@ -146,6 +150,7 @@ sccache
 LTO
 jq
 jaq
+towncrier
 
 # Cloud services
 SNS

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,13 @@ cargo clippy -- --deny warnings
 
 Use `cargo check -p <crate> --keep-going` to surface all errors at once rather than stopping at the first.
 
+## Contribution Notes
+
+- Add a towncrier fragment for code changes in `changelog.d/`, named `<identifier>.<category>.md`.
+- Use a public GitHub issue number when one exists, otherwise use `+some-name`.
+- Valid categories are `added`, `fixed`, `internal`, and `changed`.
+- Use `internal` for test-only, CI-only, and other changes users do not care about.
+
 ## Project Overview
 
 mirrord is a tool that lets developers run local processes in the context of their cloud environment.

--- a/changelog.d/+deny-unknown-config-fields.fixed.md
+++ b/changelog.d/+deny-unknown-config-fields.fixed.md
@@ -1,0 +1,1 @@
+Fix a bug where unknown fields in some nested mirrord config sections were accepted during deserialization instead of being rejected.

--- a/mirrord-schema.json
+++ b/mirrord-schema.json
@@ -691,12 +691,14 @@
           "type": "string"
         }
       },
+      "additionalProperties": false,
       "required": [
         "name"
       ]
     },
     "AppleVariablesConfig": {
-      "type": "object"
+      "type": "object",
+      "additionalProperties": false
     },
     "BodyFilter": {
       "description": "Currently only JSON body filtering is supported.",
@@ -717,6 +719,7 @@
               "type": "string"
             }
           },
+          "additionalProperties": false,
           "required": [
             "body",
             "query",
@@ -735,7 +738,8 @@
             "null"
           ]
         }
-      }
+      },
+      "additionalProperties": false
     },
     "CiFileConfig": {
       "description": "Configuration for mirrord for CI.\n\n```json\n{\n  \"ci\": {\n    \"output_dir\": \"/tmp/mirrord/\",\n  }\n}\n```",
@@ -790,6 +794,7 @@
           ]
         }
       },
+      "additionalProperties": false,
       "required": [
         "params"
       ]
@@ -848,7 +853,8 @@
             }
           ]
         }
-      }
+      },
+      "additionalProperties": false
     },
     "ConnectionSourceType": {
       "description": "The type of environment variable source for connection params.",
@@ -1018,66 +1024,340 @@
       "description": "Configuration for a database branch.\n\nExample:\n\n```json\n{\n  \"id\": \"my-branch-db\",\n  \"name\": \"my-database-name\",\n  \"ttl_secs\": 120,\n  \"type\": \"mysql\",\n  \"version\": \"8.0\",\n  \"connection\": {\n    \"url\": {\n      \"type\": \"env\",\n      \"variable\": \"DB_CONNECTION_URL\"\n    }\n  }\n}\n```",
       "oneOf": [
         {
+          "description": "When configuring a branch for MongoDB, set `type` to `mongodb`.",
           "type": "object",
           "properties": {
+            "connection": {
+              "title": "feature.db_branches[].connection (type: mysql, pg, mongodb) {#feature-db_branches-sql-connection}",
+              "description": "`connection` describes how to get the connection information to the source database.\nWhen the branch database is ready for use, Mirrord operator will replace the connection\ninformation with the branch database's.",
+              "$ref": "#/$defs/DbBranchingConnectionSource"
+            },
+            "copy": {
+              "$ref": "#/$defs/MongodbBranchCopyConfig",
+              "default": {
+                "collections": null,
+                "mode": "empty"
+              }
+            },
+            "creation_timeout_secs": {
+              "title": "feature.db_branches[].creation_timeout_secs (type: mysql, pg, mongodb) {#feature-db_branches-sql-creation_timeout_secs}",
+              "description": "The timeout in seconds to wait for a database branch to become ready after creation.\nDefaults to 60 seconds. Adjust this value based on your database size and cluster\nperformance.",
+              "type": "integer",
+              "format": "uint64",
+              "default": 60,
+              "minimum": 0
+            },
+            "id": {
+              "title": "feature.db_branches[].id (type: mysql, pg, mongodb) {#feature-db_branches-sql-id}",
+              "description": "Users can choose to specify a unique `id`. This is useful for reusing or sharing\nthe same database branch among Kubernetes users.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "name": {
+              "title": "feature.db_branches[].name (type: mysql, pg, mongodb) {#feature-db_branches-sql-name}",
+              "description": "When source database connection detail is not accessible to mirrord operator, users\ncan specify the database `name` so it is included in the connection options mirrord\nuses as the override.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "ttl_secs": {
+              "title": "feature.db_branches[].ttl_secs (type: mysql, pg, mongodb) {#feature-db_branches-sql-ttl_secs}",
+              "description": "Mirrord operator starts counting the TTL when a branch is no longer used by any session.\nThe time-to-live (TTL) for the branch database is set to 300 seconds by default.\nUsers can set `ttl_secs` to customize this value according to their need. Please note\nthat longer TTL paired with frequent mirrord session turnover can result in increased\nresource usage. For this reason, branch database TTL caps out at 15 min.",
+              "type": "integer",
+              "format": "uint64",
+              "default": 300,
+              "minimum": 0
+            },
             "type": {
               "type": "string",
               "const": "mongodb"
+            },
+            "version": {
+              "title": "feature.db_branches[].version (type: mysql, pg, mongodb) {#feature-db_branches-sql-version}",
+              "description": "Mirrord operator uses a default version of the database image unless `version` is given.",
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
-          "$ref": "#/$defs/MongodbBranchConfig",
+          "additionalProperties": false,
           "required": [
-            "type"
+            "type",
+            "connection"
           ]
         },
         {
+          "description": "When configuring a branch for MSSQL, set `type` to `mssql`.",
           "type": "object",
           "properties": {
+            "connection": {
+              "title": "feature.db_branches[].connection (type: mysql, pg, mongodb) {#feature-db_branches-sql-connection}",
+              "description": "`connection` describes how to get the connection information to the source database.\nWhen the branch database is ready for use, Mirrord operator will replace the connection\ninformation with the branch database's.",
+              "$ref": "#/$defs/DbBranchingConnectionSource"
+            },
+            "copy": {
+              "$ref": "#/$defs/MssqlBranchCopyConfig",
+              "default": {
+                "mode": "empty",
+                "tables": null
+              }
+            },
+            "creation_timeout_secs": {
+              "title": "feature.db_branches[].creation_timeout_secs (type: mysql, pg, mongodb) {#feature-db_branches-sql-creation_timeout_secs}",
+              "description": "The timeout in seconds to wait for a database branch to become ready after creation.\nDefaults to 60 seconds. Adjust this value based on your database size and cluster\nperformance.",
+              "type": "integer",
+              "format": "uint64",
+              "default": 60,
+              "minimum": 0
+            },
+            "id": {
+              "title": "feature.db_branches[].id (type: mysql, pg, mongodb) {#feature-db_branches-sql-id}",
+              "description": "Users can choose to specify a unique `id`. This is useful for reusing or sharing\nthe same database branch among Kubernetes users.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "name": {
+              "title": "feature.db_branches[].name (type: mysql, pg, mongodb) {#feature-db_branches-sql-name}",
+              "description": "When source database connection detail is not accessible to mirrord operator, users\ncan specify the database `name` so it is included in the connection options mirrord\nuses as the override.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "ttl_secs": {
+              "title": "feature.db_branches[].ttl_secs (type: mysql, pg, mongodb) {#feature-db_branches-sql-ttl_secs}",
+              "description": "Mirrord operator starts counting the TTL when a branch is no longer used by any session.\nThe time-to-live (TTL) for the branch database is set to 300 seconds by default.\nUsers can set `ttl_secs` to customize this value according to their need. Please note\nthat longer TTL paired with frequent mirrord session turnover can result in increased\nresource usage. For this reason, branch database TTL caps out at 15 min.",
+              "type": "integer",
+              "format": "uint64",
+              "default": 300,
+              "minimum": 0
+            },
             "type": {
               "type": "string",
               "const": "mssql"
+            },
+            "version": {
+              "title": "feature.db_branches[].version (type: mysql, pg, mongodb) {#feature-db_branches-sql-version}",
+              "description": "Mirrord operator uses a default version of the database image unless `version` is given.",
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
-          "$ref": "#/$defs/MssqlBranchConfig",
+          "additionalProperties": false,
           "required": [
-            "type"
+            "type",
+            "connection"
           ]
         },
         {
+          "description": "When configuring a branch for MySQL, set `type` to `mysql`.",
           "type": "object",
           "properties": {
+            "connection": {
+              "title": "feature.db_branches[].connection (type: mysql, pg, mongodb) {#feature-db_branches-sql-connection}",
+              "description": "`connection` describes how to get the connection information to the source database.\nWhen the branch database is ready for use, Mirrord operator will replace the connection\ninformation with the branch database's.",
+              "$ref": "#/$defs/DbBranchingConnectionSource"
+            },
+            "copy": {
+              "$ref": "#/$defs/MysqlBranchCopyConfig",
+              "default": {
+                "mode": "empty",
+                "tables": null
+              }
+            },
+            "creation_timeout_secs": {
+              "title": "feature.db_branches[].creation_timeout_secs (type: mysql, pg, mongodb) {#feature-db_branches-sql-creation_timeout_secs}",
+              "description": "The timeout in seconds to wait for a database branch to become ready after creation.\nDefaults to 60 seconds. Adjust this value based on your database size and cluster\nperformance.",
+              "type": "integer",
+              "format": "uint64",
+              "default": 60,
+              "minimum": 0
+            },
+            "id": {
+              "title": "feature.db_branches[].id (type: mysql, pg, mongodb) {#feature-db_branches-sql-id}",
+              "description": "Users can choose to specify a unique `id`. This is useful for reusing or sharing\nthe same database branch among Kubernetes users.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "name": {
+              "title": "feature.db_branches[].name (type: mysql, pg, mongodb) {#feature-db_branches-sql-name}",
+              "description": "When source database connection detail is not accessible to mirrord operator, users\ncan specify the database `name` so it is included in the connection options mirrord\nuses as the override.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "ttl_secs": {
+              "title": "feature.db_branches[].ttl_secs (type: mysql, pg, mongodb) {#feature-db_branches-sql-ttl_secs}",
+              "description": "Mirrord operator starts counting the TTL when a branch is no longer used by any session.\nThe time-to-live (TTL) for the branch database is set to 300 seconds by default.\nUsers can set `ttl_secs` to customize this value according to their need. Please note\nthat longer TTL paired with frequent mirrord session turnover can result in increased\nresource usage. For this reason, branch database TTL caps out at 15 min.",
+              "type": "integer",
+              "format": "uint64",
+              "default": 300,
+              "minimum": 0
+            },
             "type": {
               "type": "string",
               "const": "mysql"
+            },
+            "version": {
+              "title": "feature.db_branches[].version (type: mysql, pg, mongodb) {#feature-db_branches-sql-version}",
+              "description": "Mirrord operator uses a default version of the database image unless `version` is given.",
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
-          "$ref": "#/$defs/MysqlBranchConfig",
+          "additionalProperties": false,
           "required": [
-            "type"
+            "type",
+            "connection"
           ]
         },
         {
+          "description": "When configuring a branch for PostgreSQL, set `type` to `pg`.",
           "type": "object",
           "properties": {
+            "connection": {
+              "title": "feature.db_branches[].connection (type: mysql, pg, mongodb) {#feature-db_branches-sql-connection}",
+              "description": "`connection` describes how to get the connection information to the source database.\nWhen the branch database is ready for use, Mirrord operator will replace the connection\ninformation with the branch database's.",
+              "$ref": "#/$defs/DbBranchingConnectionSource"
+            },
+            "copy": {
+              "$ref": "#/$defs/PgBranchCopyConfig",
+              "default": {
+                "mode": "empty",
+                "tables": null
+              }
+            },
+            "creation_timeout_secs": {
+              "title": "feature.db_branches[].creation_timeout_secs (type: mysql, pg, mongodb) {#feature-db_branches-sql-creation_timeout_secs}",
+              "description": "The timeout in seconds to wait for a database branch to become ready after creation.\nDefaults to 60 seconds. Adjust this value based on your database size and cluster\nperformance.",
+              "type": "integer",
+              "format": "uint64",
+              "default": 60,
+              "minimum": 0
+            },
+            "iam_auth": {
+              "title": "feature.db_branches[].iam_auth (type: pg) {#feature-db_branches-pg-iam_auth}",
+              "description": "IAM authentication for the source database.\nUse this when your source database (AWS RDS, GCP Cloud SQL) requires IAM authentication\ninstead of password-based authentication.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/IamAuthConfig"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "id": {
+              "title": "feature.db_branches[].id (type: mysql, pg, mongodb) {#feature-db_branches-sql-id}",
+              "description": "Users can choose to specify a unique `id`. This is useful for reusing or sharing\nthe same database branch among Kubernetes users.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "name": {
+              "title": "feature.db_branches[].name (type: mysql, pg, mongodb) {#feature-db_branches-sql-name}",
+              "description": "When source database connection detail is not accessible to mirrord operator, users\ncan specify the database `name` so it is included in the connection options mirrord\nuses as the override.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "ttl_secs": {
+              "title": "feature.db_branches[].ttl_secs (type: mysql, pg, mongodb) {#feature-db_branches-sql-ttl_secs}",
+              "description": "Mirrord operator starts counting the TTL when a branch is no longer used by any session.\nThe time-to-live (TTL) for the branch database is set to 300 seconds by default.\nUsers can set `ttl_secs` to customize this value according to their need. Please note\nthat longer TTL paired with frequent mirrord session turnover can result in increased\nresource usage. For this reason, branch database TTL caps out at 15 min.",
+              "type": "integer",
+              "format": "uint64",
+              "default": 300,
+              "minimum": 0
+            },
             "type": {
               "type": "string",
               "const": "pg"
+            },
+            "version": {
+              "title": "feature.db_branches[].version (type: mysql, pg, mongodb) {#feature-db_branches-sql-version}",
+              "description": "Mirrord operator uses a default version of the database image unless `version` is given.",
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
-          "$ref": "#/$defs/PgBranchConfig",
+          "additionalProperties": false,
           "required": [
-            "type"
+            "type",
+            "connection"
           ]
         },
         {
+          "description": "When configuring a branch for Redis, set `type` to `redis`.\n\nExample with URL-based connection:\n```json\n{\n  \"type\": \"redis\",\n  \"location\": \"local\",\n  \"connection\": {\n    \"url\": {\n      \"type\": \"env\",\n      \"variable\": \"REDIS_URL\"\n    }\n  }\n}\n```\n\nExample with separated settings:\n```json\n{\n  \"type\": \"redis\",\n  \"location\": \"local\",\n  \"connection\": {\n    \"host\": { \"type\": \"env\", \"variable\": \"REDIS_HOST\" },\n    \"port\": 6379,\n    \"password\": { \"type\": \"env\", \"variable\": \"REDIS_PASSWORD\" }\n  }\n}\n```",
           "type": "object",
           "properties": {
+            "connection": {
+              "title": "feature.db_branches[].connection (type: redis) {#feature-db_branches-redis-connection}",
+              "description": "Connection configuration for the Redis instance.",
+              "$ref": "#/$defs/RedisConnectionConfig",
+              "default": {
+                "database": null,
+                "host": null,
+                "password": null,
+                "port": null,
+                "tls": null,
+                "url": null,
+                "username": null
+              }
+            },
+            "id": {
+              "title": "feature.db_branches[].id (type: redis) {#feature-db_branches-redis-id}",
+              "description": "Optional unique identifier for reusing branches across sessions.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "default": null
+            },
+            "local": {
+              "title": "feature.db_branches[].local (type: redis) {#feature-db_branches-redis-local}",
+              "description": "Local Redis runtime configuration.\nOnly used when `location` is `local`.",
+              "$ref": "#/$defs/RedisLocalConfig",
+              "default": {
+                "container_command": null,
+                "container_runtime": "docker",
+                "options": {
+                  "args": []
+                },
+                "port": 6379,
+                "runtime": "container",
+                "server_command": null,
+                "version": "7-alpine"
+              }
+            },
+            "location": {
+              "title": "feature.db_branches[].location (type: redis) {#feature-db_branches-redis-location}",
+              "description": "Where the Redis instance should run.\n- `local`: Spawns a local Redis instance managed by mirrord.\n- `remote`: Uses the remote Redis (default behavior, no-op).",
+              "$ref": "#/$defs/RedisBranchLocation",
+              "default": "remote"
+            },
             "type": {
               "type": "string",
               "const": "redis"
             }
           },
-          "$ref": "#/$defs/RedisBranchConfig",
+          "additionalProperties": false,
           "required": [
             "type"
           ]
@@ -1101,6 +1381,7 @@
               "$ref": "#/$defs/DbBranchingConnectionSourceKind"
             }
           },
+          "additionalProperties": false,
           "required": [
             "url"
           ]
@@ -1122,6 +1403,7 @@
               "type": "string"
             }
           },
+          "additionalProperties": false,
           "required": [
             "url"
           ]
@@ -1151,6 +1433,7 @@
               "type": "string"
             }
           },
+          "additionalProperties": false,
           "required": [
             "type",
             "variable"
@@ -1173,6 +1456,7 @@
               "type": "string"
             }
           },
+          "additionalProperties": false,
           "required": [
             "type",
             "variable"
@@ -1192,6 +1476,7 @@
               "const": "secret"
             }
           },
+          "additionalProperties": false,
           "required": [
             "type",
             "name",
@@ -1911,6 +2196,7 @@
               "const": "aws_rds"
             }
           },
+          "additionalProperties": false,
           "required": [
             "type"
           ]
@@ -1954,6 +2240,7 @@
               "const": "gcp_cloud_sql"
             }
           },
+          "additionalProperties": false,
           "required": [
             "type"
           ]
@@ -2168,6 +2455,7 @@
               "type": "string"
             }
           },
+          "additionalProperties": false,
           "required": [
             "header"
           ]
@@ -2181,6 +2469,7 @@
               "type": "string"
             }
           },
+          "additionalProperties": false,
           "required": [
             "path"
           ]
@@ -2192,6 +2481,7 @@
               "type": "string"
             }
           },
+          "additionalProperties": false,
           "required": [
             "method"
           ]
@@ -2210,6 +2500,7 @@
               "type": "string"
             }
           },
+          "additionalProperties": false,
           "required": [
             "query"
           ]
@@ -2367,6 +2658,7 @@
           }
         }
       },
+      "additionalProperties": false,
       "required": [
         "protocol"
       ]
@@ -2385,67 +2677,6 @@
         }
       },
       "additionalProperties": false
-    },
-    "MongodbBranchConfig": {
-      "description": "When configuring a branch for MongoDB, set `type` to `mongodb`.",
-      "type": "object",
-      "properties": {
-        "connection": {
-          "title": "feature.db_branches[].connection (type: mysql, pg, mongodb) {#feature-db_branches-sql-connection}",
-          "description": "`connection` describes how to get the connection information to the source database.\nWhen the branch database is ready for use, Mirrord operator will replace the connection\ninformation with the branch database's.",
-          "$ref": "#/$defs/DbBranchingConnectionSource"
-        },
-        "copy": {
-          "$ref": "#/$defs/MongodbBranchCopyConfig",
-          "default": {
-            "collections": null,
-            "mode": "empty"
-          }
-        },
-        "creation_timeout_secs": {
-          "title": "feature.db_branches[].creation_timeout_secs (type: mysql, pg, mongodb) {#feature-db_branches-sql-creation_timeout_secs}",
-          "description": "The timeout in seconds to wait for a database branch to become ready after creation.\nDefaults to 60 seconds. Adjust this value based on your database size and cluster\nperformance.",
-          "type": "integer",
-          "format": "uint64",
-          "default": 60,
-          "minimum": 0
-        },
-        "id": {
-          "title": "feature.db_branches[].id (type: mysql, pg, mongodb) {#feature-db_branches-sql-id}",
-          "description": "Users can choose to specify a unique `id`. This is useful for reusing or sharing\nthe same database branch among Kubernetes users.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "name": {
-          "title": "feature.db_branches[].name (type: mysql, pg, mongodb) {#feature-db_branches-sql-name}",
-          "description": "When source database connection detail is not accessible to mirrord operator, users\ncan specify the database `name` so it is included in the connection options mirrord\nuses as the override.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "ttl_secs": {
-          "title": "feature.db_branches[].ttl_secs (type: mysql, pg, mongodb) {#feature-db_branches-sql-ttl_secs}",
-          "description": "Mirrord operator starts counting the TTL when a branch is no longer used by any session.\nThe time-to-live (TTL) for the branch database is set to 300 seconds by default.\nUsers can set `ttl_secs` to customize this value according to their need. Please note\nthat longer TTL paired with frequent mirrord session turnover can result in increased\nresource usage. For this reason, branch database TTL caps out at 15 min.",
-          "type": "integer",
-          "format": "uint64",
-          "default": 300,
-          "minimum": 0
-        },
-        "version": {
-          "title": "feature.db_branches[].version (type: mysql, pg, mongodb) {#feature-db_branches-sql-version}",
-          "description": "Mirrord operator uses a default version of the database image unless `version` is given.",
-          "type": [
-            "string",
-            "null"
-          ]
-        }
-      },
-      "required": [
-        "connection"
-      ]
     },
     "MongodbBranchCopyConfig": {
       "description": "Users can choose from the following copy mode to bootstrap their MongoDB branch database:\n\n- Empty\n\n  Creates an empty database. If the source DB connection options are found from the chosen\n  target, mirrord operator extracts the database name and create an empty DB. Otherwise, mirrord\n  operator looks for the `name` field from the branch DB config object. This option is useful\n  for users that run DB migrations themselves before starting the application.\n\n- All\n\n  Copies both schema and data of all collections. Supports optional collection filters\n  to copy only specific collections or filter documents within collections.",
@@ -2467,6 +2698,7 @@
               "const": "empty"
             }
           },
+          "additionalProperties": false,
           "required": [
             "mode"
           ]
@@ -2489,71 +2721,11 @@
               "const": "all"
             }
           },
+          "additionalProperties": false,
           "required": [
             "mode"
           ]
         }
-      ]
-    },
-    "MssqlBranchConfig": {
-      "description": "When configuring a branch for MSSQL, set `type` to `mssql`.",
-      "type": "object",
-      "properties": {
-        "connection": {
-          "title": "feature.db_branches[].connection (type: mysql, pg, mongodb) {#feature-db_branches-sql-connection}",
-          "description": "`connection` describes how to get the connection information to the source database.\nWhen the branch database is ready for use, Mirrord operator will replace the connection\ninformation with the branch database's.",
-          "$ref": "#/$defs/DbBranchingConnectionSource"
-        },
-        "copy": {
-          "$ref": "#/$defs/MssqlBranchCopyConfig",
-          "default": {
-            "mode": "empty",
-            "tables": null
-          }
-        },
-        "creation_timeout_secs": {
-          "title": "feature.db_branches[].creation_timeout_secs (type: mysql, pg, mongodb) {#feature-db_branches-sql-creation_timeout_secs}",
-          "description": "The timeout in seconds to wait for a database branch to become ready after creation.\nDefaults to 60 seconds. Adjust this value based on your database size and cluster\nperformance.",
-          "type": "integer",
-          "format": "uint64",
-          "default": 60,
-          "minimum": 0
-        },
-        "id": {
-          "title": "feature.db_branches[].id (type: mysql, pg, mongodb) {#feature-db_branches-sql-id}",
-          "description": "Users can choose to specify a unique `id`. This is useful for reusing or sharing\nthe same database branch among Kubernetes users.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "name": {
-          "title": "feature.db_branches[].name (type: mysql, pg, mongodb) {#feature-db_branches-sql-name}",
-          "description": "When source database connection detail is not accessible to mirrord operator, users\ncan specify the database `name` so it is included in the connection options mirrord\nuses as the override.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "ttl_secs": {
-          "title": "feature.db_branches[].ttl_secs (type: mysql, pg, mongodb) {#feature-db_branches-sql-ttl_secs}",
-          "description": "Mirrord operator starts counting the TTL when a branch is no longer used by any session.\nThe time-to-live (TTL) for the branch database is set to 300 seconds by default.\nUsers can set `ttl_secs` to customize this value according to their need. Please note\nthat longer TTL paired with frequent mirrord session turnover can result in increased\nresource usage. For this reason, branch database TTL caps out at 15 min.",
-          "type": "integer",
-          "format": "uint64",
-          "default": 300,
-          "minimum": 0
-        },
-        "version": {
-          "title": "feature.db_branches[].version (type: mysql, pg, mongodb) {#feature-db_branches-sql-version}",
-          "description": "Mirrord operator uses a default version of the database image unless `version` is given.",
-          "type": [
-            "string",
-            "null"
-          ]
-        }
-      },
-      "required": [
-        "connection"
       ]
     },
     "MssqlBranchCopyConfig": {
@@ -2576,6 +2748,7 @@
               }
             }
           },
+          "additionalProperties": false,
           "required": [
             "mode"
           ]
@@ -2597,6 +2770,7 @@
               }
             }
           },
+          "additionalProperties": false,
           "required": [
             "mode"
           ]
@@ -2609,71 +2783,11 @@
               "const": "all"
             }
           },
+          "additionalProperties": false,
           "required": [
             "mode"
           ]
         }
-      ]
-    },
-    "MysqlBranchConfig": {
-      "description": "When configuring a branch for MySQL, set `type` to `mysql`.",
-      "type": "object",
-      "properties": {
-        "connection": {
-          "title": "feature.db_branches[].connection (type: mysql, pg, mongodb) {#feature-db_branches-sql-connection}",
-          "description": "`connection` describes how to get the connection information to the source database.\nWhen the branch database is ready for use, Mirrord operator will replace the connection\ninformation with the branch database's.",
-          "$ref": "#/$defs/DbBranchingConnectionSource"
-        },
-        "copy": {
-          "$ref": "#/$defs/MysqlBranchCopyConfig",
-          "default": {
-            "mode": "empty",
-            "tables": null
-          }
-        },
-        "creation_timeout_secs": {
-          "title": "feature.db_branches[].creation_timeout_secs (type: mysql, pg, mongodb) {#feature-db_branches-sql-creation_timeout_secs}",
-          "description": "The timeout in seconds to wait for a database branch to become ready after creation.\nDefaults to 60 seconds. Adjust this value based on your database size and cluster\nperformance.",
-          "type": "integer",
-          "format": "uint64",
-          "default": 60,
-          "minimum": 0
-        },
-        "id": {
-          "title": "feature.db_branches[].id (type: mysql, pg, mongodb) {#feature-db_branches-sql-id}",
-          "description": "Users can choose to specify a unique `id`. This is useful for reusing or sharing\nthe same database branch among Kubernetes users.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "name": {
-          "title": "feature.db_branches[].name (type: mysql, pg, mongodb) {#feature-db_branches-sql-name}",
-          "description": "When source database connection detail is not accessible to mirrord operator, users\ncan specify the database `name` so it is included in the connection options mirrord\nuses as the override.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "ttl_secs": {
-          "title": "feature.db_branches[].ttl_secs (type: mysql, pg, mongodb) {#feature-db_branches-sql-ttl_secs}",
-          "description": "Mirrord operator starts counting the TTL when a branch is no longer used by any session.\nThe time-to-live (TTL) for the branch database is set to 300 seconds by default.\nUsers can set `ttl_secs` to customize this value according to their need. Please note\nthat longer TTL paired with frequent mirrord session turnover can result in increased\nresource usage. For this reason, branch database TTL caps out at 15 min.",
-          "type": "integer",
-          "format": "uint64",
-          "default": 300,
-          "minimum": 0
-        },
-        "version": {
-          "title": "feature.db_branches[].version (type: mysql, pg, mongodb) {#feature-db_branches-sql-version}",
-          "description": "Mirrord operator uses a default version of the database image unless `version` is given.",
-          "type": [
-            "string",
-            "null"
-          ]
-        }
-      },
-      "required": [
-        "connection"
       ]
     },
     "MysqlBranchCopyConfig": {
@@ -2696,6 +2810,7 @@
               }
             }
           },
+          "additionalProperties": false,
           "required": [
             "mode"
           ]
@@ -2717,6 +2832,7 @@
               }
             }
           },
+          "additionalProperties": false,
           "required": [
             "mode"
           ]
@@ -2729,6 +2845,7 @@
               "const": "all"
             }
           },
+          "additionalProperties": false,
           "required": [
             "mode"
           ]
@@ -2885,84 +3002,12 @@
               "type": "string"
             }
           },
+          "additionalProperties": false,
           "required": [
             "secret",
             "key"
           ]
         }
-      ]
-    },
-    "PgBranchConfig": {
-      "description": "When configuring a branch for PostgreSQL, set `type` to `pg`.",
-      "type": "object",
-      "properties": {
-        "connection": {
-          "title": "feature.db_branches[].connection (type: mysql, pg, mongodb) {#feature-db_branches-sql-connection}",
-          "description": "`connection` describes how to get the connection information to the source database.\nWhen the branch database is ready for use, Mirrord operator will replace the connection\ninformation with the branch database's.",
-          "$ref": "#/$defs/DbBranchingConnectionSource"
-        },
-        "copy": {
-          "$ref": "#/$defs/PgBranchCopyConfig",
-          "default": {
-            "mode": "empty",
-            "tables": null
-          }
-        },
-        "creation_timeout_secs": {
-          "title": "feature.db_branches[].creation_timeout_secs (type: mysql, pg, mongodb) {#feature-db_branches-sql-creation_timeout_secs}",
-          "description": "The timeout in seconds to wait for a database branch to become ready after creation.\nDefaults to 60 seconds. Adjust this value based on your database size and cluster\nperformance.",
-          "type": "integer",
-          "format": "uint64",
-          "default": 60,
-          "minimum": 0
-        },
-        "iam_auth": {
-          "title": "feature.db_branches[].iam_auth (type: pg) {#feature-db_branches-pg-iam_auth}",
-          "description": "IAM authentication for the source database.\nUse this when your source database (AWS RDS, GCP Cloud SQL) requires IAM authentication\ninstead of password-based authentication.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/IamAuthConfig"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "id": {
-          "title": "feature.db_branches[].id (type: mysql, pg, mongodb) {#feature-db_branches-sql-id}",
-          "description": "Users can choose to specify a unique `id`. This is useful for reusing or sharing\nthe same database branch among Kubernetes users.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "name": {
-          "title": "feature.db_branches[].name (type: mysql, pg, mongodb) {#feature-db_branches-sql-name}",
-          "description": "When source database connection detail is not accessible to mirrord operator, users\ncan specify the database `name` so it is included in the connection options mirrord\nuses as the override.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "ttl_secs": {
-          "title": "feature.db_branches[].ttl_secs (type: mysql, pg, mongodb) {#feature-db_branches-sql-ttl_secs}",
-          "description": "Mirrord operator starts counting the TTL when a branch is no longer used by any session.\nThe time-to-live (TTL) for the branch database is set to 300 seconds by default.\nUsers can set `ttl_secs` to customize this value according to their need. Please note\nthat longer TTL paired with frequent mirrord session turnover can result in increased\nresource usage. For this reason, branch database TTL caps out at 15 min.",
-          "type": "integer",
-          "format": "uint64",
-          "default": 300,
-          "minimum": 0
-        },
-        "version": {
-          "title": "feature.db_branches[].version (type: mysql, pg, mongodb) {#feature-db_branches-sql-version}",
-          "description": "Mirrord operator uses a default version of the database image unless `version` is given.",
-          "type": [
-            "string",
-            "null"
-          ]
-        }
-      },
-      "required": [
-        "connection"
       ]
     },
     "PgBranchCopyConfig": {
@@ -2985,6 +3030,7 @@
               }
             }
           },
+          "additionalProperties": false,
           "required": [
             "mode"
           ]
@@ -3006,6 +3052,7 @@
               }
             }
           },
+          "additionalProperties": false,
           "required": [
             "mode"
           ]
@@ -3018,6 +3065,7 @@
               "const": "all"
             }
           },
+          "additionalProperties": false,
           "required": [
             "mode"
           ]
@@ -3130,6 +3178,7 @@
               "const": "SQS"
             }
           },
+          "additionalProperties": false,
           "required": [
             "queue_type"
           ]
@@ -3149,6 +3198,7 @@
               "const": "Kafka"
             }
           },
+          "additionalProperties": false,
           "required": [
             "queue_type",
             "message_filter"
@@ -3169,63 +3219,13 @@
               "const": "RMQ"
             }
           },
+          "additionalProperties": false,
           "required": [
             "queue_type",
             "message_filter"
           ]
         }
       ]
-    },
-    "RedisBranchConfig": {
-      "description": "When configuring a branch for Redis, set `type` to `redis`.\n\nExample with URL-based connection:\n```json\n{\n  \"type\": \"redis\",\n  \"location\": \"local\",\n  \"connection\": {\n    \"url\": {\n      \"type\": \"env\",\n      \"variable\": \"REDIS_URL\"\n    }\n  }\n}\n```\n\nExample with separated settings:\n```json\n{\n  \"type\": \"redis\",\n  \"location\": \"local\",\n  \"connection\": {\n    \"host\": { \"type\": \"env\", \"variable\": \"REDIS_HOST\" },\n    \"port\": 6379,\n    \"password\": { \"type\": \"env\", \"variable\": \"REDIS_PASSWORD\" }\n  }\n}\n```",
-      "type": "object",
-      "properties": {
-        "connection": {
-          "title": "feature.db_branches[].connection (type: redis) {#feature-db_branches-redis-connection}",
-          "description": "Connection configuration for the Redis instance.",
-          "$ref": "#/$defs/RedisConnectionConfig",
-          "default": {
-            "database": null,
-            "host": null,
-            "password": null,
-            "port": null,
-            "tls": null,
-            "url": null,
-            "username": null
-          }
-        },
-        "id": {
-          "title": "feature.db_branches[].id (type: redis) {#feature-db_branches-redis-id}",
-          "description": "Optional unique identifier for reusing branches across sessions.",
-          "type": [
-            "string",
-            "null"
-          ],
-          "default": null
-        },
-        "local": {
-          "title": "feature.db_branches[].local (type: redis) {#feature-db_branches-redis-local}",
-          "description": "Local Redis runtime configuration.\nOnly used when `location` is `local`.",
-          "$ref": "#/$defs/RedisLocalConfig",
-          "default": {
-            "container_command": null,
-            "container_runtime": "docker",
-            "options": {
-              "args": []
-            },
-            "port": 6379,
-            "runtime": "container",
-            "server_command": null,
-            "version": "7-alpine"
-          }
-        },
-        "location": {
-          "title": "feature.db_branches[].location (type: redis) {#feature-db_branches-redis-location}",
-          "description": "Where the Redis instance should run.\n- `local`: Spawns a local Redis instance managed by mirrord.\n- `remote`: Uses the remote Redis (default behavior, no-op).",
-          "$ref": "#/$defs/RedisBranchLocation",
-          "default": "remote"
-        }
-      }
     },
     "RedisBranchLocation": {
       "type": "string",
@@ -3323,7 +3323,8 @@
           ],
           "default": null
         }
-      }
+      },
+      "additionalProperties": false
     },
     "RedisEnvSource": {
       "description": "<!--${internal}-->\nEnvironment variable source for Redis values.",
@@ -3343,6 +3344,7 @@
           "type": "string"
         }
       },
+      "additionalProperties": false,
       "required": [
         "type",
         "variable"
@@ -3412,7 +3414,8 @@
           "type": "string",
           "default": "7-alpine"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "RedisOptions": {
       "description": "Example:\n```json\n{\n  \"args\": [\"--maxmemory\", \"256mb\", \"--appendonly\", \"yes\"]\n}\n```",
@@ -3426,7 +3429,8 @@
             "type": "string"
           }
         }
-      }
+      },
+      "additionalProperties": false
     },
     "RedisRuntime": {
       "description": "For container-based runtimes, mirrord spawns the Redis image in a container.\nFor `redis_server`, it runs the native binary directly.\n\nBackends:\n- `container` (default) - Uses a container runtime (Docker/Podman/nerdctl), configured via\n  `container_runtime`.\n- `redis_server` - Uses native redis-server binary\n- `auto` - Tries container first, falls back to redis-server",
@@ -3509,7 +3513,8 @@
             }
           ]
         }
-      }
+      },
+      "additionalProperties": false
     },
     "SecurityProfile": {
       "type": "object",
@@ -3524,6 +3529,7 @@
           "type": "string"
         }
       },
+      "additionalProperties": false,
       "required": [
         "type"
       ]

--- a/mirrord/config/src/agent.rs
+++ b/mirrord/config/src/agent.rs
@@ -546,6 +546,7 @@ impl AgentImageFileConfig {
 /// <!--${internal}-->
 /// Specifies a secret reference for the agent pod.
 #[derive(Clone, Debug, PartialEq, Eq, JsonSchema, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct AgentPullSecret {
     /// Name of the secret.
     pub name: String,
@@ -620,6 +621,7 @@ impl AgentFileConfig {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct SecurityContext {
     pub app_armor_profile: Option<AppArmorProfile>,
     pub seccomp_profile: Option<SeccompProfile>,
@@ -639,6 +641,7 @@ pub type AppArmorProfile = SecurityProfile;
 pub type SeccompProfile = SecurityProfile;
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct SecurityProfile {
     pub localhost_profile: Option<String>,
 

--- a/mirrord/config/src/experimental.rs
+++ b/mirrord/config/src/experimental.rs
@@ -212,6 +212,7 @@ impl CollectAnalytics for &ExperimentalConfig {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, JsonSchema, Default)]
+#[serde(deny_unknown_fields)]
 pub struct AppleVariablesConfig {}
 
 /// Configuration for adding artificial latency to outgoing network operations.

--- a/mirrord/config/src/feature/database_branches.rs
+++ b/mirrord/config/src/feature/database_branches.rs
@@ -29,6 +29,7 @@ pub type PgIamAuthConfig = IamAuthConfig;
 /// Shared copy config for individual items (tables, collections, etc.).
 /// All database engines use this same struct for per-item copy configuration.
 #[derive(Clone, Debug, Eq, PartialEq, JsonSchema, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct BranchItemCopyConfig {
     pub filter: Option<String>,
 }
@@ -41,7 +42,7 @@ pub struct BranchItemCopyConfig {
 /// - `{ "type": "env", "variable": "VAR_NAME" }` - direct env var from pod spec
 /// - `{ "type": "env_from", "variable": "VAR_NAME" }` - from configMapRef/secretRef
 #[derive(Clone, Debug, Eq, PartialEq, JsonSchema, Serialize, Deserialize)]
-#[serde(tag = "type", rename_all = "snake_case")]
+#[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
 pub enum IamAuthConfig {
     /// For AWS RDS/Aurora IAM authentication, set `type` to `"aws_rds"`.
     ///
@@ -214,7 +215,7 @@ impl DatabaseBranchesConfig {
 /// }
 /// ```
 #[derive(Clone, Debug, Eq, PartialEq, JsonSchema, Serialize, Deserialize)]
-#[serde(tag = "type", rename_all = "lowercase")]
+#[serde(tag = "type", rename_all = "lowercase", deny_unknown_fields)]
 pub enum DatabaseBranchConfig {
     Mongodb(Box<MongodbBranchConfig>),
     Mssql(Box<MssqlBranchConfig>),
@@ -296,7 +297,7 @@ pub struct DatabaseBranchBaseConfig {
 /// ```
 #[derive(Clone, Debug, Eq, PartialEq, JsonSchema, Deserialize)]
 #[schemars(rename = "DbBranchingConnectionSource")]
-#[serde(untagged)]
+#[serde(untagged, deny_unknown_fields)]
 pub enum ConnectionSource {
     Url {
         url: TargetEnvironmentVariableSource,
@@ -354,6 +355,7 @@ pub enum ConnectionSourceType {
 /// The `type` field is optional - when omitted, the operator auto-detects
 /// whether the variable comes from `env` or `envFrom` on the target pod.
 #[derive(Clone, Debug, Eq, PartialEq, JsonSchema, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ConnectionParamsConfig {
     #[serde(rename = "type", default, skip_serializing_if = "Option::is_none")]
     pub source_type: Option<ConnectionSourceType>,
@@ -369,7 +371,7 @@ pub struct ConnectionParamsConfig {
 /// As an object: `{ "secret": "my-secret", "key": "password" }` — read directly from a
 /// Kubernetes Secret.
 #[derive(Clone, Debug, Eq, PartialEq, JsonSchema, Serialize, Deserialize)]
-#[serde(untagged)]
+#[serde(untagged, deny_unknown_fields)]
 pub enum ParamSource {
     Variable(String),
     Secret {
@@ -392,6 +394,7 @@ impl ParamSource {
 /// At least one parameter must be specified.
 /// Each parameter is either a plain string (env var name) or an object with `secret` and `key`.
 #[derive(Clone, Debug, Eq, PartialEq, JsonSchema, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ConnectionParamsVars {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub host: Option<ParamSource>,
@@ -414,7 +417,7 @@ pub struct ConnectionParamsVars {
 /// - `secret` read directly from a Kubernetes Secret.
 #[derive(Clone, Debug, Eq, PartialEq, JsonSchema, Serialize, Deserialize)]
 #[schemars(rename = "DbBranchingConnectionSourceKind")]
-#[serde(tag = "type", rename_all = "snake_case")]
+#[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
 pub enum TargetEnvironmentVariableSource {
     Env {
         container: Option<String>,

--- a/mirrord/config/src/feature/database_branches/mongodb.rs
+++ b/mirrord/config/src/feature/database_branches/mongodb.rs
@@ -7,6 +7,7 @@ use super::DatabaseBranchBaseConfig;
 
 /// When configuring a branch for MongoDB, set `type` to `mongodb`.
 #[derive(Clone, Debug, Eq, PartialEq, JsonSchema, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct MongodbBranchConfig {
     #[serde(flatten)]
     pub base: DatabaseBranchBaseConfig,
@@ -29,7 +30,7 @@ pub struct MongodbBranchConfig {
 ///   Copies both schema and data of all collections. Supports optional collection filters
 ///   to copy only specific collections or filter documents within collections.
 #[derive(Clone, Debug, Eq, PartialEq, JsonSchema, Serialize, Deserialize)]
-#[serde(tag = "mode", rename_all = "lowercase")]
+#[serde(tag = "mode", rename_all = "lowercase", deny_unknown_fields)]
 pub enum MongodbBranchCopyConfig {
     Empty {
         collections: Option<BTreeMap<String, MongodbBranchCollectionCopyConfig>>,

--- a/mirrord/config/src/feature/database_branches/mssql.rs
+++ b/mirrord/config/src/feature/database_branches/mssql.rs
@@ -7,6 +7,7 @@ use super::DatabaseBranchBaseConfig;
 
 /// When configuring a branch for MSSQL, set `type` to `mssql`.
 #[derive(Clone, Debug, Eq, PartialEq, JsonSchema, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct MssqlBranchConfig {
     #[serde(flatten)]
     pub base: DatabaseBranchBaseConfig,
@@ -33,7 +34,7 @@ pub struct MssqlBranchConfig {
 ///   Copies both schema and data of all tables. This option shall only be used
 ///   when the data volume of the source database is minimal.
 #[derive(Clone, Debug, Eq, PartialEq, JsonSchema, Serialize, Deserialize)]
-#[serde(tag = "mode", rename_all = "lowercase")]
+#[serde(tag = "mode", rename_all = "lowercase", deny_unknown_fields)]
 pub enum MssqlBranchCopyConfig {
     Empty {
         tables: Option<BTreeMap<String, MssqlBranchTableCopyConfig>>,

--- a/mirrord/config/src/feature/database_branches/mysql.rs
+++ b/mirrord/config/src/feature/database_branches/mysql.rs
@@ -7,6 +7,7 @@ use super::DatabaseBranchBaseConfig;
 
 /// When configuring a branch for MySQL, set `type` to `mysql`.
 #[derive(Clone, Debug, Eq, PartialEq, JsonSchema, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct MysqlBranchConfig {
     #[serde(flatten)]
     pub base: DatabaseBranchBaseConfig,
@@ -33,7 +34,7 @@ pub struct MysqlBranchConfig {
 ///   Copies both schema and data of all tables. This option shall only be used
 ///   when the data volume of the source database is minimal.
 #[derive(Clone, Debug, Eq, PartialEq, JsonSchema, Serialize, Deserialize)]
-#[serde(tag = "mode", rename_all = "lowercase")]
+#[serde(tag = "mode", rename_all = "lowercase", deny_unknown_fields)]
 pub enum MysqlBranchCopyConfig {
     Empty {
         tables: Option<BTreeMap<String, MysqlBranchTableCopyConfig>>,

--- a/mirrord/config/src/feature/database_branches/pg.rs
+++ b/mirrord/config/src/feature/database_branches/pg.rs
@@ -7,6 +7,7 @@ use super::{DatabaseBranchBaseConfig, IamAuthConfig};
 
 /// When configuring a branch for PostgreSQL, set `type` to `pg`.
 #[derive(Clone, Debug, Eq, PartialEq, JsonSchema, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct PgBranchConfig {
     #[serde(flatten)]
     pub base: DatabaseBranchBaseConfig,
@@ -41,7 +42,7 @@ pub struct PgBranchConfig {
 ///   Copies both schema and data of all tables. This option shall only be used
 ///   when the data volume of the source database is minimal.
 #[derive(Clone, Debug, Eq, PartialEq, JsonSchema, Serialize, Deserialize)]
-#[serde(tag = "mode", rename_all = "lowercase")]
+#[serde(tag = "mode", rename_all = "lowercase", deny_unknown_fields)]
 pub enum PgBranchCopyConfig {
     Empty {
         tables: Option<BTreeMap<String, PgBranchTableCopyConfig>>,

--- a/mirrord/config/src/feature/database_branches/redis.rs
+++ b/mirrord/config/src/feature/database_branches/redis.rs
@@ -32,6 +32,7 @@ use crate::container::ContainerRuntime;
 /// }
 /// ```
 #[derive(Clone, Debug, Eq, PartialEq, JsonSchema, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct RedisBranchConfig {
     /// #### feature.db_branches[].id (type: redis) {#feature-db_branches-redis-id}
     ///
@@ -87,6 +88,7 @@ pub enum RedisBranchLocation {
 /// }
 /// ```
 #[derive(Clone, Debug, Eq, PartialEq, JsonSchema, Serialize, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
 pub struct RedisConnectionConfig {
     /// ##### feature.db_branches[].connection.url (type: redis)
     ///
@@ -161,7 +163,7 @@ impl RedisConnectionConfig {
 ///
 /// Values can be specified directly or sourced from environment variables.
 #[derive(Clone, Debug, Eq, PartialEq, JsonSchema, Serialize, Deserialize)]
-#[serde(untagged)]
+#[serde(untagged, deny_unknown_fields)]
 pub enum RedisValueSource {
     Direct(String),
     Env(RedisEnvSource),
@@ -180,6 +182,7 @@ impl RedisValueSource {
 /// <!--${internal}-->
 /// Environment variable source for Redis values.
 #[derive(Clone, Debug, Eq, PartialEq, JsonSchema, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct RedisEnvSource {
     #[serde(rename = "type")]
     pub source_type: RedisEnvSourceType,
@@ -200,6 +203,7 @@ pub enum RedisEnvSourceType {
 
 /// Configuration for local Redis runtime.
 #[derive(Clone, Debug, Eq, PartialEq, JsonSchema, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct RedisLocalConfig {
     /// ##### feature.db_branches[].local.port (type: redis)
     ///
@@ -288,6 +292,7 @@ pub enum RedisRuntime {
 /// }
 /// ```
 #[derive(Clone, Debug, Eq, PartialEq, JsonSchema, Serialize, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
 pub struct RedisOptions {
     /// Raw arguments passed directly to redis-server or as Docker CMD args.
     /// Use standard Redis config syntax (e.g., "--maxmemory 256mb").

--- a/mirrord/config/src/feature/network/incoming/http_filter.rs
+++ b/mirrord/config/src/feature/network/incoming/http_filter.rs
@@ -467,7 +467,7 @@ impl HttpFilterConfig {
 }
 
 #[derive(PartialEq, Eq, Clone, Debug, JsonSchema, Serialize, Deserialize)]
-#[serde(untagged)]
+#[serde(untagged, deny_unknown_fields)]
 pub enum InnerFilter {
     /// ##### feature.network.incoming.inner_filter.header_filter {#feature-network-incoming-inner-header-filter}
     ///
@@ -519,7 +519,7 @@ pub enum InnerFilter {
 
 /// Currently only JSON body filtering is supported.
 #[derive(PartialEq, Eq, Clone, Debug, JsonSchema, Serialize, Deserialize)]
-#[serde(tag = "body", rename_all = "lowercase")]
+#[serde(tag = "body", rename_all = "lowercase", deny_unknown_fields)]
 pub enum BodyFilter {
     /// ##### feature.network.incoming.inner_filter.body_filter.json {#feature-network-incoming-inner-body-filter-json}
     ///

--- a/mirrord/config/src/feature/network/incoming/tls_delivery.rs
+++ b/mirrord/config/src/feature/network/incoming/tls_delivery.rs
@@ -66,6 +66,7 @@ use crate::config::{ConfigContext, ConfigError};
 ///    used;
 /// 4. Otherwise, `localhost` will be used.
 #[derive(Deserialize, Serialize, Clone, Debug, JsonSchema, PartialEq, Eq, Default)]
+#[serde(deny_unknown_fields)]
 pub struct LocalTlsDelivery {
     /// ##### feature.network.incoming.tls_delivery.protocol {#feature-network-incoming-tls_delivery-protocol}
     ///

--- a/mirrord/config/src/feature/split_queues.rs
+++ b/mirrord/config/src/feature/split_queues.rs
@@ -196,7 +196,7 @@ pub type QueueMessageFilter = BTreeMap<String, String>;
 /// The type of queue to be split, currently `SQS` and `Kafka` are supported. More queue types might
 /// be added in the future.
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, JsonSchema)]
-#[serde(tag = "queue_type")]
+#[serde(tag = "queue_type", deny_unknown_fields)]
 pub enum QueueFilter {
     /// ### feature.split_queues.{}.jq_filter {#feature-split_queues-queue_id-jq_filter}
     /// Only supported with `queue_type` of `SQS`.

--- a/mirrord/config/src/lib.rs
+++ b/mirrord/config/src/lib.rs
@@ -1241,6 +1241,14 @@ mod tests {
                 }
             }
         }
+
+        fn parse_result(&self, value: &str) -> Result<LayerFileConfig, String> {
+            match self {
+                ConfigType::Json => serde_json::from_str(value).map_err(|err| err.to_string()),
+                ConfigType::Toml => toml::from_str(value).map_err(|err| err.to_string()),
+                ConfigType::Yaml => serde_yaml::from_str(value).map_err(|err| err.to_string()),
+            }
+        }
     }
 
     #[rstest]
@@ -1378,6 +1386,105 @@ mod tests {
         };
 
         assert_eq!(config, expect);
+    }
+
+    #[test]
+    fn rejects_unknown_fields_in_agent_pull_secrets() {
+        let input = r#"
+        {
+            "agent": {
+                "image_pull_secrets": [
+                    {
+                        "name": "testsecret",
+                        "unknown": "value"
+                    }
+                ]
+            }
+        }
+        "#;
+
+        let error = ConfigType::Json
+            .parse_result(input)
+            .expect_err("agent.image_pull_secrets should reject unknown fields");
+
+        assert!(error.contains("unknown field"));
+    }
+
+    #[test]
+    fn rejects_unknown_fields_in_split_queues() {
+        let input = r#"
+        {
+            "feature": {
+                "split_queues": {
+                    "orders": {
+                        "queue_type": "Kafka",
+                        "message_filter": {
+                            "customer-id": ".+"
+                        },
+                        "unknown": true
+                    }
+                }
+            }
+        }
+        "#;
+
+        let error = ConfigType::Json
+            .parse_result(input)
+            .expect_err("feature.split_queues.orders should reject unknown fields");
+
+        assert!(error.contains("unknown field"));
+    }
+
+    #[test]
+    fn rejects_unknown_fields_in_db_branches() {
+        let input = r#"
+        {
+            "feature": {
+                "db_branches": [
+                    {
+                        "type": "mysql",
+                        "connection": {
+                            "type": "env",
+                            "params": {
+                                "host": "DB_HOST"
+                            }
+                        },
+                        "unknown": true
+                    }
+                ]
+            }
+        }
+        "#;
+
+        let error = ConfigType::Json
+            .parse_result(input)
+            .expect_err("feature.db_branches[] should reject unknown fields");
+
+        assert!(error.contains("unknown field"));
+    }
+
+    #[test]
+    fn rejects_unknown_fields_in_tls_delivery() {
+        let input = r#"
+        {
+            "feature": {
+                "network": {
+                    "incoming": {
+                        "tls_delivery": {
+                            "protocol": "tls",
+                            "unknown": true
+                        }
+                    }
+                }
+            }
+        }
+        "#;
+
+        let error = ConfigType::Json
+            .parse_result(input)
+            .expect_err("feature.network.incoming.tls_delivery should reject unknown fields");
+
+        assert!(error.contains("unknown field"));
     }
 
     /// <!--${internal}-->


### PR DESCRIPTION
Currently there are multiple configuration fields in the mirrord configuration schema that allow unknown fields to be specified under them.
This is bad and could trip users in many different ways (AI hallucinates a new field, human makes a typo, human tries to use a field not supported in the mirrord version they're using, etc.). When a non-existing field is specified, we should error out and exit early, instead of (like now) deserialize to some configuration that is not what the user asked for.

- The first commit adds UTs that fail with the existing code.
- The second commit adds the attribute to deny unknown fields from the conf structs that don't have it yet.

Structs that derive `MirrordConfig` have that setting already, but ones that don't currently need to explicitly add that attribute. We have [a technical-backlog item
](https://linear.app/metalbear/issue/MBE-1730/force-new-config-structs-to-deny-unknown-fields) to find a way for us not to keep adding new fields that allow unknown fields.
<!-- Thank you for contributing to mirrord! -->
<!-- Please use the checklist below as a guide for docs, tests and admin tasks for your PR -->
<!-- Feel free to ~strikethrough~ any items that you don't think apply -->

### Quality Checklist:

- [x] I have documented new code sufficiently
- [ ] ~I have checked and updated the relevant existing docs in code, including removing outdated material~
- [ ] ~I have written user-facing website docs for new features, or opened a (sub)issue to do so~
- [ ] ~I have checked and updated existing website docs for changed features~
- [x] I have tested this change and know it succeeds and fails as expected
- [x] I have written unit tests or purposefully omitted them
- [x] I have written e2e tests or purposefully omitted them
- [x] I have explained what this PR introduces and why, and linked to relevant context (e.g. linear issues, related PRs,
  documentation)
- [x] I have introduced a short, clear and well-formatted changelog entry

<!-- need help with the changelog? see ../CONTRIBUTING.md#submitting-a-pull-request -->
<!-- Add more details of your changes below if needed -->