### PR TITLE
Fix monitor logo + align with operator-dashboard design system (PRO-93)

### DIFF
--- a/changelog.d/+monitor-header-design.changed.md
+++ b/changelog.d/+monitor-header-design.changed.md
@@ -1,0 +1,1 @@
+Fix the squashed mirrord logo in the session monitor header and align the monitor's typography, color tokens, and header layout with the operator-dashboard's design system so both apps share the same look.

--- a/packages/monitor/src/components/AppHeader.tsx
+++ b/packages/monitor/src/components/AppHeader.tsx
@@ -10,31 +10,42 @@ interface Props {
 
 export default function AppHeader({ connected, isDarkMode, onToggleTheme }: Props) {
   return (
-    <header className="dark:bg-dark-background bg-white/80 backdrop-blur-sm border-b border-border dark:border-transparent shrink-0">
-      <div className="px-6">
-        <div className="flex items-center justify-between h-12 text-foreground">
+    <header className="relative shrink-0 bg-background border-b border-border text-foreground">
+      <div className="absolute bottom-0 left-0 right-0 h-[2px] bg-gradient-to-r from-transparent via-primary to-transparent opacity-40" />
+      <div className="px-4 sm:px-6 lg:px-8">
+        <div className="flex items-center justify-between h-14">
           <div className="flex items-center gap-3">
-            <img src={MirrordIcon} alt="mirrord" className="w-7 h-7 dark:invert" />
-            <span className="font-semibold text-base">{strings.app.title}</span>
-            <span className="opacity-30">|</span>
-            <span className="text-sm font-medium opacity-80">{strings.app.subtitle}</span>
+            <img
+              src={MirrordIcon}
+              alt={strings.app.title}
+              className={cn('w-8 h-8', isDarkMode && 'invert')}
+            />
+            <div className="hidden sm:flex items-center gap-2">
+              <span className="font-semibold text-h4">{strings.app.title}</span>
+              <span className="text-foreground/30">|</span>
+              <span className="text-body-sm font-medium text-foreground/70">
+                {strings.app.subtitle}
+              </span>
+            </div>
+            <span className="font-semibold text-h4 sm:hidden">{strings.app.title}</span>
           </div>
+
           <div className="flex items-center gap-3">
             <div className="flex items-center gap-2">
               <div
                 className={cn('h-2 w-2 rounded-full', connected ? 'bg-green-500' : 'bg-red-500')}
               />
-              <span className="text-xs opacity-60">
+              <span className="text-body-sm text-foreground/60">
                 {connected ? strings.app.connected : strings.app.disconnected}
               </span>
             </div>
-            <span className="opacity-20">|</span>
+
             <Button
               variant="ghost"
               size="icon"
               onClick={onToggleTheme}
               title={isDarkMode ? strings.app.themeLight : strings.app.themeDark}
-              className="h-7 w-7 opacity-60 hover:opacity-100"
+              className="h-8 w-8 text-foreground/60 hover:text-foreground"
             >
               {isDarkMode ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
             </Button>

--- a/packages/monitor/src/index.css
+++ b/packages/monitor/src/index.css
@@ -1,13 +1,16 @@
+@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
 body {
   margin: 0;
+  font-family: 'Poppins', system-ui, -apple-system, sans-serif;
   -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
-/* Custom scrollbar for dark theme */
 ::-webkit-scrollbar {
   width: 6px;
 }
@@ -19,7 +22,6 @@ body {
   border-radius: 3px;
 }
 
-/* Event row fade-in animation */
 @keyframes eventFadeIn {
   from {
     opacity: 0;
@@ -34,4 +36,3 @@ body {
 .event-row-animate {
   animation: eventFadeIn 0.2s ease-out;
 }
-

--- a/packages/monitor/tailwind.config.js
+++ b/packages/monitor/tailwind.config.js
@@ -1,10 +1,29 @@
 import {
   brandColors,
+  lightModeColors,
   darkModeColors,
+  LIGHT_BORDER,
   DARK_BORDER,
   FONT_FAMILY_SANS,
+  FONT_FAMILY_HEADING,
+  FONT_FAMILY_BODY,
   FONT_FAMILY_CODE,
-} from '@metalbear/ui';
+  FONT_SIZE_HEADING_1,
+  FONT_SIZE_HEADING_2,
+  FONT_SIZE_HEADING_3,
+  FONT_SIZE_HEADING_4,
+  FONT_SIZE_BODY_LG,
+  FONT_SIZE_BODY_MD,
+  FONT_SIZE_BODY_SM,
+  FONT_WEIGHT_REGULAR,
+  FONT_WEIGHT_MEDIUM,
+  FONT_WEIGHT_SEMIBOLD,
+  FONT_WEIGHT_BOLD,
+  LINE_HEIGHT_TIGHT,
+  LINE_HEIGHT_SNUG,
+  LINE_HEIGHT_NORMAL,
+  LINE_HEIGHT_RELAXED,
+} from '@metalbear/ui'
 
 /** @type {import('tailwindcss').Config} */
 export default {
@@ -18,15 +37,57 @@ export default {
     extend: {
       fontFamily: {
         sans: FONT_FAMILY_SANS.split(', '),
+        heading: FONT_FAMILY_HEADING.split(', '),
+        body: FONT_FAMILY_BODY.split(', '),
         code: FONT_FAMILY_CODE.split(', '),
       },
+      fontSize: {
+        h1: [FONT_SIZE_HEADING_1, { lineHeight: LINE_HEIGHT_TIGHT }],
+        h2: [FONT_SIZE_HEADING_2, { lineHeight: LINE_HEIGHT_TIGHT }],
+        h3: [FONT_SIZE_HEADING_3, { lineHeight: LINE_HEIGHT_SNUG }],
+        h4: [FONT_SIZE_HEADING_4, { lineHeight: LINE_HEIGHT_SNUG }],
+        'body-lg': [FONT_SIZE_BODY_LG, { lineHeight: LINE_HEIGHT_NORMAL }],
+        'body-md': [FONT_SIZE_BODY_MD, { lineHeight: LINE_HEIGHT_NORMAL }],
+        'body-sm': [FONT_SIZE_BODY_SM, { lineHeight: LINE_HEIGHT_NORMAL }],
+      },
+      fontWeight: {
+        regular: FONT_WEIGHT_REGULAR,
+        medium: FONT_WEIGHT_MEDIUM,
+        semibold: FONT_WEIGHT_SEMIBOLD,
+        bold: FONT_WEIGHT_BOLD,
+      },
+      lineHeight: {
+        tight: LINE_HEIGHT_TIGHT,
+        snug: LINE_HEIGHT_SNUG,
+        normal: LINE_HEIGHT_NORMAL,
+        relaxed: LINE_HEIGHT_RELAXED,
+      },
       colors: {
+        // Brand colors from @metalbear/ui
         brand: brandColors,
+        // Semantic colors
         primary: {
           DEFAULT: brandColors.purple,
           light: brandColors.purpleMedium,
           dark: brandColors.purpleDark,
         },
+        secondary: {
+          DEFAULT: brandColors.yellow,
+        },
+        destructive: {
+          DEFAULT: brandColors.redBlush,
+        },
+        // Light mode
+        light: {
+          background: lightModeColors.background,
+          foreground: lightModeColors.foreground,
+          primary: lightModeColors.primary,
+          secondary: lightModeColors.secondary,
+          muted: lightModeColors.muted,
+          accent: lightModeColors.accent,
+          border: LIGHT_BORDER,
+        },
+        // Dark mode
         dark: {
           background: darkModeColors.background,
           foreground: darkModeColors.foreground,
@@ -34,6 +95,10 @@ export default {
           muted: darkModeColors.muted,
           border: DARK_BORDER,
         },
+      },
+      boxShadow: {
+        brand: `0 4px 14px 0 ${brandColors.purple}59`,
+        'brand-hover': `0 6px 20px 0 ${brandColors.purple}80`,
       },
     },
   },


### PR DESCRIPTION
## Summary

Fix the broken-looking mirrord logo in the session monitor header (PRO-93) and align the monitor's design system with the operator-dashboard so both apps share the same typography, colors, and header layout.

### What was wrong

The header in `packages/monitor/src/components/AppHeader.tsx` rendered the mirrord brand mark squashed into a 28x28 box with `dark:invert` (broken in dark mode), and put a duplicate "mirrord" text right next to it.

### What changed

- **Logo:** swapped to icon-only `MirrordIcon` at the same `w-8 h-8` the operator-dashboard uses, with conditional `invert` filter for dark mode.
- **Typography:** imported `FONT_SIZE_HEADING_*`, `FONT_SIZE_BODY_*`, `FONT_WEIGHT_*`, `LINE_HEIGHT_*` from `@metalbear/ui` and exposed them as `text-h1..h4`, `text-body-lg/md/sm`, `font-regular/medium/semibold/bold`, etc. Same tokens the operator-dashboard uses.
- **Theming:** added Poppins font + standard light/dark palettes + brand box-shadows. Header now uses semantic tailwind classes (`bg-background`, `text-foreground`, `border-border`, `via-primary`) so the whole app themes together via the existing UI-kit `dark` class, not just the header.
- **Header structure:** `h-14`, responsive `hidden sm:flex` brand block, gradient accent line under the bar — mirrors the operator-dashboard's `AppBar.tsx` exactly.

### One intentional difference vs operator-dashboard

I dropped the `max-w-7xl mx-auto` container from the monitor header. The monitor uses a full-width sidebar + detail layout (event stream wants horizontal real estate); centering only the header would float the logo in the middle while the sidebar starts at the page edge, which looks worse than just spanning everything full-width.

## Test plan

- [x] `pnpm run build` clean (no TS errors)
- [x] Verified visually in light + dark mode against `mirrord ui` running on staging
- [x] Header now matches operator-dashboard's `AppBar` styling (font, sizing, gradient, theme switching)

🤖 Generated with [Claude Code](https://claude.com/claude-code)