### PR TITLE
Preview: Make `preview status` only show active sessions by default

### DIFF
--- a/changelog.d/+preview-status-filters.changed.md
+++ b/changelog.d/+preview-status-filters.changed.md
@@ -1,0 +1,2 @@
+Preview sessions are now deleted automatically when their TTL expires, and failed sessions are cleaned up automatically after the retention window configured by `operator.preview.cleanupAfterMins` in the chart configuration.
+Alongside this change, `mirrord preview status` now only shows active sessions by default, and a new `--failed` flag lets you inspect failed sessions that haven't been cleaned up yet.

--- a/mirrord/cli/src/config.rs
+++ b/mirrord/cli/src/config.rs
@@ -1379,6 +1379,12 @@ pub(super) struct PreviewStatusArgs {
     /// Query all namespaces.
     #[arg(short = 'A', long = "all-namespaces", conflicts_with = "namespace")]
     pub all_namespaces: bool,
+
+    /// Show only failed sessions.
+    ///
+    /// By default, `mirrord preview status` only shows active sessions.
+    #[arg(long)]
+    pub failed: bool,
 }
 
 impl PreviewStatusArgs {

--- a/mirrord/cli/src/preview.rs
+++ b/mirrord/cli/src/preview.rs
@@ -337,16 +337,6 @@ async fn preview_start(
                                 }
                                 PreviewSessionPhase::Failed => {
                                     let failure_message = status.failure_message.clone().expect("Failed session must have failure_message");
-                                    // Sessions that fail to spawn should not be retained —
-                                    // delete the CRD so the operator can clean up and the
-                                    // user can retry without stale resources blocking them.
-                                    if let Err(err) = delete::delete_and_finalize(api, &session.name_any(), &DeleteParams::default()).await {
-                                        subtask.warning(&format!(
-                                            "failed to delete failed session '{}': {err}, \
-                                             you may need to delete it manually or with `mirrord preview stop`",
-                                            session.name_any(),
-                                        ));
-                                    }
                                     subtask.failure(None);
                                     return Err(CliError::PreviewSessionFailed(failure_message));
                                 }
@@ -404,7 +394,8 @@ async fn preview_start(
 
 /// Handle `mirrord preview status` command.
 ///
-/// Lists preview environments, optionally filtered by key and namespace.
+/// Lists preview environments, optionally filtered by key, namespace, and whether failed
+/// sessions should be shown.
 #[tracing::instrument(level = Level::TRACE, ret, skip_all)]
 async fn preview_status(
     args: PreviewStatusArgs,
@@ -447,6 +438,37 @@ async fn preview_status(
         })?
         .items;
 
+    let sessions: Vec<_> = sessions
+        .iter()
+        .filter(|session| {
+            let (failed, expired) = session
+                .status
+                .as_ref()
+                .map(|status| {
+                    let failed_phase = matches!(status.phase, PreviewSessionPhase::Failed);
+
+                    // Older operators reused the `Failed` phase with a specific failure message
+                    // when the preview TTL elapsed instead of deleting them, so we need to handle
+                    // that to hide expired preview sessions in a backwards compatible way.
+                    // See https://github.com/metalbear-co/operator/blob/17e4c645d59affefc672f597a10e2880c405f043/crates/operator-preview-env/src/task.rs#L774-L775
+                    let expired = failed_phase
+                        && status.failure_message.as_deref() == Some("preview session TTL expired");
+
+                    let failed = failed_phase && !expired;
+
+                    (failed, expired)
+                })
+                .unwrap_or_default();
+
+            if args.failed {
+                failed
+            } else {
+                // Not failed and not expired = alive
+                !failed && !expired
+            }
+        })
+        .collect();
+
     if sessions.is_empty() {
         subtask.success(Some("no preview sessions found"));
         progress.success(None);
@@ -482,7 +504,7 @@ async fn preview_status(
                 .and_then(|s| s.pod_name.as_deref())
                 .unwrap_or("<unknown>");
 
-            let status = match session.status.as_ref().map(|s| &s.phase) {
+            let status = match session.status.as_ref().map(|status| status.phase) {
                 Some(PreviewSessionPhase::Initializing) => "initializing".to_owned(),
                 Some(PreviewSessionPhase::Waiting) => "waiting".to_owned(),
                 Some(PreviewSessionPhase::Ready) => {
@@ -506,14 +528,12 @@ async fn preview_status(
                         }
                     }
                 }
-                Some(PreviewSessionPhase::Failed) => {
-                    let msg = session
-                        .status
-                        .as_ref()
-                        .and_then(|s| s.failure_message.as_deref())
-                        .unwrap_or("unknown");
-                    format!("stopped ({msg})")
-                }
+                Some(PreviewSessionPhase::Failed) => session
+                    .status
+                    .as_ref()
+                    .and_then(|status| status.failure_message.as_deref())
+                    .unwrap_or("unknown")
+                    .to_owned(),
                 Some(PreviewSessionPhase::Unknown) => "unknown".to_owned(),
                 None => "pending".to_owned(),
             };
@@ -541,7 +561,6 @@ async fn preview_status(
 
     Ok(())
 }
-
 /// Handle `mirrord preview stop` command.
 ///
 /// Deletes preview environments matching the given key and, optionally, a target filter and

--- a/mirrord/operator/src/crd/preview.rs
+++ b/mirrord/operator/src/crd/preview.rs
@@ -2,8 +2,8 @@
 //!
 //! The CLI creates a [`PreviewSession`] resource in the cluster, and the operator reconciles
 //! it by spawning a preview pod and routing traffic to it. The CR's status subresource
-//! tracks the session lifecycle (`Initializing` → `Waiting` → `Ready` / `Failed`), which
-//! the CLI watches to report progress back to the user.
+//! tracks the session lifecycle (`Initializing` → `Waiting` → `Ready` / `Failed`), which the
+//! CLI watches to report progress back to the user.
 
 use std::{collections::BTreeMap, time::Duration};
 
@@ -123,6 +123,10 @@ pub struct PreviewSessionStatus {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub failure_message: Option<String>,
 
+    /// Timestamp of when the session entered the `Failed` phase.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub failed_at: Option<MicroTime>,
+
     /// Timestamp when the session's TTL expires.
     ///
     /// Set when the session enters the `Ready` phase for finite TTL sessions.
@@ -135,8 +139,8 @@ pub struct PreviewSessionStatus {
 
 /// Phase of a preview session's lifecycle.
 ///
-/// Progresses through `Initializing` → `Waiting` → `Ready`. Any phase may transition to
-/// `Failed` on error.
+/// Progresses through `Initializing` → `Waiting` → `Ready`. Any phase may transition to `Failed`
+/// on error.
 #[derive(Clone, Copy, Debug, Deserialize, Serialize, JsonSchema, Eq, PartialEq)]
 pub enum PreviewSessionPhase {
     /// Operator is setting up — the preview pod has not been created yet.
@@ -172,6 +176,9 @@ pub struct PreviewStatusUpdate {
     failure_message: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
+    failed_at: Option<MicroTime>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     expires_at: Option<MicroTime>,
 }
 
@@ -202,6 +209,12 @@ impl PreviewStatusUpdate {
     /// Sets `.status.failureMessage`.
     pub fn failure_message(mut self, failure_message: String) -> Self {
         self.failure_message = Some(failure_message);
+        self
+    }
+
+    /// Sets `.status.failedAt`.
+    pub fn failed_at(mut self, failed_at: MicroTime) -> Self {
+        self.failed_at = Some(failed_at);
         self
     }
 


### PR DESCRIPTION
<!-- Thank you for contributing to mirrord! -->
<!-- Please use the checklist below as a guide for docs, tests and admin tasks for your PR -->
<!-- Feel free to ~strikethrough~ any items that you don't think apply -->

### Summary

See the write up on the operator :))

### Quality Checklist:

- [x] I have documented new code sufficiently
- [x] I have checked and updated the relevant existing docs in code, including removing outdated material
- [x] I have written user-facing website docs for new features, or opened a (sub)issue to do so
- [x] I have checked and updated existing website docs for changed features
- [x] I have tested this change and know it succeeds and fails as expected
- [x] I have written unit tests or purposefully omitted them
- [x] I have written e2e tests or purposefully omitted them
- [x] I have explained what this PR introduces and why, and linked to relevant context (e.g. linear issues, related PRs,
  documentation)
- [x] I have introduced a short, clear and well-formatted changelog entry

<!-- need help with the changelog? see ../CONTRIBUTING.md#submitting-a-pull-request -->
<!-- Add more details of your changes below if needed -->

### Related PRs:
- https://github.com/metalbear-co/operator/pull/1487
