### PR TITLE
FIX libuv getaddrinfo EAI errors

### DIFF
--- a/changelog.d/+libuv-getaddrinfo.fixed.md
+++ b/changelog.d/+libuv-getaddrinfo.fixed.md
@@ -1,0 +1,1 @@
+Fixed a Node/libuv crash when mirrord's Unix `getaddrinfo` hook returned a non-`EAI_*` error after remote DNS found no records.

--- a/mirrord/layer-lib/src/error.rs
+++ b/mirrord/layer-lib/src/error.rs
@@ -552,6 +552,7 @@ pub fn getaddrinfo_error_code(fail: HookError) -> i32 {
         }
         HookError::DNSNoName => libc::EAI_NONAME,
         other => {
+            // The conversion has side effects - logs, possible gracefull exit, etc.
             let _ = i64::from(other);
             libc::EAI_FAIL
         }
@@ -683,39 +684,5 @@ impl From<frida_gum::Error> for LayerError {
 impl From<HookError> for *mut hostent {
     fn from(_fail: HookError) -> Self {
         ptr::null_mut()
-    }
-}
-
-#[cfg(all(test, unix))]
-mod tests {
-    use mirrord_protocol::{DnsLookupError, ResolveErrorKindInternal, ResponseError};
-
-    use super::{HookError, getaddrinfo_error_code};
-
-    #[test]
-    fn getaddrinfo_maps_dns_lookup_failures_to_eai_codes() {
-        let code = getaddrinfo_error_code(HookError::ResponseError(ResponseError::DnsLookup(
-            DnsLookupError {
-                kind: ResolveErrorKindInternal::NoRecordsFound(0),
-            },
-        )));
-
-        assert_eq!(code, libc::EAI_NONAME);
-    }
-
-    #[test]
-    fn getaddrinfo_maps_no_name_to_eai_noname() {
-        assert_eq!(
-            getaddrinfo_error_code(HookError::DNSNoName),
-            libc::EAI_NONAME
-        );
-    }
-
-    #[test]
-    fn getaddrinfo_maps_other_hook_errors_to_eai_fail() {
-        assert_eq!(
-            getaddrinfo_error_code(HookError::NullPointer),
-            libc::EAI_FAIL
-        );
     }
 }

--- a/mirrord/layer-lib/src/error.rs
+++ b/mirrord/layer-lib/src/error.rs
@@ -539,6 +539,25 @@ fn translate_dns_fail(dns_fail: DnsLookupError) -> i32 {
     } as _)
 }
 
+/// `getaddrinfo(3)` returns `EAI_*` codes directly instead of reporting failures via `errno`.
+///
+/// We still preserve the generic hook-error side effects for non-DNS failures, such as logging and
+/// graceful exits, before collapsing them into `EAI_FAIL` for callers like libuv that validate the
+/// return value.
+#[cfg(unix)]
+pub fn getaddrinfo_error_code(fail: HookError) -> i32 {
+    match fail {
+        HookError::ResponseError(ResponseError::DnsLookup(dns_fail)) => {
+            translate_dns_fail(dns_fail)
+        }
+        HookError::DNSNoName => libc::EAI_NONAME,
+        other => {
+            let _ = i64::from(other);
+            libc::EAI_FAIL
+        }
+    }
+}
+
 /// mapping based on - <https://man7.org/linux/man-pages/man3/errno.3.html>
 impl From<HookError> for i64 {
     fn from(fail: HookError) -> Self {
@@ -664,5 +683,39 @@ impl From<frida_gum::Error> for LayerError {
 impl From<HookError> for *mut hostent {
     fn from(_fail: HookError) -> Self {
         ptr::null_mut()
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use mirrord_protocol::{DnsLookupError, ResolveErrorKindInternal, ResponseError};
+
+    use super::{HookError, getaddrinfo_error_code};
+
+    #[test]
+    fn getaddrinfo_maps_dns_lookup_failures_to_eai_codes() {
+        let code = getaddrinfo_error_code(HookError::ResponseError(ResponseError::DnsLookup(
+            DnsLookupError {
+                kind: ResolveErrorKindInternal::NoRecordsFound(0),
+            },
+        )));
+
+        assert_eq!(code, libc::EAI_NONAME);
+    }
+
+    #[test]
+    fn getaddrinfo_maps_no_name_to_eai_noname() {
+        assert_eq!(
+            getaddrinfo_error_code(HookError::DNSNoName),
+            libc::EAI_NONAME
+        );
+    }
+
+    #[test]
+    fn getaddrinfo_maps_other_hook_errors_to_eai_fail() {
+        assert_eq!(
+            getaddrinfo_error_code(HookError::NullPointer),
+            libc::EAI_FAIL
+        );
     }
 }

--- a/mirrord/layer-tests/tests/node_getaddrinfo_no_name.rs
+++ b/mirrord/layer-tests/tests/node_getaddrinfo_no_name.rs
@@ -1,0 +1,77 @@
+#![cfg(target_family = "unix")]
+#![warn(clippy::indexing_slicing)]
+
+use std::{io::Write, time::Duration};
+
+use mirrord_protocol::{
+    ClientMessage, DaemonMessage,
+    dns::{DnsLookup, GetAddrInfoRequestV2, GetAddrInfoResponse},
+};
+use rstest::rstest;
+use tempfile::NamedTempFile;
+
+mod common;
+
+pub use common::*;
+
+/// Verify that Node gets a regular lookup error instead of aborting when remote DNS returns no
+/// records.
+#[rstest]
+#[tokio::test]
+#[timeout(Duration::from_secs(60))]
+async fn test_node_getaddrinfo_no_name_returns_error() {
+    let mut app = NamedTempFile::with_suffix(".js").unwrap();
+    app.as_file_mut()
+        .write_all(
+            br#"const dns = require("dns");
+
+dns.lookup("missing.example.test", (err) => {
+    if (!err) {
+        console.error("lookup unexpectedly succeeded");
+        process.exit(1);
+    }
+
+    console.log(`lookup failed with ${err.code ?? "UNKNOWN"}`);
+    process.exit(0);
+});
+"#,
+        )
+        .unwrap();
+
+    let application = Application::DynamicApp(
+        "node".to_string(),
+        vec![app.path().to_string_lossy().to_string()],
+    );
+
+    let (mut test_process, mut intproxy) = application
+        .start_process(vec![("MIRRORD_REMOTE_DNS", "true")], None)
+        .await;
+
+    if cfg!(target_os = "macos") {
+        intproxy
+            .expect_file_open_for_reading("/etc/resolv.conf", 2136)
+            .await;
+        intproxy
+            .consume_xstats_then_expect_file_read("search home\nnameserver 10.0.0.138\n", 2136)
+            .await;
+        intproxy.expect_file_close(2136).await;
+    }
+
+    let message = intproxy.recv().await;
+    let ClientMessage::GetAddrInfoRequestV2(GetAddrInfoRequestV2 { node, .. }) = message else {
+        panic!("Invalid message received from layer: {message:?}");
+    };
+    assert_eq!(node, "missing.example.test");
+
+    intproxy
+        .send(DaemonMessage::GetAddrInfoResponse(GetAddrInfoResponse(Ok(
+            DnsLookup(vec![]),
+        ))))
+        .await;
+
+    test_process.wait_assert_success().await;
+    test_process
+        .assert_stdout_contains("lookup failed with")
+        .await;
+    test_process.assert_no_error_in_stderr().await;
+}

--- a/mirrord/layer-tests/tests/node_getaddrinfo_no_name.rs
+++ b/mirrord/layer-tests/tests/node_getaddrinfo_no_name.rs
@@ -6,7 +6,10 @@ use std::{io::Write, path::PathBuf, time::Duration};
 use mirrord_protocol::{
     ClientMessage, DaemonMessage, FileRequest, FileResponse,
     dns::{DnsLookup, GetAddrInfoRequestV2, GetAddrInfoResponse},
-    file::{OpenFileRequest, OpenFileResponse, OpenOptionsInternal},
+    file::{
+        OpenFileRequest, OpenFileResponse, OpenOptionsInternal, SeekFileRequest, SeekFileResponse,
+        SeekFromInternal,
+    },
 };
 use rstest::rstest;
 use tempfile::NamedTempFile;
@@ -75,9 +78,39 @@ dns.lookup("missing.example.test", (err) => {
                         OpenFileResponse { fd: RESOLV_CONF_FD },
                     ))))
                     .await;
-                intproxy
-                    .consume_xstats_then_expect_file_read(RESOLV_CONF_CONTENTS, RESOLV_CONF_FD)
-                    .await;
+
+                match intproxy.consume_xstats().await {
+                    ClientMessage::FileRequest(FileRequest::Seek(SeekFileRequest {
+                        fd,
+                        seek_from: SeekFromInternal::Start(0),
+                    })) => {
+                        assert_eq!(fd, RESOLV_CONF_FD);
+
+                        intproxy
+                            .send(DaemonMessage::File(FileResponse::Seek(Ok(
+                                SeekFileResponse { result_offset: 0 },
+                            ))))
+                            .await;
+                        intproxy
+                            .consume_xstats_then_expect_file_read(
+                                RESOLV_CONF_CONTENTS,
+                                RESOLV_CONF_FD,
+                            )
+                            .await;
+                    }
+                    message => {
+                        let buffer_size =
+                            TestIntProxy::expect_message_file_read(message, RESOLV_CONF_FD).await;
+                        intproxy
+                            .answer_file_read_twice(
+                                RESOLV_CONF_CONTENTS,
+                                RESOLV_CONF_FD,
+                                buffer_size,
+                            )
+                            .await;
+                    }
+                }
+
                 intproxy.expect_file_close(RESOLV_CONF_FD).await;
             }
             other => panic!("Invalid message received from layer: {other:?}"),

--- a/mirrord/layer-tests/tests/node_getaddrinfo_no_name.rs
+++ b/mirrord/layer-tests/tests/node_getaddrinfo_no_name.rs
@@ -1,7 +1,7 @@
 #![cfg(target_family = "unix")]
 #![warn(clippy::indexing_slicing)]
 
-use std::{io::Write, path::PathBuf, time::Duration};
+use std::{io::Write, path::Path, time::Duration};
 
 use mirrord_protocol::{
     ClientMessage, DaemonMessage, FileRequest, FileResponse,
@@ -18,14 +18,68 @@ mod common;
 
 pub use common::*;
 
+async fn serve_remote_file(intproxy: &mut TestIntProxy, contents: &str, remote_fd: u64) {
+    intproxy
+        .send(DaemonMessage::File(FileResponse::Open(Ok(
+            OpenFileResponse { fd: remote_fd },
+        ))))
+        .await;
+
+    let mut cursor = 0usize;
+
+    loop {
+        match intproxy.consume_xstats().await {
+            ClientMessage::FileRequest(FileRequest::Seek(SeekFileRequest {
+                fd,
+                seek_from: SeekFromInternal::Start(0),
+            })) => {
+                assert_eq!(fd, remote_fd);
+                cursor = 0;
+
+                intproxy
+                    .send(DaemonMessage::File(FileResponse::Seek(Ok(
+                        SeekFileResponse { result_offset: 0 },
+                    ))))
+                    .await;
+            }
+            ClientMessage::FileRequest(FileRequest::Read(ReadFileRequest {
+                remote_fd: requested_fd,
+                buffer_size,
+            })) => {
+                assert_eq!(requested_fd, remote_fd);
+
+                let end = cursor
+                    .saturating_add(buffer_size as usize)
+                    .min(contents.len());
+                let bytes = contents
+                    .as_bytes()
+                    .get(cursor..end)
+                    .unwrap_or_default()
+                    .to_vec();
+                cursor = end;
+
+                intproxy.answer_file_read(bytes).await;
+            }
+            ClientMessage::FileRequest(FileRequest::Close(CloseFileRequest { fd })) => {
+                assert_eq!(fd, remote_fd);
+                break;
+            }
+            other => panic!("Invalid message while serving remote file: {other:?}"),
+        }
+    }
+}
+
 /// Verify that Node gets a regular lookup error instead of aborting when remote DNS returns no
 /// records.
 #[rstest]
 #[tokio::test]
 #[timeout(Duration::from_secs(60))]
 async fn test_node_getaddrinfo_no_name_returns_error() {
+    const HOSTNAME_CONTENTS: &str = "github-actions\n";
+    const HOSTS_CONTENTS: &str = "127.0.0.1 localhost\n::1 localhost\n";
+    const NSSWITCH_CONTENTS: &str = "hosts: files dns\n";
     const RESOLV_CONF_CONTENTS: &str = "search home\nnameserver 10.0.0.138\n";
-    const RESOLV_CONF_FD: u64 = 2136;
+    const REMOTE_FILE_FD: u64 = 2136;
 
     let mut app = NamedTempFile::with_suffix(".js").unwrap();
     app.as_file_mut()
@@ -71,58 +125,18 @@ dns.lookup("missing.example.test", (err) => {
                         create_new: false,
                     },
             })) => {
-                assert_eq!(path, PathBuf::from("/etc/resolv.conf"));
+                let contents = match path.as_path() {
+                    path if path == Path::new("/etc/hostname") => HOSTNAME_CONTENTS,
+                    path if path == Path::new("/etc/hosts") => HOSTS_CONTENTS,
+                    path if path == Path::new("/etc/nsswitch.conf") => NSSWITCH_CONTENTS,
+                    path if path == Path::new("/etc/resolv.conf") => RESOLV_CONF_CONTENTS,
+                    _ => panic!(
+                        "Unexpected file opened before getaddrinfo: {}",
+                        path.display()
+                    ),
+                };
 
-                intproxy
-                    .send(DaemonMessage::File(FileResponse::Open(Ok(
-                        OpenFileResponse { fd: RESOLV_CONF_FD },
-                    ))))
-                    .await;
-
-                let mut cursor = 0usize;
-
-                loop {
-                    match intproxy.consume_xstats().await {
-                        ClientMessage::FileRequest(FileRequest::Seek(SeekFileRequest {
-                            fd,
-                            seek_from: SeekFromInternal::Start(0),
-                        })) => {
-                            assert_eq!(fd, RESOLV_CONF_FD);
-                            cursor = 0;
-
-                            intproxy
-                                .send(DaemonMessage::File(FileResponse::Seek(Ok(
-                                    SeekFileResponse { result_offset: 0 },
-                                ))))
-                                .await;
-                        }
-                        ClientMessage::FileRequest(FileRequest::Read(ReadFileRequest {
-                            remote_fd,
-                            buffer_size,
-                        })) => {
-                            assert_eq!(remote_fd, RESOLV_CONF_FD);
-
-                            let end = cursor
-                                .saturating_add(buffer_size as usize)
-                                .min(RESOLV_CONF_CONTENTS.len());
-                            let bytes = RESOLV_CONF_CONTENTS
-                                .as_bytes()
-                                .get(cursor..end)
-                                .unwrap_or_default()
-                                .to_vec();
-                            cursor = end;
-
-                            intproxy.answer_file_read(bytes).await;
-                        }
-                        ClientMessage::FileRequest(FileRequest::Close(CloseFileRequest { fd })) => {
-                            assert_eq!(fd, RESOLV_CONF_FD);
-                            break;
-                        }
-                        other => {
-                            panic!("Invalid message while serving /etc/resolv.conf: {other:?}")
-                        }
-                    }
-                }
+                serve_remote_file(&mut intproxy, contents, REMOTE_FILE_FD).await;
             }
             other => panic!("Invalid message received from layer: {other:?}"),
         }

--- a/mirrord/layer-tests/tests/node_getaddrinfo_no_name.rs
+++ b/mirrord/layer-tests/tests/node_getaddrinfo_no_name.rs
@@ -1,11 +1,12 @@
 #![cfg(target_family = "unix")]
 #![warn(clippy::indexing_slicing)]
 
-use std::{io::Write, time::Duration};
+use std::{io::Write, path::PathBuf, time::Duration};
 
 use mirrord_protocol::{
-    ClientMessage, DaemonMessage,
+    ClientMessage, DaemonMessage, FileRequest, FileResponse,
     dns::{DnsLookup, GetAddrInfoRequestV2, GetAddrInfoResponse},
+    file::{OpenFileRequest, OpenFileResponse, OpenOptionsInternal},
 };
 use rstest::rstest;
 use tempfile::NamedTempFile;
@@ -20,6 +21,9 @@ pub use common::*;
 #[tokio::test]
 #[timeout(Duration::from_secs(60))]
 async fn test_node_getaddrinfo_no_name_returns_error() {
+    const RESOLV_CONF_CONTENTS: &str = "search home\nnameserver 10.0.0.138\n";
+    const RESOLV_CONF_FD: u64 = 2136;
+
     let mut app = NamedTempFile::with_suffix(".js").unwrap();
     app.as_file_mut()
         .write_all(
@@ -47,19 +51,37 @@ dns.lookup("missing.example.test", (err) => {
         .start_process(vec![("MIRRORD_REMOTE_DNS", "true")], None)
         .await;
 
-    if cfg!(target_os = "macos") {
-        intproxy
-            .expect_file_open_for_reading("/etc/resolv.conf", 2136)
-            .await;
-        intproxy
-            .consume_xstats_then_expect_file_read("search home\nnameserver 10.0.0.138\n", 2136)
-            .await;
-        intproxy.expect_file_close(2136).await;
-    }
+    let GetAddrInfoRequestV2 { node, .. } = loop {
+        let message = intproxy.consume_xstats().await;
 
-    let message = intproxy.recv().await;
-    let ClientMessage::GetAddrInfoRequestV2(GetAddrInfoRequestV2 { node, .. }) = message else {
-        panic!("Invalid message received from layer: {message:?}");
+        match message {
+            ClientMessage::GetAddrInfoRequestV2(request) => break request,
+            ClientMessage::FileRequest(FileRequest::Open(OpenFileRequest {
+                path,
+                open_options:
+                    OpenOptionsInternal {
+                        read: true,
+                        write: false,
+                        append: false,
+                        truncate: false,
+                        create: false,
+                        create_new: false,
+                    },
+            })) => {
+                assert_eq!(path, PathBuf::from("/etc/resolv.conf"));
+
+                intproxy
+                    .send(DaemonMessage::File(FileResponse::Open(Ok(
+                        OpenFileResponse { fd: RESOLV_CONF_FD },
+                    ))))
+                    .await;
+                intproxy
+                    .consume_xstats_then_expect_file_read(RESOLV_CONF_CONTENTS, RESOLV_CONF_FD)
+                    .await;
+                intproxy.expect_file_close(RESOLV_CONF_FD).await;
+            }
+            other => panic!("Invalid message received from layer: {other:?}"),
+        }
     };
     assert_eq!(node, "missing.example.test");
 

--- a/mirrord/layer-tests/tests/node_getaddrinfo_no_name.rs
+++ b/mirrord/layer-tests/tests/node_getaddrinfo_no_name.rs
@@ -7,8 +7,8 @@ use mirrord_protocol::{
     ClientMessage, DaemonMessage, FileRequest, FileResponse,
     dns::{DnsLookup, GetAddrInfoRequestV2, GetAddrInfoResponse},
     file::{
-        OpenFileRequest, OpenFileResponse, OpenOptionsInternal, SeekFileRequest, SeekFileResponse,
-        SeekFromInternal,
+        CloseFileRequest, OpenFileRequest, OpenFileResponse, OpenOptionsInternal, ReadFileRequest,
+        SeekFileRequest, SeekFileResponse, SeekFromInternal,
     },
 };
 use rstest::rstest;
@@ -79,39 +79,50 @@ dns.lookup("missing.example.test", (err) => {
                     ))))
                     .await;
 
-                match intproxy.consume_xstats().await {
-                    ClientMessage::FileRequest(FileRequest::Seek(SeekFileRequest {
-                        fd,
-                        seek_from: SeekFromInternal::Start(0),
-                    })) => {
-                        assert_eq!(fd, RESOLV_CONF_FD);
+                let mut cursor = 0usize;
 
-                        intproxy
-                            .send(DaemonMessage::File(FileResponse::Seek(Ok(
-                                SeekFileResponse { result_offset: 0 },
-                            ))))
-                            .await;
-                        intproxy
-                            .consume_xstats_then_expect_file_read(
-                                RESOLV_CONF_CONTENTS,
-                                RESOLV_CONF_FD,
-                            )
-                            .await;
-                    }
-                    message => {
-                        let buffer_size =
-                            TestIntProxy::expect_message_file_read(message, RESOLV_CONF_FD).await;
-                        intproxy
-                            .answer_file_read_twice(
-                                RESOLV_CONF_CONTENTS,
-                                RESOLV_CONF_FD,
-                                buffer_size,
-                            )
-                            .await;
+                loop {
+                    match intproxy.consume_xstats().await {
+                        ClientMessage::FileRequest(FileRequest::Seek(SeekFileRequest {
+                            fd,
+                            seek_from: SeekFromInternal::Start(0),
+                        })) => {
+                            assert_eq!(fd, RESOLV_CONF_FD);
+                            cursor = 0;
+
+                            intproxy
+                                .send(DaemonMessage::File(FileResponse::Seek(Ok(
+                                    SeekFileResponse { result_offset: 0 },
+                                ))))
+                                .await;
+                        }
+                        ClientMessage::FileRequest(FileRequest::Read(ReadFileRequest {
+                            remote_fd,
+                            buffer_size,
+                        })) => {
+                            assert_eq!(remote_fd, RESOLV_CONF_FD);
+
+                            let end = cursor
+                                .saturating_add(buffer_size as usize)
+                                .min(RESOLV_CONF_CONTENTS.len());
+                            let bytes = RESOLV_CONF_CONTENTS
+                                .as_bytes()
+                                .get(cursor..end)
+                                .unwrap_or_default()
+                                .to_vec();
+                            cursor = end;
+
+                            intproxy.answer_file_read(bytes).await;
+                        }
+                        ClientMessage::FileRequest(FileRequest::Close(CloseFileRequest { fd })) => {
+                            assert_eq!(fd, RESOLV_CONF_FD);
+                            break;
+                        }
+                        other => {
+                            panic!("Invalid message while serving /etc/resolv.conf: {other:?}")
+                        }
                     }
                 }
-
-                intproxy.expect_file_close(RESOLV_CONF_FD).await;
             }
             other => panic!("Invalid message received from layer: {other:?}"),
         }

--- a/mirrord/layer-tests/tests/node_getaddrinfo_no_name.rs
+++ b/mirrord/layer-tests/tests/node_getaddrinfo_no_name.rs
@@ -125,15 +125,15 @@ dns.lookup("missing.example.test", (err) => {
                         create_new: false,
                     },
             })) => {
+                // Some Linux images probe additional host-related config files before DNS
+                // resolution. Unknown read-only files can safely behave like empty files here;
+                // the regression only needs `resolv.conf` and a few common hostname sources.
                 let contents = match path.as_path() {
                     path if path == Path::new("/etc/hostname") => HOSTNAME_CONTENTS,
                     path if path == Path::new("/etc/hosts") => HOSTS_CONTENTS,
                     path if path == Path::new("/etc/nsswitch.conf") => NSSWITCH_CONTENTS,
                     path if path == Path::new("/etc/resolv.conf") => RESOLV_CONF_CONTENTS,
-                    _ => panic!(
-                        "Unexpected file opened before getaddrinfo: {}",
-                        path.display()
-                    ),
+                    _ => "",
                 };
 
                 serve_remote_file(&mut intproxy, contents, REMOTE_FILE_FD).await;

--- a/mirrord/layer/src/socket/hooks.rs
+++ b/mirrord/layer/src/socket/hooks.rs
@@ -10,6 +10,7 @@ use mirrord_config::experimental::ExperimentalConfig;
 use mirrord_layer_lib::socket::apple_dnsinfo::*;
 use mirrord_layer_lib::{
     detour::{Detour, DetourGuard},
+    error::getaddrinfo_error_code,
     mutex::Mutex,
     socket::ops::socket,
 };
@@ -341,18 +342,18 @@ unsafe extern "C" fn getaddrinfo_detour(
         let rawish_service = (!raw_service.is_null()).then(|| CStr::from_ptr(raw_service));
         let rawish_hints = raw_hints.as_ref();
 
-        getaddrinfo(rawish_node, rawish_service, rawish_hints)
-            .map(|c_addr_info_ptr| {
+        match getaddrinfo(rawish_node, rawish_service, rawish_hints) {
+            Detour::Success(c_addr_info_ptr) => {
                 out_addr_info.copy_from_nonoverlapping(&c_addr_info_ptr, 1);
                 MANAGED_ADDRINFO
                     .lock()
                     .expect("MANAGED_ADDRINFO lock failed")
                     .insert(c_addr_info_ptr as usize);
                 0
-            })
-            .unwrap_or_bypass_with(|_| {
-                FN_GETADDRINFO(raw_node, raw_service, raw_hints, out_addr_info)
-            })
+            }
+            Detour::Bypass(_) => FN_GETADDRINFO(raw_node, raw_service, raw_hints, out_addr_info),
+            Detour::Error(error) => getaddrinfo_error_code(error),
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- return `EAI_*` codes from the Unix `getaddrinfo` detour instead of generic hook error conversions
- keep generic hook-error side effects for non-DNS failures, but collapse them to `EAI_FAIL` for `getaddrinfo` callers
- add a Node regression test that reproduces the empty-remote-DNS-response path without aborting in libuv

## Root Cause
`getaddrinfo(3)` reports failures through its return value, not through `errno`. The Unix mirrord detour was using the generic `Detour::Error -> HookError::into()` path, so `HookError::DNSNoName` and similar non-`DnsLookup` errors could become `-1`/`errno`-style failures instead of valid `EAI_*` results. libuv validates those return codes and aborts when it sees an unknown value.

## Fix
Handle Unix `getaddrinfo` errors explicitly. `ResponseError::DnsLookup` still maps to the native DNS codes, `DNSNoName` now maps to `EAI_NONAME`, and other hook errors preserve their logging/graceful-exit behavior before returning `EAI_FAIL` to the caller.
