### PR TITLE
WIN-107 WIN-105 MBE-1731 flaky tests fix - outgoing tcp unique connection_ids

### DIFF
--- a/changelog.d/+outgoing-high-port-timeout-windows.internal.md
+++ b/changelog.d/+outgoing-high-port-timeout-windows.internal.md
@@ -1,1 +1,1 @@
-Increased the timeout for the `outgoing_tcp_high_port` layer integration test from 15s to 30s to reduce CI flakiness under slower startup and scheduling conditions.
+Increased the timeout for the `outgoing_tcp_high_port` layer integration test from 15 s to 30 s to reduce CI flakiness under slower startup and scheduling conditions.

--- a/changelog.d/+outgoing-high-port-timeout-windows.internal.md
+++ b/changelog.d/+outgoing-high-port-timeout-windows.internal.md
@@ -1,0 +1,1 @@
+Increased the timeout for the `outgoing_tcp_high_port` layer integration test from 15s to 30s to reduce CI flakiness under slower startup and scheduling conditions.

--- a/changelog.d/+outgoing-tcp-test-ids.internal.md
+++ b/changelog.d/+outgoing-tcp-test-ids.internal.md
@@ -1,0 +1,1 @@
+Stabilized Windows outgoing layer integration tests by using distinct mocked agent `connection_id` values per connection in TCP test flows, avoiding cross-connection races in interceptor cleanup.

--- a/mirrord/layer-tests/tests/outgoing.rs
+++ b/mirrord/layer-tests/tests/outgoing.rs
@@ -113,31 +113,42 @@ async fn outgoing_tcp_logic(with_config: Option<&str>, config_dir: &Path) {
         .map(|s| s.parse::<SocketAddr>().unwrap())
         .collect::<Vec<_>>();
 
-    for peer in peers {
+    for (connection_id, peer) in peers.into_iter().enumerate() {
+        let connection_id = connection_id as u64;
+
         let (uid, addr) = intproxy.recv_tcp_connect().await;
         assert_eq!(addr, peer);
         intproxy
-            .send_tcp_connect_ok(uid, 0, addr, RUST_OUTGOING_LOCAL.parse().unwrap())
+            .send_tcp_connect_ok(
+                uid,
+                connection_id,
+                addr,
+                RUST_OUTGOING_LOCAL.parse().unwrap(),
+            )
             .await;
 
         let msg = intproxy.recv().await;
         let ClientMessage::TcpOutgoing(LayerTcpOutgoing::Write(LayerWrite {
-            connection_id: 0,
+            connection_id: returned_connection_id,
             bytes,
         })) = msg
         else {
             panic!("Invalid message received from layer: {msg:?}");
         };
+        assert_eq!(returned_connection_id, connection_id);
+
         intproxy
             .send(DaemonMessage::TcpOutgoing(DaemonTcpOutgoing::Read(Ok(
                 DaemonRead {
-                    connection_id: 0,
+                    connection_id,
                     bytes,
                 },
             ))))
             .await;
         intproxy
-            .send(DaemonMessage::TcpOutgoing(DaemonTcpOutgoing::Close(0)))
+            .send(DaemonMessage::TcpOutgoing(DaemonTcpOutgoing::Close(
+                connection_id,
+            )))
             .await;
     }
 
@@ -191,33 +202,36 @@ async fn outgoing_tcp_bound_socket() {
     let expected_peer_address = "1.1.1.1:4567".parse::<SocketAddr>().unwrap();
 
     // Test apps runs logic twice for 2 bind addresses.
-    for _ in 0..2 {
+    for connection_id in 0_u64..2 {
         let (uid, addr) = intproxy.recv_tcp_connect().await;
         assert_eq!(addr, expected_peer_address);
         intproxy
-            .send_tcp_connect_ok(uid, 0, addr, "1.2.3.4:6000".parse().unwrap())
+            .send_tcp_connect_ok(uid, connection_id, addr, "1.2.3.4:6000".parse().unwrap())
             .await;
 
         let msg = intproxy.recv().await;
         let ClientMessage::TcpOutgoing(LayerTcpOutgoing::Write(LayerWrite {
-            connection_id: 0,
+            connection_id: returned_connection_id,
             bytes,
         })) = msg
         else {
             panic!("Invalid message received from layer: {msg:?}");
         };
+        assert_eq!(returned_connection_id, connection_id);
 
         intproxy
             .send(DaemonMessage::TcpOutgoing(DaemonTcpOutgoing::Read(Ok(
                 DaemonRead {
-                    connection_id: 0,
+                    connection_id,
                     bytes,
                 },
             ))))
             .await;
 
         intproxy
-            .send(DaemonMessage::TcpOutgoing(DaemonTcpOutgoing::Close(0)))
+            .send(DaemonMessage::TcpOutgoing(DaemonTcpOutgoing::Close(
+                connection_id,
+            )))
             .await;
     }
 

--- a/mirrord/layer-tests/tests/outgoing.rs
+++ b/mirrord/layer-tests/tests/outgoing.rs
@@ -241,7 +241,7 @@ async fn outgoing_tcp_bound_socket() {
 /// Verifies that issue <https://github.com/metalbear-co/mirrord/issues/3212> is fixed.
 #[rstest]
 #[tokio::test]
-#[timeout(Duration::from_secs(15))]
+#[timeout(Duration::from_secs(30))]
 async fn outgoing_tcp_high_port() {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let listener_addr = listener.local_addr().unwrap();


### PR DESCRIPTION
### What This PR Changes
This PR addresses Windows integration-test flakiness in mirrord-layer-tests outgoing TCP cases:

Stabilizes outgoing_tcp test flows by using unique mocked connection_id values per connection instead of reusing 0.
Increases Windows timeout for outgoing_tcp_high_port from 15s to 30s (keeps 15s on non-Windows).

### Why
We observed intermittent CI timeouts where:

* outgoing_tcp::with_config_1_None and outgoing_tcp::with_config_2_Some___outgoing_filter_json___ could process initial connect(s) and then hang or panic.

* outgoing_tcp_high_port would occasionally time out under Windows CI scheduling/startup variance.

#### Root causes:
Reusing a single mocked connection id in test flows can race with async close/cleanup handling across sequential connections.
The outgoing_tcp_high_port timeout was too tight for occasional Windows CI variance.
___

<!-- Thank you for contributing to mirrord! -->
<!-- Please use the checklist below as a guide for docs, tests and admin tasks for your PR -->
<!-- Feel free to ~strikethrough~ any items that you don't think apply -->

### Quality Checklist:

- [ ] I have documented new code sufficiently
- [ ] I have checked and updated the relevant existing docs in code, including removing outdated material
- [ ] I have written user-facing website docs for new features, or opened a (sub)issue to do so
- [ ] I have checked and updated existing website docs for changed features
- [x] I have tested this change and know it succeeds and fails as expected
- [x] I have written unit tests or purposefully omitted them
- [x] I have written e2e tests or purposefully omitted them
- [x] I have explained what this PR introduces and why, and linked to relevant context (e.g. linear issues, related PRs,
  documentation)
- [x] I have introduced a short, clear and well-formatted changelog entry

<!-- need help with the changelog? see ../CONTRIBUTING.md#submitting-a-pull-request -->
<!-- Add more details of your changes below if needed -->