### PR TITLE
Add `feature.network.incoming.raw_tcp_ports`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5152,7 +5152,7 @@ dependencies = [
 
 [[package]]
 name = "mirrord-protocol"
-version = "1.26.3"
+version = "1.27.0"
 dependencies = [
  "actix-codec",
  "bincode",

--- a/changelog.d/+raw-tcp-ports.added.md
+++ b/changelog.d/+raw-tcp-ports.added.md
@@ -1,0 +1,1 @@
+Added `feature.network.incoming.raw_tcp_ports` for raw TCP steal ports that should bypass HTTP detection and TLS handling.

--- a/mirrord-schema.json
+++ b/mirrord-schema.json
@@ -2404,6 +2404,20 @@
             "minimum": 0
           }
         },
+        "raw_tcp_ports": {
+          "title": "raw_tcp_ports",
+          "description": "Ports to steal as raw TCP. Incoming connections on these ports bypass HTTP detection and\nTLS handling, so they are forwarded immediately to the local application.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "integer",
+            "format": "uint16",
+            "maximum": 65535,
+            "minimum": 0
+          }
+        },
         "tls_delivery": {
           "title": "tls_delivery",
           "description": "(Operator Only): configures how mirrord delivers stolen TLS traffic\nto the local application.",

--- a/mirrord/agent/src/incoming.rs
+++ b/mirrord/agent/src/incoming.rs
@@ -29,6 +29,15 @@ pub use steal_handle::{StealHandle, StolenTraffic};
 pub use task::{RedirectorTask, RedirectorTaskConfig};
 use tokio::net::TcpStream;
 
+/// Port-wide handling mode for redirected incoming connections.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum IncomingPortMode {
+    /// Use the normal incoming path: apply configured TLS handling and detect HTTP traffic.
+    Detect,
+    /// Forward bytes immediately as raw TCP, bypassing HTTP detection and TLS handling.
+    RawTcp,
+}
+
 /// A component that implements redirecting incoming TCP connections.
 pub trait PortRedirector {
     type Error: Sized;

--- a/mirrord/agent/src/incoming/connection.rs
+++ b/mirrord/agent/src/incoming/connection.rs
@@ -159,6 +159,32 @@ impl MaybeHttp {
     /// Timeout for detemining if the redirected connection is HTTP.
     pub const HTTP_DETECTION_TIMEOUT: Duration = Duration::from_secs(10);
 
+    /// Wraps the given redirected connection as raw TCP.
+    ///
+    /// Used when the port is known to carry raw TCP traffic, avoiding the detection timeout
+    /// that would stall server-first protocols (e.g. SMTP, FTP).
+    pub fn accept_raw_tcp(redirected: Redirected) -> Result<Self, HttpDetectError> {
+        let metric_guard = MetricGuard::new(&REDIRECTED_CONNECTIONS);
+        let local_addr = redirected
+            .stream
+            .local_addr()
+            .map_err(HttpDetectError::LocalAddr)?;
+
+        Ok(Self {
+            info: ConnectionInfo {
+                original_destination: redirected.destination,
+                local_addr,
+                peer_addr: redirected.source,
+                tls_connector: None,
+            },
+            http_version: None,
+            stream: Box::new(IncomingIoWrapper {
+                io: redirected.stream,
+                _metric_guard: metric_guard,
+            }),
+        })
+    }
+
     /// Accepts the (possibly TLS) connection and detects if the redirected connection is
     /// HTTP.
     pub async fn detect(

--- a/mirrord/agent/src/incoming/steal_handle.rs
+++ b/mirrord/agent/src/incoming/steal_handle.rs
@@ -9,6 +9,7 @@ use tokio_stream::{StreamMap, StreamNotifyClose, wrappers::ReceiverStream};
 use tokio_util::sync::CancellationToken;
 
 use super::{
+    IncomingPortMode,
     connection::{ConnectionInfo, http::RedirectedHttp, tcp::RedirectedTcp},
     error::RedirectorTaskError,
     task::{RedirectRequest, TaskError},
@@ -47,7 +48,11 @@ impl StealHandle {
     /// If this method returns [`Ok`], it means that the port redirection
     /// was done in the [`RedirectorTask`](super::RedirectorTask),
     /// and incoming connections are now being stolen.
-    pub async fn steal(&mut self, port: u16) -> Result<(), RedirectorTaskError> {
+    pub async fn steal(
+        &mut self,
+        port: u16,
+        mode: IncomingPortMode,
+    ) -> Result<(), RedirectorTaskError> {
         if self.stolen_ports.contains_key(&port) {
             return Ok(());
         };
@@ -55,7 +60,11 @@ impl StealHandle {
         let (receiver_tx, receiver_rx) = oneshot::channel();
         if self
             .message_tx
-            .send(RedirectRequest::Steal { port, receiver_tx })
+            .send(RedirectRequest::Steal {
+                port,
+                mode,
+                receiver_tx,
+            })
             .await
             .is_err()
         {

--- a/mirrord/agent/src/incoming/task.rs
+++ b/mirrord/agent/src/incoming/task.rs
@@ -20,7 +20,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::Level;
 
 use super::{
-    PortRedirector, Redirected,
+    IncomingPortMode, PortRedirector, Redirected,
     connection::{ConnectionInfo, MaybeHttp, http::RedirectedHttp, tcp::RedirectedTcp},
     error::RedirectorTaskError,
     steal_handle::{StealHandle, StolenTraffic},
@@ -173,17 +173,21 @@ where
             let tx = self.internal_tx.clone();
             let tls_store = self.tls_store.clone();
             let shutdown = state.shutdown.child_token();
+            let port_mode = state.mode;
             Self::spawn_tracked_connection(
                 self.internal_tx.clone(),
                 destination.port(),
                 state,
                 async move {
-                    let detection_result = tokio::select! {
-                        r = MaybeHttp::detect(conn, &tls_store) => r,
-                        _ = shutdown.cancelled() => {
-                            tracing::debug!("Shutting down redirected connection during HTTP detection");
-                            return;
-                        }
+                    let detection_result = match port_mode {
+                        IncomingPortMode::Detect => tokio::select! {
+                            r = MaybeHttp::detect(conn, &tls_store) => r,
+                            _ = shutdown.cancelled() => {
+                                tracing::debug!("Shutting down redirected connection during HTTP detection");
+                                return;
+                            }
+                        },
+                        IncomingPortMode::RawTcp => MaybeHttp::accept_raw_tcp(conn),
                     };
 
                     match detection_result {
@@ -397,10 +401,13 @@ where
                             mirror_txs: vec![conn_tx.clone()],
                             shutdown: Default::default(),
                             connections: Default::default(),
+                            mode: IncomingPortMode::Detect,
                         });
                     }
                     Entry::Occupied(mut e) => {
-                        e.get_mut().mirror_txs.push(conn_tx.clone());
+                        let state = e.get_mut();
+                        state.warn_on_mode_conflict(port, IncomingPortMode::Detect, "mirroring");
+                        state.mirror_txs.push(conn_tx.clone());
                     }
                 };
 
@@ -413,13 +420,18 @@ where
                 let _ = receiver_tx.send(conn_rx);
             }
 
-            RedirectRequest::Steal { port, receiver_tx } => {
+            RedirectRequest::Steal {
+                port,
+                mode,
+                receiver_tx,
+            } => {
                 let (conn_tx, conn_rx) = mpsc::channel(32);
 
                 match self.ports.entry(port) {
                     Entry::Vacant(e) => {
                         tracing::debug!(
                             from_port = port,
+                            ?mode,
                             "Creating a new port redirection for a stealing client"
                         );
                         self.redirector.add_redirection(port).await?;
@@ -428,10 +440,13 @@ where
                             mirror_txs: Default::default(),
                             shutdown: Default::default(),
                             connections: Default::default(),
+                            mode,
                         });
                     }
                     Entry::Occupied(mut e) => {
-                        e.get_mut().steal_tx.replace(conn_tx.clone());
+                        let state = e.get_mut();
+                        state.steal_tx.replace(conn_tx.clone());
+                        state.warn_on_mode_conflict(port, mode, "stealing");
                     }
                 }
 
@@ -584,6 +599,7 @@ pub type MirroredConnectionsRx = mpsc::Receiver<MirroredTraffic>;
 pub enum RedirectRequest {
     Steal {
         port: u16,
+        mode: IncomingPortMode,
         receiver_tx: oneshot::Sender<StolenConnectionsRx>,
     },
     Mirror {
@@ -599,9 +615,10 @@ impl fmt::Debug for RedirectRequest {
                 .debug_struct("Mirror")
                 .field("port", port)
                 .finish_non_exhaustive(),
-            Self::Steal { port, .. } => f
+            Self::Steal { port, mode, .. } => f
                 .debug_struct("Steal")
                 .field("port", port)
+                .field("mode", mode)
                 .finish_non_exhaustive(),
         }
     }
@@ -663,6 +680,11 @@ struct PortState {
     shutdown: CancellationToken,
     /// Used to track connection IO tasks and wait for their graceful shutdown.
     connections: JoinSet<()>,
+    /// How incoming connections for this port should be handled before delivery.
+    ///
+    /// This is shared port-wide. The mode chosen by the subscriber that creates the redirection
+    /// wins for the lifetime of that redirection.
+    mode: IncomingPortMode,
 }
 
 impl fmt::Debug for PortState {
@@ -676,11 +698,24 @@ impl fmt::Debug for PortState {
                     .is_some_and(|tx| tx.is_closed().not()),
             )
             .field("mirrorers", &self.mirror_txs.len())
+            .field("mode", &self.mode)
             .finish()
     }
 }
 
 impl PortState {
+    fn warn_on_mode_conflict(&self, port: u16, requested_mode: IncomingPortMode, subscriber: &str) {
+        if self.mode != requested_mode {
+            tracing::warn!(
+                from_port = port,
+                existing_mode = ?self.mode,
+                ?requested_mode,
+                subscriber,
+                "Port is already redirected with a different incoming mode; keeping existing mode",
+            );
+        }
+    }
+
     /// Tell and wait for all connections to gracefully shut down.
     /// This function is essentially `AsyncDrop`, and it should always
     /// be called before removing the redirection.
@@ -708,7 +743,8 @@ mod test {
     };
 
     use crate::incoming::{
-        RedirectorTask, RedirectorTaskConfig, StolenTraffic, test::DummyRedirector,
+        IncomingPortMode, MirroredTraffic, RedirectorTask, RedirectorTaskConfig, StolenTraffic,
+        test::DummyRedirector,
     };
 
     #[rstest]
@@ -729,7 +765,7 @@ mod test {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let port = listener.local_addr().unwrap().port();
 
-        handle.steal(port).await.unwrap();
+        handle.steal(port, IncomingPortMode::Detect).await.unwrap();
         assert!(state.borrow().has_redirections([port]));
 
         let mut tcp = tx.make_connection(listener.local_addr().unwrap()).await;
@@ -818,7 +854,7 @@ mod test {
         );
         tokio::spawn(task.run());
 
-        handle.steal(80).await.unwrap();
+        handle.steal(80, IncomingPortMode::Detect).await.unwrap();
         assert!(state.borrow().has_redirections([80]));
 
         handle.stop_steal(80);
@@ -827,7 +863,7 @@ mod test {
             .await
             .unwrap();
 
-        handle.steal(81).await.unwrap();
+        handle.steal(81, IncomingPortMode::Detect).await.unwrap();
         assert!(state.borrow().has_redirections([81]));
 
         std::mem::drop(handle);
@@ -835,6 +871,76 @@ mod test {
             .wait_for(|state| state.has_redirections([]))
             .await
             .unwrap();
+    }
+
+    #[rstest]
+    #[timeout(Duration::from_secs(5))]
+    #[tokio::test]
+    async fn mirror_detection_survives_later_raw_tcp_steal() {
+        let (redirector, _state, mut conn_tx) = DummyRedirector::new();
+        let (task, mut steal_handle, mut mirror_handle) = RedirectorTask::new(
+            redirector,
+            Default::default(),
+            RedirectorTaskConfig::from_env(),
+        );
+        tokio::spawn(task.run());
+
+        mirror_handle.mirror(80).await.unwrap();
+        steal_handle
+            .steal(80, IncomingPortMode::RawTcp)
+            .await
+            .unwrap();
+
+        let mut client_conn = conn_tx
+            .make_connection("127.0.0.1:80".parse().unwrap())
+            .await;
+        client_conn
+            .write_all(b"GET / HTTP/1.1\r\nHost: example.com\r\n\r\n")
+            .await
+            .unwrap();
+
+        let MirroredTraffic::Http(_) = mirror_handle.next().await.unwrap().unwrap() else {
+            panic!("mirror subscriber lost HTTP detection mode");
+        };
+        let StolenTraffic::Http(_) = steal_handle.next().await.unwrap().unwrap() else {
+            panic!("steal subscriber lost HTTP detection mode");
+        };
+    }
+
+    #[rstest]
+    #[timeout(Duration::from_secs(5))]
+    #[tokio::test]
+    async fn raw_tcp_steal_mode_survives_later_mirror() {
+        let (redirector, _state, mut conn_tx) = DummyRedirector::new();
+        let (task, mut steal_handle, mut mirror_handle) = RedirectorTask::new(
+            redirector,
+            Default::default(),
+            RedirectorTaskConfig::from_env(),
+        );
+        tokio::spawn(task.run());
+
+        steal_handle
+            .steal(80, IncomingPortMode::RawTcp)
+            .await
+            .unwrap();
+        mirror_handle.mirror(80).await.unwrap();
+
+        let mut client_conn = conn_tx
+            .make_connection("127.0.0.1:80".parse().unwrap())
+            .await;
+        client_conn
+            .write_all(b"GET / HTTP/1.1\r\nHost: example.com\r\n\r\n")
+            .await
+            .unwrap();
+
+        let MirroredTraffic::Tcp(_) = mirror_handle.next().await.unwrap().unwrap() else {
+            panic!("mirror subscriber changed raw TCP steal mode");
+        };
+        let StolenTraffic::Tcp { join_handle_tx, .. } = steal_handle.next().await.unwrap().unwrap()
+        else {
+            panic!("steal subscriber changed raw TCP steal mode");
+        };
+        join_handle_tx.send(tokio::spawn(async {})).unwrap();
     }
 
     /// Regression test for a bug with HTTP graceful shutdown.
@@ -856,7 +962,7 @@ mod test {
         );
         let redirector_task = tokio::spawn(task.run());
 
-        handle.steal(80).await.unwrap();
+        handle.steal(80, IncomingPortMode::Detect).await.unwrap();
         let client_conn = conn_tx
             .make_connection("127.0.0.1:80".parse().unwrap())
             .await;

--- a/mirrord/agent/src/steal.rs
+++ b/mirrord/agent/src/steal.rs
@@ -1,9 +1,9 @@
-use mirrord_protocol::{LogMessage, Port};
+use mirrord_protocol::{LogMessage, Port, RemoteResult};
 use tokio::sync::mpsc::Sender;
 
 use crate::{
     http::filter::HttpFilter,
-    incoming::{StolenHttp, StolenTcp},
+    incoming::{IncomingPortMode, StolenHttp, StolenTcp},
     util::{ClientId, protocol_version::ClientProtocolVersion},
 };
 
@@ -28,8 +28,8 @@ enum Command {
 
     /// The layer wants to subscribe to this [`Port`].
     ///
-    /// The agent starts stealing traffic from this [`Port`].
-    PortSubscribe(Port, Option<HttpFilter>),
+    /// The agent starts stealing traffic from this [`Port`] with the requested incoming mode.
+    PortSubscribe(Port, Option<HttpFilter>, IncomingPortMode),
 
     /// The layer wants to unsubscribe from this [`Port`].
     ///
@@ -51,5 +51,5 @@ enum StealerMessage {
     StolenTcp(StolenTcp),
     StolenHttp(StolenHttp),
     Log(LogMessage),
-    PortSubscribed(Port),
+    PortSubscribeResult(RemoteResult<Port>),
 }

--- a/mirrord/agent/src/steal/api.rs
+++ b/mirrord/agent/src/steal/api.rs
@@ -31,8 +31,8 @@ use crate::{
     error::AgentResult,
     http::{MIRRORD_AGENT_HTTP_HEADER_NAME, filter::HttpFilter},
     incoming::{
-        ConnError, IncomingStream, IncomingStreamItem, RedirectorTaskConfig, ResponseBodyProvider,
-        ResponseProvider, StolenHttp, StolenTcp,
+        ConnError, IncomingPortMode, IncomingStream, IncomingStreamItem, RedirectorTaskConfig,
+        ResponseBodyProvider, ResponseProvider, StolenHttp, StolenTcp,
     },
     steal::api::wait_body::WaitForFullBody,
     task::status::BgTaskStatus,
@@ -163,8 +163,8 @@ impl TcpStealerApi {
                         StealerMessage::Log(log) => {
                             break Ok(DaemonMessage::LogMessage(log));
                         },
-                        StealerMessage::PortSubscribed(port) => {
-                            break Ok(DaemonMessage::TcpSteal(DaemonTcp::SubscribeResult(Ok(port))));
+                        StealerMessage::PortSubscribeResult(result) => {
+                            break Ok(DaemonMessage::TcpSteal(DaemonTcp::SubscribeResult(result)));
                         },
                         StealerMessage::StolenHttp(http) => self.handle_request(http)?,
                         StealerMessage::StolenTcp(tcp) => self.handle_connection(tcp)?,
@@ -490,8 +490,9 @@ impl TcpStealerApi {
     ) -> AgentResult<()> {
         match message {
             LayerTcpSteal::PortSubscribe(steal_type) => {
-                let (port, filter) = match steal_type {
-                    StealType::All(port) => (port, None),
+                let (port, filter, mode) = match steal_type {
+                    StealType::All(port) => (port, None, IncomingPortMode::Detect),
+                    StealType::AllRawTcp(port) => (port, None, IncomingPortMode::RawTcp),
                     StealType::FilteredHttp(port, filter) => (
                         port,
                         Some(
@@ -501,6 +502,7 @@ impl TcpStealerApi {
                             .map_err(Box::new)
                             .map_err(AgentError::InvalidHttpFilter)?,
                         ),
+                        IncomingPortMode::Detect,
                     ),
                     StealType::FilteredHttpEx(port, filter) => (
                         port,
@@ -509,10 +511,11 @@ impl TcpStealerApi {
                                 .map_err(Box::new)
                                 .map_err(AgentError::InvalidHttpFilter)?,
                         ),
+                        IncomingPortMode::Detect,
                     ),
                 };
 
-                self.send_command(Command::PortSubscribe(port, filter))
+                self.send_command(Command::PortSubscribe(port, filter, mode))
                     .await?;
             }
 

--- a/mirrord/agent/src/steal/subscriptions.rs
+++ b/mirrord/agent/src/steal/subscriptions.rs
@@ -5,11 +5,12 @@ use std::{
     sync::atomic::Ordering,
 };
 
+use mirrord_protocol::{RemoteResult, ResponseError};
 use tracing::Level;
 
 use crate::{
     http::filter::HttpFilter,
-    incoming::{RedirectorTaskError, StealHandle, StolenTraffic},
+    incoming::{IncomingPortMode, RedirectorTaskError, StealHandle, StolenTraffic},
     metrics::{STEAL_FILTERED_PORT_SUBSCRIPTION, STEAL_UNFILTERED_PORT_SUBSCRIPTION},
     util::ClientId,
 };
@@ -26,7 +27,7 @@ pub struct PortSubscriptions {
 
 impl Drop for PortSubscriptions {
     fn drop(&mut self) {
-        let (filtered, unfiltered) =
+        let (unfiltered, filtered) =
             self.subscriptions
                 .values()
                 .fold(
@@ -78,53 +79,77 @@ impl PortSubscriptions {
     /// * `client_id` - identifier of the client that issued the subscription
     /// * `port` - number of the port to steal from
     /// * `filter` - optional [`HttpFilter`]
+    /// * `mode` - how redirected connections should be handled before delivery
     #[tracing::instrument(level = Level::DEBUG, err(level = Level::DEBUG))]
     pub async fn add(
         &mut self,
         client_id: ClientId,
         port: u16,
         filter: Option<HttpFilter>,
-    ) -> Result<(), RedirectorTaskError> {
+        mode: IncomingPortMode,
+    ) -> Result<RemoteResult<()>, RedirectorTaskError> {
+        let requested_mode = if filter.is_some() {
+            IncomingPortMode::Detect
+        } else {
+            mode
+        };
+
         let replaced = match self.subscriptions.entry(port) {
-            Entry::Occupied(mut e) => match (e.get_mut(), filter) {
-                (PortSubscription::Unfiltered(..), Some(filter)) => {
-                    STEAL_UNFILTERED_PORT_SUBSCRIPTION.fetch_sub(1, Ordering::Relaxed);
-                    STEAL_FILTERED_PORT_SUBSCRIPTION.fetch_add(1, Ordering::Relaxed);
-                    e.insert(PortSubscription::Filtered([(client_id, filter)].into()));
-                    true
+            Entry::Occupied(mut e) => {
+                let prev_mode = e.get().mode();
+
+                if prev_mode != requested_mode {
+                    tracing::warn!(
+                        port,
+                        ?prev_mode,
+                        ?requested_mode,
+                        "Port is already subscribed with a different incoming mode",
+                    );
+
+                    return Ok(Err(ResponseError::PortAlreadyStolen(port)));
                 }
 
-                (PortSubscription::Unfiltered(..), None) => {
-                    e.insert(PortSubscription::Unfiltered(client_id));
-                    true
-                }
+                match (e.get_mut(), filter) {
+                    (PortSubscription::Unfiltered(..), Some(filter)) => {
+                        STEAL_UNFILTERED_PORT_SUBSCRIPTION.fetch_sub(1, Ordering::Relaxed);
+                        STEAL_FILTERED_PORT_SUBSCRIPTION.fetch_add(1, Ordering::Relaxed);
+                        e.insert(PortSubscription::Filtered([(client_id, filter)].into()));
+                        true
+                    }
 
-                (PortSubscription::Filtered(filters), Some(filter)) => {
-                    match filters.insert(client_id, filter) {
-                        Some(..) => true,
-                        None => {
-                            STEAL_FILTERED_PORT_SUBSCRIPTION.fetch_add(1, Ordering::Relaxed);
-                            false
+                    (PortSubscription::Unfiltered(..), None) => {
+                        e.insert(PortSubscription::Unfiltered(client_id, mode));
+                        true
+                    }
+
+                    (PortSubscription::Filtered(filters), Some(filter)) => {
+                        match filters.insert(client_id, filter) {
+                            Some(..) => true,
+                            None => {
+                                STEAL_FILTERED_PORT_SUBSCRIPTION.fetch_add(1, Ordering::Relaxed);
+                                false
+                            }
                         }
                     }
-                }
 
-                (PortSubscription::Filtered(filters), None) => {
-                    STEAL_FILTERED_PORT_SUBSCRIPTION.fetch_sub(filters.len(), Ordering::Relaxed);
-                    STEAL_UNFILTERED_PORT_SUBSCRIPTION.fetch_add(filters.len(), Ordering::Relaxed);
-                    e.insert(PortSubscription::Unfiltered(client_id));
-                    true
+                    (PortSubscription::Filtered(filters), None) => {
+                        STEAL_FILTERED_PORT_SUBSCRIPTION
+                            .fetch_sub(filters.len(), Ordering::Relaxed);
+                        STEAL_UNFILTERED_PORT_SUBSCRIPTION.fetch_add(1, Ordering::Relaxed);
+                        e.insert(PortSubscription::Unfiltered(client_id, mode));
+                        true
+                    }
                 }
-            },
+            }
 
             Entry::Vacant(e) => {
-                self.handle.steal(port).await?;
+                self.handle.steal(port, mode).await?;
                 if filter.is_some() {
                     STEAL_FILTERED_PORT_SUBSCRIPTION.fetch_add(1, Ordering::Relaxed);
                 } else {
                     STEAL_UNFILTERED_PORT_SUBSCRIPTION.fetch_add(1, Ordering::Relaxed);
                 }
-                e.insert(PortSubscription::new(client_id, filter));
+                e.insert(PortSubscription::new(client_id, filter, mode));
                 false
             }
         };
@@ -134,7 +159,7 @@ impl PortSubscriptions {
             tracing::debug!("An existing port subscription was evicted.");
         }
 
-        Ok(())
+        Ok(Ok(()))
     }
 
     /// Remove a subscription from this set, if it exists.
@@ -150,7 +175,9 @@ impl PortSubscriptions {
         };
 
         match e.get_mut() {
-            PortSubscription::Unfiltered(subscribed_client) if *subscribed_client == client_id => {
+            PortSubscription::Unfiltered(subscribed_client, ..)
+                if *subscribed_client == client_id =>
+            {
                 e.remove();
                 STEAL_UNFILTERED_PORT_SUBSCRIPTION
                     .fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
@@ -181,7 +208,7 @@ impl PortSubscriptions {
     pub fn remove_all(&mut self, client_id: ClientId) {
         self.subscriptions
             .retain(|port, subscription| match subscription {
-                PortSubscription::Unfiltered(subscribed_client)
+                PortSubscription::Unfiltered(subscribed_client, ..)
                     if *subscribed_client == client_id =>
                 {
                     STEAL_UNFILTERED_PORT_SUBSCRIPTION
@@ -240,7 +267,9 @@ pub enum PortSubscription {
     /// No filter, incoming connections are stolen whole on behalf of the client.
     ///
     /// Belongs to a single client.
-    Unfiltered(ClientId),
+    ///
+    /// The mode chosen when the unfiltered subscription was accepted.
+    Unfiltered(ClientId, IncomingPortMode),
     /// Only HTTP requests matching one of the [`HttpFilter`]s should be stolen (on behalf of the
     /// filter owner).
     ///
@@ -250,19 +279,31 @@ pub enum PortSubscription {
 
 impl PortSubscription {
     /// Create a new instance. Variant is picked based on the optional `filter`.
-    fn new(client_id: ClientId, filter: Option<HttpFilter>) -> Self {
+    fn new(client_id: ClientId, filter: Option<HttpFilter>, mode: IncomingPortMode) -> Self {
         match filter {
             Some(filter) => Self::Filtered(HashMap::from_iter([(client_id, filter)])),
-            None => Self::Unfiltered(client_id),
+            None => Self::Unfiltered(client_id, mode),
+        }
+    }
+
+    /// Returns the effective incoming mode for this subscription.
+    ///
+    /// Filtered subscriptions always imply normal detection.
+    pub fn mode(&self) -> IncomingPortMode {
+        match self {
+            Self::Unfiltered(_, mode) => *mode,
+            Self::Filtered(_) => IncomingPortMode::Detect,
         }
     }
 }
 
 #[cfg(test)]
 mod test {
+    use mirrord_protocol::ResponseError;
+
     use crate::{
         http::filter::HttpFilter,
-        incoming::{RedirectorTask, RedirectorTaskConfig, test::DummyRedirector},
+        incoming::{IncomingPortMode, RedirectorTask, RedirectorTaskConfig, test::DummyRedirector},
         steal::subscriptions::{PortSubscription, PortSubscriptions},
         util::ClientId,
     };
@@ -272,7 +313,7 @@ mod test {
         fn has_client(&self, client_id: ClientId) -> bool {
             match self {
                 Self::Filtered(filters) => filters.contains_key(&client_id),
-                Self::Unfiltered(subscribed_client) => *subscribed_client == client_id,
+                Self::Unfiltered(subscribed_client, ..) => *subscribed_client == client_id,
             }
         }
     }
@@ -293,21 +334,42 @@ mod test {
         let mut subscriptions = PortSubscriptions::new(steal_handle);
 
         // Adding unfiltered subscription.
-        subscriptions.add(0, 80, None).await.unwrap();
+        subscriptions
+            .add(0, 80, None, IncomingPortMode::Detect)
+            .await
+            .unwrap()
+            .unwrap();
         assert!(state.borrow().has_redirections([80]));
         let sub = subscriptions.subscriptions.get(&80).unwrap();
-        assert!(matches!(sub, PortSubscription::Unfiltered(0)), "{sub:?}");
+        assert!(
+            matches!(
+                sub,
+                PortSubscription::Unfiltered(0, IncomingPortMode::Detect)
+            ),
+            "{sub:?}"
+        );
 
         // Another client's subscription should overwrite.
-        subscriptions.add(1, 80, None).await.unwrap();
+        subscriptions
+            .add(1, 80, None, IncomingPortMode::Detect)
+            .await
+            .unwrap()
+            .unwrap();
         assert!(state.borrow().has_redirections([80]));
         let sub = subscriptions.subscriptions.get(&80).unwrap();
-        assert!(matches!(sub, PortSubscription::Unfiltered(1)), "{sub:?}");
+        assert!(
+            matches!(
+                sub,
+                PortSubscription::Unfiltered(1, IncomingPortMode::Detect)
+            ),
+            "{sub:?}"
+        );
 
         // Same client's next subscription should overwrite.
         subscriptions
-            .add(1, 80, Some(dummy_filter()))
+            .add(1, 80, Some(dummy_filter()), IncomingPortMode::Detect)
             .await
+            .unwrap()
             .unwrap();
         assert!(state.borrow().has_redirections([80]));
         let sub = subscriptions.subscriptions.get(&80).unwrap();
@@ -329,6 +391,36 @@ mod test {
     }
 
     #[tokio::test]
+    async fn reject_mode_change_for_existing_subscription() {
+        let (redirector, _state, _tx) = DummyRedirector::new();
+        let (redirector_task, steal_handle, _) = RedirectorTask::new(
+            redirector,
+            Default::default(),
+            RedirectorTaskConfig::from_env(),
+        );
+        tokio::spawn(redirector_task.run());
+        let mut subscriptions = PortSubscriptions::new(steal_handle);
+
+        subscriptions
+            .add(0, 80, Some(dummy_filter()), IncomingPortMode::Detect)
+            .await
+            .unwrap()
+            .unwrap();
+
+        let result = subscriptions
+            .add(1, 80, None, IncomingPortMode::RawTcp)
+            .await
+            .unwrap();
+
+        assert!(matches!(result, Err(ResponseError::PortAlreadyStolen(80))));
+        let sub = subscriptions.subscriptions.get(&80).unwrap();
+        assert!(
+            matches!(sub, PortSubscription::Filtered(filters) if filters.len() == 1 && sub.has_client(0)),
+            "{sub:?}"
+        );
+    }
+
+    #[tokio::test]
     async fn multiple_subscriptions_multiple_ports() {
         let (redirector, mut state, _tx) = DummyRedirector::new();
         let (redirector_task, steal_handle, _) = RedirectorTask::new(
@@ -340,19 +432,30 @@ mod test {
         let mut subscriptions = PortSubscriptions::new(steal_handle);
 
         // Adding unfiltered subscription for port 80.
-        subscriptions.add(0, 80, None).await.unwrap();
+        subscriptions
+            .add(0, 80, None, IncomingPortMode::Detect)
+            .await
+            .unwrap()
+            .unwrap();
 
         // Adding filtered subscription for port 81.
         subscriptions
-            .add(1, 81, Some(dummy_filter()))
+            .add(1, 81, Some(dummy_filter()), IncomingPortMode::Detect)
             .await
+            .unwrap()
             .unwrap();
 
         // Checking state.
         assert!(state.borrow().has_redirections([80, 81]));
         let sub = subscriptions.subscriptions.get(&80).unwrap();
         assert!(sub.has_client(0));
-        assert!(matches!(sub, PortSubscription::Unfiltered(0)), "{sub:?}");
+        assert!(
+            matches!(
+                sub,
+                PortSubscription::Unfiltered(0, IncomingPortMode::Detect)
+            ),
+            "{sub:?}"
+        );
         let sub = subscriptions.subscriptions.get(&81).unwrap();
         assert!(sub.has_client(1));
         assert!(
@@ -387,19 +490,30 @@ mod test {
         let mut subscriptions = PortSubscriptions::new(steal_handle);
 
         // Adding unfiltered subscription for port 80.
-        subscriptions.add(0, 80, None).await.unwrap();
+        subscriptions
+            .add(0, 80, None, IncomingPortMode::Detect)
+            .await
+            .unwrap()
+            .unwrap();
 
         // Adding filtered subscription for port 81.
         subscriptions
-            .add(0, 81, Some(dummy_filter()))
+            .add(0, 81, Some(dummy_filter()), IncomingPortMode::Detect)
             .await
+            .unwrap()
             .unwrap();
 
         // Checking state.
         assert!(state.borrow().has_redirections([80, 81]));
         let sub = subscriptions.subscriptions.get(&80).unwrap();
         assert!(sub.has_client(0));
-        assert!(matches!(sub, PortSubscription::Unfiltered(0)), "{sub:?}");
+        assert!(
+            matches!(
+                sub,
+                PortSubscription::Unfiltered(0, IncomingPortMode::Detect)
+            ),
+            "{sub:?}"
+        );
         let sub = subscriptions.subscriptions.get(&81).unwrap();
         assert!(sub.has_client(0));
         assert!(

--- a/mirrord/agent/src/steal/task.rs
+++ b/mirrord/agent/src/steal/task.rs
@@ -171,7 +171,7 @@ impl TcpStealerTask {
             }
 
             (
-                PortSubscription::Unfiltered(client_id),
+                PortSubscription::Unfiltered(client_id, ..),
                 StolenTraffic::Tcp {
                     conn,
                     join_handle_tx,
@@ -213,7 +213,7 @@ impl TcpStealerTask {
                 return;
             }
 
-            (PortSubscription::Unfiltered(client_id), StolenTraffic::Http(http)) => {
+            (PortSubscription::Unfiltered(client_id, ..), StolenTraffic::Http(http)) => {
                 let Some(client) = clients.get(client_id) else {
                     tracing::error!(
                         client_id,
@@ -342,19 +342,24 @@ impl TcpStealerTask {
                 });
             }
 
-            Command::PortSubscribe(port, filter) => {
-                let Some(client) = self.clients.get(&command.client_id) else {
+            Command::PortSubscribe(port, filter, mode) => {
+                let Some(message_tx) = self
+                    .clients
+                    .get(&command.client_id)
+                    .map(|client| client.message_tx.clone())
+                else {
                     // The client disconnected after sending the message.
                     return Ok(());
                 };
 
-                self.subscriptions
-                    .add(command.client_id, port, filter)
-                    .await?;
+                let result = self
+                    .subscriptions
+                    .add(command.client_id, port, filter, mode)
+                    .await?
+                    .map(|()| port);
 
-                let _ = client
-                    .message_tx
-                    .send(StealerMessage::PortSubscribed(port))
+                let _ = message_tx
+                    .send(StealerMessage::PortSubscribeResult(result))
                     .await;
             }
 

--- a/mirrord/cli/src/port_forward.rs
+++ b/mirrord/cli/src/port_forward.rs
@@ -977,6 +977,7 @@ impl LocalConnectionTask {
 pub struct IncomingMode {
     pub steal: bool,
     pub http_settings: Option<HttpSettings>,
+    pub raw_tcp_ports: HashSet<Port>,
 }
 #[derive(Debug)]
 pub struct HttpSettings {
@@ -998,6 +999,7 @@ impl IncomingMode {
             return Self {
                 steal: config.is_steal(),
                 http_settings: None,
+                raw_tcp_ports: config.raw_tcp_ports.clone(),
             };
         }
 
@@ -1024,23 +1026,28 @@ impl IncomingMode {
         Self {
             steal: config.is_steal(),
             http_settings: Some(HttpSettings { filter, ports }),
+            raw_tcp_ports: config.raw_tcp_ports.clone(),
         }
     }
 
     /// Returns [`PortSubscription`] request to be used for the given port.
     pub fn subscription(&self, port: Port) -> PortSubscription {
         if self.steal {
-            let steal_type = match &self.http_settings {
-                None => StealType::All(port),
-                Some(settings) => {
-                    if settings
-                        .ports
-                        .as_ref()
-                        .is_some_and(|p| p.contains(&port).not())
-                    {
-                        StealType::All(port)
-                    } else {
-                        StealType::FilteredHttpEx(port, settings.filter.clone())
+            let steal_type = if self.raw_tcp_ports.contains(&port) {
+                StealType::AllRawTcp(port)
+            } else {
+                match &self.http_settings {
+                    None => StealType::All(port),
+                    Some(settings) => {
+                        if settings
+                            .ports
+                            .as_ref()
+                            .is_some_and(|p| p.contains(&port).not())
+                        {
+                            StealType::All(port)
+                        } else {
+                            StealType::FilteredHttpEx(port, settings.filter.clone())
+                        }
                     }
                 }
             };

--- a/mirrord/config/src/feature/network/incoming.rs
+++ b/mirrord/config/src/feature/network/incoming.rs
@@ -134,6 +134,10 @@ impl MirrordConfig for IncomingFileConfig {
                     .transpose()?
                     .unwrap_or_default(),
                 ports: advanced.ports.map(|ports| ports.into_iter().collect()),
+                raw_tcp_ports: advanced
+                    .raw_tcp_ports
+                    .map(|ports| ports.into_iter().collect())
+                    .unwrap_or_default(),
                 https_delivery: advanced.https_delivery,
                 tls_delivery: advanced.tls_delivery,
             },
@@ -308,6 +312,12 @@ pub struct IncomingAdvancedFileConfig {
     ///
     /// Mutually exclusive with [`ignore_ports`](###ignore_ports).
     pub ports: Option<Vec<u16>>,
+
+    /// ### raw_tcp_ports
+    ///
+    /// Ports to steal as raw TCP. Incoming connections on these ports bypass HTTP detection and
+    /// TLS handling, so they are forwarded immediately to the local application.
+    pub raw_tcp_ports: Option<Vec<u16>>,
 
     /// ### https_delivery
     ///
@@ -485,6 +495,12 @@ pub struct IncomingConfig {
     /// Mutually exclusive with
     /// [`feature.network.incoming.ignore_ports`](#feature-network-ignore_ports).
     pub ports: Option<HashSet<u16>>,
+
+    /// ##### feature.network.incoming.raw_tcp_ports {#feature-network-incoming-raw_tcp_ports}
+    ///
+    /// Ports to steal as raw TCP. Incoming connections on these ports bypass HTTP detection and
+    /// TLS handling, so they are forwarded immediately to the local application.
+    pub raw_tcp_ports: HashSet<u16>,
 
     /// ##### feature.network.incoming.https_delivery {#feature-network-incoming-https_delivery}
     ///
@@ -689,6 +705,7 @@ impl CollectAnalytics for &IncomingConfig {
         analytics.add("listen_ports_count", self.listen_ports.len());
         analytics.add("ignore_localhost", self.ignore_localhost);
         analytics.add("ignore_ports_count", self.ignore_ports.len());
+        analytics.add("raw_tcp_ports_count", self.raw_tcp_ports.len());
         analytics.add("http", &self.http_filter);
     }
 }

--- a/mirrord/config/src/lib.rs
+++ b/mirrord/config/src/lib.rs
@@ -657,6 +657,36 @@ impl LayerConfig {
             ))?
         }
 
+        if self.feature.network.incoming.is_steal()
+            && self.feature.network.incoming.http_filter.is_filter_set()
+            && !self.feature.network.incoming.raw_tcp_ports.is_empty()
+        {
+            match &self.feature.network.incoming.http_filter.ports {
+                Some(http_filter_ports) => {
+                    if let Some(port) = self
+                        .feature
+                        .network
+                        .incoming
+                        .raw_tcp_ports
+                        .iter()
+                        .find(|&&port| http_filter_ports.contains(&port))
+                    {
+                        Err(ConfigError::Conflict(format!(
+                            "Cannot include port `{port}` in both \
+                            `feature.network.incoming.raw_tcp_ports` and \
+                            `feature.network.incoming.http_filter.ports`"
+                        )))?
+                    }
+                }
+                None => Err(ConfigError::Conflict(
+                    "Cannot use `feature.network.incoming.raw_tcp_ports` when \
+                        `feature.network.incoming.http_filter` applies to all ports. \
+                        Set `feature.network.incoming.http_filter.ports` to the HTTP ports."
+                        .to_owned(),
+                ))?,
+            }
+        }
+
         match (
             &self.feature.network.incoming.https_delivery,
             &self.feature.network.incoming.tls_delivery,
@@ -908,6 +938,12 @@ impl LayerConfig {
             != default.feature.network.incoming.http_filter.ports
         {
             context.add_warning(ignored("feature.network.incoming.http_filter.ports"));
+        }
+
+        if self.feature.network.incoming.raw_tcp_ports
+            != default.feature.network.incoming.raw_tcp_ports
+        {
+            context.add_warning(ignored("feature.network.incoming.raw_tcp_ports"));
         }
 
         if matches!(self.feature.network.incoming.mode, IncomingMode::Steal)
@@ -1350,6 +1386,7 @@ mod tests {
                             listen_ports: None,
                             on_concurrent_steal: None,
                             ports: None,
+                            raw_tcp_ports: None,
                             https_delivery: Default::default(),
                             tls_delivery: Default::default(),
                         }),

--- a/mirrord/intproxy/src/proxies/incoming/port_subscription_ext.rs
+++ b/mirrord/intproxy/src/proxies/incoming/port_subscription_ext.rs
@@ -3,16 +3,15 @@
 use mirrord_intproxy_protocol::PortSubscription;
 use mirrord_protocol::{
     ClientMessage, Port,
-    tcp::{LayerTcp, LayerTcpSteal, MIRROR_HTTP_FILTER_VERSION, MirrorType, StealType},
+    tcp::{
+        LayerTcp, LayerTcpSteal, MIRROR_HTTP_FILTER_VERSION, MirrorType, STEAL_RAW_TCP_VERSION,
+        StealType,
+    },
 };
 
 /// Retrieves subscribed port from the given [`StealType`].
 fn get_port(steal_type: &StealType) -> Port {
-    match steal_type {
-        StealType::All(port) => *port,
-        StealType::FilteredHttp(port, _) => *port,
-        StealType::FilteredHttpEx(port, _) => *port,
-    }
+    steal_type.get_port()
 }
 
 /// Trait for [`PortSubscription`] that handles differences in [`mirrord_protocol::tcp`] between the
@@ -20,6 +19,9 @@ fn get_port(steal_type: &StealType) -> Port {
 pub trait PortSubscriptionExt {
     /// Returns the subscribed port.
     fn port(&self) -> Port;
+
+    /// Returns whether this subscription requests raw TCP mode.
+    fn requests_raw_tcp(&self) -> bool;
 
     /// Returns a subscribe request to be sent to the agent.
     fn agent_subscribe(&self, protocol_version: Option<&semver::Version>) -> ClientMessage;
@@ -34,6 +36,10 @@ impl PortSubscriptionExt for PortSubscription {
             Self::Mirror(mirror_type) => mirror_type.get_port(),
             Self::Steal(steal_type) => get_port(steal_type),
         }
+    }
+
+    fn requests_raw_tcp(&self) -> bool {
+        matches!(self, Self::Steal(StealType::AllRawTcp(..)))
     }
 
     /// [`LayerTcp::PortSubscribe`], [`LayerTcp::PortSubscribeFilteredHttp`], or
@@ -66,7 +72,33 @@ impl PortSubscriptionExt for PortSubscription {
                 }
             },
             Self::Steal(steal_type) => {
-                ClientMessage::TcpSteal(LayerTcpSteal::PortSubscribe(steal_type.clone()))
+                // AllRawTcp requires a minimum agent protocol version. Fall back to All for
+                // older or not-yet-negotiated agents to preserve backward compatibility.
+                let effective = match steal_type {
+                    StealType::AllRawTcp(port) => {
+                        if protocol_version.is_some_and(|v| STEAL_RAW_TCP_VERSION.matches(v)) {
+                            steal_type.clone()
+                        } else {
+                            if protocol_version.is_some() {
+                                tracing::warn!(
+                                    ?protocol_version,
+                                    port,
+                                    "Agent protocol version does not support StealType::AllRawTcp. \
+                                     Falling back to StealType::All; HTTP detection will still run \
+                                     on this port.",
+                                );
+                            } else {
+                                tracing::debug!(
+                                    port,
+                                    "Agent protocol version unknown, downgrading AllRawTcp to All",
+                                );
+                            }
+                            StealType::All(*port)
+                        }
+                    }
+                    other => other.clone(),
+                };
+                ClientMessage::TcpSteal(LayerTcpSteal::PortSubscribe(effective))
             }
         }
     }

--- a/mirrord/intproxy/src/proxies/incoming/subscriptions.rs
+++ b/mirrord/intproxy/src/proxies/incoming/subscriptions.rs
@@ -196,12 +196,8 @@ impl SubscriptionsManager {
         request: PortSubscribe,
         protocol_version: Option<&Version>,
     ) -> Option<Either<ProxyMessage, ClientMessage>> {
-        self.remote_ports.add(
-            layer_id,
-            (request.subscription.port(), request.listening_on),
-        );
-
         let port = request.subscription.port();
+        let requested_raw_tcp = request.subscription.requests_raw_tcp();
         let source = Source {
             layer: layer_id,
             message: message_id,
@@ -209,11 +205,42 @@ impl SubscriptionsManager {
         };
 
         match self.subscriptions.entry(port) {
-            Entry::Occupied(mut e) => e
-                .get_mut()
-                .push_source(source)
-                .map(|m| Either::Left(ProxyMessage::ToLayer(m))),
+            Entry::Occupied(mut e) => {
+                let current_raw_tcp = e
+                    .get()
+                    .active_source
+                    .request
+                    .subscription
+                    .requests_raw_tcp();
+
+                if current_raw_tcp != requested_raw_tcp {
+                    tracing::warn!(
+                        port,
+                        current_raw_tcp,
+                        requested_raw_tcp,
+                        "Port is already subscribed with a different incoming mode",
+                    );
+
+                    return Some(Either::Left(ProxyMessage::ToLayer(ToLayer {
+                        message_id: source.message,
+                        layer_id: source.layer,
+                        message: ProxyToLayerMessage::Incoming(IncomingResponse::PortSubscribe(
+                            Err(ResponseError::PortAlreadyStolen(port)),
+                        )),
+                    })));
+                }
+
+                self.remote_ports
+                    .add(layer_id, (port, source.request.listening_on));
+
+                e.get_mut()
+                    .push_source(source)
+                    .map(|m| Either::Left(ProxyMessage::ToLayer(m)))
+            }
             Entry::Vacant(e) => {
+                self.remote_ports
+                    .add(layer_id, (port, source.request.listening_on));
+
                 let (subscription, message) = Subscription::new(source, protocol_version);
                 e.insert(subscription);
                 Some(Either::Right(message))
@@ -346,7 +373,8 @@ impl SubscriptionsManager {
 #[cfg(test)]
 mod test {
     use mirrord_intproxy_protocol::PortSubscription;
-    use mirrord_protocol::tcp::{LayerTcp, MirrorType};
+    use mirrord_protocol::tcp::{Filter, LayerTcp, LayerTcpSteal, MirrorType, StealType};
+    use semver::Version;
 
     use super::*;
 
@@ -497,6 +525,62 @@ mod test {
             Some(ClientMessage::Tcp(LayerTcp::PortUnsubscribe(80)))
         ));
         assert!(manager.get(80).is_none());
+    }
+
+    #[test]
+    fn rejects_mode_change_for_existing_subscription() {
+        let listener_1 = "127.0.0.1:1111".parse().unwrap();
+        let listener_2 = "127.0.0.1:2222".parse().unwrap();
+        let protocol_version = Version::new(1, 27, 0);
+
+        let mut manager = SubscriptionsManager::default();
+
+        let response = manager.layer_subscribed(
+            LayerId(0),
+            0,
+            PortSubscribe {
+                listening_on: listener_1,
+                subscription: PortSubscription::Steal(StealType::FilteredHttp(
+                    80,
+                    Filter::new("host: api".to_owned()).unwrap(),
+                )),
+            },
+            Some(&protocol_version),
+        );
+        assert!(
+            matches!(
+                response,
+                Some(Either::Right(ClientMessage::TcpSteal(
+                    LayerTcpSteal::PortSubscribe(StealType::FilteredHttp(80, _))
+                )))
+            ),
+            "{response:?}"
+        );
+
+        let response = manager.layer_subscribed(
+            LayerId(0),
+            1,
+            PortSubscribe {
+                listening_on: listener_2,
+                subscription: PortSubscription::Steal(StealType::AllRawTcp(80)),
+            },
+            Some(&protocol_version),
+        );
+
+        assert!(
+            matches!(
+                response,
+                Some(Either::Left(ProxyMessage::ToLayer(ToLayer {
+                    layer_id: LayerId(0),
+                    message_id: 1,
+                    message: ProxyToLayerMessage::Incoming(IncomingResponse::PortSubscribe(Err(
+                        ResponseError::PortAlreadyStolen(80)
+                    ))),
+                })))
+            ),
+            "{response:?}"
+        );
+        assert_eq!(manager.get(80).unwrap().listening_on, listener_1);
     }
 
     #[test]

--- a/mirrord/layer-lib/src/setup.rs
+++ b/mirrord/layer-lib/src/setup.rs
@@ -279,6 +279,7 @@ pub struct HttpSettings {
 pub struct IncomingMode {
     pub steal: bool,
     pub http_settings: Option<HttpSettings>,
+    pub raw_tcp_ports: HashSet<Port>,
 }
 
 impl IncomingMode {
@@ -306,23 +307,28 @@ impl IncomingMode {
         Self {
             steal: config.is_steal(),
             http_settings,
+            raw_tcp_ports: config.raw_tcp_ports.clone(),
         }
     }
 
     /// Returns [`PortSubscription`] request to be used for the given port.
     pub fn subscription(&self, port: Port) -> PortSubscription {
         if self.steal {
-            let steal_type = match &self.http_settings {
-                None => StealType::All(port),
-                Some(settings) => {
-                    if settings
-                        .ports
-                        .as_ref()
-                        .is_some_and(|p| p.contains(&port).not())
-                    {
-                        StealType::All(port)
-                    } else {
-                        StealType::FilteredHttpEx(port, settings.filter.clone())
+            let steal_type = if self.raw_tcp_ports.contains(&port) {
+                StealType::AllRawTcp(port)
+            } else {
+                match &self.http_settings {
+                    None => StealType::All(port),
+                    Some(settings) => {
+                        if settings
+                            .ports
+                            .as_ref()
+                            .is_some_and(|p| p.contains(&port).not())
+                        {
+                            StealType::All(port)
+                        } else {
+                            StealType::FilteredHttpEx(port, settings.filter.clone())
+                        }
                     }
                 }
             };

--- a/mirrord/layer-tests/tests/filter_ports.rs
+++ b/mirrord/layer-tests/tests/filter_ports.rs
@@ -23,6 +23,7 @@ use tokio::net::TcpStream;
 fn build_config(
     incoming_ports: Option<&[u16]>,
     filter_ports: Option<&[u16]>,
+    raw_tcp_ports: Option<&[u16]>,
     have_filter: bool,
 ) -> Value {
     // Start with the innermost fixed part: the "incoming" object
@@ -60,6 +61,13 @@ fn build_config(
             .insert("ports".to_string(), json!(ports));
     }
 
+    if let Some(ports) = raw_tcp_ports {
+        incoming
+            .as_object_mut()
+            .unwrap()
+            .insert("raw_tcp_ports".to_string(), json!(ports));
+    }
+
     // Now build the full config using the modified incoming object
     json!({
         "feature": {
@@ -73,6 +81,7 @@ fn build_config(
 enum BindMode {
     Local,
     Unfiltered,
+    UnfilteredRawTcp,
     Filtered,
 }
 
@@ -81,6 +90,10 @@ fn expected_behavior(port: u16, incoming: &IncomingConfig) -> BindMode {
         && remote_ports.contains(&port).not()
     {
         return BindMode::Local;
+    }
+
+    if incoming.raw_tcp_ports.contains(&port) {
+        return BindMode::UnfilteredRawTcp;
     }
 
     if incoming.http_filter.is_filter_set().not() {
@@ -124,7 +137,7 @@ async fn filter_ports(
 
     #[values(true, false)] have_filter: bool,
 ) {
-    let config = build_config(incoming_ports, http_filter_ports, have_filter);
+    let config = build_config(incoming_ports, http_filter_ports, None, have_filter);
     let mut config_file = tempfile::NamedTempFile::with_suffix(".json").unwrap();
     config_file
         .as_file_mut()
@@ -161,6 +174,14 @@ async fn filter_ports(
                 ) if stolen_port == port
             );
         }
+        BindMode::UnfilteredRawTcp => {
+            assert_matches!(
+                intproxy.recv().await,
+                ClientMessage::TcpSteal(
+                    LayerTcpSteal::PortSubscribe(StealType::AllRawTcp(stolen_port))
+                ) if stolen_port == port
+            );
+        }
         BindMode::Filtered => {
             assert_matches!(
                 intproxy.recv().await,
@@ -171,6 +192,37 @@ async fn filter_ports(
             );
         }
     }
+
+    drop(test_process)
+}
+
+#[rstest]
+#[tokio::test]
+#[timeout(std::time::Duration::from_secs(60))]
+async fn raw_tcp_ports_subscribe_raw_tcp(
+    #[values(Application::RustListenPorts)] application: Application,
+    #[values(rand::random_range(10000..60000))] port: u16,
+) {
+    let config = build_config(Some(&[port]), None, Some(&[port]), false);
+    let mut config_file = tempfile::NamedTempFile::with_suffix(".json").unwrap();
+    config_file
+        .as_file_mut()
+        .write_all(serde_json::to_string(&config).unwrap().as_bytes())
+        .unwrap();
+
+    let (test_process, mut intproxy) = application
+        .start_process(
+            vec![("APP_PORTS", &port.to_string())],
+            Some(config_file.path()),
+        )
+        .await;
+
+    assert_matches!(
+        intproxy.recv().await,
+        ClientMessage::TcpSteal(
+            LayerTcpSteal::PortSubscribe(StealType::AllRawTcp(stolen_port))
+        ) if stolen_port == port
+    );
 
     drop(test_process)
 }

--- a/mirrord/protocol/Cargo.toml
+++ b/mirrord/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mirrord-protocol"
-version = "1.26.3"
+version = "1.27.0"
 authors.workspace = true
 description.workspace = true
 documentation.workspace = true

--- a/mirrord/protocol/src/error.rs
+++ b/mirrord/protocol/src/error.rs
@@ -109,7 +109,7 @@ pub enum BlockedAction {
 impl fmt::Display for BlockedAction {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            BlockedAction::Steal(StealType::All(port)) => {
+            BlockedAction::Steal(StealType::All(port) | StealType::AllRawTcp(port)) => {
                 write!(f, "Stealing traffic from port {port}")
             }
             BlockedAction::Steal(StealType::FilteredHttp(port, filter)) => {

--- a/mirrord/protocol/src/tcp.rs
+++ b/mirrord/protocol/src/tcp.rs
@@ -442,11 +442,17 @@ pub enum StealType {
     FilteredHttp(Port, Filter),
     /// Steal HTTP traffic matching a given filter - supporting more than once kind of filter
     FilteredHttpEx(Port, HttpFilter),
+    /// Steal all traffic to this port as raw TCP.
+    ///
+    /// Used for ports configured as `raw_tcp_ports`, bypassing HTTP detection and TLS handling
+    /// so server-first protocols can be forwarded immediately.
+    AllRawTcp(Port),
 }
 
 impl StealType {
     pub fn get_port(&self) -> Port {
         let (StealType::All(port)
+        | StealType::AllRawTcp(port)
         | StealType::FilteredHttpEx(port, ..)
         | StealType::FilteredHttp(port, ..)) = self;
         *port
@@ -642,6 +648,10 @@ pub static HTTP_BODY_JSON_FILTER_VERSION: LazyLock<VersionReq> =
 /// ([`HttpFilter::Body`]) by JSON.
 pub static HTTP_HEADER_JQ_FILTER_VERSION: LazyLock<VersionReq> =
     LazyLock::new(|| ">=1.26.0".parse().expect("Bad Identifier"));
+
+/// Minimal mirrord-protocol version that allows [`StealType::AllRawTcp`].
+pub static STEAL_RAW_TCP_VERSION: LazyLock<VersionReq> =
+    LazyLock::new(|| ">=1.27.0".parse().expect("Bad Identifier"));
 
 /// Protocol break - on version 2, please add source port, dest/src IP to the message
 /// so we can avoid losing this information.


### PR DESCRIPTION
### Summary

Introduces a new `feature.network.incoming.raw_tcp_ports` config option — a list of ports that should be stolen as raw TCP, bypassing HTTP detection and TLS handling entirely.

By default, mirrord runs HTTP detection on every stolen port by reading the first bytes the client sends. For **server-first protocols** (SMTP, FTP, custom binary protocols, etc.) the client sends nothing after connecting — it waits for the server to speak first. Because the detection read blocks until data arrives, and data never arrives, these connections hang indefinitely and are never forwarded to the local application.

Ports listed in `raw_tcp_ports` skip detection and are forwarded to the local application immediately as raw byte streams.

### What changed

**Protocol (`mirrord-protocol` → 1.27.0)**
- Added `StealType::AllRawTcp(Port)` — a new steal subscription variant that signals the agent to skip HTTP detection for a port.
- Added `STEAL_RAW_TCP_VERSION` (`>=1.27.0`) for capability negotiation.
- `StealType::get_port()` now covers the new variant.
- `BlockedAction` display updated to include `AllRawTcp`.

**Config (`mirrord-config`)**
- Added `raw_tcp_ports: Option<Vec<u16>>` to `IncomingConfig`.
- Validation rejects `raw_tcp_ports` when an HTTP filter applies to all ports (i.e., `http_filter.ports` is unset), and rejects any port that appears in both `raw_tcp_ports` and `http_filter.ports`.
- Mirror mode adds a `raw_tcp_ports` warning (the field is silently ignored in mirror mode).
- Analytics tracks `raw_tcp_ports_count`.

**Layer (`mirrord-layer-lib`)**
- `IncomingMode` carries the `raw_tcp_ports` set.
- `IncomingMode::subscription()` emits `StealType::AllRawTcp` for ports in the set, taking priority over HTTP filter logic.

**intproxy (`mirrord-intproxy`)**
- `PortSubscriptionExt::requests_raw_tcp()` identifies raw TCP subscriptions.
- `agent_subscribe()` downgrades `AllRawTcp` to `All` when talking to an older agent (with a warning), preserving backward compatibility.
- `SubscriptionsManager::layer_subscribed()` rejects a second subscription on the same port if it requests a different mode, returning `PortAlreadyStolen`.

**Agent (`mirrord-agent`)**
- Added `IncomingPortMode` enum (`Detect` | `RawTcp`) tracked per port in `PortState`.
- `MaybeHttp::accept_raw_tcp()` wraps a redirected connection without running detection.
- `RedirectorTask` uses `port_mode` to branch: `RawTcp` ports skip the detection `select!` entirely.
- `StealHandle::steal()` now takes a `mode` argument.
- Mode conflicts (e.g., a later subscriber requests a different mode) produce a warning but don't change the mode established by the first subscriber.
- `steal/api.rs` maps `StealType::AllRawTcp` → `IncomingPortMode::RawTcp`; all other steal types → `IncomingPortMode::Detect`.

### Tests

- `mirror_detection_survives_later_raw_tcp_steal` / `raw_tcp_steal_mode_survives_later_mirror` — verify that port-wide mode is fixed by the first subscriber.
- `rejects_mode_change_for_existing_subscription` — intproxy correctly rejects a second layer that tries to change the mode.
- `raw_tcp_ports_subscribe_raw_tcp` — layer-level integration test confirming `AllRawTcp` is sent to the agent for ports in `raw_tcp_ports`.


### Quality Checklist:

- [X] I have documented new code sufficiently
- [X] I have checked and updated the relevant existing docs in code, including removing outdated material
- [ ] I have written user-facing website docs for new features, or opened a (sub)issue to do so
- [ ] I have checked and updated existing website docs for changed features
- [X] I have tested this change and know it succeeds and fails as expected
- [X] I have written unit tests or purposefully omitted them
- [X] I have written e2e tests or purposefully omitted them
- [X] I have explained what this PR introduces and why, and linked to relevant context (e.g. linear issues, related PRs,
  documentation)
- [X] I have introduced a short, clear and well-formatted changelog entry

<!-- need help with the changelog? see ../CONTRIBUTING.md#submitting-a-pull-request -->
<!-- Add more details of your changes below if needed -->