### PR TITLE
Make session kill actually terminate the user application

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4986,6 +4986,7 @@ dependencies = [
  "http-body-util",
  "hyper 1.8.1",
  "hyper-util",
+ "libc",
  "mirrord-analytics",
  "mirrord-config",
  "mirrord-intproxy-protocol",

--- a/changelog.d/+session-kill-processes.fixed.md
+++ b/changelog.d/+session-kill-processes.fixed.md
@@ -1,0 +1,1 @@
+`mirrord session delete` and the session monitor UI's Kill button now actually terminate the user application. Previously they only removed the session socket, leaving the user process and intproxy alive and holding zombie steal/mirror subscriptions on the cluster pod.

--- a/mirrord/intproxy/Cargo.toml
+++ b/mirrord/intproxy/Cargo.toml
@@ -52,6 +52,7 @@ tokio-util.workspace = true
 axum.workspace = true
 serde_json.workspace = true
 home.workspace = true
+libc.workspace = true
 mirrord-session-monitor-protocol.workspace = true
 
 [dev-dependencies]

--- a/mirrord/intproxy/src/session_monitor/api.rs
+++ b/mirrord/intproxy/src/session_monitor/api.rs
@@ -91,12 +91,33 @@ async fn events(
     )
 }
 
-/// Cancels the API server's cancellation token, triggering graceful shutdown of the API server
-/// only. The mirrord session lifecycle is managed separately by the intproxy.
+/// Tears down the mirrord session: `SIGTERM`s every layer-connected process so the user
+/// application exits, then cancels the API server's shutdown token. Once the user app
+/// processes die, their layer connections close and the intproxy exits on its idle timeout.
+///
+/// Without this, `mirrord session delete` (or the UI Kill button) only removes the socket
+/// while the user app and intproxy keep running, leaving zombie steal/mirror subscriptions
+/// on the cluster pod.
 #[cfg(unix)]
 async fn kill(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    let pids: Vec<u32> = {
+        let info = state.session_info.read().await;
+        info.processes.iter().map(|p| p.pid).collect()
+    };
+
+    for pid in &pids {
+        // SAFETY: `kill(2)` with a process-group or PID argument is a single syscall that
+        // cannot corrupt our process. If the PID is gone or we lack permission, kill returns
+        // -1 and sets errno; we log and continue.
+        let ret = unsafe { libc::kill(*pid as libc::pid_t, libc::SIGTERM) };
+        if ret != 0 {
+            let err = std::io::Error::last_os_error();
+            tracing::warn!(pid = *pid, %err, "Failed to SIGTERM layer-connected process");
+        }
+    }
+
     state.shutdown.cancel();
-    Json(serde_json::json!({"status": "shutting_down"}))
+    Json(serde_json::json!({"status": "shutting_down", "signaled_pids": pids}))
 }
 
 /// Subscribes to monitor events and updates session_info on LayerConnected, LayerDisconnected,


### PR DESCRIPTION
## Summary

The session monitor's `/kill` endpoint (called by both `mirrord session delete` and the UI Kill button) only cancelled the API server's shutdown token. The user app and intproxy kept running, leaving zombie steal/mirror subscriptions on the cluster pod — users had to fall back to \`killall mirrord\`.

This PR has \`/kill\` SIGTERM every layer-connected PID first. When those processes exit, their layer connections close and the intproxy reaches its idle timeout and exits on its own, tearing down the session cleanly.

## Why

Confirmed as unintentional via Slack:
- **2025-12-18 #solutions:** Aviram asked *\"does killing local intproxy make the session go away?\"* — thread has no answer.
- Multiple threads in #imprint, #metalbear-monday-support, #metalbear-capital-on-tap where the workaround for leftover sessions is \`killall mirrord\`.
- Prior debugging observations (#12054–#12057) identified exactly this: *\"API kill endpoint only shuts down API server, not the session.\"*

## Test plan

Tested end-to-end against staging (\`deploy/app-metalbear-co\`):

**Before /kill:**
\`\`\`
app-server         pid 70493 running
mirrord intproxy   pid 70543 running
session socket     ~/.mirrord/sessions/<id>.sock present
\`\`\`

**After POST /kill:**
- Response: \`{\"signaled_pids\":[70493],\"status\":\"shutting_down\"}\`
- app-server exits immediately (SIGTERM)
- Session socket removed
- Intproxy self-exits within ~3s once the last layer disconnects

No zombies remaining.

- [x] \`cargo clippy -p mirrord-intproxy -- -D warnings\` passes
- [x] End-to-end verified against staging
- [ ] Works on Linux (haven't tested, but \`libc::kill\` + \`SIGTERM\` is portable Unix)

## Base

Stacked on #4152 (han/local-api-security-v2) since the session monitor API is introduced there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)