### PR TITLE
make it possible to run the integration tests with the devshell on macos

### DIFF
--- a/changelog.d/+devshell-integration-tests.internal.md
+++ b/changelog.d/+devshell-integration-tests.internal.md
@@ -1,0 +1,1 @@
+Added integration-test packages, `cargo-nextest`, and `cargo-shear` to the Nix shell.

--- a/flake.nix
+++ b/flake.nix
@@ -77,8 +77,20 @@
               rustToolchain.rust-analyzer
               rustPlatform.bindgenHook
 
-              # Wizard
-              nodejs_25
+              # Frontends
+              pnpm
+
+              # Integration tests
+              cargo-nextest
+              go
+              nodejs # Install required libraries with `npm install express portfinder --no-save` after entering the devshell.
+              (python3.withPackages (
+                pypkgs: with pypkgs; [
+                  fastapi
+                  flask
+                  uvicorn
+                ]
+              ))
 
               # Release
               python3Packages.towncrier

--- a/mirrord/layer-tests/tests/apps/env_bash_cat.sh
+++ b/mirrord/layer-tests/tests/apps/env_bash_cat.sh
@@ -12,6 +12,6 @@
 # 5. bash executes cat, mirrrord intercepts that call, makes a SIP-free version of cat and executes that one instead.
 
 # cat is a SIPed binary on mac.
-cat /very_interesting_file
+/bin/cat /very_interesting_file
 # sleep so we get close request (else bash might exit before we have time to close it)
 sleep 1

--- a/mirrord/layer-tests/tests/apps/node_spawn.mjs
+++ b/mirrord/layer-tests/tests/apps/node_spawn.mjs
@@ -6,7 +6,7 @@ const asyncExec = promisify(exec);
 
 async function run() {
   try {
-    const { stdout, stderr } = await asyncExec('cat /app/test.txt');
+    const { stdout, stderr } = await asyncExec('/bin/cat /app/test.txt');
 
     console.log(stdout);
     if (stderr) {

--- a/mirrord/layer-tests/tests/fileops.rs
+++ b/mirrord/layer-tests/tests/fileops.rs
@@ -71,7 +71,7 @@ async fn read_from_mirrord_bin() {
     // Make sure we write and read from different paths (this is "meta check").
     assert_ne!(file_path, path_in_mirrord_bin);
 
-    let executable = sip_patch("cat", SipPatchOptions::default(), None)
+    let executable = sip_patch("/bin/cat", SipPatchOptions::default(), None)
         .unwrap()
         .unwrap();
 


### PR DESCRIPTION
<!-- Thank you for contributing to mirrord! -->
<!-- Please use the checklist below as a guide for docs, tests and admin tasks for your PR -->
<!-- Feel free to ~strikethrough~ any items that you don't think apply -->

This only required adding the relevant packages to the devshell and forcing the tests to use the system `cat` instead of grabbing it from `$PATH`, which is problematic in this case. See the first commit's description for a bit more context.

### Quality Checklist:

- [x] I have documented new code sufficiently
- [x] I have checked and updated the relevant existing docs in code, including removing outdated material
- [-] I have written user-facing website docs for new features, or opened a (sub)issue to do so
- [-] I have checked and updated existing website docs for changed features
- [x] I have tested this change and know it succeeds and fails as expected
- [x] I have written unit tests or purposefully omitted them
- [x] I have written e2e tests or purposefully omitted them
- [x] I have explained what this PR introduces and why, and linked to relevant context (e.g. linear issues, related PRs,
  documentation)
- [x] I have introduced a short, clear and well-formatted changelog entry

<!-- need help with the changelog? see ../CONTRIBUTING.md#submitting-a-pull-request -->
<!-- Add more details of your changes below if needed -->
