### PR TITLE
feat(mirrord-operator): add MirrordSession type for API aggregation [PRO-65]

### DIFF
--- a/changelog.d/+pro-65-http-filter-ui-plumbing.added.md
+++ b/changelog.d/+pro-65-http-filter-ui-plumbing.added.md
@@ -1,0 +1,1 @@
+`mirrord ui` now surfaces each operator session's `http_filter.header_filter` in the `/api/operator-sessions` response, letting the browser extension derive the header it needs to inject instead of assuming a fixed baggage convention.

--- a/changelog.d/+pro-65-mirrord-session-namespaced.changed.md
+++ b/changelog.d/+pro-65-mirrord-session-namespaced.changed.md
@@ -1,0 +1,1 @@
+`mirrord ui` now watches the namespaced `MirrordSession` CRD (a projection the operator writes alongside each `MirrordClusterSession`) instead of the cluster-scoped CRD. Consumers see the same `OperatorSessionSummary` shape but RBAC on shared clusters can now be scoped per namespace.

--- a/changelog.d/+pro-65-mirrord-session-namespaced.changed.md
+++ b/changelog.d/+pro-65-mirrord-session-namespaced.changed.md
@@ -1,1 +1,1 @@
-`mirrord ui` now watches the namespaced `MirrordSession` CRD (a projection the operator writes alongside each `MirrordClusterSession`) instead of the cluster-scoped CRD. Consumers see the same `OperatorSessionSummary` shape but RBAC on shared clusters can now be scoped per namespace.
+`mirrord ui` now watches the `MirrordSession` CRD, which the operator writes into the target's namespace alongside each `MirrordClusterSession`. Consumers see the same `OperatorSessionSummary` shape, and access on shared clusters can scope per namespace through role-based access control.

--- a/mirrord/cli/src/ui.rs
+++ b/mirrord/cli/src/ui.rs
@@ -409,6 +409,40 @@ async fn session_events_sse(
         .into_response()
 }
 
+#[derive(Serialize)]
+struct OperatorSessionsResponse {
+    /// Sessions grouped by key. The key is the map key; value is the list
+    /// of sessions under that key. Sessions whose `spec.key` is `None` are
+    /// collected under a sentinel key `""` (empty string).
+    by_key: std::collections::BTreeMap<String, Vec<OperatorSessionSummary>>,
+    /// Flat list of all sessions, for clients that prefer not to consume
+    /// the grouped view.
+    sessions: Vec<OperatorSessionSummary>,
+    /// Current watch status (for UI diagnostics).
+    watch_status: OperatorWatchStatus,
+}
+
+async fn list_operator_sessions(
+    State(state): State<Arc<AppState>>,
+) -> axum::Json<OperatorSessionsResponse> {
+    let map = state.operator_sessions.read().await;
+    let watch_status = state.operator_watch_status.read().await.clone();
+
+    let mut by_key: std::collections::BTreeMap<String, Vec<OperatorSessionSummary>> =
+        std::collections::BTreeMap::new();
+    let sessions: Vec<OperatorSessionSummary> = map.values().cloned().collect();
+    for s in &sessions {
+        let k = s.key.clone().unwrap_or_default();
+        by_key.entry(k).or_default().push(s.clone());
+    }
+
+    axum::Json(OperatorSessionsResponse {
+        by_key,
+        sessions,
+        watch_status,
+    })
+}
+
 async fn kill_session(State(state): State<Arc<AppState>>, Path(id): Path<String>) -> Response {
     let (client, socket_path) = {
         let sessions = state.sessions.read().await;
@@ -694,7 +728,8 @@ fn build_router(state: Arc<AppState>) -> Router {
         .route("/sessions", get(list_sessions))
         .route("/sessions/{id}", get(get_session))
         .route("/sessions/{id}/events", get(session_events_sse))
-        .route("/sessions/{id}/kill", post(kill_session));
+        .route("/sessions/{id}/kill", post(kill_session))
+        .route("/operator-sessions", get(list_operator_sessions));
 
     let authenticated_routes = Router::new()
         .nest("/api", api_routes)

--- a/mirrord/cli/src/ui.rs
+++ b/mirrord/cli/src/ui.rs
@@ -838,6 +838,8 @@ mod tests {
         let (notify_tx, _) = broadcast::channel(16);
         Arc::new(AppState {
             sessions: RwLock::new(HashMap::new()),
+            operator_sessions: RwLock::new(std::collections::BTreeMap::new()),
+            operator_watch_status: RwLock::new(OperatorWatchStatus::default()),
             notify_tx,
             token: TEST_TOKEN.to_owned(),
         })
@@ -1034,5 +1036,86 @@ mod tests {
             response.headers().get(header::SET_COOKIE).is_some(),
             "cookie must be set on the first authenticated request, even if the body is 404"
         );
+    }
+
+    mod operator_sessions {
+        use mirrord_operator::crd::session::{
+            MirrordClusterSession, MirrordClusterSessionSpec, SessionOwner, SessionTarget,
+        };
+
+        use super::*;
+
+        fn sample_cr(name: &str, key: Option<&str>) -> MirrordClusterSession {
+            MirrordClusterSession::new(
+                name,
+                MirrordClusterSessionSpec {
+                    jira_metrics: None,
+                    owner: SessionOwner {
+                        user_id: "u".into(),
+                        username: "alice".into(),
+                        hostname: "h".into(),
+                        k8s_username: "alice@ex".into(),
+                    },
+                    namespace: "default".into(),
+                    target: Some(SessionTarget {
+                        api_version: "apps/v1".into(),
+                        kind: "Deployment".into(),
+                        name: "web".into(),
+                        container: "app".into(),
+                    }),
+                    ci_info: None,
+                    copy_target: None,
+                    multi_cluster_parent_name: None,
+                    key: key.map(|s| s.to_owned()),
+                },
+            )
+        }
+
+        #[test]
+        fn summary_from_cr_extracts_key() {
+            let cr = sample_cr("cr-1", Some("alice-session"));
+            let summary = OperatorSessionSummary::from_cr(&cr).unwrap();
+            assert_eq!(summary.name, "cr-1");
+            assert_eq!(summary.key.as_deref(), Some("alice-session"));
+            assert_eq!(summary.namespace, "default");
+            assert_eq!(
+                summary.target.as_ref().map(|t| t.name.as_str()),
+                Some("web")
+            );
+        }
+
+        #[test]
+        fn summary_from_cr_preserves_none_key() {
+            let cr = sample_cr("cr-2", None);
+            let summary = OperatorSessionSummary::from_cr(&cr).unwrap();
+            assert!(summary.key.is_none());
+        }
+
+        #[tokio::test]
+        async fn operator_sessions_groups_by_key_with_none_bucket() {
+            let (tx, _rx) = broadcast::channel::<SessionNotification>(16);
+            let state = Arc::new(AppState {
+                sessions: RwLock::new(HashMap::new()),
+                operator_sessions: RwLock::new({
+                    let mut m = std::collections::BTreeMap::new();
+                    let s1 = OperatorSessionSummary::from_cr(&sample_cr("a", Some("k"))).unwrap();
+                    let s2 = OperatorSessionSummary::from_cr(&sample_cr("b", Some("k"))).unwrap();
+                    let s3 = OperatorSessionSummary::from_cr(&sample_cr("c", None)).unwrap();
+                    m.insert("a".into(), s1);
+                    m.insert("b".into(), s2);
+                    m.insert("c".into(), s3);
+                    m
+                }),
+                operator_watch_status: RwLock::new(OperatorWatchStatus::Watching),
+                notify_tx: tx,
+                token: "t".into(),
+            });
+
+            let resp = list_operator_sessions(axum::extract::State(state)).await.0;
+            assert_eq!(resp.sessions.len(), 3);
+            assert_eq!(resp.by_key.get("k").map(|v| v.len()), Some(2));
+            assert_eq!(resp.by_key.get("").map(|v| v.len()), Some(1));
+            assert!(matches!(resp.watch_status, OperatorWatchStatus::Watching));
+        }
     }
 }

--- a/mirrord/cli/src/ui.rs
+++ b/mirrord/cli/src/ui.rs
@@ -704,51 +704,56 @@ fn start_operator_watcher(state: Arc<AppState>) {
 
         *state.operator_watch_status.write().await = OperatorWatchStatus::Watching;
 
-        let mut stream = watcher(api, watcher::Config::default()).boxed();
-        while let Some(ev) = stream.next().await {
-            match ev {
-                Ok(watcher::Event::Apply(cr)) => {
-                    if let Some(summary) = OperatorSessionSummary::from_cr(&cr) {
-                        let key = summary.name.clone();
-                        let is_new = {
-                            let mut map = state.operator_sessions.write().await;
-                            let prior = map.insert(key.clone(), summary.clone());
-                            prior.is_none()
-                        };
-                        let _ = state.notify_tx.send(if is_new {
+        // Poll instead of watch: the API-aggregated endpoint serves LIST/GET only,
+        // not the streaming WATCH protocol (no resourceVersion, no chunked events).
+        // Reconcile the local map against each LIST and emit add/update/remove
+        // notifications. Five seconds is a UI-friendly cadence for a tab the user
+        // is actively looking at.
+        let mut interval = tokio::time::interval(std::time::Duration::from_secs(5));
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        loop {
+            interval.tick().await;
+            match api.list(&ListParams::default()).await {
+                Ok(list) => {
+                    let observed: HashMap<String, OperatorSessionSummary> = list
+                        .items
+                        .iter()
+                        .filter_map(OperatorSessionSummary::from_cr)
+                        .map(|s| (s.name.clone(), s))
+                        .collect();
+                    let mut map = state.operator_sessions.write().await;
+                    for (name, summary) in &observed {
+                        let prior = map.insert(name.clone(), summary.clone());
+                        let _ = state.notify_tx.send(if prior.is_none() {
                             SessionNotification::OperatorSessionAdded {
-                                session: Box::new(summary),
+                                session: Box::new(summary.clone()),
                             }
                         } else {
                             SessionNotification::OperatorSessionUpdated {
-                                session: Box::new(summary),
+                                session: Box::new(summary.clone()),
                             }
                         });
                     }
-                }
-                Ok(watcher::Event::Delete(cr)) => {
-                    if let Some(name) = cr.metadata.name {
-                        state.operator_sessions.write().await.remove(&name);
+                    let stale: Vec<String> = map
+                        .keys()
+                        .filter(|name| !observed.contains_key(*name))
+                        .cloned()
+                        .collect();
+                    for name in stale {
+                        map.remove(&name);
                         let _ = state
                             .notify_tx
                             .send(SessionNotification::OperatorSessionRemoved { name });
                     }
                 }
-                Ok(watcher::Event::Init)
-                | Ok(watcher::Event::InitApply(_))
-                | Ok(watcher::Event::InitDone) => {
-                    // watcher relist lifecycle; no action needed.
-                }
                 Err(err) => {
-                    let reason = format!("watcher error: {err}");
+                    let reason = format!("list error: {err}");
                     warn!("{reason}");
                     *state.operator_watch_status.write().await =
                         OperatorWatchStatus::Error { message: reason };
                 }
             }
         }
-
-        warn!("operator session watcher stream ended unexpectedly");
     });
 }
 

--- a/mirrord/cli/src/ui.rs
+++ b/mirrord/cli/src/ui.rs
@@ -4,6 +4,12 @@
 //! active mirrord sessions. It watches `~/.mirrord/sessions/` for Unix socket files, connects
 //! to each session's HTTP API, and serves a React frontend plus REST/SSE/WebSocket endpoints on
 //! localhost.
+//!
+//! ## Browser extension handoff
+//!
+//! On startup, `mirrord ui` prints both the web UI URL and a `chrome-extension://` configure URL.
+//! The extension id is pinned in the mirrord-browser manifest's `"key"` field, which produces a
+//! deterministic id when loaded unpacked or published to the Chrome Web Store.
 
 use std::{
     collections::{HashMap, hash_map::Entry},
@@ -87,6 +93,19 @@ pub struct OperatorSessionSummary {
     pub owner: Option<OperatorSessionOwner>,
     pub target: Option<OperatorSessionTarget>,
     pub created_at: Option<String>,
+    /// Subset of the dev's `http_filter` needed by external consumers (the
+    /// browser extension parses `header_filter` to build a matching DNR rule).
+    /// `None` if the session was started by an older CLI or operator that
+    /// didn't persist it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub http_filter: Option<OperatorSessionHttpFilter>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OperatorSessionHttpFilter {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub header_filter: Option<String>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -126,6 +145,12 @@ impl OperatorSessionSummary {
                 .creation_timestamp
                 .as_ref()
                 .map(|ts| ts.0.to_string()),
+            http_filter: spec
+                .http_filter
+                .as_ref()
+                .map(|f| OperatorSessionHttpFilter {
+                    header_filter: f.header_filter.clone(),
+                }),
         })
     }
 }
@@ -809,7 +834,13 @@ pub async fn ui_command(args: UiArgs) -> Result<(), CliError> {
         .local_addr()
         .map_err(|e| CliError::UiError(format!("failed to get listener address: {e}")))?;
     let url = format!("http://{addr}?token={token}");
-    eprintln!("mirrord session monitor: {url}");
+    let extension_url = build_extension_configure_url(&addr, &token);
+
+    eprintln!();
+    eprintln!("  mirrord session monitor");
+    eprintln!("    Web UI:             {url}");
+    eprintln!("    Browser extension:  {extension_url}");
+    eprintln!();
 
     if let Err(err) = opener::open(&url) {
         warn!(?err, "Failed to open browser");
@@ -820,6 +851,23 @@ pub async fn ui_command(args: UiArgs) -> Result<(), CliError> {
         .map_err(|e| CliError::UiError(format!("server error: {e}")))?;
 
     Ok(())
+}
+
+/// Chrome extension id produced by the `"key"` field in the mirrord-browser
+/// manifest. Stable across dev (unpacked) and production (Chrome Web Store)
+/// installs, so the CLI can hand a clickable configure URL to the user.
+const MIRRORD_EXTENSION_ID: &str = "bijejadnnfgjkfdocgocklekjhnhkhkf";
+
+/// Build a `chrome-extension://…/pages/configure.html?backend=…&token=…` URL
+/// that configures the browser extension to talk to this UI server.
+fn build_extension_configure_url(addr: &SocketAddr, token: &str) -> String {
+    let backend = format!("http://{addr}");
+    let backend_encoded: String =
+        url::form_urlencoded::byte_serialize(backend.as_bytes()).collect();
+    format!(
+        "chrome-extension://{id}/pages/configure.html?backend={backend_encoded}&token={token}",
+        id = MIRRORD_EXTENSION_ID
+    )
 }
 
 #[cfg(test)]

--- a/mirrord/cli/src/ui.rs
+++ b/mirrord/cli/src/ui.rs
@@ -35,7 +35,7 @@ use axum_extra::extract::cookie::{Cookie, CookieJar, SameSite};
 use eventsource_stream::Eventsource;
 use futures::stream::StreamExt as _;
 use kube::{Api, Client, api::ListParams, runtime::watcher};
-use mirrord_operator::crd::session::MirrordClusterSession;
+use mirrord_operator::crd::session::MirrordSession;
 use mirrord_session_monitor_client::{
     SessionError, connect_to_session, session_socket_entries, sessions_dir,
 };
@@ -124,7 +124,10 @@ pub struct OperatorSessionTarget {
 }
 
 impl OperatorSessionSummary {
-    fn from_cr(cr: &mirrord_operator::crd::session::MirrordClusterSession) -> Option<Self> {
+    /// Builds a summary from the namespaced [`MirrordSession`] projection.
+    /// We watch this CRD (not the cluster-scoped parent) so RBAC can be scoped
+    /// per namespace on shared clusters.
+    fn from_cr(cr: &MirrordSession) -> Option<Self> {
         let name = cr.metadata.name.clone()?;
         let spec = &cr.spec;
         Some(Self {
@@ -681,7 +684,11 @@ fn start_operator_watcher(state: Arc<AppState>) {
             }
         };
 
-        let api: Api<MirrordClusterSession> = Api::all(client);
+        // Watch the namespaced `MirrordSession` projection instead of the
+        // cluster-scoped `MirrordClusterSession`. `Api::all` still spans every
+        // namespace for the list/watch; callers only see sessions their RBAC
+        // permits.
+        let api: Api<MirrordSession> = Api::all(client);
 
         // Probe the CRD with a single list; if this fails because the CRD isn't
         // installed or access is denied, surface a clean "unavailable" status
@@ -1088,16 +1095,15 @@ mod tests {
 
     mod operator_sessions {
         use mirrord_operator::crd::session::{
-            MirrordClusterSession, MirrordClusterSessionSpec, SessionOwner, SessionTarget,
+            MirrordSession, MirrordSessionSpec, SessionOwner, SessionTarget,
         };
 
         use super::*;
 
-        fn sample_cr(name: &str, key: Option<&str>) -> MirrordClusterSession {
-            MirrordClusterSession::new(
+        fn sample_cr(name: &str, key: Option<&str>) -> MirrordSession {
+            MirrordSession::new(
                 name,
-                MirrordClusterSessionSpec {
-                    jira_metrics: None,
+                MirrordSessionSpec {
                     owner: SessionOwner {
                         user_id: "u".into(),
                         username: "alice".into(),
@@ -1111,10 +1117,9 @@ mod tests {
                         name: "web".into(),
                         container: "app".into(),
                     }),
-                    ci_info: None,
-                    copy_target: None,
-                    multi_cluster_parent_name: None,
                     key: key.map(|s| s.to_owned()),
+                    http_filter: None,
+                    cluster_session_name: name.to_owned(),
                 },
             )
         }

--- a/mirrord/cli/src/ui.rs
+++ b/mirrord/cli/src/ui.rs
@@ -5,11 +5,6 @@
 //! to each session's HTTP API, and serves a React frontend plus REST/SSE/WebSocket endpoints on
 //! localhost.
 //!
-//! ## Browser extension handoff
-//!
-//! On startup, `mirrord ui` prints both the web UI URL and a `chrome-extension://` configure URL.
-//! The extension id is pinned in the mirrord-browser manifest's `"key"` field, which produces a
-//! deterministic id when loaded unpacked or published to the Chrome Web Store.
 
 use std::{
     collections::{HashMap, hash_map::Entry},
@@ -79,24 +74,15 @@ enum SessionNotification {
     },
 }
 
-/// Wire-format summary of an operator-side session that the browser extension
-/// and local UI tab can render. Derived from `MirrordClusterSession`.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct OperatorSessionSummary {
-    /// Kubernetes object name of the underlying `MirrordClusterSession` CR.
     pub name: String,
-    /// Session key (grouping identity). `None` if the session was started by an
-    /// older CLI that didn't send a key, or by an operator that doesn't persist it yet.
     pub key: Option<String>,
     pub namespace: String,
     pub owner: Option<OperatorSessionOwner>,
     pub target: Option<OperatorSessionTarget>,
     pub created_at: Option<String>,
-    /// Subset of the dev's `http_filter` needed by external consumers (the
-    /// browser extension parses `header_filter` to build a matching DNR rule).
-    /// `None` if the session was started by an older CLI or operator that
-    /// didn't persist it.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub http_filter: Option<OperatorSessionHttpFilter>,
 }
@@ -124,9 +110,6 @@ pub struct OperatorSessionTarget {
 }
 
 impl OperatorSessionSummary {
-    /// Builds a summary from the [`MirrordSession`] served by the operator's API
-    /// aggregation endpoint. The metadata carries the namespace and creation
-    /// timestamp; the spec carries the joinable identity (key, target, filter).
     fn from_cr(cr: &MirrordSession) -> Option<Self> {
         let name = cr.metadata.name.clone()?;
         let namespace = cr.metadata.namespace.clone()?;
@@ -440,14 +423,8 @@ async fn session_events_sse(
 
 #[derive(Serialize)]
 struct OperatorSessionsResponse {
-    /// Sessions grouped by key. The key is the map key; value is the list
-    /// of sessions under that key. Sessions whose `spec.key` is `None` are
-    /// collected under a sentinel key `""` (empty string).
     by_key: std::collections::BTreeMap<String, Vec<OperatorSessionSummary>>,
-    /// Flat list of all sessions, for clients that prefer not to consume
-    /// the grouped view.
     sessions: Vec<OperatorSessionSummary>,
-    /// Current watch status (for UI diagnostics).
     watch_status: OperatorWatchStatus,
 }
 
@@ -667,11 +644,6 @@ fn start_filesystem_watcher(
     Ok(())
 }
 
-/// Starts a tokio task that watches `MirrordClusterSession` CRs via `kube::Api` and
-/// updates `AppState::operator_sessions`. Broadcasts `OperatorSession*` events on
-/// `notify_tx`. If the cluster isn't reachable or the CRD isn't installed, logs a
-/// warning and sets `operator_watch_status` to `Unavailable { reason }`. The `mirrord
-/// ui` daemon continues running for local sessions either way.
 fn start_operator_watcher(state: Arc<AppState>) {
     tokio::spawn(async move {
         let client = match Client::try_default().await {
@@ -685,15 +657,8 @@ fn start_operator_watcher(state: Arc<AppState>) {
             }
         };
 
-        // Watch the namespaced `MirrordSession` projection instead of the
-        // cluster-scoped `MirrordClusterSession`. `Api::all` still spans every
-        // namespace for the list/watch; callers only see sessions their RBAC
-        // permits.
         let api: Api<MirrordSession> = Api::all(client);
 
-        // Probe the CRD with a single list; if this fails because the CRD isn't
-        // installed or access is denied, surface a clean "unavailable" status
-        // instead of retrying forever.
         if let Err(err) = api.list(&ListParams::default().limit(1)).await {
             let reason = format!("operator CRD not available: {err}");
             warn!("{reason}");
@@ -704,11 +669,6 @@ fn start_operator_watcher(state: Arc<AppState>) {
 
         *state.operator_watch_status.write().await = OperatorWatchStatus::Watching;
 
-        // Poll instead of watch: the API-aggregated endpoint serves LIST/GET only,
-        // not the streaming WATCH protocol (no resourceVersion, no chunked events).
-        // Reconcile the local map against each LIST and emit add/update/remove
-        // notifications. Five seconds is a UI-friendly cadence for a tab the user
-        // is actively looking at.
         let mut interval = tokio::time::interval(std::time::Duration::from_secs(5));
         interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
         loop {
@@ -866,13 +826,8 @@ pub async fn ui_command(args: UiArgs) -> Result<(), CliError> {
     Ok(())
 }
 
-/// Chrome extension id produced by the `"key"` field in the mirrord-browser
-/// manifest. Stable across dev (unpacked) and production (Chrome Web Store)
-/// installs, so the CLI can hand a clickable configure URL to the user.
 const MIRRORD_EXTENSION_ID: &str = "bijejadnnfgjkfdocgocklekjhnhkhkf";
 
-/// Build a `chrome-extension://…/pages/configure.html?backend=…&token=…` URL
-/// that configures the browser extension to talk to this UI server.
 fn build_extension_configure_url(addr: &SocketAddr, token: &str) -> String {
     let backend = format!("http://{addr}");
     let backend_encoded: String =

--- a/mirrord/cli/src/ui.rs
+++ b/mirrord/cli/src/ui.rs
@@ -1119,7 +1119,6 @@ mod tests {
                     }),
                     key: key.map(|s| s.to_owned()),
                     http_filter: None,
-                    cluster_session_name: name.to_owned(),
                 },
             )
         }

--- a/mirrord/cli/src/ui.rs
+++ b/mirrord/cli/src/ui.rs
@@ -54,8 +54,78 @@ struct FrontendAssets;
 #[derive(Clone, Debug, Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 enum SessionNotification {
-    SessionAdded { session: Box<TrackedSession> },
-    SessionRemoved { session_id: String },
+    SessionAdded {
+        session: Box<TrackedSession>,
+    },
+    SessionRemoved {
+        session_id: String,
+    },
+    OperatorSessionAdded {
+        session: Box<OperatorSessionSummary>,
+    },
+    OperatorSessionRemoved {
+        name: String,
+    },
+    OperatorSessionUpdated {
+        session: Box<OperatorSessionSummary>,
+    },
+}
+
+/// Wire-format summary of an operator-side session that the browser extension
+/// and local UI tab can render. Derived from `MirrordClusterSession`.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OperatorSessionSummary {
+    /// Kubernetes object name of the underlying `MirrordClusterSession` CR.
+    pub name: String,
+    /// Session key (grouping identity). `None` if the session was started by an
+    /// older CLI that didn't send a key, or by an operator that doesn't persist it yet.
+    pub key: Option<String>,
+    pub namespace: String,
+    pub owner: Option<OperatorSessionOwner>,
+    pub target: Option<OperatorSessionTarget>,
+    pub created_at: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OperatorSessionOwner {
+    pub username: String,
+    pub k8s_username: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OperatorSessionTarget {
+    pub kind: String,
+    pub name: String,
+    pub container: String,
+}
+
+impl OperatorSessionSummary {
+    fn from_cr(cr: &mirrord_operator::crd::session::MirrordClusterSession) -> Option<Self> {
+        let name = cr.metadata.name.clone()?;
+        let spec = &cr.spec;
+        Some(Self {
+            name,
+            key: spec.key.clone(),
+            namespace: spec.namespace.clone(),
+            owner: Some(OperatorSessionOwner {
+                username: spec.owner.username.clone(),
+                k8s_username: spec.owner.k8s_username.clone(),
+            }),
+            target: spec.target.as_ref().map(|t| OperatorSessionTarget {
+                kind: t.kind.clone(),
+                name: t.name.clone(),
+                container: t.container.clone(),
+            }),
+            created_at: cr
+                .metadata
+                .creation_timestamp
+                .as_ref()
+                .map(|ts| ts.0.to_string()),
+        })
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -74,8 +144,24 @@ impl Serialize for TrackedSession {
 
 struct AppState {
     sessions: RwLock<HashMap<String, TrackedSession>>,
+    operator_sessions: RwLock<std::collections::BTreeMap<String, OperatorSessionSummary>>,
+    operator_watch_status: RwLock<OperatorWatchStatus>,
     notify_tx: broadcast::Sender<SessionNotification>,
     token: String,
+}
+
+#[derive(Clone, Debug, Serialize, Default)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum OperatorWatchStatus {
+    #[default]
+    NotStarted,
+    Watching,
+    Error {
+        message: String,
+    },
+    Unavailable {
+        reason: String,
+    },
 }
 
 #[derive(Deserialize)]
@@ -582,6 +668,8 @@ pub async fn ui_command(args: UiArgs) -> Result<(), CliError> {
 
     let state = Arc::new(AppState {
         sessions: RwLock::new(HashMap::new()),
+        operator_sessions: RwLock::new(std::collections::BTreeMap::new()),
+        operator_watch_status: RwLock::new(OperatorWatchStatus::NotStarted),
         notify_tx,
         token: token.clone(),
     });

--- a/mirrord/cli/src/ui.rs
+++ b/mirrord/cli/src/ui.rs
@@ -124,16 +124,17 @@ pub struct OperatorSessionTarget {
 }
 
 impl OperatorSessionSummary {
-    /// Builds a summary from the namespaced [`MirrordSession`] projection.
-    /// We watch this CRD (not the cluster-scoped parent) so RBAC can be scoped
-    /// per namespace on shared clusters.
+    /// Builds a summary from the [`MirrordSession`] served by the operator's API
+    /// aggregation endpoint. The metadata carries the namespace and creation
+    /// timestamp; the spec carries the joinable identity (key, target, filter).
     fn from_cr(cr: &MirrordSession) -> Option<Self> {
         let name = cr.metadata.name.clone()?;
+        let namespace = cr.metadata.namespace.clone()?;
         let spec = &cr.spec;
         Some(Self {
             name,
-            key: spec.key.clone(),
-            namespace: spec.namespace.clone(),
+            key: Some(spec.key.clone()),
+            namespace,
             owner: Some(OperatorSessionOwner {
                 username: spec.owner.username.clone(),
                 k8s_username: spec.owner.k8s_username.clone(),
@@ -1100,8 +1101,8 @@ mod tests {
 
         use super::*;
 
-        fn sample_cr(name: &str, key: Option<&str>) -> MirrordSession {
-            MirrordSession::new(
+        fn sample_cr(name: &str, key: &str) -> MirrordSession {
+            let mut cr = MirrordSession::new(
                 name,
                 MirrordSessionSpec {
                     owner: SessionOwner {
@@ -1110,22 +1111,23 @@ mod tests {
                         hostname: "h".into(),
                         k8s_username: "alice@ex".into(),
                     },
-                    namespace: "default".into(),
                     target: Some(SessionTarget {
                         api_version: "apps/v1".into(),
                         kind: "Deployment".into(),
                         name: "web".into(),
                         container: "app".into(),
                     }),
-                    key: key.map(|s| s.to_owned()),
+                    key: key.to_owned(),
                     http_filter: None,
                 },
-            )
+            );
+            cr.metadata.namespace = Some("default".into());
+            cr
         }
 
         #[test]
         fn summary_from_cr_extracts_key() {
-            let cr = sample_cr("cr-1", Some("alice-session"));
+            let cr = sample_cr("cr-1", "alice-session");
             let summary = OperatorSessionSummary::from_cr(&cr).unwrap();
             assert_eq!(summary.name, "cr-1");
             assert_eq!(summary.key.as_deref(), Some("alice-session"));
@@ -1136,13 +1138,6 @@ mod tests {
             );
         }
 
-        #[test]
-        fn summary_from_cr_preserves_none_key() {
-            let cr = sample_cr("cr-2", None);
-            let summary = OperatorSessionSummary::from_cr(&cr).unwrap();
-            assert!(summary.key.is_none());
-        }
-
         #[tokio::test]
         async fn operator_sessions_groups_by_key_with_none_bucket() {
             let (tx, _rx) = broadcast::channel::<SessionNotification>(16);
@@ -1150,9 +1145,9 @@ mod tests {
                 sessions: RwLock::new(HashMap::new()),
                 operator_sessions: RwLock::new({
                     let mut m = std::collections::BTreeMap::new();
-                    let s1 = OperatorSessionSummary::from_cr(&sample_cr("a", Some("k"))).unwrap();
-                    let s2 = OperatorSessionSummary::from_cr(&sample_cr("b", Some("k"))).unwrap();
-                    let s3 = OperatorSessionSummary::from_cr(&sample_cr("c", None)).unwrap();
+                    let s1 = OperatorSessionSummary::from_cr(&sample_cr("a", "k")).unwrap();
+                    let s2 = OperatorSessionSummary::from_cr(&sample_cr("b", "k")).unwrap();
+                    let s3 = OperatorSessionSummary::from_cr(&sample_cr("c", "k2")).unwrap();
                     m.insert("a".into(), s1);
                     m.insert("b".into(), s2);
                     m.insert("c".into(), s3);
@@ -1166,7 +1161,7 @@ mod tests {
             let resp = list_operator_sessions(axum::extract::State(state)).await.0;
             assert_eq!(resp.sessions.len(), 3);
             assert_eq!(resp.by_key.get("k").map(|v| v.len()), Some(2));
-            assert_eq!(resp.by_key.get("").map(|v| v.len()), Some(1));
+            assert_eq!(resp.by_key.get("k2").map(|v| v.len()), Some(1));
             assert!(matches!(resp.watch_status, OperatorWatchStatus::Watching));
         }
     }

--- a/mirrord/cli/src/ui.rs
+++ b/mirrord/cli/src/ui.rs
@@ -28,6 +28,8 @@ use axum::{
 use axum_extra::extract::cookie::{Cookie, CookieJar, SameSite};
 use eventsource_stream::Eventsource;
 use futures::stream::StreamExt as _;
+use kube::{Api, Client, api::ListParams, runtime::watcher};
+use mirrord_operator::crd::session::MirrordClusterSession;
 use mirrord_session_monitor_client::{
     SessionError, connect_to_session, session_socket_entries, sessions_dir,
 };
@@ -602,6 +604,87 @@ fn start_filesystem_watcher(
     Ok(())
 }
 
+/// Starts a tokio task that watches `MirrordClusterSession` CRs via `kube::Api` and
+/// updates `AppState::operator_sessions`. Broadcasts `OperatorSession*` events on
+/// `notify_tx`. If the cluster isn't reachable or the CRD isn't installed, logs a
+/// warning and sets `operator_watch_status` to `Unavailable { reason }`. The `mirrord
+/// ui` daemon continues running for local sessions either way.
+fn start_operator_watcher(state: Arc<AppState>) {
+    tokio::spawn(async move {
+        let client = match Client::try_default().await {
+            Ok(client) => client,
+            Err(err) => {
+                let reason = format!("kube client init failed: {err}");
+                warn!("{reason}");
+                *state.operator_watch_status.write().await =
+                    OperatorWatchStatus::Unavailable { reason };
+                return;
+            }
+        };
+
+        let api: Api<MirrordClusterSession> = Api::all(client);
+
+        // Probe the CRD with a single list; if this fails because the CRD isn't
+        // installed or access is denied, surface a clean "unavailable" status
+        // instead of retrying forever.
+        if let Err(err) = api.list(&ListParams::default().limit(1)).await {
+            let reason = format!("operator CRD not available: {err}");
+            warn!("{reason}");
+            *state.operator_watch_status.write().await =
+                OperatorWatchStatus::Unavailable { reason };
+            return;
+        }
+
+        *state.operator_watch_status.write().await = OperatorWatchStatus::Watching;
+
+        let mut stream = watcher(api, watcher::Config::default()).boxed();
+        while let Some(ev) = stream.next().await {
+            match ev {
+                Ok(watcher::Event::Apply(cr)) => {
+                    if let Some(summary) = OperatorSessionSummary::from_cr(&cr) {
+                        let key = summary.name.clone();
+                        let is_new = {
+                            let mut map = state.operator_sessions.write().await;
+                            let prior = map.insert(key.clone(), summary.clone());
+                            prior.is_none()
+                        };
+                        let _ = state.notify_tx.send(if is_new {
+                            SessionNotification::OperatorSessionAdded {
+                                session: Box::new(summary),
+                            }
+                        } else {
+                            SessionNotification::OperatorSessionUpdated {
+                                session: Box::new(summary),
+                            }
+                        });
+                    }
+                }
+                Ok(watcher::Event::Delete(cr)) => {
+                    if let Some(name) = cr.metadata.name {
+                        state.operator_sessions.write().await.remove(&name);
+                        let _ = state
+                            .notify_tx
+                            .send(SessionNotification::OperatorSessionRemoved { name });
+                    }
+                }
+                Ok(watcher::Event::Init)
+                | Ok(watcher::Event::InitApply(_))
+                | Ok(watcher::Event::InitDone) => {
+                    // watcher relist lifecycle; no action needed.
+                }
+                Err(err) => {
+                    let reason = format!("watcher error: {err}");
+                    warn!("{reason}");
+                    *state.operator_watch_status.write().await =
+                        OperatorWatchStatus::Error { message: reason };
+                }
+            }
+        }
+
+        warn!("operator session watcher stream ended unexpectedly");
+    });
+}
+
 async fn health() -> impl IntoResponse {
     axum::Json(serde_json::json!({"status": "ok"}))
 }
@@ -678,6 +761,7 @@ pub async fn ui_command(args: UiArgs) -> Result<(), CliError> {
     #[cfg(target_os = "macos")]
     start_periodic_rescan(sessions_dir.clone(), state.clone());
     start_filesystem_watcher(&sessions_dir, state.clone())?;
+    start_operator_watcher(state.clone());
 
     let app = build_router(state);
 

--- a/mirrord/operator/src/client.rs
+++ b/mirrord/operator/src/client.rs
@@ -1620,6 +1620,7 @@ impl OperatorApi<PreparedClientCert> {
             sqs_output_queues: Default::default(),
             rmq_output_queues: Default::default(),
             key: Some(key),
+            header_filter: None,
         };
 
         if use_proxy {

--- a/mirrord/operator/src/client.rs
+++ b/mirrord/operator/src/client.rs
@@ -2272,6 +2272,7 @@ mod test {
             sqs_output_queues: Default::default(),
             rmq_output_queues: Default::default(),
             key,
+            header_filter: None,
         };
 
         let produced = OperatorApi::target_connect_url(use_proxy, &target, &params);
@@ -2392,6 +2393,7 @@ mod test {
             sqs_output_queues: Default::default(),
             rmq_output_queues: Default::default(),
             key,
+            header_filter: None,
         };
         let produced =
             OperatorApi::target_connect_url_from_config(use_proxy, &target, namespace, &params);

--- a/mirrord/operator/src/client/connect_params.rs
+++ b/mirrord/operator/src/client/connect_params.rs
@@ -86,6 +86,13 @@ pub struct ConnectParams<'a> {
     /// Key for this session
     #[serde(skip_serializing_if = "Option::is_none")]
     pub key: Option<&'a str>,
+
+    /// Raw `feature.network.incoming.http_filter.header_filter` value.
+    /// Persisted on `MirrordClusterSession.spec.httpFilter.headerFilter` so
+    /// consumers like the browser extension can compute the injection pattern
+    /// without the dev declaring it twice.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub header_filter: Option<&'a str>,
 }
 
 /// Per-dialect branch database names, used to keep the connect params
@@ -133,6 +140,13 @@ impl<'a> ConnectParams<'a> {
             sqs_output_queues: HashMap::new(),
             rmq_output_queues: HashMap::new(),
             key: Some(key),
+            header_filter: config
+                .feature
+                .network
+                .incoming
+                .http_filter
+                .header_filter
+                .as_deref(),
         }
     }
 }

--- a/mirrord/operator/src/client/connect_params.rs
+++ b/mirrord/operator/src/client/connect_params.rs
@@ -87,10 +87,6 @@ pub struct ConnectParams<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub key: Option<&'a str>,
 
-    /// Raw `feature.network.incoming.http_filter.header_filter` value.
-    /// Persisted on `MirrordClusterSession.spec.httpFilter.headerFilter` so
-    /// consumers like the browser extension can compute the injection pattern
-    /// without the dev declaring it twice.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub header_filter: Option<&'a str>,
 }

--- a/mirrord/operator/src/crd.rs
+++ b/mirrord/operator/src/crd.rs
@@ -984,6 +984,7 @@ mod tests {
         preview::PreviewSession,
         profile::{MirrordClusterProfile, MirrordProfile},
         rabbitmq::MirrordRmqSession,
+        session::MirrordClusterSession,
     };
 
     fn write_crd_yaml<T: CustomResourceExt>() {
@@ -1015,6 +1016,12 @@ mod tests {
         write_crd_yaml::<MirrordClusterProfile>();
         write_crd_yaml::<MirrordProfile>();
         write_crd_yaml::<PreviewSession>();
+        write_crd_yaml::<MirrordClusterSession>();
+    }
+
+    #[test]
+    fn dump_mirrord_cluster_session() {
+        write_crd_yaml::<MirrordClusterSession>();
     }
 
     #[test]

--- a/mirrord/operator/src/crd/session.rs
+++ b/mirrord/operator/src/crd/session.rs
@@ -229,6 +229,23 @@ pub struct MirrordClusterSessionSpec {
     /// Consumers (browser extension, dashboard) group sessions by this value.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub key: Option<String>,
+
+    /// HTTP filter configuration applied by the agent on incoming traffic.
+    /// Surfaced so external consumers (e.g. the browser extension) can derive
+    /// the exact header they need to inject without requiring the developer
+    /// to declare the injection pattern separately.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub http_filter: Option<SessionHttpFilter>,
+}
+
+/// Subset of the CLI's `HttpFilterConfig` stored on the session CR for
+/// external consumers. Only fields the extension can act on are surfaced.
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionHttpFilter {
+    /// Raw `feature.network.incoming.http_filter.header_filter` regex.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub header_filter: Option<String>,
 }
 
 /// Resources needed to report session metrics to the mirrord Jira app.

--- a/mirrord/operator/src/crd/session.rs
+++ b/mirrord/operator/src/crd/session.rs
@@ -7,6 +7,7 @@ use k8s_openapi::{
         batch::v1::{CronJob, Job},
         core::v1::{Pod, Service},
     },
+    apimachinery::pkg::apis::meta::v1::MicroTime,
 };
 use kube::CustomResource;
 use mirrord_config::target::Target;
@@ -188,4 +189,83 @@ pub struct SessionCiInfo {
     /// PR, manual, push, ...
     #[serde(skip_serializing_if = "Option::is_none")]
     pub triggered_by: Option<String>,
+}
+
+/// Mirror of `operator_crd::crd::session::MirrordClusterSession`.
+///
+/// Defined here so the mirrord CLI (and any other client in this repo) can use
+/// `kube::Api<MirrordClusterSession>` without depending on the operator repo.
+/// Wire-compatibility with the operator-side definition is maintained by keeping
+/// this struct's field set and serde attributes in lockstep.
+#[derive(CustomResource, Clone, Debug, Deserialize, Eq, PartialEq, Serialize, JsonSchema)]
+#[kube(
+    group = "mirrord.metalbear.co",
+    version = "v1alpha",
+    kind = "MirrordClusterSession",
+    status = "MirrordClusterSessionStatus"
+)]
+#[serde(rename_all = "camelCase")]
+pub struct MirrordClusterSessionSpec {
+    /// Resources needed to report session metrics to the mirrord Jira app.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub jira_metrics: Option<SessionJiraMetrics>,
+    /// Owner of this session.
+    pub owner: SessionOwner,
+    /// Kubernetes namespace of the session.
+    pub namespace: String,
+    /// Target of the session. None for targetless sessions.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target: Option<SessionTarget>,
+    /// CI info when a session is started with `mirrord ci start`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ci_info: Option<SessionCiInfo>,
+    /// Copy target configuration for this session.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub copy_target: Option<SessionCopyTarget>,
+    /// Multi-cluster: name of the parent MirrordMultiClusterSession.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub multi_cluster_parent_name: Option<String>,
+    /// Session key as supplied by the CLI at connect time.
+    /// Consumers (browser extension, dashboard) group sessions by this value.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub key: Option<String>,
+}
+
+/// Resources needed to report session metrics to the mirrord Jira app.
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionJiraMetrics {
+    /// The user's current git branch.
+    pub branch_name: String,
+}
+
+/// Describes copy target configuration for a session.
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionCopyTarget {
+    /// Whether the original target should be scaled down.
+    pub scaledown: bool,
+}
+
+/// Status of a mirrord cluster session.
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct MirrordClusterSessionStatus {
+    /// Last time when the session was observed to have an open user connection.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub connected_timestamp: Option<MicroTime>,
+    /// If the session has been closed, describes the reason.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub closed: Option<SessionClosed>,
+}
+
+/// Describes the reason for which a mirrord session was closed.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionClosed {
+    /// Short reason in PascalCase.
+    pub reason: String,
+    /// Optional human friendly message.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
 }

--- a/mirrord/operator/src/crd/session.rs
+++ b/mirrord/operator/src/crd/session.rs
@@ -134,10 +134,6 @@ impl SessionTarget {
     }
 }
 
-/// Public projection of an active mirrord session, intended for users discovering
-/// joinable sessions. Served by the operator via API aggregation against
-/// `operator.metalbear.co/v1/mirrordsessions`. Never persisted in etcd; the operator
-/// computes the response from its internal session store on every request.
 #[derive(CustomResource, Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
 #[kube(
     group = "operator.metalbear.co",
@@ -191,12 +187,6 @@ pub struct SessionCiInfo {
     pub triggered_by: Option<String>,
 }
 
-/// Mirror of `operator_crd::crd::session::MirrordClusterSession`.
-///
-/// Defined here so the mirrord CLI (and any other client in this repo) can use
-/// `kube::Api<MirrordClusterSession>` without depending on the operator repo.
-/// Wire-compatibility with the operator-side definition is maintained by keeping
-/// this struct's field set and serde attributes in lockstep.
 #[derive(CustomResource, Clone, Debug, Deserialize, Eq, PartialEq, Serialize, JsonSchema)]
 #[kube(
     group = "mirrord.metalbear.co",
@@ -206,83 +196,57 @@ pub struct SessionCiInfo {
 )]
 #[serde(rename_all = "camelCase")]
 pub struct MirrordClusterSessionSpec {
-    /// Resources needed to report session metrics to the mirrord Jira app.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub jira_metrics: Option<SessionJiraMetrics>,
-    /// Owner of this session.
     pub owner: SessionOwner,
-    /// Kubernetes namespace of the session.
     pub namespace: String,
-    /// Target of the session. None for targetless sessions.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub target: Option<SessionTarget>,
-    /// CI info when a session is started with `mirrord ci start`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ci_info: Option<SessionCiInfo>,
-    /// Copy target configuration for this session.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub copy_target: Option<SessionCopyTarget>,
-    /// Multi-cluster: name of the parent MirrordMultiClusterSession.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub multi_cluster_parent_name: Option<String>,
-    /// Session key as supplied by the CLI at connect time.
-    /// Consumers (browser extension, dashboard) group sessions by this value.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub key: Option<String>,
 
-    /// HTTP filter configuration applied by the agent on incoming traffic.
-    /// Surfaced so external consumers (e.g. the browser extension) can derive
-    /// the exact header they need to inject without requiring the developer
-    /// to declare the injection pattern separately.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub http_filter: Option<SessionHttpFilter>,
 }
 
-/// Subset of the CLI's `HttpFilterConfig` stored on the session CR for
-/// external consumers. Only fields the extension can act on are surfaced.
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct SessionHttpFilter {
-    /// Raw `feature.network.incoming.http_filter.header_filter` regex.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub header_filter: Option<String>,
 }
 
-/// Resources needed to report session metrics to the mirrord Jira app.
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct SessionJiraMetrics {
-    /// The user's current git branch.
     pub branch_name: String,
 }
 
-/// Describes copy target configuration for a session.
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct SessionCopyTarget {
-    /// Whether the original target should be scaled down.
     pub scaledown: bool,
 }
 
-/// Status of a mirrord cluster session.
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct MirrordClusterSessionStatus {
-    /// Last time when the session was observed to have an open user connection.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub connected_timestamp: Option<MicroTime>,
-    /// If the session has been closed, describes the reason.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub closed: Option<SessionClosed>,
 }
 
-/// Describes the reason for which a mirrord session was closed.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct SessionClosed {
-    /// Short reason in PascalCase.
     pub reason: String,
-    /// Optional human friendly message.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
 }

--- a/mirrord/operator/src/crd/session.rs
+++ b/mirrord/operator/src/crd/session.rs
@@ -248,31 +248,6 @@ pub struct SessionHttpFilter {
     pub header_filter: Option<String>,
 }
 
-/// Namespaced projection of a CLI-initiated session.
-///
-/// The operator dual-writes this alongside the cluster-scoped
-/// [`MirrordClusterSession`] so external consumers (browser extension,
-/// `mirrord ui`) can discover sessions via RBAC scoped to the target's
-/// namespace, instead of relying on cluster-wide permissions.
-#[derive(CustomResource, Clone, Debug, Deserialize, Eq, PartialEq, Serialize, JsonSchema)]
-#[kube(
-    group = "mirrord.metalbear.co",
-    version = "v1alpha",
-    kind = "MirrordSession",
-    namespaced
-)]
-#[serde(rename_all = "camelCase")]
-pub struct MirrordSessionSpec {
-    pub owner: SessionOwner,
-    pub namespace: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub target: Option<SessionTarget>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub key: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub http_filter: Option<SessionHttpFilter>,
-}
-
 /// Resources needed to report session metrics to the mirrord Jira app.
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]

--- a/mirrord/operator/src/crd/session.rs
+++ b/mirrord/operator/src/crd/session.rs
@@ -248,6 +248,32 @@ pub struct SessionHttpFilter {
     pub header_filter: Option<String>,
 }
 
+/// Namespaced projection of a CLI-initiated session.
+///
+/// The operator dual-writes this alongside the cluster-scoped
+/// [`MirrordClusterSession`] so external consumers (browser extension,
+/// `mirrord ui`) can discover sessions via RBAC scoped to the target's
+/// namespace, instead of relying on cluster-wide permissions.
+#[derive(CustomResource, Clone, Debug, Deserialize, Eq, PartialEq, Serialize, JsonSchema)]
+#[kube(
+    group = "mirrord.metalbear.co",
+    version = "v1alpha",
+    kind = "MirrordSession",
+    namespaced
+)]
+#[serde(rename_all = "camelCase")]
+pub struct MirrordSessionSpec {
+    pub owner: SessionOwner,
+    pub namespace: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target: Option<SessionTarget>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub key: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub http_filter: Option<SessionHttpFilter>,
+    pub cluster_session_name: String,
+}
+
 /// Resources needed to report session metrics to the mirrord Jira app.
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]

--- a/mirrord/operator/src/crd/session.rs
+++ b/mirrord/operator/src/crd/session.rs
@@ -271,7 +271,6 @@ pub struct MirrordSessionSpec {
     pub key: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub http_filter: Option<SessionHttpFilter>,
-    pub cluster_session_name: String,
 }
 
 /// Resources needed to report session metrics to the mirrord Jira app.

--- a/mirrord/operator/src/crd/session.rs
+++ b/mirrord/operator/src/crd/session.rs
@@ -8,6 +8,7 @@ use k8s_openapi::{
         core::v1::{Pod, Service},
     },
 };
+use kube::CustomResource;
 use mirrord_config::target::Target;
 use mirrord_kube::api::kubernetes::rollout::Rollout;
 use schemars::JsonSchema;
@@ -130,6 +131,37 @@ impl SessionTarget {
         .parse()
         .ok()
     }
+}
+
+/// Public projection of an active mirrord session, intended for users discovering
+/// joinable sessions. Served by the operator via API aggregation against
+/// `operator.metalbear.co/v1/mirrordsessions`. Never persisted in etcd; the operator
+/// computes the response from its internal session store on every request.
+#[derive(CustomResource, Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[kube(
+    group = "operator.metalbear.co",
+    version = "v1",
+    kind = "MirrordSession",
+    namespaced
+)]
+#[serde(rename_all = "camelCase")]
+pub struct MirrordSessionSpec {
+    pub owner: SessionOwner,
+
+    pub key: String,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target: Option<SessionTarget>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub http_filter: Option<MirrordSessionHttpFilter>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct MirrordSessionHttpFilter {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub header_filter: Option<String>,
 }
 
 /// Information about the CI session started from `mirrord ci start`.


### PR DESCRIPTION
## Summary

Adds a public `MirrordSession` Resource type to `mirrord-operator` so the operator (in metalbear-co/operator) can serve `mirrordsessions.operator.metalbear.co` via API aggregation rather than as a stored CRD. The CLI's `kube::Api<MirrordSession>` calls work transparently against the aggregated endpoint since the type implements `kube::Resource`.

The type is never persisted in etcd; the operator computes responses from its internal `SessionStore` (which mirrors `MirrordClusterSession`) on every request. This preserves user identity through every request, which is the [team-agreed](https://metalbear.slack.com/archives/C08TYT624SV/p1775646314030139) reason to favor API aggregation over standard CRDs for public resources.

This replaces the previous PR #4198 which took the standard-CRD path.

## Test plan

- [ ] `cargo check -p mirrord-operator --features crd` (already verified locally)
- [ ] Operator-side PR (in metalbear-co/operator) consumes this type and serves `kubectl get mirrordsessions -n <ns>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)