### PR TITLE
feat(mirrord-cli): extend mirrord ui with operator-session support

### DIFF
--- a/changelog.d/+pro-65-http-filter-ui-plumbing.added.md
+++ b/changelog.d/+pro-65-http-filter-ui-plumbing.added.md
@@ -1,0 +1,1 @@
+`mirrord ui` now surfaces each operator session's `http_filter.header_filter` in the `/api/operator-sessions` response, letting the browser extension derive the header it needs to inject instead of assuming a fixed baggage convention.

--- a/changelog.d/+pro-65-mirrord-session-namespaced.changed.md
+++ b/changelog.d/+pro-65-mirrord-session-namespaced.changed.md
@@ -1,0 +1,1 @@
+`mirrord ui` now watches the namespaced `MirrordSession` CRD (a projection the operator writes alongside each `MirrordClusterSession`) instead of the cluster-scoped CRD. Consumers see the same `OperatorSessionSummary` shape but RBAC on shared clusters can now be scoped per namespace.

--- a/changelog.d/+pro-65-mirrord-session-namespaced.changed.md
+++ b/changelog.d/+pro-65-mirrord-session-namespaced.changed.md
@@ -1,1 +1,1 @@
-`mirrord ui` now watches the namespaced `MirrordSession` CRD (a projection the operator writes alongside each `MirrordClusterSession`) instead of the cluster-scoped CRD. Consumers see the same `OperatorSessionSummary` shape but RBAC on shared clusters can now be scoped per namespace.
+`mirrord ui` now watches the `MirrordSession` CRD, which the operator writes into the target's namespace alongside each `MirrordClusterSession`. Consumers see the same `OperatorSessionSummary` shape, and access on shared clusters can scope per namespace through role-based access control.

--- a/mirrord/cli/src/ui.rs
+++ b/mirrord/cli/src/ui.rs
@@ -409,6 +409,40 @@ async fn session_events_sse(
         .into_response()
 }
 
+#[derive(Serialize)]
+struct OperatorSessionsResponse {
+    /// Sessions grouped by key. The key is the map key; value is the list
+    /// of sessions under that key. Sessions whose `spec.key` is `None` are
+    /// collected under a sentinel key `""` (empty string).
+    by_key: std::collections::BTreeMap<String, Vec<OperatorSessionSummary>>,
+    /// Flat list of all sessions, for clients that prefer not to consume
+    /// the grouped view.
+    sessions: Vec<OperatorSessionSummary>,
+    /// Current watch status (for UI diagnostics).
+    watch_status: OperatorWatchStatus,
+}
+
+async fn list_operator_sessions(
+    State(state): State<Arc<AppState>>,
+) -> axum::Json<OperatorSessionsResponse> {
+    let map = state.operator_sessions.read().await;
+    let watch_status = state.operator_watch_status.read().await.clone();
+
+    let mut by_key: std::collections::BTreeMap<String, Vec<OperatorSessionSummary>> =
+        std::collections::BTreeMap::new();
+    let sessions: Vec<OperatorSessionSummary> = map.values().cloned().collect();
+    for s in &sessions {
+        let k = s.key.clone().unwrap_or_default();
+        by_key.entry(k).or_default().push(s.clone());
+    }
+
+    axum::Json(OperatorSessionsResponse {
+        by_key,
+        sessions,
+        watch_status,
+    })
+}
+
 async fn kill_session(State(state): State<Arc<AppState>>, Path(id): Path<String>) -> Response {
     let (client, socket_path) = {
         let sessions = state.sessions.read().await;
@@ -694,7 +728,8 @@ fn build_router(state: Arc<AppState>) -> Router {
         .route("/sessions", get(list_sessions))
         .route("/sessions/{id}", get(get_session))
         .route("/sessions/{id}/events", get(session_events_sse))
-        .route("/sessions/{id}/kill", post(kill_session));
+        .route("/sessions/{id}/kill", post(kill_session))
+        .route("/operator-sessions", get(list_operator_sessions));
 
     let authenticated_routes = Router::new()
         .nest("/api", api_routes)

--- a/mirrord/cli/src/ui.rs
+++ b/mirrord/cli/src/ui.rs
@@ -838,6 +838,8 @@ mod tests {
         let (notify_tx, _) = broadcast::channel(16);
         Arc::new(AppState {
             sessions: RwLock::new(HashMap::new()),
+            operator_sessions: RwLock::new(std::collections::BTreeMap::new()),
+            operator_watch_status: RwLock::new(OperatorWatchStatus::default()),
             notify_tx,
             token: TEST_TOKEN.to_owned(),
         })
@@ -1034,5 +1036,86 @@ mod tests {
             response.headers().get(header::SET_COOKIE).is_some(),
             "cookie must be set on the first authenticated request, even if the body is 404"
         );
+    }
+
+    mod operator_sessions {
+        use mirrord_operator::crd::session::{
+            MirrordClusterSession, MirrordClusterSessionSpec, SessionOwner, SessionTarget,
+        };
+
+        use super::*;
+
+        fn sample_cr(name: &str, key: Option<&str>) -> MirrordClusterSession {
+            MirrordClusterSession::new(
+                name,
+                MirrordClusterSessionSpec {
+                    jira_metrics: None,
+                    owner: SessionOwner {
+                        user_id: "u".into(),
+                        username: "alice".into(),
+                        hostname: "h".into(),
+                        k8s_username: "alice@ex".into(),
+                    },
+                    namespace: "default".into(),
+                    target: Some(SessionTarget {
+                        api_version: "apps/v1".into(),
+                        kind: "Deployment".into(),
+                        name: "web".into(),
+                        container: "app".into(),
+                    }),
+                    ci_info: None,
+                    copy_target: None,
+                    multi_cluster_parent_name: None,
+                    key: key.map(|s| s.to_owned()),
+                },
+            )
+        }
+
+        #[test]
+        fn summary_from_cr_extracts_key() {
+            let cr = sample_cr("cr-1", Some("alice-session"));
+            let summary = OperatorSessionSummary::from_cr(&cr).unwrap();
+            assert_eq!(summary.name, "cr-1");
+            assert_eq!(summary.key.as_deref(), Some("alice-session"));
+            assert_eq!(summary.namespace, "default");
+            assert_eq!(
+                summary.target.as_ref().map(|t| t.name.as_str()),
+                Some("web")
+            );
+        }
+
+        #[test]
+        fn summary_from_cr_preserves_none_key() {
+            let cr = sample_cr("cr-2", None);
+            let summary = OperatorSessionSummary::from_cr(&cr).unwrap();
+            assert!(summary.key.is_none());
+        }
+
+        #[tokio::test]
+        async fn operator_sessions_groups_by_key_with_none_bucket() {
+            let (tx, _rx) = broadcast::channel::<SessionNotification>(16);
+            let state = Arc::new(AppState {
+                sessions: RwLock::new(HashMap::new()),
+                operator_sessions: RwLock::new({
+                    let mut m = std::collections::BTreeMap::new();
+                    let s1 = OperatorSessionSummary::from_cr(&sample_cr("a", Some("k"))).unwrap();
+                    let s2 = OperatorSessionSummary::from_cr(&sample_cr("b", Some("k"))).unwrap();
+                    let s3 = OperatorSessionSummary::from_cr(&sample_cr("c", None)).unwrap();
+                    m.insert("a".into(), s1);
+                    m.insert("b".into(), s2);
+                    m.insert("c".into(), s3);
+                    m
+                }),
+                operator_watch_status: RwLock::new(OperatorWatchStatus::Watching),
+                notify_tx: tx,
+                token: "t".into(),
+            });
+
+            let resp = list_operator_sessions(axum::extract::State(state)).await.0;
+            assert_eq!(resp.sessions.len(), 3);
+            assert_eq!(resp.by_key.get("k").map(|v| v.len()), Some(2));
+            assert_eq!(resp.by_key.get("").map(|v| v.len()), Some(1));
+            assert!(matches!(resp.watch_status, OperatorWatchStatus::Watching));
+        }
     }
 }

--- a/mirrord/cli/src/ui.rs
+++ b/mirrord/cli/src/ui.rs
@@ -4,7 +4,6 @@
 //! active mirrord sessions. It watches `~/.mirrord/sessions/` for Unix socket files, connects
 //! to each session's HTTP API, and serves a React frontend plus REST/SSE/WebSocket endpoints on
 //! localhost.
-//!
 
 use std::{
     collections::{HashMap, hash_map::Entry},

--- a/mirrord/cli/src/ui.rs
+++ b/mirrord/cli/src/ui.rs
@@ -4,6 +4,12 @@
 //! active mirrord sessions. It watches `~/.mirrord/sessions/` for Unix socket files, connects
 //! to each session's HTTP API, and serves a React frontend plus REST/SSE/WebSocket endpoints on
 //! localhost.
+//!
+//! ## Browser extension handoff
+//!
+//! On startup, `mirrord ui` prints both the web UI URL and a `chrome-extension://` configure URL.
+//! The extension id is pinned in the mirrord-browser manifest's `"key"` field, which produces a
+//! deterministic id when loaded unpacked or published to the Chrome Web Store.
 
 use std::{
     collections::{HashMap, hash_map::Entry},
@@ -87,6 +93,19 @@ pub struct OperatorSessionSummary {
     pub owner: Option<OperatorSessionOwner>,
     pub target: Option<OperatorSessionTarget>,
     pub created_at: Option<String>,
+    /// Subset of the dev's `http_filter` needed by external consumers (the
+    /// browser extension parses `header_filter` to build a matching DNR rule).
+    /// `None` if the session was started by an older CLI or operator that
+    /// didn't persist it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub http_filter: Option<OperatorSessionHttpFilter>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OperatorSessionHttpFilter {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub header_filter: Option<String>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -126,6 +145,12 @@ impl OperatorSessionSummary {
                 .creation_timestamp
                 .as_ref()
                 .map(|ts| ts.0.to_string()),
+            http_filter: spec
+                .http_filter
+                .as_ref()
+                .map(|f| OperatorSessionHttpFilter {
+                    header_filter: f.header_filter.clone(),
+                }),
         })
     }
 }
@@ -809,7 +834,13 @@ pub async fn ui_command(args: UiArgs) -> Result<(), CliError> {
         .local_addr()
         .map_err(|e| CliError::UiError(format!("failed to get listener address: {e}")))?;
     let url = format!("http://{addr}?token={token}");
-    eprintln!("mirrord session monitor: {url}");
+    let extension_url = build_extension_configure_url(&addr, &token);
+
+    eprintln!();
+    eprintln!("  mirrord session monitor");
+    eprintln!("    Web UI:             {url}");
+    eprintln!("    Browser extension:  {extension_url}");
+    eprintln!();
 
     if let Err(err) = opener::open(&url) {
         warn!(?err, "Failed to open browser");
@@ -820,6 +851,23 @@ pub async fn ui_command(args: UiArgs) -> Result<(), CliError> {
         .map_err(|e| CliError::UiError(format!("server error: {e}")))?;
 
     Ok(())
+}
+
+/// Chrome extension id produced by the `"key"` field in the mirrord-browser
+/// manifest. Stable across dev (unpacked) and production (Chrome Web Store)
+/// installs, so the CLI can hand a clickable configure URL to the user.
+const MIRRORD_EXTENSION_ID: &str = "bijejadnnfgjkfdocgocklekjhnhkhkf";
+
+/// Build a `chrome-extension://…/pages/configure.html?backend=…&token=…` URL
+/// that configures the browser extension to talk to this UI server.
+fn build_extension_configure_url(addr: &SocketAddr, token: &str) -> String {
+    let backend = format!("http://{addr}");
+    let backend_encoded: String =
+        url::form_urlencoded::byte_serialize(backend.as_bytes()).collect();
+    format!(
+        "chrome-extension://{id}/pages/configure.html?backend={backend_encoded}&token={token}",
+        id = MIRRORD_EXTENSION_ID
+    )
 }
 
 #[cfg(test)]

--- a/mirrord/cli/src/ui.rs
+++ b/mirrord/cli/src/ui.rs
@@ -35,7 +35,7 @@ use axum_extra::extract::cookie::{Cookie, CookieJar, SameSite};
 use eventsource_stream::Eventsource;
 use futures::stream::StreamExt as _;
 use kube::{Api, Client, api::ListParams, runtime::watcher};
-use mirrord_operator::crd::session::MirrordClusterSession;
+use mirrord_operator::crd::session::MirrordSession;
 use mirrord_session_monitor_client::{
     SessionError, connect_to_session, session_socket_entries, sessions_dir,
 };
@@ -124,7 +124,10 @@ pub struct OperatorSessionTarget {
 }
 
 impl OperatorSessionSummary {
-    fn from_cr(cr: &mirrord_operator::crd::session::MirrordClusterSession) -> Option<Self> {
+    /// Builds a summary from the namespaced [`MirrordSession`] projection.
+    /// We watch this CRD (not the cluster-scoped parent) so RBAC can be scoped
+    /// per namespace on shared clusters.
+    fn from_cr(cr: &MirrordSession) -> Option<Self> {
         let name = cr.metadata.name.clone()?;
         let spec = &cr.spec;
         Some(Self {
@@ -681,7 +684,11 @@ fn start_operator_watcher(state: Arc<AppState>) {
             }
         };
 
-        let api: Api<MirrordClusterSession> = Api::all(client);
+        // Watch the namespaced `MirrordSession` projection instead of the
+        // cluster-scoped `MirrordClusterSession`. `Api::all` still spans every
+        // namespace for the list/watch; callers only see sessions their RBAC
+        // permits.
+        let api: Api<MirrordSession> = Api::all(client);
 
         // Probe the CRD with a single list; if this fails because the CRD isn't
         // installed or access is denied, surface a clean "unavailable" status
@@ -1088,16 +1095,15 @@ mod tests {
 
     mod operator_sessions {
         use mirrord_operator::crd::session::{
-            MirrordClusterSession, MirrordClusterSessionSpec, SessionOwner, SessionTarget,
+            MirrordSession, MirrordSessionSpec, SessionOwner, SessionTarget,
         };
 
         use super::*;
 
-        fn sample_cr(name: &str, key: Option<&str>) -> MirrordClusterSession {
-            MirrordClusterSession::new(
+        fn sample_cr(name: &str, key: Option<&str>) -> MirrordSession {
+            MirrordSession::new(
                 name,
-                MirrordClusterSessionSpec {
-                    jira_metrics: None,
+                MirrordSessionSpec {
                     owner: SessionOwner {
                         user_id: "u".into(),
                         username: "alice".into(),
@@ -1111,10 +1117,9 @@ mod tests {
                         name: "web".into(),
                         container: "app".into(),
                     }),
-                    ci_info: None,
-                    copy_target: None,
-                    multi_cluster_parent_name: None,
                     key: key.map(|s| s.to_owned()),
+                    http_filter: None,
+                    cluster_session_name: name.to_owned(),
                 },
             )
         }

--- a/mirrord/cli/src/ui.rs
+++ b/mirrord/cli/src/ui.rs
@@ -5,11 +5,6 @@
 //! to each session's HTTP API, and serves a React frontend plus REST/SSE/WebSocket endpoints on
 //! localhost.
 //!
-//! ## Browser extension handoff
-//!
-//! On startup, `mirrord ui` prints both the web UI URL and a `chrome-extension://` configure URL.
-//! The extension id is pinned in the mirrord-browser manifest's `"key"` field, which produces a
-//! deterministic id when loaded unpacked or published to the Chrome Web Store.
 
 use std::{
     collections::{HashMap, hash_map::Entry},
@@ -79,24 +74,15 @@ enum SessionNotification {
     },
 }
 
-/// Wire-format summary of an operator-side session that the browser extension
-/// and local UI tab can render. Derived from `MirrordClusterSession`.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct OperatorSessionSummary {
-    /// Kubernetes object name of the underlying `MirrordClusterSession` CR.
     pub name: String,
-    /// Session key (grouping identity). `None` if the session was started by an
-    /// older CLI that didn't send a key, or by an operator that doesn't persist it yet.
     pub key: Option<String>,
     pub namespace: String,
     pub owner: Option<OperatorSessionOwner>,
     pub target: Option<OperatorSessionTarget>,
     pub created_at: Option<String>,
-    /// Subset of the dev's `http_filter` needed by external consumers (the
-    /// browser extension parses `header_filter` to build a matching DNR rule).
-    /// `None` if the session was started by an older CLI or operator that
-    /// didn't persist it.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub http_filter: Option<OperatorSessionHttpFilter>,
 }
@@ -124,9 +110,6 @@ pub struct OperatorSessionTarget {
 }
 
 impl OperatorSessionSummary {
-    /// Builds a summary from the namespaced [`MirrordSession`] projection.
-    /// We watch this CRD (not the cluster-scoped parent) so RBAC can be scoped
-    /// per namespace on shared clusters.
     fn from_cr(cr: &MirrordSession) -> Option<Self> {
         let name = cr.metadata.name.clone()?;
         let spec = &cr.spec;
@@ -439,14 +422,8 @@ async fn session_events_sse(
 
 #[derive(Serialize)]
 struct OperatorSessionsResponse {
-    /// Sessions grouped by key. The key is the map key; value is the list
-    /// of sessions under that key. Sessions whose `spec.key` is `None` are
-    /// collected under a sentinel key `""` (empty string).
     by_key: std::collections::BTreeMap<String, Vec<OperatorSessionSummary>>,
-    /// Flat list of all sessions, for clients that prefer not to consume
-    /// the grouped view.
     sessions: Vec<OperatorSessionSummary>,
-    /// Current watch status (for UI diagnostics).
     watch_status: OperatorWatchStatus,
 }
 
@@ -666,11 +643,6 @@ fn start_filesystem_watcher(
     Ok(())
 }
 
-/// Starts a tokio task that watches `MirrordClusterSession` CRs via `kube::Api` and
-/// updates `AppState::operator_sessions`. Broadcasts `OperatorSession*` events on
-/// `notify_tx`. If the cluster isn't reachable or the CRD isn't installed, logs a
-/// warning and sets `operator_watch_status` to `Unavailable { reason }`. The `mirrord
-/// ui` daemon continues running for local sessions either way.
 fn start_operator_watcher(state: Arc<AppState>) {
     tokio::spawn(async move {
         let client = match Client::try_default().await {
@@ -684,15 +656,8 @@ fn start_operator_watcher(state: Arc<AppState>) {
             }
         };
 
-        // Watch the namespaced `MirrordSession` projection instead of the
-        // cluster-scoped `MirrordClusterSession`. `Api::all` still spans every
-        // namespace for the list/watch; callers only see sessions their RBAC
-        // permits.
         let api: Api<MirrordSession> = Api::all(client);
 
-        // Probe the CRD with a single list; if this fails because the CRD isn't
-        // installed or access is denied, surface a clean "unavailable" status
-        // instead of retrying forever.
         if let Err(err) = api.list(&ListParams::default().limit(1)).await {
             let reason = format!("operator CRD not available: {err}");
             warn!("{reason}");
@@ -735,9 +700,7 @@ fn start_operator_watcher(state: Arc<AppState>) {
                 }
                 Ok(watcher::Event::Init)
                 | Ok(watcher::Event::InitApply(_))
-                | Ok(watcher::Event::InitDone) => {
-                    // watcher relist lifecycle; no action needed.
-                }
+                | Ok(watcher::Event::InitDone) => {}
                 Err(err) => {
                     let reason = format!("watcher error: {err}");
                     warn!("{reason}");
@@ -860,13 +823,8 @@ pub async fn ui_command(args: UiArgs) -> Result<(), CliError> {
     Ok(())
 }
 
-/// Chrome extension id produced by the `"key"` field in the mirrord-browser
-/// manifest. Stable across dev (unpacked) and production (Chrome Web Store)
-/// installs, so the CLI can hand a clickable configure URL to the user.
 const MIRRORD_EXTENSION_ID: &str = "bijejadnnfgjkfdocgocklekjhnhkhkf";
 
-/// Build a `chrome-extension://…/pages/configure.html?backend=…&token=…` URL
-/// that configures the browser extension to talk to this UI server.
 fn build_extension_configure_url(addr: &SocketAddr, token: &str) -> String {
     let backend = format!("http://{addr}");
     let backend_encoded: String =

--- a/mirrord/cli/src/ui.rs
+++ b/mirrord/cli/src/ui.rs
@@ -1119,7 +1119,6 @@ mod tests {
                     }),
                     key: key.map(|s| s.to_owned()),
                     http_filter: None,
-                    cluster_session_name: name.to_owned(),
                 },
             )
         }

--- a/mirrord/cli/src/ui.rs
+++ b/mirrord/cli/src/ui.rs
@@ -54,8 +54,78 @@ struct FrontendAssets;
 #[derive(Clone, Debug, Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 enum SessionNotification {
-    SessionAdded { session: Box<TrackedSession> },
-    SessionRemoved { session_id: String },
+    SessionAdded {
+        session: Box<TrackedSession>,
+    },
+    SessionRemoved {
+        session_id: String,
+    },
+    OperatorSessionAdded {
+        session: Box<OperatorSessionSummary>,
+    },
+    OperatorSessionRemoved {
+        name: String,
+    },
+    OperatorSessionUpdated {
+        session: Box<OperatorSessionSummary>,
+    },
+}
+
+/// Wire-format summary of an operator-side session that the browser extension
+/// and local UI tab can render. Derived from `MirrordClusterSession`.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OperatorSessionSummary {
+    /// Kubernetes object name of the underlying `MirrordClusterSession` CR.
+    pub name: String,
+    /// Session key (grouping identity). `None` if the session was started by an
+    /// older CLI that didn't send a key, or by an operator that doesn't persist it yet.
+    pub key: Option<String>,
+    pub namespace: String,
+    pub owner: Option<OperatorSessionOwner>,
+    pub target: Option<OperatorSessionTarget>,
+    pub created_at: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OperatorSessionOwner {
+    pub username: String,
+    pub k8s_username: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OperatorSessionTarget {
+    pub kind: String,
+    pub name: String,
+    pub container: String,
+}
+
+impl OperatorSessionSummary {
+    fn from_cr(cr: &mirrord_operator::crd::session::MirrordClusterSession) -> Option<Self> {
+        let name = cr.metadata.name.clone()?;
+        let spec = &cr.spec;
+        Some(Self {
+            name,
+            key: spec.key.clone(),
+            namespace: spec.namespace.clone(),
+            owner: Some(OperatorSessionOwner {
+                username: spec.owner.username.clone(),
+                k8s_username: spec.owner.k8s_username.clone(),
+            }),
+            target: spec.target.as_ref().map(|t| OperatorSessionTarget {
+                kind: t.kind.clone(),
+                name: t.name.clone(),
+                container: t.container.clone(),
+            }),
+            created_at: cr
+                .metadata
+                .creation_timestamp
+                .as_ref()
+                .map(|ts| ts.0.to_string()),
+        })
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -74,8 +144,24 @@ impl Serialize for TrackedSession {
 
 struct AppState {
     sessions: RwLock<HashMap<String, TrackedSession>>,
+    operator_sessions: RwLock<std::collections::BTreeMap<String, OperatorSessionSummary>>,
+    operator_watch_status: RwLock<OperatorWatchStatus>,
     notify_tx: broadcast::Sender<SessionNotification>,
     token: String,
+}
+
+#[derive(Clone, Debug, Serialize, Default)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum OperatorWatchStatus {
+    #[default]
+    NotStarted,
+    Watching,
+    Error {
+        message: String,
+    },
+    Unavailable {
+        reason: String,
+    },
 }
 
 #[derive(Deserialize)]
@@ -582,6 +668,8 @@ pub async fn ui_command(args: UiArgs) -> Result<(), CliError> {
 
     let state = Arc::new(AppState {
         sessions: RwLock::new(HashMap::new()),
+        operator_sessions: RwLock::new(std::collections::BTreeMap::new()),
+        operator_watch_status: RwLock::new(OperatorWatchStatus::NotStarted),
         notify_tx,
         token: token.clone(),
     });

--- a/mirrord/cli/src/ui.rs
+++ b/mirrord/cli/src/ui.rs
@@ -4,6 +4,12 @@
 //! active mirrord sessions. It watches `~/.mirrord/sessions/` for Unix socket files, connects
 //! to each session's HTTP API, and serves a React frontend plus REST/SSE/WebSocket endpoints on
 //! localhost.
+//!
+//! ## Browser extension handoff
+//!
+//! On startup, `mirrord ui` prints both the web UI URL and a `chrome-extension://` configure URL.
+//! The extension id is pinned in the mirrord-browser manifest's `"key"` field, which produces a
+//! deterministic id when loaded unpacked or published to the Chrome Web Store.
 
 use std::{
     collections::{HashMap, hash_map::Entry},
@@ -73,15 +79,24 @@ enum SessionNotification {
     },
 }
 
+/// Wire-format summary of an operator-side session that the browser extension
+/// and local UI tab can render. Derived from `MirrordClusterSession`.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct OperatorSessionSummary {
+    /// Kubernetes object name of the underlying `MirrordClusterSession` CR.
     pub name: String,
+    /// Session key (grouping identity). `None` if the session was started by an
+    /// older CLI that didn't send a key, or by an operator that doesn't persist it yet.
     pub key: Option<String>,
     pub namespace: String,
     pub owner: Option<OperatorSessionOwner>,
     pub target: Option<OperatorSessionTarget>,
     pub created_at: Option<String>,
+    /// Subset of the dev's `http_filter` needed by external consumers (the
+    /// browser extension parses `header_filter` to build a matching DNR rule).
+    /// `None` if the session was started by an older CLI or operator that
+    /// didn't persist it.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub http_filter: Option<OperatorSessionHttpFilter>,
 }
@@ -109,6 +124,9 @@ pub struct OperatorSessionTarget {
 }
 
 impl OperatorSessionSummary {
+    /// Builds a summary from the namespaced [`MirrordSession`] projection.
+    /// We watch this CRD (not the cluster-scoped parent) so RBAC can be scoped
+    /// per namespace on shared clusters.
     fn from_cr(cr: &MirrordSession) -> Option<Self> {
         let name = cr.metadata.name.clone()?;
         let spec = &cr.spec;
@@ -666,6 +684,10 @@ fn start_operator_watcher(state: Arc<AppState>) {
             }
         };
 
+        // Watch the namespaced `MirrordSession` projection instead of the
+        // cluster-scoped `MirrordClusterSession`. `Api::all` still spans every
+        // namespace for the list/watch; callers only see sessions their RBAC
+        // permits.
         let api: Api<MirrordSession> = Api::all(client);
 
         // Probe the CRD with a single list; if this fails because the CRD isn't
@@ -838,8 +860,13 @@ pub async fn ui_command(args: UiArgs) -> Result<(), CliError> {
     Ok(())
 }
 
+/// Chrome extension id produced by the `"key"` field in the mirrord-browser
+/// manifest. Stable across dev (unpacked) and production (Chrome Web Store)
+/// installs, so the CLI can hand a clickable configure URL to the user.
 const MIRRORD_EXTENSION_ID: &str = "bijejadnnfgjkfdocgocklekjhnhkhkf";
 
+/// Build a `chrome-extension://…/pages/configure.html?backend=…&token=…` URL
+/// that configures the browser extension to talk to this UI server.
 fn build_extension_configure_url(addr: &SocketAddr, token: &str) -> String {
     let backend = format!("http://{addr}");
     let backend_encoded: String =

--- a/mirrord/cli/src/ui.rs
+++ b/mirrord/cli/src/ui.rs
@@ -1,10 +1,3 @@
-//! # mirrord UI (Session Monitor)
-//!
-//! The `mirrord ui` command launches a web-based session monitor that aggregates events from all
-//! active mirrord sessions. It watches `~/.mirrord/sessions/` for Unix socket files, connects
-//! to each session's HTTP API, and serves a React frontend plus REST/SSE/WebSocket endpoints on
-//! localhost.
-
 use std::{
     collections::{HashMap, hash_map::Entry},
     convert::Infallible,
@@ -181,8 +174,6 @@ struct TokenQuery {
     token: Option<String>,
 }
 
-/// Middleware that validates the request carries a valid auth token, either via the `mirrord_token`
-/// cookie or the `?token=` query parameter.
 async fn token_auth(
     State(state): State<Arc<AppState>>,
     jar: CookieJar,
@@ -214,8 +205,6 @@ async fn token_auth(
     StatusCode::UNAUTHORIZED.into_response()
 }
 
-/// Opens an SSE connection to a session's Unix socket /events endpoint and returns
-/// a pinned `Eventsource` stream that yields parsed SSE events.
 async fn open_sse_stream(
     client: &reqwest::Client,
 ) -> Result<
@@ -240,8 +229,6 @@ async fn open_sse_stream(
     Ok(Box::pin(byte_stream.eventsource()))
 }
 
-/// Appends parsed SSE values to the session's event buffer, capping at
-/// [`MAX_EVENTS_PER_SESSION`].
 async fn buffer_session_events(session_id: &str, values: Vec<serde_json::Value>, state: &AppState) {
     let mut sessions = state.sessions.write().await;
     let Some(session) = sessions.get_mut(session_id) else {
@@ -255,7 +242,6 @@ async fn buffer_session_events(session_id: &str, values: Vec<serde_json::Value>,
     }
 }
 
-/// Connects to a session's SSE /events endpoint and buffers events into the shared state.
 async fn stream_session_events(session_id: String, client: reqwest::Client, state: Arc<AppState>) {
     let mut sse_stream = match open_sse_stream(&client).await {
         Ok(s) => s,
@@ -421,14 +407,8 @@ async fn session_events_sse(
 
 #[derive(Serialize)]
 struct OperatorSessionsResponse {
-    /// Sessions grouped by key. The key is the map key; value is the list
-    /// of sessions under that key. Sessions whose `spec.key` is `None` are
-    /// collected under a sentinel key `""` (empty string).
     by_key: std::collections::BTreeMap<String, Vec<OperatorSessionSummary>>,
-    /// Flat list of all sessions, for clients that prefer not to consume
-    /// the grouped view.
     sessions: Vec<OperatorSessionSummary>,
-    /// Current watch status (for UI diagnostics).
     watch_status: OperatorWatchStatus,
 }
 
@@ -469,7 +449,6 @@ async fn kill_session(State(state): State<Arc<AppState>>, Path(id): Path<String>
                 serde_json::json!({"status": "ok"})
             });
 
-            // Clean up socket file and remove session from tracking
             if let Err(err) = std::fs::remove_file(&socket_path) {
                 warn!(%id, ?err, "Failed to remove session socket after kill");
             }
@@ -488,7 +467,6 @@ async fn kill_session(State(state): State<Arc<AppState>>, Path(id): Path<String>
     }
 }
 
-/// Validates the WebSocket upgrade Origin header, rejecting non-localhost origins.
 fn validate_ws_origin(headers: &HeaderMap) -> bool {
     match headers.get(header::ORIGIN) {
         None => true, // No origin header is acceptable for non-browser clients
@@ -574,15 +552,12 @@ async fn static_handler(uri: axum::http::Uri) -> impl IntoResponse {
         return ([(header::CONTENT_TYPE, mime)], data).into_response();
     }
 
-    // SPA fallback
     match get_asset("index.html") {
         Some(data) => ([(header::CONTENT_TYPE, "text/html")], data).into_response(),
         None => StatusCode::NOT_FOUND.into_response(),
     }
 }
 
-/// Spawns a background task that rescans the sessions directory every 2 seconds.
-/// Filesystem watchers can miss events on macOS, so this serves as a fallback.
 #[cfg(target_os = "macos")]
 fn start_periodic_rescan(sessions_dir: PathBuf, state: Arc<AppState>) {
     tokio::spawn(async move {
@@ -593,8 +568,6 @@ fn start_periodic_rescan(sessions_dir: PathBuf, state: Arc<AppState>) {
     });
 }
 
-/// Sets up a filesystem watcher on the sessions directory and spawns a background task
-/// to handle socket file creation and removal events.
 fn start_filesystem_watcher(
     sessions_dir: &std::path::Path,
     state: Arc<AppState>,
@@ -648,11 +621,6 @@ fn start_filesystem_watcher(
     Ok(())
 }
 
-/// Starts a tokio task that watches `MirrordClusterSession` CRs via `kube::Api` and
-/// updates `AppState::operator_sessions`. Broadcasts `OperatorSession*` events on
-/// `notify_tx`. If the cluster isn't reachable or the CRD isn't installed, logs a
-/// warning and sets `operator_watch_status` to `Unavailable { reason }`. The `mirrord
-/// ui` daemon continues running for local sessions either way.
 fn start_operator_watcher(state: Arc<AppState>) {
     tokio::spawn(async move {
         let client = match Client::try_default().await {
@@ -668,9 +636,6 @@ fn start_operator_watcher(state: Arc<AppState>) {
 
         let api: Api<MirrordSession> = Api::all(client);
 
-        // Probe the CRD with a single list; if this fails because the CRD isn't
-        // installed or access is denied, surface a clean "unavailable" status
-        // instead of retrying forever.
         if let Err(err) = api.list(&ListParams::default().limit(1)).await {
             let reason = format!("operator CRD not available: {err}");
             warn!("{reason}");
@@ -713,9 +678,7 @@ fn start_operator_watcher(state: Arc<AppState>) {
                 }
                 Ok(watcher::Event::Init)
                 | Ok(watcher::Event::InitApply(_))
-                | Ok(watcher::Event::InitDone) => {
-                    // watcher relist lifecycle; no action needed.
-                }
+                | Ok(watcher::Event::InitDone) => {}
                 Err(err) => {
                     let reason = format!("watcher error: {err}");
                     warn!("{reason}");
@@ -747,10 +710,6 @@ fn build_router(state: Arc<AppState>) -> Router {
         .fallback(static_handler)
         .layer(middleware::from_fn_with_state(state.clone(), token_auth));
 
-    // posthog-js lazy-loads its session recorder bundle from the api host at runtime, so the
-    // PostHog origin must be listed in both `script-src` (for the recorder bundle) and
-    // `connect-src` (for `/e/` event capture and `/s/` session replay ingest). Without these,
-    // telemetry is silently dropped by the browser's CSP enforcement.
     let csp_value = HeaderValue::from_static(
         "default-src 'self'; script-src 'self' https://hog.metalbear.com; \
          style-src 'self' 'unsafe-inline'; \
@@ -790,7 +749,6 @@ pub async fn ui_command(args: UiArgs) -> Result<(), CliError> {
 
     let (notify_tx, _) = broadcast::channel::<SessionNotification>(256);
 
-    // Generate auth token for this UI server instance
     let token_bytes: [u8; 32] = rand::rng().random();
     let token = hex::encode(token_bytes);
 
@@ -885,14 +843,11 @@ mod tests {
             .status()
     }
 
-    /// `/health` is intentionally outside the auth middleware so k8s probes can hit it.
     #[tokio::test]
     async fn health_endpoint_does_not_require_token() {
         assert_eq!(status_of(req("/health")).await, StatusCode::OK);
     }
 
-    /// Without a token, every API request should be rejected. This is the core protection
-    /// against malicious local processes and CSRF from other browser tabs.
     #[tokio::test]
     async fn api_without_token_returns_unauthorized() {
         assert_eq!(
@@ -901,8 +856,6 @@ mod tests {
         );
     }
 
-    /// A request with the wrong token must also be rejected (no timing oracle, just a
-    /// constant-time string compare via `==` is fine because the token is high-entropy).
     #[tokio::test]
     async fn api_with_wrong_token_returns_unauthorized() {
         assert_eq!(
@@ -911,8 +864,6 @@ mod tests {
         );
     }
 
-    /// First request with a valid `?token=` query param should both succeed AND set the
-    /// `mirrord_token` cookie so subsequent requests can authenticate via cookie alone.
     #[tokio::test]
     async fn api_with_valid_token_query_param_sets_cookie() {
         let response = build_router(test_state())
@@ -937,8 +888,6 @@ mod tests {
         );
     }
 
-    /// Once the cookie is set, requests should authenticate via cookie without needing
-    /// the query param. This is what the React frontend does after the initial page load.
     #[tokio::test]
     async fn api_with_valid_cookie_succeeds() {
         let request = Request::builder()
@@ -949,8 +898,6 @@ mod tests {
         assert_eq!(status_of(request).await, StatusCode::OK);
     }
 
-    /// A wrong cookie must be rejected. Without this, an attacker who guesses or steals
-    /// a stale token could impersonate the user.
     #[tokio::test]
     async fn api_with_wrong_cookie_returns_unauthorized() {
         let request = Request::builder()
@@ -961,8 +908,6 @@ mod tests {
         assert_eq!(status_of(request).await, StatusCode::UNAUTHORIZED);
     }
 
-    /// All authenticated responses should carry the security headers from the RFC.
-    /// These protect against clickjacking, MIME sniffing, referrer leaks, and XSS.
     #[tokio::test]
     async fn responses_include_security_headers() {
         let response = build_router(test_state())
@@ -978,7 +923,6 @@ mod tests {
         );
         assert_eq!(headers.get(header::REFERRER_POLICY).unwrap(), "no-referrer");
 
-        // Per the RFC, CSP must restrict scripts to 'self' (no inline scripts).
         let csp = headers.get(header::CONTENT_SECURITY_POLICY).unwrap();
         let csp_str = csp.to_str().unwrap();
         assert!(csp_str.contains("script-src 'self'"));
@@ -987,10 +931,6 @@ mod tests {
         assert!(csp_str.contains("object-src 'none'"));
     }
 
-    /// WebSocket upgrades from a non-localhost Origin must be rejected. WebSocket
-    /// connections do NOT enforce same-origin policy by default, so without this check
-    /// any malicious website the user visits could open `ws://localhost:59281/ws` and
-    /// stream every session event in real time.
     #[test]
     fn validate_ws_origin_rejects_non_localhost() {
         let mut headers = HeaderMap::new();
@@ -1004,7 +944,6 @@ mod tests {
         );
     }
 
-    /// Localhost origins (in any common form) should be accepted.
     #[test]
     fn validate_ws_origin_accepts_localhost() {
         for origin in [
@@ -1022,16 +961,12 @@ mod tests {
         }
     }
 
-    /// Non-browser clients (curl, native code) typically omit the Origin header. We accept
-    /// these because the Unix socket and TCP localhost binding are the access control there.
     #[test]
     fn validate_ws_origin_accepts_missing_origin() {
         let headers = HeaderMap::new();
         assert!(validate_ws_origin(&headers));
     }
 
-    /// CSRF check: a malicious form-POST from another origin would not include the cookie
-    /// (because of SameSite=Strict), so any state-changing endpoint must reject it.
     #[tokio::test]
     async fn kill_endpoint_without_token_returns_unauthorized() {
         let request = Request::builder()
@@ -1042,24 +977,17 @@ mod tests {
         assert_eq!(status_of(request).await, StatusCode::UNAUTHORIZED);
     }
 
-    /// Static assets are served behind the auth middleware so the token cookie is set on
-    /// the very first page load (the user clicks `?token=...` in their browser, the static
-    /// HTML response sets the cookie, and subsequent API/WS calls authenticate via cookie).
     #[tokio::test]
     async fn static_handler_without_token_returns_unauthorized() {
         assert_eq!(status_of(req("/")).await, StatusCode::UNAUTHORIZED);
     }
 
-    /// The `?token=` query param works for any path, including the root, so the initial
-    /// page load establishes the cookie.
     #[tokio::test]
     async fn static_handler_with_token_sets_cookie() {
         let response = build_router(test_state())
             .oneshot(req(&format!("/?token={TEST_TOKEN}")))
             .await
             .unwrap();
-        // Status may be 200 (if asset embedded) or 404 (if no embedded assets in test build)
-        // either way, the cookie should be set.
         assert!(
             response.headers().get(header::SET_COOKIE).is_some(),
             "cookie must be set on the first authenticated request, even if the body is 404"

--- a/mirrord/cli/src/ui.rs
+++ b/mirrord/cli/src/ui.rs
@@ -28,6 +28,8 @@ use axum::{
 use axum_extra::extract::cookie::{Cookie, CookieJar, SameSite};
 use eventsource_stream::Eventsource;
 use futures::stream::StreamExt as _;
+use kube::{Api, Client, api::ListParams, runtime::watcher};
+use mirrord_operator::crd::session::MirrordClusterSession;
 use mirrord_session_monitor_client::{
     SessionError, connect_to_session, session_socket_entries, sessions_dir,
 };
@@ -602,6 +604,87 @@ fn start_filesystem_watcher(
     Ok(())
 }
 
+/// Starts a tokio task that watches `MirrordClusterSession` CRs via `kube::Api` and
+/// updates `AppState::operator_sessions`. Broadcasts `OperatorSession*` events on
+/// `notify_tx`. If the cluster isn't reachable or the CRD isn't installed, logs a
+/// warning and sets `operator_watch_status` to `Unavailable { reason }`. The `mirrord
+/// ui` daemon continues running for local sessions either way.
+fn start_operator_watcher(state: Arc<AppState>) {
+    tokio::spawn(async move {
+        let client = match Client::try_default().await {
+            Ok(client) => client,
+            Err(err) => {
+                let reason = format!("kube client init failed: {err}");
+                warn!("{reason}");
+                *state.operator_watch_status.write().await =
+                    OperatorWatchStatus::Unavailable { reason };
+                return;
+            }
+        };
+
+        let api: Api<MirrordClusterSession> = Api::all(client);
+
+        // Probe the CRD with a single list; if this fails because the CRD isn't
+        // installed or access is denied, surface a clean "unavailable" status
+        // instead of retrying forever.
+        if let Err(err) = api.list(&ListParams::default().limit(1)).await {
+            let reason = format!("operator CRD not available: {err}");
+            warn!("{reason}");
+            *state.operator_watch_status.write().await =
+                OperatorWatchStatus::Unavailable { reason };
+            return;
+        }
+
+        *state.operator_watch_status.write().await = OperatorWatchStatus::Watching;
+
+        let mut stream = watcher(api, watcher::Config::default()).boxed();
+        while let Some(ev) = stream.next().await {
+            match ev {
+                Ok(watcher::Event::Apply(cr)) => {
+                    if let Some(summary) = OperatorSessionSummary::from_cr(&cr) {
+                        let key = summary.name.clone();
+                        let is_new = {
+                            let mut map = state.operator_sessions.write().await;
+                            let prior = map.insert(key.clone(), summary.clone());
+                            prior.is_none()
+                        };
+                        let _ = state.notify_tx.send(if is_new {
+                            SessionNotification::OperatorSessionAdded {
+                                session: Box::new(summary),
+                            }
+                        } else {
+                            SessionNotification::OperatorSessionUpdated {
+                                session: Box::new(summary),
+                            }
+                        });
+                    }
+                }
+                Ok(watcher::Event::Delete(cr)) => {
+                    if let Some(name) = cr.metadata.name {
+                        state.operator_sessions.write().await.remove(&name);
+                        let _ = state
+                            .notify_tx
+                            .send(SessionNotification::OperatorSessionRemoved { name });
+                    }
+                }
+                Ok(watcher::Event::Init)
+                | Ok(watcher::Event::InitApply(_))
+                | Ok(watcher::Event::InitDone) => {
+                    // watcher relist lifecycle; no action needed.
+                }
+                Err(err) => {
+                    let reason = format!("watcher error: {err}");
+                    warn!("{reason}");
+                    *state.operator_watch_status.write().await =
+                        OperatorWatchStatus::Error { message: reason };
+                }
+            }
+        }
+
+        warn!("operator session watcher stream ended unexpectedly");
+    });
+}
+
 async fn health() -> impl IntoResponse {
     axum::Json(serde_json::json!({"status": "ok"}))
 }
@@ -678,6 +761,7 @@ pub async fn ui_command(args: UiArgs) -> Result<(), CliError> {
     #[cfg(target_os = "macos")]
     start_periodic_rescan(sessions_dir.clone(), state.clone());
     start_filesystem_watcher(&sessions_dir, state.clone())?;
+    start_operator_watcher(state.clone());
 
     let app = build_router(state);
 

--- a/mirrord/cli/src/ui.rs
+++ b/mirrord/cli/src/ui.rs
@@ -1,3 +1,10 @@
+//! # mirrord UI (Session Monitor)
+//!
+//! The `mirrord ui` command launches a web-based session monitor that aggregates events from all
+//! active mirrord sessions. It watches `~/.mirrord/sessions/` for Unix socket files, connects
+//! to each session's HTTP API, and serves a React frontend plus REST/SSE/WebSocket endpoints on
+//! localhost.
+
 use std::{
     collections::{HashMap, hash_map::Entry},
     convert::Infallible,
@@ -174,6 +181,8 @@ struct TokenQuery {
     token: Option<String>,
 }
 
+/// Middleware that validates the request carries a valid auth token, either via the `mirrord_token`
+/// cookie or the `?token=` query parameter.
 async fn token_auth(
     State(state): State<Arc<AppState>>,
     jar: CookieJar,
@@ -205,6 +214,8 @@ async fn token_auth(
     StatusCode::UNAUTHORIZED.into_response()
 }
 
+/// Opens an SSE connection to a session's Unix socket /events endpoint and returns
+/// a pinned `Eventsource` stream that yields parsed SSE events.
 async fn open_sse_stream(
     client: &reqwest::Client,
 ) -> Result<
@@ -229,6 +240,8 @@ async fn open_sse_stream(
     Ok(Box::pin(byte_stream.eventsource()))
 }
 
+/// Appends parsed SSE values to the session's event buffer, capping at
+/// [`MAX_EVENTS_PER_SESSION`].
 async fn buffer_session_events(session_id: &str, values: Vec<serde_json::Value>, state: &AppState) {
     let mut sessions = state.sessions.write().await;
     let Some(session) = sessions.get_mut(session_id) else {
@@ -242,6 +255,7 @@ async fn buffer_session_events(session_id: &str, values: Vec<serde_json::Value>,
     }
 }
 
+/// Connects to a session's SSE /events endpoint and buffers events into the shared state.
 async fn stream_session_events(session_id: String, client: reqwest::Client, state: Arc<AppState>) {
     let mut sse_stream = match open_sse_stream(&client).await {
         Ok(s) => s,
@@ -407,8 +421,14 @@ async fn session_events_sse(
 
 #[derive(Serialize)]
 struct OperatorSessionsResponse {
+    /// Sessions grouped by key. The key is the map key; value is the list
+    /// of sessions under that key. Sessions whose `spec.key` is `None` are
+    /// collected under a sentinel key `""` (empty string).
     by_key: std::collections::BTreeMap<String, Vec<OperatorSessionSummary>>,
+    /// Flat list of all sessions, for clients that prefer not to consume
+    /// the grouped view.
     sessions: Vec<OperatorSessionSummary>,
+    /// Current watch status (for UI diagnostics).
     watch_status: OperatorWatchStatus,
 }
 
@@ -449,6 +469,7 @@ async fn kill_session(State(state): State<Arc<AppState>>, Path(id): Path<String>
                 serde_json::json!({"status": "ok"})
             });
 
+            // Clean up socket file and remove session from tracking
             if let Err(err) = std::fs::remove_file(&socket_path) {
                 warn!(%id, ?err, "Failed to remove session socket after kill");
             }
@@ -467,6 +488,7 @@ async fn kill_session(State(state): State<Arc<AppState>>, Path(id): Path<String>
     }
 }
 
+/// Validates the WebSocket upgrade Origin header, rejecting non-localhost origins.
 fn validate_ws_origin(headers: &HeaderMap) -> bool {
     match headers.get(header::ORIGIN) {
         None => true, // No origin header is acceptable for non-browser clients
@@ -552,12 +574,15 @@ async fn static_handler(uri: axum::http::Uri) -> impl IntoResponse {
         return ([(header::CONTENT_TYPE, mime)], data).into_response();
     }
 
+    // SPA fallback
     match get_asset("index.html") {
         Some(data) => ([(header::CONTENT_TYPE, "text/html")], data).into_response(),
         None => StatusCode::NOT_FOUND.into_response(),
     }
 }
 
+/// Spawns a background task that rescans the sessions directory every 2 seconds.
+/// Filesystem watchers can miss events on macOS, so this serves as a fallback.
 #[cfg(target_os = "macos")]
 fn start_periodic_rescan(sessions_dir: PathBuf, state: Arc<AppState>) {
     tokio::spawn(async move {
@@ -568,6 +593,8 @@ fn start_periodic_rescan(sessions_dir: PathBuf, state: Arc<AppState>) {
     });
 }
 
+/// Sets up a filesystem watcher on the sessions directory and spawns a background task
+/// to handle socket file creation and removal events.
 fn start_filesystem_watcher(
     sessions_dir: &std::path::Path,
     state: Arc<AppState>,
@@ -621,6 +648,11 @@ fn start_filesystem_watcher(
     Ok(())
 }
 
+/// Starts a tokio task that watches `MirrordClusterSession` CRs via `kube::Api` and
+/// updates `AppState::operator_sessions`. Broadcasts `OperatorSession*` events on
+/// `notify_tx`. If the cluster isn't reachable or the CRD isn't installed, logs a
+/// warning and sets `operator_watch_status` to `Unavailable { reason }`. The `mirrord
+/// ui` daemon continues running for local sessions either way.
 fn start_operator_watcher(state: Arc<AppState>) {
     tokio::spawn(async move {
         let client = match Client::try_default().await {
@@ -636,6 +668,9 @@ fn start_operator_watcher(state: Arc<AppState>) {
 
         let api: Api<MirrordSession> = Api::all(client);
 
+        // Probe the CRD with a single list; if this fails because the CRD isn't
+        // installed or access is denied, surface a clean "unavailable" status
+        // instead of retrying forever.
         if let Err(err) = api.list(&ListParams::default().limit(1)).await {
             let reason = format!("operator CRD not available: {err}");
             warn!("{reason}");
@@ -678,7 +713,9 @@ fn start_operator_watcher(state: Arc<AppState>) {
                 }
                 Ok(watcher::Event::Init)
                 | Ok(watcher::Event::InitApply(_))
-                | Ok(watcher::Event::InitDone) => {}
+                | Ok(watcher::Event::InitDone) => {
+                    // watcher relist lifecycle; no action needed.
+                }
                 Err(err) => {
                     let reason = format!("watcher error: {err}");
                     warn!("{reason}");
@@ -710,6 +747,10 @@ fn build_router(state: Arc<AppState>) -> Router {
         .fallback(static_handler)
         .layer(middleware::from_fn_with_state(state.clone(), token_auth));
 
+    // posthog-js lazy-loads its session recorder bundle from the api host at runtime, so the
+    // PostHog origin must be listed in both `script-src` (for the recorder bundle) and
+    // `connect-src` (for `/e/` event capture and `/s/` session replay ingest). Without these,
+    // telemetry is silently dropped by the browser's CSP enforcement.
     let csp_value = HeaderValue::from_static(
         "default-src 'self'; script-src 'self' https://hog.metalbear.com; \
          style-src 'self' 'unsafe-inline'; \
@@ -749,6 +790,7 @@ pub async fn ui_command(args: UiArgs) -> Result<(), CliError> {
 
     let (notify_tx, _) = broadcast::channel::<SessionNotification>(256);
 
+    // Generate auth token for this UI server instance
     let token_bytes: [u8; 32] = rand::rng().random();
     let token = hex::encode(token_bytes);
 
@@ -843,11 +885,14 @@ mod tests {
             .status()
     }
 
+    /// `/health` is intentionally outside the auth middleware so k8s probes can hit it.
     #[tokio::test]
     async fn health_endpoint_does_not_require_token() {
         assert_eq!(status_of(req("/health")).await, StatusCode::OK);
     }
 
+    /// Without a token, every API request should be rejected. This is the core protection
+    /// against malicious local processes and CSRF from other browser tabs.
     #[tokio::test]
     async fn api_without_token_returns_unauthorized() {
         assert_eq!(
@@ -856,6 +901,8 @@ mod tests {
         );
     }
 
+    /// A request with the wrong token must also be rejected (no timing oracle, just a
+    /// constant-time string compare via `==` is fine because the token is high-entropy).
     #[tokio::test]
     async fn api_with_wrong_token_returns_unauthorized() {
         assert_eq!(
@@ -864,6 +911,8 @@ mod tests {
         );
     }
 
+    /// First request with a valid `?token=` query param should both succeed AND set the
+    /// `mirrord_token` cookie so subsequent requests can authenticate via cookie alone.
     #[tokio::test]
     async fn api_with_valid_token_query_param_sets_cookie() {
         let response = build_router(test_state())
@@ -888,6 +937,8 @@ mod tests {
         );
     }
 
+    /// Once the cookie is set, requests should authenticate via cookie without needing
+    /// the query param. This is what the React frontend does after the initial page load.
     #[tokio::test]
     async fn api_with_valid_cookie_succeeds() {
         let request = Request::builder()
@@ -898,6 +949,8 @@ mod tests {
         assert_eq!(status_of(request).await, StatusCode::OK);
     }
 
+    /// A wrong cookie must be rejected. Without this, an attacker who guesses or steals
+    /// a stale token could impersonate the user.
     #[tokio::test]
     async fn api_with_wrong_cookie_returns_unauthorized() {
         let request = Request::builder()
@@ -908,6 +961,8 @@ mod tests {
         assert_eq!(status_of(request).await, StatusCode::UNAUTHORIZED);
     }
 
+    /// All authenticated responses should carry the security headers from the RFC.
+    /// These protect against clickjacking, MIME sniffing, referrer leaks, and XSS.
     #[tokio::test]
     async fn responses_include_security_headers() {
         let response = build_router(test_state())
@@ -923,6 +978,7 @@ mod tests {
         );
         assert_eq!(headers.get(header::REFERRER_POLICY).unwrap(), "no-referrer");
 
+        // Per the RFC, CSP must restrict scripts to 'self' (no inline scripts).
         let csp = headers.get(header::CONTENT_SECURITY_POLICY).unwrap();
         let csp_str = csp.to_str().unwrap();
         assert!(csp_str.contains("script-src 'self'"));
@@ -931,6 +987,10 @@ mod tests {
         assert!(csp_str.contains("object-src 'none'"));
     }
 
+    /// WebSocket upgrades from a non-localhost Origin must be rejected. WebSocket
+    /// connections do NOT enforce same-origin policy by default, so without this check
+    /// any malicious website the user visits could open `ws://localhost:59281/ws` and
+    /// stream every session event in real time.
     #[test]
     fn validate_ws_origin_rejects_non_localhost() {
         let mut headers = HeaderMap::new();
@@ -944,6 +1004,7 @@ mod tests {
         );
     }
 
+    /// Localhost origins (in any common form) should be accepted.
     #[test]
     fn validate_ws_origin_accepts_localhost() {
         for origin in [
@@ -961,12 +1022,16 @@ mod tests {
         }
     }
 
+    /// Non-browser clients (curl, native code) typically omit the Origin header. We accept
+    /// these because the Unix socket and TCP localhost binding are the access control there.
     #[test]
     fn validate_ws_origin_accepts_missing_origin() {
         let headers = HeaderMap::new();
         assert!(validate_ws_origin(&headers));
     }
 
+    /// CSRF check: a malicious form-POST from another origin would not include the cookie
+    /// (because of SameSite=Strict), so any state-changing endpoint must reject it.
     #[tokio::test]
     async fn kill_endpoint_without_token_returns_unauthorized() {
         let request = Request::builder()
@@ -977,17 +1042,24 @@ mod tests {
         assert_eq!(status_of(request).await, StatusCode::UNAUTHORIZED);
     }
 
+    /// Static assets are served behind the auth middleware so the token cookie is set on
+    /// the very first page load (the user clicks `?token=...` in their browser, the static
+    /// HTML response sets the cookie, and subsequent API/WS calls authenticate via cookie).
     #[tokio::test]
     async fn static_handler_without_token_returns_unauthorized() {
         assert_eq!(status_of(req("/")).await, StatusCode::UNAUTHORIZED);
     }
 
+    /// The `?token=` query param works for any path, including the root, so the initial
+    /// page load establishes the cookie.
     #[tokio::test]
     async fn static_handler_with_token_sets_cookie() {
         let response = build_router(test_state())
             .oneshot(req(&format!("/?token={TEST_TOKEN}")))
             .await
             .unwrap();
+        // Status may be 200 (if asset embedded) or 404 (if no embedded assets in test build)
+        // either way, the cookie should be set.
         assert!(
             response.headers().get(header::SET_COOKIE).is_some(),
             "cookie must be set on the first authenticated request, even if the body is 404"

--- a/mirrord/cli/src/ui.rs
+++ b/mirrord/cli/src/ui.rs
@@ -4,12 +4,6 @@
 //! active mirrord sessions. It watches `~/.mirrord/sessions/` for Unix socket files, connects
 //! to each session's HTTP API, and serves a React frontend plus REST/SSE/WebSocket endpoints on
 //! localhost.
-//!
-//! ## Browser extension handoff
-//!
-//! On startup, `mirrord ui` prints both the web UI URL and a `chrome-extension://` configure URL.
-//! The extension id is pinned in the mirrord-browser manifest's `"key"` field, which produces a
-//! deterministic id when loaded unpacked or published to the Chrome Web Store.
 
 use std::{
     collections::{HashMap, hash_map::Entry},
@@ -79,24 +73,15 @@ enum SessionNotification {
     },
 }
 
-/// Wire-format summary of an operator-side session that the browser extension
-/// and local UI tab can render. Derived from `MirrordClusterSession`.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct OperatorSessionSummary {
-    /// Kubernetes object name of the underlying `MirrordClusterSession` CR.
     pub name: String,
-    /// Session key (grouping identity). `None` if the session was started by an
-    /// older CLI that didn't send a key, or by an operator that doesn't persist it yet.
     pub key: Option<String>,
     pub namespace: String,
     pub owner: Option<OperatorSessionOwner>,
     pub target: Option<OperatorSessionTarget>,
     pub created_at: Option<String>,
-    /// Subset of the dev's `http_filter` needed by external consumers (the
-    /// browser extension parses `header_filter` to build a matching DNR rule).
-    /// `None` if the session was started by an older CLI or operator that
-    /// didn't persist it.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub http_filter: Option<OperatorSessionHttpFilter>,
 }
@@ -124,9 +109,6 @@ pub struct OperatorSessionTarget {
 }
 
 impl OperatorSessionSummary {
-    /// Builds a summary from the namespaced [`MirrordSession`] projection.
-    /// We watch this CRD (not the cluster-scoped parent) so RBAC can be scoped
-    /// per namespace on shared clusters.
     fn from_cr(cr: &MirrordSession) -> Option<Self> {
         let name = cr.metadata.name.clone()?;
         let spec = &cr.spec;
@@ -684,10 +666,6 @@ fn start_operator_watcher(state: Arc<AppState>) {
             }
         };
 
-        // Watch the namespaced `MirrordSession` projection instead of the
-        // cluster-scoped `MirrordClusterSession`. `Api::all` still spans every
-        // namespace for the list/watch; callers only see sessions their RBAC
-        // permits.
         let api: Api<MirrordSession> = Api::all(client);
 
         // Probe the CRD with a single list; if this fails because the CRD isn't
@@ -860,13 +838,8 @@ pub async fn ui_command(args: UiArgs) -> Result<(), CliError> {
     Ok(())
 }
 
-/// Chrome extension id produced by the `"key"` field in the mirrord-browser
-/// manifest. Stable across dev (unpacked) and production (Chrome Web Store)
-/// installs, so the CLI can hand a clickable configure URL to the user.
 const MIRRORD_EXTENSION_ID: &str = "bijejadnnfgjkfdocgocklekjhnhkhkf";
 
-/// Build a `chrome-extension://…/pages/configure.html?backend=…&token=…` URL
-/// that configures the browser extension to talk to this UI server.
 fn build_extension_configure_url(addr: &SocketAddr, token: &str) -> String {
     let backend = format!("http://{addr}");
     let backend_encoded: String =

--- a/mirrord/operator/src/client.rs
+++ b/mirrord/operator/src/client.rs
@@ -1559,6 +1559,7 @@ impl OperatorApi<PreparedClientCert> {
             sqs_output_queues: Default::default(),
             rmq_output_queues: Default::default(),
             key: Some(key),
+            header_filter: None,
         };
 
         if use_proxy {

--- a/mirrord/operator/src/client.rs
+++ b/mirrord/operator/src/client.rs
@@ -2211,6 +2211,7 @@ mod test {
             sqs_output_queues: Default::default(),
             rmq_output_queues: Default::default(),
             key,
+            header_filter: None,
         };
 
         let produced = OperatorApi::target_connect_url(use_proxy, &target, &params);
@@ -2331,6 +2332,7 @@ mod test {
             sqs_output_queues: Default::default(),
             rmq_output_queues: Default::default(),
             key,
+            header_filter: None,
         };
         let produced =
             OperatorApi::target_connect_url_from_config(use_proxy, &target, namespace, &params);

--- a/mirrord/operator/src/client/connect_params.rs
+++ b/mirrord/operator/src/client/connect_params.rs
@@ -87,6 +87,10 @@ pub struct ConnectParams<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub key: Option<&'a str>,
 
+    /// Raw `feature.network.incoming.http_filter.header_filter` value.
+    /// Persisted on `MirrordClusterSession.spec.httpFilter.headerFilter` so
+    /// consumers like the browser extension can compute the injection pattern
+    /// without the dev declaring it twice.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub header_filter: Option<&'a str>,
 }

--- a/mirrord/operator/src/client/connect_params.rs
+++ b/mirrord/operator/src/client/connect_params.rs
@@ -86,6 +86,13 @@ pub struct ConnectParams<'a> {
     /// Key for this session
     #[serde(skip_serializing_if = "Option::is_none")]
     pub key: Option<&'a str>,
+
+    /// Raw `feature.network.incoming.http_filter.header_filter` value.
+    /// Persisted on `MirrordClusterSession.spec.httpFilter.headerFilter` so
+    /// consumers like the browser extension can compute the injection pattern
+    /// without the dev declaring it twice.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub header_filter: Option<&'a str>,
 }
 
 /// Per-dialect branch database names, used to keep the connect params
@@ -133,6 +140,13 @@ impl<'a> ConnectParams<'a> {
             sqs_output_queues: HashMap::new(),
             rmq_output_queues: HashMap::new(),
             key: Some(key),
+            header_filter: config
+                .feature
+                .network
+                .incoming
+                .http_filter
+                .header_filter
+                .as_deref(),
         }
     }
 }

--- a/mirrord/operator/src/client/connect_params.rs
+++ b/mirrord/operator/src/client/connect_params.rs
@@ -87,10 +87,6 @@ pub struct ConnectParams<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub key: Option<&'a str>,
 
-    /// Raw `feature.network.incoming.http_filter.header_filter` value.
-    /// Persisted on `MirrordClusterSession.spec.httpFilter.headerFilter` so
-    /// consumers like the browser extension can compute the injection pattern
-    /// without the dev declaring it twice.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub header_filter: Option<&'a str>,
 }

--- a/mirrord/operator/src/crd.rs
+++ b/mirrord/operator/src/crd.rs
@@ -968,6 +968,7 @@ mod tests {
         preview::PreviewSession,
         profile::{MirrordClusterProfile, MirrordProfile},
         rabbitmq::MirrordRmqSession,
+        session::MirrordClusterSession,
     };
 
     fn write_crd_yaml<T: CustomResourceExt>() {
@@ -999,6 +1000,12 @@ mod tests {
         write_crd_yaml::<MirrordClusterProfile>();
         write_crd_yaml::<MirrordProfile>();
         write_crd_yaml::<PreviewSession>();
+        write_crd_yaml::<MirrordClusterSession>();
+    }
+
+    #[test]
+    fn dump_mirrord_cluster_session() {
+        write_crd_yaml::<MirrordClusterSession>();
     }
 
     #[test]

--- a/mirrord/operator/src/crd/session.rs
+++ b/mirrord/operator/src/crd/session.rs
@@ -240,7 +240,6 @@ pub struct MirrordSessionSpec {
     pub key: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub http_filter: Option<SessionHttpFilter>,
-    pub cluster_session_name: String,
 }
 
 /// Resources needed to report session metrics to the mirrord Jira app.

--- a/mirrord/operator/src/crd/session.rs
+++ b/mirrord/operator/src/crd/session.rs
@@ -15,17 +15,12 @@ use mirrord_kube::api::kubernetes::rollout::Rollout;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-/// Describes an owner of a mirrord session.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct SessionOwner {
-    /// Unique ID.
     pub user_id: String,
-    /// Name of the POSIX user that executed the CLI command.
     pub username: String,
-    /// Hostname of the machine where the CLI command was executed.
     pub hostname: String,
-    /// Name of the Kubernetes user who's identity was assumed by the CLI.
     pub k8s_username: String,
 }
 
@@ -39,17 +34,12 @@ impl fmt::Display for SessionOwner {
     }
 }
 
-/// Describes a target of a mirrord session.
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct SessionTarget {
-    /// Kubernetes resource apiVersion.
     pub api_version: String,
-    /// Kubernetes resource kind.
     pub kind: String,
-    /// Kubernetes resource name.
     pub name: String,
-    /// Name of the container defined in the Pod spec.
     pub container: String,
 }
 
@@ -64,9 +54,6 @@ impl fmt::Display for SessionTarget {
 }
 
 impl SessionTarget {
-    /// Create a [`SessionTarget`] from a [`Target`] with a resolved container.
-    ///
-    /// Returns `None` for [`Target::Targetless`] or if the [`Target`] doesn't have a container.
     pub fn from_config(target: Target) -> Option<Self> {
         match target {
             Target::Deployment(t) => Some(Self {
@@ -121,7 +108,6 @@ impl SessionTarget {
         }
     }
 
-    /// Parse back into a [`Target`] by reconstructing the canonical target path string.
     pub fn into_config(self) -> Option<Target> {
         format!(
             "{}/{}/container/{}",
@@ -134,38 +120,22 @@ impl SessionTarget {
     }
 }
 
-/// Information about the CI session started from `mirrord ci start`.
-///
-/// We try to get some of these fields automatically, but for some that we cannot, the user may
-/// pass them as cli args to `mirrord ci start`, see `cli::ci::StartArgs`.
-///
-/// These values are passed to the operator, and handled by the `ci_controller`.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct SessionCiInfo {
-    /// CI provider, e.g. "github", "gitlab", ...
     #[serde(skip_serializing_if = "Option::is_none")]
     pub provider: Option<String>,
 
-    /// Staging, production, test, nightly, ...
     #[serde(skip_serializing_if = "Option::is_none")]
     pub environment: Option<String>,
 
-    /// Pipeline/job name, e.g. "e2e-tests".
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pipeline: Option<String>,
 
-    /// PR, manual, push, ...
     #[serde(skip_serializing_if = "Option::is_none")]
     pub triggered_by: Option<String>,
 }
 
-/// Mirror of `operator_crd::crd::session::MirrordClusterSession`.
-///
-/// Defined here so the mirrord CLI (and any other client in this repo) can use
-/// `kube::Api<MirrordClusterSession>` without depending on the operator repo.
-/// Wire-compatibility with the operator-side definition is maintained by keeping
-/// this struct's field set and serde attributes in lockstep.
 #[derive(CustomResource, Clone, Debug, Deserialize, Eq, PartialEq, Serialize, JsonSchema)]
 #[kube(
     group = "mirrord.metalbear.co",
@@ -175,23 +145,16 @@ pub struct SessionCiInfo {
 )]
 #[serde(rename_all = "camelCase")]
 pub struct MirrordClusterSessionSpec {
-    /// Resources needed to report session metrics to the mirrord Jira app.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub jira_metrics: Option<SessionJiraMetrics>,
-    /// Owner of this session.
     pub owner: SessionOwner,
-    /// Kubernetes namespace of the session.
     pub namespace: String,
-    /// Target of the session. None for targetless sessions.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub target: Option<SessionTarget>,
-    /// CI info when a session is started with `mirrord ci start`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ci_info: Option<SessionCiInfo>,
-    /// Copy target configuration for this session.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub copy_target: Option<SessionCopyTarget>,
-    /// Multi-cluster: name of the parent MirrordMultiClusterSession.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub multi_cluster_parent_name: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -227,41 +190,31 @@ pub struct MirrordSessionSpec {
     pub http_filter: Option<SessionHttpFilter>,
 }
 
-/// Resources needed to report session metrics to the mirrord Jira app.
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct SessionJiraMetrics {
-    /// The user's current git branch.
     pub branch_name: String,
 }
 
-/// Describes copy target configuration for a session.
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct SessionCopyTarget {
-    /// Whether the original target should be scaled down.
     pub scaledown: bool,
 }
 
-/// Status of a mirrord cluster session.
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct MirrordClusterSessionStatus {
-    /// Last time when the session was observed to have an open user connection.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub connected_timestamp: Option<MicroTime>,
-    /// If the session has been closed, describes the reason.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub closed: Option<SessionClosed>,
 }
 
-/// Describes the reason for which a mirrord session was closed.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct SessionClosed {
-    /// Short reason in PascalCase.
     pub reason: String,
-    /// Optional human friendly message.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
 }

--- a/mirrord/operator/src/crd/session.rs
+++ b/mirrord/operator/src/crd/session.rs
@@ -194,20 +194,35 @@ pub struct MirrordClusterSessionSpec {
     /// Multi-cluster: name of the parent MirrordMultiClusterSession.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub multi_cluster_parent_name: Option<String>,
+    /// Session key as supplied by the CLI at connect time.
+    /// Consumers (browser extension, dashboard) group sessions by this value.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub key: Option<String>,
 
+    /// HTTP filter configuration applied by the agent on incoming traffic.
+    /// Surfaced so external consumers (e.g. the browser extension) can derive
+    /// the exact header they need to inject without requiring the developer
+    /// to declare the injection pattern separately.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub http_filter: Option<SessionHttpFilter>,
 }
 
+/// Subset of the CLI's `HttpFilterConfig` stored on the session CR for
+/// external consumers. Only fields the extension can act on are surfaced.
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct SessionHttpFilter {
+    /// Raw `feature.network.incoming.http_filter.header_filter` regex.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub header_filter: Option<String>,
 }
 
+/// Namespaced projection of a CLI-initiated session.
+///
+/// The operator dual-writes this alongside the cluster-scoped
+/// [`MirrordClusterSession`] so external consumers (browser extension,
+/// `mirrord ui`) can discover sessions via RBAC scoped to the target's
+/// namespace, instead of relying on cluster-wide permissions.
 #[derive(CustomResource, Clone, Debug, Deserialize, Eq, PartialEq, Serialize, JsonSchema)]
 #[kube(
     group = "mirrord.metalbear.co",

--- a/mirrord/operator/src/crd/session.rs
+++ b/mirrord/operator/src/crd/session.rs
@@ -194,35 +194,20 @@ pub struct MirrordClusterSessionSpec {
     /// Multi-cluster: name of the parent MirrordMultiClusterSession.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub multi_cluster_parent_name: Option<String>,
-    /// Session key as supplied by the CLI at connect time.
-    /// Consumers (browser extension, dashboard) group sessions by this value.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub key: Option<String>,
 
-    /// HTTP filter configuration applied by the agent on incoming traffic.
-    /// Surfaced so external consumers (e.g. the browser extension) can derive
-    /// the exact header they need to inject without requiring the developer
-    /// to declare the injection pattern separately.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub http_filter: Option<SessionHttpFilter>,
 }
 
-/// Subset of the CLI's `HttpFilterConfig` stored on the session CR for
-/// external consumers. Only fields the extension can act on are surfaced.
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct SessionHttpFilter {
-    /// Raw `feature.network.incoming.http_filter.header_filter` regex.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub header_filter: Option<String>,
 }
 
-/// Namespaced projection of a CLI-initiated session.
-///
-/// The operator dual-writes this alongside the cluster-scoped
-/// [`MirrordClusterSession`] so external consumers (browser extension,
-/// `mirrord ui`) can discover sessions via RBAC scoped to the target's
-/// namespace, instead of relying on cluster-wide permissions.
 #[derive(CustomResource, Clone, Debug, Deserialize, Eq, PartialEq, Serialize, JsonSchema)]
 #[kube(
     group = "mirrord.metalbear.co",

--- a/mirrord/operator/src/crd/session.rs
+++ b/mirrord/operator/src/crd/session.rs
@@ -15,12 +15,17 @@ use mirrord_kube::api::kubernetes::rollout::Rollout;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+/// Describes an owner of a mirrord session.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct SessionOwner {
+    /// Unique ID.
     pub user_id: String,
+    /// Name of the POSIX user that executed the CLI command.
     pub username: String,
+    /// Hostname of the machine where the CLI command was executed.
     pub hostname: String,
+    /// Name of the Kubernetes user who's identity was assumed by the CLI.
     pub k8s_username: String,
 }
 
@@ -34,12 +39,17 @@ impl fmt::Display for SessionOwner {
     }
 }
 
+/// Describes a target of a mirrord session.
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct SessionTarget {
+    /// Kubernetes resource apiVersion.
     pub api_version: String,
+    /// Kubernetes resource kind.
     pub kind: String,
+    /// Kubernetes resource name.
     pub name: String,
+    /// Name of the container defined in the Pod spec.
     pub container: String,
 }
 
@@ -54,6 +64,9 @@ impl fmt::Display for SessionTarget {
 }
 
 impl SessionTarget {
+    /// Create a [`SessionTarget`] from a [`Target`] with a resolved container.
+    ///
+    /// Returns `None` for [`Target::Targetless`] or if the [`Target`] doesn't have a container.
     pub fn from_config(target: Target) -> Option<Self> {
         match target {
             Target::Deployment(t) => Some(Self {
@@ -108,6 +121,7 @@ impl SessionTarget {
         }
     }
 
+    /// Parse back into a [`Target`] by reconstructing the canonical target path string.
     pub fn into_config(self) -> Option<Target> {
         format!(
             "{}/{}/container/{}",
@@ -120,22 +134,38 @@ impl SessionTarget {
     }
 }
 
+/// Information about the CI session started from `mirrord ci start`.
+///
+/// We try to get some of these fields automatically, but for some that we cannot, the user may
+/// pass them as cli args to `mirrord ci start`, see `cli::ci::StartArgs`.
+///
+/// These values are passed to the operator, and handled by the `ci_controller`.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct SessionCiInfo {
+    /// CI provider, e.g. "github", "gitlab", ...
     #[serde(skip_serializing_if = "Option::is_none")]
     pub provider: Option<String>,
 
+    /// Staging, production, test, nightly, ...
     #[serde(skip_serializing_if = "Option::is_none")]
     pub environment: Option<String>,
 
+    /// Pipeline/job name, e.g. "e2e-tests".
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pipeline: Option<String>,
 
+    /// PR, manual, push, ...
     #[serde(skip_serializing_if = "Option::is_none")]
     pub triggered_by: Option<String>,
 }
 
+/// Mirror of `operator_crd::crd::session::MirrordClusterSession`.
+///
+/// Defined here so the mirrord CLI (and any other client in this repo) can use
+/// `kube::Api<MirrordClusterSession>` without depending on the operator repo.
+/// Wire-compatibility with the operator-side definition is maintained by keeping
+/// this struct's field set and serde attributes in lockstep.
 #[derive(CustomResource, Clone, Debug, Deserialize, Eq, PartialEq, Serialize, JsonSchema)]
 #[kube(
     group = "mirrord.metalbear.co",
@@ -145,16 +175,23 @@ pub struct SessionCiInfo {
 )]
 #[serde(rename_all = "camelCase")]
 pub struct MirrordClusterSessionSpec {
+    /// Resources needed to report session metrics to the mirrord Jira app.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub jira_metrics: Option<SessionJiraMetrics>,
+    /// Owner of this session.
     pub owner: SessionOwner,
+    /// Kubernetes namespace of the session.
     pub namespace: String,
+    /// Target of the session. None for targetless sessions.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub target: Option<SessionTarget>,
+    /// CI info when a session is started with `mirrord ci start`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ci_info: Option<SessionCiInfo>,
+    /// Copy target configuration for this session.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub copy_target: Option<SessionCopyTarget>,
+    /// Multi-cluster: name of the parent MirrordMultiClusterSession.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub multi_cluster_parent_name: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -190,31 +227,41 @@ pub struct MirrordSessionSpec {
     pub http_filter: Option<SessionHttpFilter>,
 }
 
+/// Resources needed to report session metrics to the mirrord Jira app.
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct SessionJiraMetrics {
+    /// The user's current git branch.
     pub branch_name: String,
 }
 
+/// Describes copy target configuration for a session.
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct SessionCopyTarget {
+    /// Whether the original target should be scaled down.
     pub scaledown: bool,
 }
 
+/// Status of a mirrord cluster session.
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct MirrordClusterSessionStatus {
+    /// Last time when the session was observed to have an open user connection.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub connected_timestamp: Option<MicroTime>,
+    /// If the session has been closed, describes the reason.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub closed: Option<SessionClosed>,
 }
 
+/// Describes the reason for which a mirrord session was closed.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct SessionClosed {
+    /// Short reason in PascalCase.
     pub reason: String,
+    /// Optional human friendly message.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
 }

--- a/mirrord/operator/src/crd/session.rs
+++ b/mirrord/operator/src/crd/session.rs
@@ -198,6 +198,23 @@ pub struct MirrordClusterSessionSpec {
     /// Consumers (browser extension, dashboard) group sessions by this value.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub key: Option<String>,
+
+    /// HTTP filter configuration applied by the agent on incoming traffic.
+    /// Surfaced so external consumers (e.g. the browser extension) can derive
+    /// the exact header they need to inject without requiring the developer
+    /// to declare the injection pattern separately.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub http_filter: Option<SessionHttpFilter>,
+}
+
+/// Subset of the CLI's `HttpFilterConfig` stored on the session CR for
+/// external consumers. Only fields the extension can act on are surfaced.
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionHttpFilter {
+    /// Raw `feature.network.incoming.http_filter.header_filter` regex.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub header_filter: Option<String>,
 }
 
 /// Resources needed to report session metrics to the mirrord Jira app.

--- a/mirrord/operator/src/crd/session.rs
+++ b/mirrord/operator/src/crd/session.rs
@@ -7,7 +7,9 @@ use k8s_openapi::{
         batch::v1::{CronJob, Job},
         core::v1::{Pod, Service},
     },
+    apimachinery::pkg::apis::meta::v1::MicroTime,
 };
+use kube::CustomResource;
 use mirrord_config::target::Target;
 use mirrord_kube::api::kubernetes::rollout::Rollout;
 use schemars::JsonSchema;
@@ -156,4 +158,83 @@ pub struct SessionCiInfo {
     /// PR, manual, push, ...
     #[serde(skip_serializing_if = "Option::is_none")]
     pub triggered_by: Option<String>,
+}
+
+/// Mirror of `operator_crd::crd::session::MirrordClusterSession`.
+///
+/// Defined here so the mirrord CLI (and any other client in this repo) can use
+/// `kube::Api<MirrordClusterSession>` without depending on the operator repo.
+/// Wire-compatibility with the operator-side definition is maintained by keeping
+/// this struct's field set and serde attributes in lockstep.
+#[derive(CustomResource, Clone, Debug, Deserialize, Eq, PartialEq, Serialize, JsonSchema)]
+#[kube(
+    group = "mirrord.metalbear.co",
+    version = "v1alpha",
+    kind = "MirrordClusterSession",
+    status = "MirrordClusterSessionStatus"
+)]
+#[serde(rename_all = "camelCase")]
+pub struct MirrordClusterSessionSpec {
+    /// Resources needed to report session metrics to the mirrord Jira app.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub jira_metrics: Option<SessionJiraMetrics>,
+    /// Owner of this session.
+    pub owner: SessionOwner,
+    /// Kubernetes namespace of the session.
+    pub namespace: String,
+    /// Target of the session. None for targetless sessions.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target: Option<SessionTarget>,
+    /// CI info when a session is started with `mirrord ci start`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ci_info: Option<SessionCiInfo>,
+    /// Copy target configuration for this session.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub copy_target: Option<SessionCopyTarget>,
+    /// Multi-cluster: name of the parent MirrordMultiClusterSession.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub multi_cluster_parent_name: Option<String>,
+    /// Session key as supplied by the CLI at connect time.
+    /// Consumers (browser extension, dashboard) group sessions by this value.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub key: Option<String>,
+}
+
+/// Resources needed to report session metrics to the mirrord Jira app.
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionJiraMetrics {
+    /// The user's current git branch.
+    pub branch_name: String,
+}
+
+/// Describes copy target configuration for a session.
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionCopyTarget {
+    /// Whether the original target should be scaled down.
+    pub scaledown: bool,
+}
+
+/// Status of a mirrord cluster session.
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct MirrordClusterSessionStatus {
+    /// Last time when the session was observed to have an open user connection.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub connected_timestamp: Option<MicroTime>,
+    /// If the session has been closed, describes the reason.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub closed: Option<SessionClosed>,
+}
+
+/// Describes the reason for which a mirrord session was closed.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionClosed {
+    /// Short reason in PascalCase.
+    pub reason: String,
+    /// Optional human friendly message.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
 }

--- a/mirrord/operator/src/crd/session.rs
+++ b/mirrord/operator/src/crd/session.rs
@@ -160,12 +160,6 @@ pub struct SessionCiInfo {
     pub triggered_by: Option<String>,
 }
 
-/// Mirror of `operator_crd::crd::session::MirrordClusterSession`.
-///
-/// Defined here so the mirrord CLI (and any other client in this repo) can use
-/// `kube::Api<MirrordClusterSession>` without depending on the operator repo.
-/// Wire-compatibility with the operator-side definition is maintained by keeping
-/// this struct's field set and serde attributes in lockstep.
 #[derive(CustomResource, Clone, Debug, Deserialize, Eq, PartialEq, Serialize, JsonSchema)]
 #[kube(
     group = "mirrord.metalbear.co",
@@ -175,54 +169,32 @@ pub struct SessionCiInfo {
 )]
 #[serde(rename_all = "camelCase")]
 pub struct MirrordClusterSessionSpec {
-    /// Resources needed to report session metrics to the mirrord Jira app.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub jira_metrics: Option<SessionJiraMetrics>,
-    /// Owner of this session.
     pub owner: SessionOwner,
-    /// Kubernetes namespace of the session.
     pub namespace: String,
-    /// Target of the session. None for targetless sessions.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub target: Option<SessionTarget>,
-    /// CI info when a session is started with `mirrord ci start`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ci_info: Option<SessionCiInfo>,
-    /// Copy target configuration for this session.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub copy_target: Option<SessionCopyTarget>,
-    /// Multi-cluster: name of the parent MirrordMultiClusterSession.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub multi_cluster_parent_name: Option<String>,
-    /// Session key as supplied by the CLI at connect time.
-    /// Consumers (browser extension, dashboard) group sessions by this value.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub key: Option<String>,
 
-    /// HTTP filter configuration applied by the agent on incoming traffic.
-    /// Surfaced so external consumers (e.g. the browser extension) can derive
-    /// the exact header they need to inject without requiring the developer
-    /// to declare the injection pattern separately.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub http_filter: Option<SessionHttpFilter>,
 }
 
-/// Subset of the CLI's `HttpFilterConfig` stored on the session CR for
-/// external consumers. Only fields the extension can act on are surfaced.
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct SessionHttpFilter {
-    /// Raw `feature.network.incoming.http_filter.header_filter` regex.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub header_filter: Option<String>,
 }
 
-/// Namespaced projection of a CLI-initiated session.
-///
-/// The operator dual-writes this alongside the cluster-scoped
-/// [`MirrordClusterSession`] so external consumers (browser extension,
-/// `mirrord ui`) can discover sessions via RBAC scoped to the target's
-/// namespace, instead of relying on cluster-wide permissions.
 #[derive(CustomResource, Clone, Debug, Deserialize, Eq, PartialEq, Serialize, JsonSchema)]
 #[kube(
     group = "mirrord.metalbear.co",
@@ -242,41 +214,31 @@ pub struct MirrordSessionSpec {
     pub http_filter: Option<SessionHttpFilter>,
 }
 
-/// Resources needed to report session metrics to the mirrord Jira app.
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct SessionJiraMetrics {
-    /// The user's current git branch.
     pub branch_name: String,
 }
 
-/// Describes copy target configuration for a session.
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct SessionCopyTarget {
-    /// Whether the original target should be scaled down.
     pub scaledown: bool,
 }
 
-/// Status of a mirrord cluster session.
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct MirrordClusterSessionStatus {
-    /// Last time when the session was observed to have an open user connection.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub connected_timestamp: Option<MicroTime>,
-    /// If the session has been closed, describes the reason.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub closed: Option<SessionClosed>,
 }
 
-/// Describes the reason for which a mirrord session was closed.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct SessionClosed {
-    /// Short reason in PascalCase.
     pub reason: String,
-    /// Optional human friendly message.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
 }

--- a/mirrord/operator/src/crd/session.rs
+++ b/mirrord/operator/src/crd/session.rs
@@ -217,6 +217,32 @@ pub struct SessionHttpFilter {
     pub header_filter: Option<String>,
 }
 
+/// Namespaced projection of a CLI-initiated session.
+///
+/// The operator dual-writes this alongside the cluster-scoped
+/// [`MirrordClusterSession`] so external consumers (browser extension,
+/// `mirrord ui`) can discover sessions via RBAC scoped to the target's
+/// namespace, instead of relying on cluster-wide permissions.
+#[derive(CustomResource, Clone, Debug, Deserialize, Eq, PartialEq, Serialize, JsonSchema)]
+#[kube(
+    group = "mirrord.metalbear.co",
+    version = "v1alpha",
+    kind = "MirrordSession",
+    namespaced
+)]
+#[serde(rename_all = "camelCase")]
+pub struct MirrordSessionSpec {
+    pub owner: SessionOwner,
+    pub namespace: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target: Option<SessionTarget>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub key: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub http_filter: Option<SessionHttpFilter>,
+    pub cluster_session_name: String,
+}
+
 /// Resources needed to report session metrics to the mirrord Jira app.
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]


### PR DESCRIPTION
## Summary
- Adds `MirrordClusterSession` CRD type to the `mirrord-operator` crate (wire-compatible with the operator-side type from operator#1466; includes `spec.key`).
- Extends `mirrord ui` daemon (`cli/src/ui.rs`) with a `kube::Api<MirrordClusterSession>` watcher that populates an in-memory map and broadcasts `OperatorSession{Added,Removed,Updated}` events on the existing WebSocket.
- Adds `GET /api/operator-sessions` route returning both flat and grouped-by-key views, plus a `watch_status` diagnostic.
- Degrades gracefully when no cluster is reachable or the CRD isn't installed (empty list + `Unavailable` status).

Unblocks PRO-65 (browser-extension "join operator session" flow, upcoming PR in mirrord-browser).

Depends on operator#1466 for `spec.key` to be populated; without it, the watcher runs but `key` will be `null` for all sessions.

## Test plan
- [x] `cargo check --workspace` passes
- [x] `cargo clippy -p mirrord -p mirrord-operator -- --deny warnings` passes
- [x] `cargo fmt --check` clean
- [x] `cargo test -p mirrord --bin mirrord -- ui::` (new summary + grouping tests pass; 16/16)
- [x] `cargo test -p mirrord-operator` passes
- [x] Manual: `mirrord ui` against a live cluster; `GET /api/operator-sessions` returns 6 live sessions with `watch_status: watching`. All sessions have `key: null` because the cluster is not yet running operator#1466; when the operator PR ships, the `by_key` grouping will populate real buckets.