### PR TITLE
Fix cargo-deny AWS rustls path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -655,8 +655,6 @@ checksum = "11493b0bad143270fb8ad284a096dd529ba91924c5409adeac856cc1bf047dbc"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
- "aws-sdk-sso",
- "aws-sdk-ssooidc",
  "aws-sdk-sts",
  "aws-smithy-async",
  "aws-smithy-http",
@@ -667,14 +665,11 @@ dependencies = [
  "aws-types",
  "bytes",
  "fastrand",
- "hex",
  "http 1.4.0",
- "sha1",
  "time",
  "tokio",
  "tracing",
  "url",
- "zeroize",
 ]
 
 [[package]]
@@ -741,54 +736,6 @@ name = "aws-sdk-sqs"
 version = "1.97.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d497fb382b906b04167e62848ad00e56c5ad523791a461d5a5611c186531d81"
-dependencies = [
- "aws-credential-types",
- "aws-runtime",
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-observability",
- "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-types",
- "bytes",
- "fastrand",
- "http 0.2.12",
- "http 1.4.0",
- "regex-lite",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-sso"
-version = "1.97.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aadc669e184501caaa6beafb28c6267fc1baef0810fb58f9b205485ca3f2567"
-dependencies = [
- "aws-credential-types",
- "aws-runtime",
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-observability",
- "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-types",
- "bytes",
- "fastrand",
- "http 0.2.12",
- "http 1.4.0",
- "regex-lite",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-ssooidc"
-version = "1.99.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1342a7db8f358d3de0aed2007a0b54e875458e39848d54cc1d46700b2bfcb0a8"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -896,23 +843,17 @@ dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "h2 0.3.27",
  "h2 0.4.13",
- "http 0.2.12",
  "http 1.4.0",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "hyper 1.8.1",
- "hyper-rustls 0.24.2",
- "hyper-rustls 0.27.7",
+ "hyper",
+ "hyper-rustls",
  "hyper-util",
  "pin-project-lite",
- "rustls 0.21.12",
- "rustls 0.23.37",
+ "rustls",
  "rustls-native-certs 0.8.3",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower 0.5.3",
  "tracing",
 ]
@@ -1078,7 +1019,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper",
  "hyper-util",
  "itoa",
  "matchit 0.8.4",
@@ -1395,7 +1336,7 @@ dependencies = [
  "hex",
  "http 1.4.0",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper",
  "hyper-named-pipe",
  "hyper-util",
  "hyperlocal",
@@ -3451,30 +3392,6 @@ checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hyper"
-version = "0.14.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2 0.3.27",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2 0.5.10",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
@@ -3503,7 +3420,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
 dependencies = [
  "hex",
- "hyper 1.8.1",
+ "hyper",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -3513,34 +3430,19 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
-dependencies = [
- "futures-util",
- "http 0.2.12",
- "hyper 0.14.32",
- "log",
- "rustls 0.21.12",
- "tokio",
- "tokio-rustls 0.24.1",
-]
-
-[[package]]
-name = "hyper-rustls"
 version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
  "http 1.4.0",
- "hyper 1.8.1",
+ "hyper",
  "hyper-util",
  "log",
- "rustls 0.23.37",
+ "rustls",
  "rustls-native-certs 0.8.3",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower-service",
  "webpki-roots",
 ]
@@ -3551,7 +3453,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper 1.8.1",
+ "hyper",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -3570,7 +3472,7 @@ dependencies = [
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
- "hyper 1.8.1",
+ "hyper",
  "ipnet",
  "libc",
  "percent-encoding",
@@ -3589,7 +3491,7 @@ checksum = "986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7"
 dependencies = [
  "hex",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -4258,8 +4160,8 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
- "hyper-rustls 0.27.7",
+ "hyper",
+ "hyper-rustls",
  "hyper-timeout",
  "hyper-util",
  "jiff",
@@ -4267,7 +4169,7 @@ dependencies = [
  "k8s-openapi",
  "kube-core",
  "pem",
- "rustls 0.23.37",
+ "rustls",
  "secrecy",
  "serde",
  "serde_json",
@@ -4718,7 +4620,7 @@ dependencies = [
  "home",
  "http-body-util",
  "humantime",
- "hyper 1.8.1",
+ "hyper",
  "hyper-util",
  "itertools 0.14.0",
  "k8s-openapi",
@@ -4754,7 +4656,7 @@ dependencies = [
  "reqwest 0.13.2",
  "rstest",
  "rust-embed",
- "rustls 0.23.37",
+ "rustls",
  "semver 1.0.27",
  "serde",
  "serde_json",
@@ -4765,7 +4667,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-retry",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tokio-stream",
  "tokio-util",
  "tower 0.5.3",
@@ -4800,7 +4702,7 @@ dependencies = [
  "http 1.4.0",
  "http-body-util",
  "httparse",
- "hyper 1.8.1",
+ "hyper",
  "hyper-util",
  "jaq-core",
  "jaq-json",
@@ -4820,7 +4722,7 @@ dependencies = [
  "rcgen",
  "reqwest 0.13.2",
  "rstest",
- "rustls 0.23.37",
+ "rustls",
  "semver 1.0.27",
  "serde",
  "serde_json",
@@ -4831,7 +4733,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-retry",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tokio-stream",
  "tokio-util",
  "tonic",
@@ -4932,7 +4834,7 @@ dependencies = [
  "nom",
  "rand 0.9.2",
  "rstest",
- "rustls 0.23.37",
+ "rustls",
  "schemars 1.2.1",
  "semver 1.0.27",
  "serde",
@@ -4982,7 +4884,7 @@ dependencies = [
  "futures",
  "home",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper",
  "hyper-util",
  "mirrord-analytics",
  "mirrord-config",
@@ -4997,7 +4899,7 @@ dependencies = [
  "rand 0.9.2",
  "rcgen",
  "rstest",
- "rustls 0.23.37",
+ "rustls",
  "semver 1.0.27",
  "serde",
  "serde_json",
@@ -5006,7 +4908,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-retry",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tokio-stream",
  "tokio-util",
  "tracing",
@@ -5220,7 +5122,7 @@ dependencies = [
  "futures",
  "http 1.4.0",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper",
  "hyper-util",
  "k8s-openapi",
  "kube",
@@ -5271,7 +5173,7 @@ dependencies = [
  "futures",
  "http-body-util",
  "http-serde",
- "hyper 1.8.1",
+ "hyper",
  "jaq-core",
  "jaq-json",
  "jaq-std",
@@ -5299,7 +5201,7 @@ dependencies = [
  "futures",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper",
  "mirrord-protocol",
  "pin-project-lite",
  "rstest",
@@ -5400,7 +5302,7 @@ dependencies = [
  "futures",
  "futures-util",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper",
  "hyper-util",
  "json-patch",
  "jsonptr",
@@ -5417,7 +5319,7 @@ dependencies = [
  "regex",
  "reqwest 0.13.2",
  "rstest",
- "rustls 0.23.37",
+ "rustls",
  "serde",
  "serde_json",
  "tempfile",
@@ -5434,12 +5336,12 @@ dependencies = [
  "http 1.4.0",
  "pem",
  "rcgen",
- "rustls 0.23.37",
+ "rustls",
  "rustls-pemfile",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tracing",
  "x509-parser",
 ]
@@ -6605,7 +6507,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.37",
+ "rustls",
  "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
@@ -6626,7 +6528,7 @@ dependencies = [
  "rand 0.9.2",
  "ring",
  "rustc-hash",
- "rustls 0.23.37",
+ "rustls",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.18",
@@ -6943,15 +6845,15 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
- "hyper-rustls 0.27.7",
+ "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.37",
+ "rustls",
  "rustls-native-certs 0.8.3",
  "rustls-pki-types",
  "serde",
@@ -6959,7 +6861,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower 0.5.3",
  "tower-http",
  "tower-service",
@@ -6985,22 +6887,22 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
- "hyper-rustls 0.27.7",
+ "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.37",
+ "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tokio-util",
  "tower 0.5.3",
  "tower-http",
@@ -7213,18 +7115,6 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
-dependencies = [
- "log",
- "ring",
- "rustls-webpki 0.101.7",
- "sct",
-]
-
-[[package]]
-name = "rustls"
 version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
@@ -7234,7 +7124,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.10",
+ "rustls-webpki",
  "subtle",
  "zeroize",
 ]
@@ -7294,10 +7184,10 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.37",
+ "rustls",
  "rustls-native-certs 0.8.3",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.10",
+ "rustls-webpki",
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
@@ -7312,19 +7202,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.7"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.103.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -7461,16 +7341,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted",
 ]
 
 [[package]]
@@ -8411,21 +8281,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
-dependencies = [
- "rustls 0.21.12",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.37",
+ "rustls",
  "tokio",
 ]
 
@@ -8585,7 +8445,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
@@ -8858,7 +8718,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.8.5",
- "rustls 0.23.37",
+ "rustls",
  "rustls-native-certs 0.7.3",
  "rustls-pki-types",
  "sha1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,9 +74,9 @@ assert-json-diff = "2"
 async-pidfd = "0.1.5"
 async-stream = "0.3"
 async-trait = "0.1"
-aws-config = { version = "1.5", features = ["behavior-version-latest"] }
+aws-config = { version = "1.5", default-features = false }
 aws-credential-types = "1.2"
-aws-sdk-sqs = "1.39"
+aws-sdk-sqs = { version = "1.39", default-features = false }
 aws-types = "1.3"
 axum = "0.8"
 axum-extra = { version = "0.10", features = ["cookie"] }

--- a/changelog.d/+cargo-deny-aws-rustls.internal.md
+++ b/changelog.d/+cargo-deny-aws-rustls.internal.md
@@ -1,0 +1,1 @@
+Fix `cargo-deny` by removing the legacy AWS rustls path from the SQS test dependencies and updating `rustls-webpki`.

--- a/deny.toml
+++ b/deny.toml
@@ -16,7 +16,6 @@ ignore = [
   "RUSTSEC-2024-0436", # paste is unmaintained but we should not have an issue with it.
   "RUSTSEC-2025-0134", # rustls-pemfile is unmaintained, but we cannot remove it yet.
   "RUSTSEC-2025-0141", # bincode is unmaintaned, but we cannot remove it yet.
-  "RUSTSEC-2026-0049", # aws crates in tests/rust-sqs-printer depend on an old version of rustls-webpki
   "RUSTSEC-2026-0097", # rand: unsound only with a custom logger using `rand::rng()`; we don't use that pattern.
   "RUSTSEC-2026-0098", # rustls-webpki: name constraints for URI names incorrectly accepted; same old rustls-webpki path as RUSTSEC-2026-0049.
   "RUSTSEC-2026-0099", # rustls-webpki: name constraints accepted for certificates asserting a wildcard name; same old rustls-webpki path as RUSTSEC-2026-0049.

--- a/deny.toml
+++ b/deny.toml
@@ -17,8 +17,6 @@ ignore = [
   "RUSTSEC-2025-0134", # rustls-pemfile is unmaintained, but we cannot remove it yet.
   "RUSTSEC-2025-0141", # bincode is unmaintaned, but we cannot remove it yet.
   "RUSTSEC-2026-0097", # rand: unsound only with a custom logger using `rand::rng()`; we don't use that pattern.
-  "RUSTSEC-2026-0098", # rustls-webpki: name constraints for URI names incorrectly accepted; same old rustls-webpki path as RUSTSEC-2026-0049.
-  "RUSTSEC-2026-0099", # rustls-webpki: name constraints accepted for certificates asserting a wildcard name; same old rustls-webpki path as RUSTSEC-2026-0049.
 ]
 
 [licenses]

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -11,9 +11,16 @@ workspace = true
 doctest = false
 
 [dependencies]
-aws-config = { workspace = true, optional = true }
+aws-config = { workspace = true, optional = true, default-features = false, features = [
+    "behavior-version-latest",
+    "default-https-client",
+    "rt-tokio",
+] }
 aws-credential-types.workspace = true
-aws-sdk-sqs = { workspace = true, optional = true }
+aws-sdk-sqs = { workspace = true, optional = true, default-features = false, features = [
+    "default-https-client",
+    "rt-tokio",
+] }
 aws-types.workspace = true
 json-patch.workspace = true
 jsonptr.workspace = true

--- a/tests/rust-sqs-printer/Cargo.toml
+++ b/tests/rust-sqs-printer/Cargo.toml
@@ -5,7 +5,14 @@ edition = "2021"
 license.workspace = true
 
 [dependencies]
-aws-config.workspace = true
-aws-sdk-sqs.workspace = true
+aws-config = { workspace = true, default-features = false, features = [
+    "behavior-version-latest",
+    "default-https-client",
+    "rt-tokio",
+] }
+aws-sdk-sqs = { workspace = true, default-features = false, features = [
+    "default-https-client",
+    "rt-tokio",
+] }
 serde_json.workspace = true
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros"] }


### PR DESCRIPTION
Closes INT-351
And also solves a new cargo-deny denial: https://github.com/metalbear-co/mirrord/actions/runs/24453915080/job/71449507715?pr=4165#step:4:9137


## Summary

- remove the legacy AWS rustls path from the SQS test dependencies
- update `Cargo.lock` to resolve `rustls-webpki` to `0.103.12`
- remove the stale RustSec ignore from `deny.toml`

## Root cause

AWS default features were pulling both the modern HTTPS client stack and the legacy `tls-rustls` stack, which kept `hyper-rustls 0.24` / `rustls 0.21` in the dependency graph.
