### PR TITLE
Fix duplicated shared SQL branch fields in generated config docs (INT-377)

### DIFF
--- a/changelog.d/+fix-db-branches-docs-duplication.fixed.md
+++ b/changelog.d/+fix-db-branches-docs-duplication.fixed.md
@@ -1,0 +1,1 @@
+Fixed duplicated `feature.db_branches[].connection` chunk (and other shared fields) on the generated config docs page. The shared SQL branch fields are now documented once instead of being repeated under each of the mysql/pg/mongodb/mssql variants.

--- a/medschool/src/parse.rs
+++ b/medschool/src/parse.rs
@@ -9,6 +9,31 @@ use crate::{
     types::{PartialField, PartialType, PartialVariant},
 };
 
+/// Marker string that can be placed inside a doc comment to hide an item from the generated docs.
+const INTERNAL_MARKER: &str = "<!--${internal}-->";
+
+/// Returns `true` if any doc attribute contains the `<!--${internal}-->` marker.
+pub fn is_internal(attributes: &[Attribute]) -> bool {
+    attributes.iter().any(|attribute| {
+        let syn::Meta::NameValue(meta_doc) = &attribute.meta else {
+            return false;
+        };
+        let Some(ident) = meta_doc.path.segments.first().map(|s| &s.ident) else {
+            return false;
+        };
+        if ident != &Ident::new("doc", ident.span()) {
+            return false;
+        }
+        let Expr::Lit(doc_expr) = &meta_doc.value else {
+            return false;
+        };
+        let syn::Lit::Str(doc_lit) = &doc_expr.lit else {
+            return false;
+        };
+        doc_lit.value().contains(INTERNAL_MARKER)
+    })
+}
+
 /// Look into the [`syn::Attribute`]s of whatever item we're handling, and extract its doc strings.
 #[tracing::instrument(level = "trace", ret)]
 pub fn docs_from_attributes(attributes: Vec<Attribute>) -> Option<Vec<String>> {
@@ -54,7 +79,7 @@ pub fn docs_from_attributes(attributes: Vec<Attribute>) -> Option<Vec<String>> {
 
     for doc in docs.iter_mut() {
         // removes docs that we don't want in `configuration.md`
-        if doc.contains(r"<!--${internal}-->") {
+        if doc.contains(INTERNAL_MARKER) {
             return None;
         }
 

--- a/medschool/src/types.rs
+++ b/medschool/src/types.rs
@@ -10,7 +10,7 @@ use std::{
 
 use syn::Type;
 
-use crate::parse::{docs_from_attributes, get_ident_from_field_skipping_generics};
+use crate::parse::{docs_from_attributes, get_ident_from_field_skipping_generics, is_internal};
 
 /// We're extracting [`syn::Item`] structs and enums into this type.
 ///
@@ -73,11 +73,21 @@ pub struct PartialVariant<'a> {
 
 /// Converts a [`syn::Field`] into [`PartialField`], using
 /// [`get_ident_from_field_skipping_generics`] to get the field type.
+///
+/// Fields whose doc comments include the `<!--${internal}-->` marker are dropped: their own docs
+/// are suppressed AND [`crate::parse::dfs_fields`] will not recurse into their type. Use this on a
+/// field when its type is already documented elsewhere in the output (for example, a shared
+/// struct that is `#[serde(flatten)]`'d into several variants — to avoid repeating its fields
+/// under each variant).
 impl TryFrom<syn::Field> for PartialField<'_> {
     type Error = ();
 
     #[tracing::instrument(level = "trace", ret)]
     fn try_from(field: syn::Field) -> Result<Self, Self::Error> {
+        if is_internal(&field.attrs) {
+            return Err(());
+        }
+
         let type_ident = match field.ty {
             Type::Path(type_path) => {
                 // `get_ident` returns `Some` if the `path` doesn't contain generics.

--- a/mirrord/config/src/feature/database_branches.rs
+++ b/mirrord/config/src/feature/database_branches.rs
@@ -304,7 +304,7 @@ pub enum DatabaseBranchConfig {
     Redis(Box<RedisBranchConfig>),
 }
 
-/// MySQL and Postgres database branch config objects share the following fields.
+/// Fields shared by MySQL, PostgreSQL, MongoDB, and MSSQL branch config objects.
 #[derive(MirrordConfig, Clone, Debug, Eq, PartialEq, JsonSchema, Serialize, Deserialize)]
 #[config(map_to = "DatabaseBranchBaseFileConfig")]
 pub struct DatabaseBranchBaseConfig {

--- a/mirrord/config/src/feature/database_branches/mssql.rs
+++ b/mirrord/config/src/feature/database_branches/mssql.rs
@@ -9,6 +9,8 @@ use super::DatabaseBranchBaseConfig;
 #[derive(Clone, Debug, Eq, PartialEq, JsonSchema, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct MssqlBranchConfig {
+    /// <!--${internal}-->
+    /// Shared fields documented once under the MongoDB branch config variant.
     #[serde(flatten)]
     pub base: DatabaseBranchBaseConfig,
 

--- a/mirrord/config/src/feature/database_branches/mysql.rs
+++ b/mirrord/config/src/feature/database_branches/mysql.rs
@@ -9,6 +9,8 @@ use super::DatabaseBranchBaseConfig;
 #[derive(Clone, Debug, Eq, PartialEq, JsonSchema, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct MysqlBranchConfig {
+    /// <!--${internal}-->
+    /// Shared fields documented once under the MongoDB branch config variant.
     #[serde(flatten)]
     pub base: DatabaseBranchBaseConfig,
 

--- a/mirrord/config/src/feature/database_branches/pg.rs
+++ b/mirrord/config/src/feature/database_branches/pg.rs
@@ -9,6 +9,8 @@ use super::{DatabaseBranchBaseConfig, IamAuthConfig};
 #[derive(Clone, Debug, Eq, PartialEq, JsonSchema, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct PgBranchConfig {
+    /// <!--${internal}-->
+    /// Shared fields documented once under the MongoDB branch config variant.
     #[serde(flatten)]
     pub base: DatabaseBranchBaseConfig,
 


### PR DESCRIPTION
## Summary

- The config options page at `metalbear.com/mirrord/docs/config/options` was rendering duplicated chunks for `feature.db_branches[].connection` (and the other shared fields — `id`, `name`, `ttl_secs`, `version`, `creation_timeout_secs`) because `DatabaseBranchBaseConfig` is `#[serde(flatten)]`'d into each of the mysql, pg, and mongodb variants. Medschool inlined the struct's fields once per variant, producing collided anchors `...-1`, `...-2`, `...-3` on the rendered page.
- medschool: when a field doc carries `<!--\${internal}-->`, drop the field entirely. Previously the marker only silenced the field's own docs — medschool still recursed into the field's type and inlined its contents, which defeats the purpose when the marker is used to hide a shared flattened struct.
- Mark `base: DatabaseBranchBaseConfig` as internal on `MysqlBranchConfig` and `PgBranchConfig`. The MongoDB variant keeps it unmarked, so the shared fields render exactly once (under the MongoDB section). Tweaked the shared struct's intro doc from "MySQL and Postgres..." to "MySQL, PostgreSQL, and MongoDB..." so it accurately describes all three.

Fixes the first bullet of [INT-377](https://linear.app/metalbear/issue/INT-377/fix-db-branching-docs-issues). The second bullet (invalid example config in the DB branching guide) is fixed in a separate PR against \`metalbear-co/docs\`.

## Test plan

- [x] \`cargo test -p medschool -p mirrord-config\` passes
- [x] Regenerate with \`cargo run -p medschool -- --input ./mirrord/config/src --output /tmp/out.md\` and confirmed each \`{#feature-db_branches-sql-*}\` anchor appears exactly once
- [x] Confirmed the intentional \`tls_delivery\` / \`https_delivery\` duplication (two different fields sharing the \`LocalTlsDelivery\` type) is preserved — only fields explicitly marked internal are affected
- [ ] Docs site rebuild picks up the regenerated markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)