### PR TITLE
Use upstreamed `kube::RetryPolicy`, and get rid of our implementation `RetryKube`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5041,7 +5041,6 @@ version = "3.201.0"
 dependencies = [
  "async-stream",
  "futures",
- "http 1.4.0",
  "itertools 0.14.0",
  "k8s-openapi",
  "kube",

--- a/changelog.d/+cor-1147.internal.md
+++ b/changelog.d/+cor-1147.internal.md
@@ -1,1 +1,1 @@
-Use upstreamed `kube::RetryPolicy`, and get rid of our implementation `RetryKube`.
+Use up-streamed `kube::RetryPolicy`, and get rid of our implementation `RetryKube`.

--- a/changelog.d/+cor-1147.internal.md
+++ b/changelog.d/+cor-1147.internal.md
@@ -1,0 +1,1 @@
+Use upstreamed `kube::RetryPolicy`, and get rid of our implementation `RetryKube`.

--- a/mirrord/cli/src/kube.rs
+++ b/mirrord/cli/src/kube.rs
@@ -2,7 +2,7 @@ use std::fmt::Debug;
 
 use kube::{Resource, api::ListParams, client::ClientBuilder};
 use mirrord_config::LayerConfig;
-use mirrord_kube::{api::kubernetes::create_kube_config, retry::RetryKube};
+use mirrord_kube::{api::kubernetes::create_kube_config, retry::retry_policy_from_config};
 use mirrord_progress::Progress;
 use serde::de::DeserializeOwned;
 use tower::{buffer::BufferLayer, retry::RetryLayer};
@@ -23,7 +23,7 @@ pub(crate) async fn kube_client_from_layer_config(
     .and_then(|config| {
         Ok(ClientBuilder::try_from(config.clone())?
             .with_layer(&BufferLayer::new(1024))
-            .with_layer(&RetryLayer::new(RetryKube::try_from(
+            .with_layer(&RetryLayer::new(retry_policy_from_config(
                 &layer_config.startup_retry,
             )?))
             .build())

--- a/mirrord/cli/src/profile.rs
+++ b/mirrord/cli/src/profile.rs
@@ -10,7 +10,9 @@ use mirrord_config::{
     feature::{FeatureConfig, network::incoming::IncomingMode},
     util::VecOrSingle,
 };
-use mirrord_kube::{api::kubernetes::create_kube_config, error::KubeApiError, retry::RetryKube};
+use mirrord_kube::{
+    api::kubernetes::create_kube_config, error::KubeApiError, retry::retry_policy_from_config,
+};
 use mirrord_operator::crd::profile::{
     FeatureAdjustment, FeatureChange, MirrordClusterProfile, MirrordProfile,
 };
@@ -241,7 +243,7 @@ async fn fetch_profile(
     let client = ClientBuilder::try_from(config)
         .map_err(KubeApiError::from)?
         .with_layer(&BufferLayer::new(1024))
-        .with_layer(&RetryLayer::new(RetryKube::try_from(
+        .with_layer(&RetryLayer::new(retry_policy_from_config(
             &layer_config.startup_retry,
         )?))
         .build();

--- a/mirrord/kube/Cargo.toml
+++ b/mirrord/kube/Cargo.toml
@@ -44,7 +44,6 @@ tokio.workspace = true
 tracing.workspace = true
 tokio-retry = { workspace = true, optional = true }
 tower = { workspace = true, features = ["retry"] }
-http.workspace = true
 itertools.workspace = true
 
 [dev-dependencies]

--- a/mirrord/kube/src/api/kubernetes.rs
+++ b/mirrord/kube/src/api/kubernetes.rs
@@ -34,7 +34,7 @@ use crate::{
         runtime::{RuntimeData, RuntimeDataProvider},
     },
     error::{KubeApiError, Result},
-    retry::RetryKube,
+    retry::retry_policy_from_config,
 };
 
 #[cfg(feature = "portforward")]
@@ -63,7 +63,7 @@ impl KubernetesAPI {
         let client = progress
             .suspend(|| ClientBuilder::try_from(client_config.clone()))?
             .with_layer(&BufferLayer::new(1024))
-            .with_layer(&RetryLayer::new(RetryKube::try_from(
+            .with_layer(&RetryLayer::new(retry_policy_from_config(
                 &config.startup_retry,
             )?))
             .build();

--- a/mirrord/kube/src/retry.rs
+++ b/mirrord/kube/src/retry.rs
@@ -1,135 +1,26 @@
-//! Implementation of our [`RetryKube`] [`Policy`] for retrying [`kube`] api requests using
-//! [`tower::retry::RetryLayer`].
-//!
-//! It's being used only for retrying [`kube::Client`] requests during mirrord startup.
+//! Implementation of a helper to convert between a [`StartupRetryConfig`] to the [`kube`] type
+//! [`RetryPolicy`], that can be used as a [`tower`] layer to retry `kube` requests that fail with
+//! recoverable errors.
 use std::time::Duration;
 
-use http::{Request, StatusCode};
-use kube::client::Body;
+use kube::client::retry::RetryPolicy;
 use mirrord_config::retry::StartupRetryConfig;
-use tower::{
-    BoxError,
-    retry::{
-        Policy,
-        backoff::{
-            Backoff, ExponentialBackoff, ExponentialBackoffMaker, InvalidBackoff, MakeBackoff,
-        },
-    },
-    util::rng::HasherRng,
-};
-use tracing::Level;
+use tower::retry::backoff::InvalidBackoff;
 
-/// Implements [`tower`] [`Policy`] for retrying kube operations for [`kube::Client`].
+/// Creates a [`RetryPolicy`] for a [`kube::Client`] from a [`StartupRetryConfig`].
 ///
-/// You can add it as a [`tower::Layer`] like this:
-///
-/// ```ignore
-/// client_builder
-///   .with_layer(&BufferLayer::new(1024))
-///   .with_layer(&RetryLayer::new(RetryKube::try_from(&config.startup_retry)?))
-/// ```
-///
-/// You should build this using the [`TryFrom<&StartupRetryConfig>`] impl.
-///
-/// - We need the `BufferLayer` so the service implements `Clone`.
-///
-/// - We're assuming that [`Request`] coming from a [`kube::Client`] use the [`Body`] with
-///   `Kind::Once(Option<Bytes>)`, since we need to clone the [`Request`] in
-///   [`Policy::clone_request`], and the other [`Body`] type cannot be cloned
-///   (`Kind::Wrap(UnsyncBoxBody<Bytes, Box<dyn StdError + Send + Sync>>)`). If [`kube`] ever
-///   changes this, then we need to change how we retry this stuff.
-#[derive(Clone)]
-pub struct RetryKube {
-    /// We call [`ExponentialBackoff::next_backoff`] to get the sleep time for the next retry.
-    backoff: ExponentialBackoff,
-
-    /// Keeps track of how many retries, so we can stop when we reach `max_retries`.
-    current_attempt: u32,
-
-    /// Limits the amount of retries.
-    ///
-    /// If this is set to `0`, then we don't retry (the request is made once, but if it fails we
-    /// don't retry it).
-    max_retries: u32,
-}
-
-impl TryFrom<&StartupRetryConfig> for RetryKube {
-    type Error = InvalidBackoff;
-
-    fn try_from(
-        StartupRetryConfig {
-            min_ms,
-            max_ms,
-            max_retries,
-        }: &StartupRetryConfig,
-    ) -> Result<Self, Self::Error> {
-        let backoff = ExponentialBackoffMaker::new(
-            Duration::from_millis(*min_ms),
-            Duration::from_millis(*max_ms),
-            2.0,
-            HasherRng::new(),
-        )?
-        .make_backoff();
-
-        Ok(Self {
-            backoff,
-            current_attempt: 0,
-            max_retries: *max_retries,
-        })
-    }
-}
-
-impl Default for RetryKube {
-    fn default() -> Self {
-        let retry_config = StartupRetryConfig {
-            min_ms: 500,
-            max_ms: 5000,
-            max_retries: 2,
-        };
-
-        Self::try_from(&retry_config).expect("Default values should be valid!")
-    }
-}
-
-impl<Res> Policy<http::Request<Body>, http::Response<Res>, BoxError> for RetryKube {
-    type Future = tokio::time::Sleep;
-
-    #[tracing::instrument(level = Level::TRACE, skip(self, result))]
-    fn retry(
-        &mut self,
-        req: &mut http::Request<Body>,
-        result: &mut Result<http::Response<Res>, BoxError>,
-    ) -> Option<Self::Future> {
-        match result {
-            Ok(response)
-                if matches!(
-                    response.status(),
-                    StatusCode::TOO_MANY_REQUESTS
-                        | StatusCode::SERVICE_UNAVAILABLE
-                        | StatusCode::GATEWAY_TIMEOUT
-                ) && self.current_attempt < self.max_retries =>
-            {
-                self.current_attempt += 1;
-                Some(self.backoff.next_backoff())
-            }
-            _ => None,
-        }
-    }
-
-    #[tracing::instrument(level = Level::TRACE, skip(self), ret)]
-    fn clone_request(&mut self, req: &http::Request<Body>) -> Option<http::Request<Body>> {
-        let body = req.body().try_clone()?;
-
-        let mut request = Request::builder()
-            .method(req.method().clone())
-            .uri(req.uri().clone())
-            .version(req.version())
-            .extension(req.extensions().clone());
-
-        if let Some(headers) = request.headers_mut() {
-            headers.extend(req.headers().clone());
-        }
-
-        request.body(body).ok()
-    }
+/// We use this `RetryPolicy` to retry some `kube` requests during mirrord startup. See
+/// [`RetryPolicy`] docs for the errors that are retryable.
+pub fn retry_policy_from_config(
+    StartupRetryConfig {
+        min_ms,
+        max_ms,
+        max_retries,
+    }: &StartupRetryConfig,
+) -> Result<RetryPolicy, InvalidBackoff> {
+    RetryPolicy::new(
+        Duration::from_millis(*min_ms),
+        Duration::from_millis(*max_ms),
+        *max_retries,
+    )
 }

--- a/mirrord/operator/src/client.rs
+++ b/mirrord/operator/src/client.rs
@@ -31,7 +31,7 @@ use mirrord_kube::{
     },
     error::KubeApiError,
     resolved::{ResolvedResource, ResolvedTarget},
-    retry::RetryKube,
+    retry::retry_policy_from_config,
 };
 use mirrord_progress::Progress;
 use mirrord_protocol::{ClientMessage, DaemonMessage};
@@ -252,7 +252,7 @@ impl OperatorApi<NoClientCert> {
             .suspend(|| ClientBuilder::try_from(base_config.clone()))
             .map_err(KubeApiError::from)?
             .with_layer(&BufferLayer::new(1024))
-            .with_layer(&RetryLayer::new(RetryKube::try_from(
+            .with_layer(&RetryLayer::new(retry_policy_from_config(
                 &config.startup_retry,
             )?))
             .build();
@@ -358,7 +358,7 @@ impl OperatorApi<NoClientCert> {
                 .map_err(OperatorApiError::CreateKubeClient)?
                 .with_layer(&BufferLayer::new(1024))
                 .with_layer(&RetryLayer::new(
-                    RetryKube::try_from(&layer_config.startup_retry).map_err(From::from)?,
+                    retry_policy_from_config(&layer_config.startup_retry).map_err(From::from)?,
                 ))
                 .build();
 
@@ -1817,7 +1817,7 @@ impl OperatorApi<PreparedClientCert> {
             .map_err(KubeApiError::from)
             .map_err(OperatorApiError::CreateKubeClient)?
             .with_layer(&BufferLayer::new(1024))
-            .with_layer(&RetryLayer::new(RetryKube::try_from(
+            .with_layer(&RetryLayer::new(retry_policy_from_config(
                 &layer_config.startup_retry,
             )?))
             .build();


### PR DESCRIPTION
<!-- Thank you for contributing to mirrord! -->
<!-- Please use the checklist below as a guide for docs, tests and admin tasks for your PR -->
<!-- Feel free to ~strikethrough~ any items that you don't think apply -->
- Issue: https://linear.app/metalbear/issue/COR-1147/upstream-retrylayer-to-kube-rs

Our kube retry thingy has been upstreamed, and we have updated our kube-rs version. So now we can just remove our custom implementation and use what's available (with a small helper function to convert from our config for this to whatever the kube `RetryPolicy` wants).

### Quality Checklist:

- [x] I have documented new code sufficiently
- [ ] I have checked and updated the relevant existing docs in code, including removing outdated material
- [ ] I have written user-facing website docs for new features, or opened a (sub)issue to do so
- [ ] I have checked and updated existing website docs for changed features
- [ ] I have tested this change and know it succeeds and fails as expected
- [ ] I have written unit tests or purposefully omitted them
- [ ] I have written e2e tests or purposefully omitted them
- [x] I have explained what this PR introduces and why, and linked to relevant context (e.g. linear issues, related PRs,
  documentation)
- [x] I have introduced a short, clear and well-formatted changelog entry

<!-- need help with the changelog? see ../CONTRIBUTING.md#submitting-a-pull-request -->
<!-- Add more details of your changes below if needed -->