### PR TITLE
Rescue #4175: monitor PRO-91 + PRO-93 + PRO-94 fixes

### DIFF
--- a/changelog.d/+monitor-header-design.changed.md
+++ b/changelog.d/+monitor-header-design.changed.md
@@ -1,0 +1,1 @@
+Fix the squashed mirrord logo in the session monitor header and align the monitor's typography, color tokens, and header layout with the operator-dashboard's design system so both apps share the same look.

--- a/changelog.d/+monitor-root-process.fixed.md
+++ b/changelog.d/+monitor-root-process.fixed.md
@@ -1,0 +1,1 @@
+Fix the root layer process being absent from the local UI processes list. Also update the `mirrord ui` help text from "Launch the session monitor UI" to "Launch the mirrord local UI".

--- a/mirrord/cli/src/config.rs
+++ b/mirrord/cli/src/config.rs
@@ -223,7 +223,7 @@ pub(super) enum Commands {
     #[command(hide = true)]
     Attach(AttachArgs),
 
-    /// Launch the session monitor UI.
+    /// Launch the mirrord local UI.
     ///
     /// Watches active mirrord sessions and displays a web dashboard showing
     /// real-time events (file operations, DNS queries, HTTP requests, etc.)

--- a/mirrord/cli/src/internal_proxy.rs
+++ b/mirrord/cli/src/internal_proxy.rs
@@ -131,6 +131,7 @@ async fn start_session_monitor(config: &LayerConfig, is_operator: bool) -> Monit
 
         let (tx, _rx) =
             tokio::sync::broadcast::channel::<mirrord_intproxy::session_monitor::MonitorEvent>(256);
+        let api_monitor_rx = tx.subscribe();
         let proxy_monitor_tx = MonitorTx::from_sender(tx.clone());
         let api_monitor_tx = MonitorTx::from_sender(tx);
 
@@ -179,6 +180,7 @@ async fn start_session_monitor(config: &LayerConfig, is_operator: bool) -> Monit
             if let Err(error) = mirrord_intproxy::session_monitor::api::start_api_server(
                 session_info,
                 api_monitor_tx,
+                api_monitor_rx,
                 shutdown,
             )
             .await

--- a/mirrord/intproxy/src/session_monitor/api.rs
+++ b/mirrord/intproxy/src/session_monitor/api.rs
@@ -99,15 +99,11 @@ async fn kill(State(state): State<Arc<AppState>>) -> impl IntoResponse {
     Json(serde_json::json!({"status": "shutting_down"}))
 }
 
-/// Subscribes to monitor events and updates session_info on LayerConnected, LayerDisconnected,
-/// and PortSubscription events.
 #[cfg(unix)]
-async fn update_session_info_from_events(state: Arc<AppState>) {
-    let mut rx = match state.monitor_tx.subscribe() {
-        Some(rx) => rx,
-        None => return,
-    };
-
+async fn update_session_info_from_events(
+    state: Arc<AppState>,
+    mut rx: tokio::sync::broadcast::Receiver<MonitorEvent>,
+) {
     loop {
         match rx.recv().await {
             Ok(MonitorEvent::LayerConnected {
@@ -168,6 +164,7 @@ fn verify_session_id(session_id: &str) -> bool {
 pub async fn start_api_server(
     session_info: SessionInfo,
     monitor_tx: MonitorTx,
+    monitor_rx: tokio::sync::broadcast::Receiver<MonitorEvent>,
     shutdown: CancellationToken,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let session_id = &session_info.session_id;
@@ -205,7 +202,7 @@ pub async fn start_api_server(
         shutdown: shutdown.clone(),
     });
 
-    tokio::spawn(update_session_info_from_events(state.clone()));
+    tokio::spawn(update_session_info_from_events(state.clone(), monitor_rx));
 
     let app = Router::new()
         .route("/health", get(health))

--- a/packages/monitor/package.json
+++ b/packages/monitor/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@fontsource/poppins": "^5.2.7",
     "@metalbear/ui": "^0.1.5",
     "@xyflow/react": "^12.10.2",
     "elkjs": "^0.11.1",

--- a/packages/monitor/pnpm-lock.yaml
+++ b/packages/monitor/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@fontsource/poppins':
+        specifier: ^5.2.7
+        version: 5.2.7
       '@metalbear/ui':
         specifier: ^0.1.5
         version: 0.1.5(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -302,6 +305,9 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@fontsource/poppins@5.2.7':
+    resolution: {integrity: sha512-6uQyPmseo4FgI97WIhA4yWRlNaoLk4vSDK/PyRwdqqZb5zAEuc+Kunt8JTMcsHYUEGYBtN15SNkMajMdqUSUmg==}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -1612,6 +1618,8 @@ snapshots:
 
   '@esbuild/win32-x64@0.25.12':
     optional: true
+
+  '@fontsource/poppins@5.2.7': {}
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:

--- a/packages/monitor/src/components/AppHeader.tsx
+++ b/packages/monitor/src/components/AppHeader.tsx
@@ -10,31 +10,42 @@ interface Props {
 
 export default function AppHeader({ connected, isDarkMode, onToggleTheme }: Props) {
   return (
-    <header className="dark:bg-dark-background bg-white/80 backdrop-blur-sm border-b border-border dark:border-transparent shrink-0">
-      <div className="px-6">
-        <div className="flex items-center justify-between h-12 text-foreground">
+    <header className="relative shrink-0 bg-background border-b border-border text-foreground">
+      <div className="absolute bottom-0 left-0 right-0 h-[2px] bg-gradient-to-r from-transparent via-primary to-transparent opacity-40" />
+      <div className="px-4 sm:px-6 lg:px-8">
+        <div className="flex items-center justify-between h-14">
           <div className="flex items-center gap-3">
-            <img src={MirrordIcon} alt="mirrord" className="w-7 h-7 dark:invert" />
-            <span className="font-semibold text-base">{strings.app.title}</span>
-            <span className="opacity-30">|</span>
-            <span className="text-sm font-medium opacity-80">{strings.app.subtitle}</span>
+            <img
+              src={MirrordIcon}
+              alt={strings.app.title}
+              className={cn('w-8 h-8', isDarkMode && 'invert')}
+            />
+            <div className="hidden sm:flex items-center gap-2">
+              <span className="font-semibold text-h4">{strings.app.title}</span>
+              <span className="text-foreground/30">|</span>
+              <span className="text-body-sm font-medium text-foreground/70">
+                {strings.app.subtitle}
+              </span>
+            </div>
+            <span className="font-semibold text-h4 sm:hidden">{strings.app.title}</span>
           </div>
+
           <div className="flex items-center gap-3">
             <div className="flex items-center gap-2">
               <div
                 className={cn('h-2 w-2 rounded-full', connected ? 'bg-green-500' : 'bg-red-500')}
               />
-              <span className="text-xs opacity-60">
+              <span className="text-body-sm text-foreground/60">
                 {connected ? strings.app.connected : strings.app.disconnected}
               </span>
             </div>
-            <span className="opacity-20">|</span>
+
             <Button
               variant="ghost"
               size="icon"
               onClick={onToggleTheme}
               title={isDarkMode ? strings.app.themeLight : strings.app.themeDark}
-              className="h-7 w-7 opacity-60 hover:opacity-100"
+              className="h-8 w-8 text-foreground/60 hover:text-foreground"
             >
               {isDarkMode ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
             </Button>

--- a/packages/monitor/src/index.css
+++ b/packages/monitor/src/index.css
@@ -1,13 +1,19 @@
+@import '@fontsource/poppins/400.css';
+@import '@fontsource/poppins/500.css';
+@import '@fontsource/poppins/600.css';
+@import '@fontsource/poppins/700.css';
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
 body {
   margin: 0;
+  font-family: 'Poppins', system-ui, -apple-system, sans-serif;
   -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
-/* Custom scrollbar for dark theme */
 ::-webkit-scrollbar {
   width: 6px;
 }
@@ -19,7 +25,6 @@ body {
   border-radius: 3px;
 }
 
-/* Event row fade-in animation */
 @keyframes eventFadeIn {
   from {
     opacity: 0;
@@ -34,4 +39,3 @@ body {
 .event-row-animate {
   animation: eventFadeIn 0.2s ease-out;
 }
-

--- a/packages/monitor/tailwind.config.js
+++ b/packages/monitor/tailwind.config.js
@@ -1,10 +1,29 @@
 import {
   brandColors,
+  lightModeColors,
   darkModeColors,
+  LIGHT_BORDER,
   DARK_BORDER,
   FONT_FAMILY_SANS,
+  FONT_FAMILY_HEADING,
+  FONT_FAMILY_BODY,
   FONT_FAMILY_CODE,
-} from '@metalbear/ui';
+  FONT_SIZE_HEADING_1,
+  FONT_SIZE_HEADING_2,
+  FONT_SIZE_HEADING_3,
+  FONT_SIZE_HEADING_4,
+  FONT_SIZE_BODY_LG,
+  FONT_SIZE_BODY_MD,
+  FONT_SIZE_BODY_SM,
+  FONT_WEIGHT_REGULAR,
+  FONT_WEIGHT_MEDIUM,
+  FONT_WEIGHT_SEMIBOLD,
+  FONT_WEIGHT_BOLD,
+  LINE_HEIGHT_TIGHT,
+  LINE_HEIGHT_SNUG,
+  LINE_HEIGHT_NORMAL,
+  LINE_HEIGHT_RELAXED,
+} from '@metalbear/ui'
 
 /** @type {import('tailwindcss').Config} */
 export default {
@@ -18,15 +37,57 @@ export default {
     extend: {
       fontFamily: {
         sans: FONT_FAMILY_SANS.split(', '),
+        heading: FONT_FAMILY_HEADING.split(', '),
+        body: FONT_FAMILY_BODY.split(', '),
         code: FONT_FAMILY_CODE.split(', '),
       },
+      fontSize: {
+        h1: [FONT_SIZE_HEADING_1, { lineHeight: LINE_HEIGHT_TIGHT }],
+        h2: [FONT_SIZE_HEADING_2, { lineHeight: LINE_HEIGHT_TIGHT }],
+        h3: [FONT_SIZE_HEADING_3, { lineHeight: LINE_HEIGHT_SNUG }],
+        h4: [FONT_SIZE_HEADING_4, { lineHeight: LINE_HEIGHT_SNUG }],
+        'body-lg': [FONT_SIZE_BODY_LG, { lineHeight: LINE_HEIGHT_NORMAL }],
+        'body-md': [FONT_SIZE_BODY_MD, { lineHeight: LINE_HEIGHT_NORMAL }],
+        'body-sm': [FONT_SIZE_BODY_SM, { lineHeight: LINE_HEIGHT_NORMAL }],
+      },
+      fontWeight: {
+        regular: FONT_WEIGHT_REGULAR,
+        medium: FONT_WEIGHT_MEDIUM,
+        semibold: FONT_WEIGHT_SEMIBOLD,
+        bold: FONT_WEIGHT_BOLD,
+      },
+      lineHeight: {
+        tight: LINE_HEIGHT_TIGHT,
+        snug: LINE_HEIGHT_SNUG,
+        normal: LINE_HEIGHT_NORMAL,
+        relaxed: LINE_HEIGHT_RELAXED,
+      },
       colors: {
+        // Brand colors from @metalbear/ui
         brand: brandColors,
+        // Semantic colors
         primary: {
           DEFAULT: brandColors.purple,
           light: brandColors.purpleMedium,
           dark: brandColors.purpleDark,
         },
+        secondary: {
+          DEFAULT: brandColors.yellow,
+        },
+        destructive: {
+          DEFAULT: brandColors.redBlush,
+        },
+        // Light mode
+        light: {
+          background: lightModeColors.background,
+          foreground: lightModeColors.foreground,
+          primary: lightModeColors.primary,
+          secondary: lightModeColors.secondary,
+          muted: lightModeColors.muted,
+          accent: lightModeColors.accent,
+          border: LIGHT_BORDER,
+        },
+        // Dark mode
         dark: {
           background: darkModeColors.background,
           foreground: darkModeColors.foreground,
@@ -34,6 +95,10 @@ export default {
           muted: darkModeColors.muted,
           border: DARK_BORDER,
         },
+      },
+      boxShadow: {
+        brand: `0 4px 14px 0 ${brandColors.purple}59`,
+        'brand-hover': `0 6px 20px 0 ${brandColors.purple}80`,
       },
     },
   },


### PR DESCRIPTION
## Context

PR #4175 (PRO-91 + PRO-93 + PRO-94) was approved by @aviramha and merged into his `aviram/pro-90-session-monitor-url-returns-404-page` branch. When #4171 then squash-merged to main, GitHub's squash only flattened Aviram's own commits — the #4175 bundle didn't make it through, so these fixes are currently missing from main.

This PR re-applies the #4175 content cleanly on top of current main (cherry-picked via `-m 1` from the #4175 merge commit, so no Aviram CI-iteration residue mixed in). Content is identical to what was already approved.

## Summary

| Ticket | Change |
|---|---|
| **PRO-91** | `mirrord ui` help text: "Launch the session monitor UI" → "Launch the mirrord local UI" |
| **PRO-93** | Fix squashed mirrord logo in monitor header; align typography/color tokens/header layout with operator-dashboard design system; bundle Poppins locally |
| **PRO-94** | Fix root layer process missing from processes list (broadcast-channel publish-before-subscribe race) |

### PRO-94 details

`start_session_monitor` created a tokio broadcast channel, dropped the initial receiver, and spawned `start_api_server` to subscribe later. The intproxy meanwhile emitted `LayerConnected` as soon as a layer connected. Tokio broadcast `send` returns `Err` with no live receivers and `MonitorTx::emit` swallows it, so events in that window were silently dropped. Root processes lost this race the most.

Fix: subscribe synchronously in `start_session_monitor` before spawning, and pass the receiver into `start_api_server` directly.

## Test plan

Originally verified on #4175 (approved by @aviramha):
- [x] `cargo clippy -p mirrord-intproxy -- -D warnings`
- [x] `pnpm run build` for `packages/monitor`
- [x] PRO-94: root process consistently tracked across multiple `mirrord exec` runs on playground (was flaky before)
- [x] PRO-93: header matches operator-dashboard visually
- [x] PRO-91: `mirrord --help | grep ui` shows new wording

## Supersedes

Content-equivalent to approved #4175. Original branch `han/monitor-fixes-bundle` was orphaned by the squash-merge of its base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)