### PR TITLE
INT-374 LocalRedis cleanup is skipped on interrupt

### DIFF
--- a/changelog.d/+local-redis.fixed.md
+++ b/changelog.d/+local-redis.fixed.md
@@ -1,0 +1,1 @@
+Fixed local Redis containers/processes not being cleaned up.

--- a/changelog.d/+local-redis.fixed.md
+++ b/changelog.d/+local-redis.fixed.md
@@ -1,1 +1,1 @@
-Fixed local Redis containers/processes not being cleaned up.
+Fixed local `Redis` containers/processes not being cleaned up.

--- a/mirrord/cli/src/config.rs
+++ b/mirrord/cli/src/config.rs
@@ -261,6 +261,29 @@ pub(super) enum Commands {
     /// Kill a local mirrord session.
     #[cfg(unix)]
     Kill(Box<KillArgs>),
+
+    /// Detached guardian that monitors a PID and cleans up resources when it exits.
+    /// Spawned by `exec` for resources (e.g. local Redis) that must be cleaned up
+    /// even after `execve` replaces the process or the CLI is interrupted.
+    #[cfg(unix)]
+    #[command(hide = true, name = "cleanup-guardian")]
+    CleanupGuardian {
+        /// PID to monitor. Cleanup runs when this PID exits.
+        #[arg(long)]
+        watch_pid: u32,
+
+        /// Container runtime command (e.g. "docker", "podman") for container cleanup.
+        #[arg(long)]
+        container_runtime: Option<String>,
+
+        /// Container name to remove.
+        #[arg(long)]
+        container_name: Option<String>,
+
+        /// PID of a process to kill during cleanup.
+        #[arg(long)]
+        process_pid: Option<u32>,
+    },
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum, Debug)]

--- a/mirrord/cli/src/db_branches.rs
+++ b/mirrord/cli/src/db_branches.rs
@@ -18,6 +18,7 @@ use crate::{
     CliResult,
     config::{DbBranchesArgs, DbBranchesCommand},
     kube::{kube_client_from_layer_config, list_resource_if_defined},
+    util::is_pid_alive,
 };
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -258,28 +259,6 @@ async fn connections_command() -> CliResult<()> {
     }
 
     Ok(())
-}
-
-#[cfg(unix)]
-fn is_pid_alive(pid: u32) -> bool {
-    use nix::{sys::signal::kill, unistd::Pid};
-
-    match kill(Pid::from_raw(pid as i32), None) {
-        Ok(()) => true,
-        Err(nix::errno::Errno::ESRCH) => false,
-        // EPERM means the process exists but we can't signal it.
-        Err(_) => true,
-    }
-}
-
-#[cfg(windows)]
-fn is_pid_alive(pid: u32) -> bool {
-    // Untested AI slop
-    std::process::Command::new("tasklist")
-        .args(["/FI", &format!("PID eq {pid}"), "/NH"])
-        .output()
-        .map(|o| String::from_utf8_lossy(&o.stdout).contains(&pid.to_string()))
-        .unwrap_or(false)
 }
 
 fn get_api<T: Resource<DynamicType = (), Scope = NamespaceResourceScope>>(

--- a/mirrord/cli/src/local_redis.rs
+++ b/mirrord/cli/src/local_redis.rs
@@ -257,6 +257,59 @@ async fn start_server<P: Progress>(
     }
 }
 
+impl LocalRedis {
+    /// Spawn a background process that polls our PID and cleans up when we exit.
+    /// Detached from both the parent process and the terminal session so it survives
+    /// `execve` and Ctrl+C.
+    #[cfg(unix)]
+    pub fn spawn_cleanup_guardian(&self) -> CliResult<()> {
+        let watched_pid = std::process::id();
+        let exe = std::env::current_exe().map_err(CliError::CliPathError)?;
+
+        let mut cmd = tokio::process::Command::new(exe);
+        cmd.arg("cleanup-guardian")
+            .arg("--watch-pid")
+            .arg(watched_pid.to_string());
+
+        match self {
+            LocalRedis::Container {
+                runtime,
+                container_name,
+            } => {
+                cmd.arg("--container-runtime")
+                    .arg(runtime.command())
+                    .arg("--container-name")
+                    .arg(container_name);
+            }
+            LocalRedis::Process(child) => {
+                cmd.arg("--process-pid").arg(child.id().to_string());
+            }
+        }
+
+        cmd.stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+
+        unsafe {
+            cmd.pre_exec(|| {
+                crate::util::reparent_to_init()?;
+                crate::util::detach_io()?;
+                Ok(())
+            });
+        }
+
+        let mut child = cmd.spawn().map_err(|e| {
+            CliError::LocalRedisError(format!("failed to spawn cleanup guardian: {e}"))
+        })?;
+
+        // reparent_to_init forks -- our immediate child exits right away,
+        // reparenting the real guardian to init. Wait for the immediate child.
+        tokio::spawn(async move { child.wait().await });
+
+        Ok(())
+    }
+}
+
 /// Check if Redis is ready by sending a PING command.
 fn is_ready(port: u16) -> bool {
     Command::new("redis-cli")

--- a/mirrord/cli/src/main.rs
+++ b/mirrord/cli/src/main.rs
@@ -820,10 +820,10 @@ async fn exec(
     };
 
     #[cfg(unix)]
-    if let Some(ref redis) = _local_redis {
-        if let Err(e) = redis.spawn_cleanup_guardian() {
-            warn!(?e, "Failed to spawn cleanup guardian for local Redis");
-        }
+    if let Some(ref redis) = _local_redis
+        && let Err(e) = redis.spawn_cleanup_guardian()
+    {
+        warn!(?e, "Failed to spawn cleanup guardian for local Redis");
     }
 
     let mut analytics = AnalyticsReporter::only_error(

--- a/mirrord/cli/src/main.rs
+++ b/mirrord/cli/src/main.rs
@@ -819,6 +819,13 @@ async fn exec(
         None
     };
 
+    #[cfg(unix)]
+    if let Some(ref redis) = _local_redis {
+        if let Err(e) = redis.spawn_cleanup_guardian() {
+            warn!(?e, "Failed to spawn cleanup guardian for local Redis");
+        }
+    }
+
     let mut analytics = AnalyticsReporter::only_error(
         config.telemetry,
         Default::default(),
@@ -1189,6 +1196,20 @@ fn main() -> miette::Result<()> {
             Commands::Session(args) => session::session_command(*args).await?,
             #[cfg(unix)]
             Commands::Kill(args) => session::kill_command(*args).await?,
+            #[cfg(unix)]
+            Commands::CleanupGuardian {
+                watch_pid,
+                container_runtime,
+                container_name,
+                process_pid,
+            } => {
+                util::run_cleanup_guardian(
+                    watch_pid,
+                    container_runtime,
+                    container_name,
+                    process_pid,
+                );
+            }
         };
 
         Ok(())

--- a/mirrord/cli/src/util.rs
+++ b/mirrord/cli/src/util.rs
@@ -145,6 +145,56 @@ pub(crate) unsafe fn reparent_to_init() -> Result<(), nix::Error> {
     }
 }
 
+/// Check whether a process with the given PID is still running.
+#[cfg(unix)]
+pub(crate) fn is_pid_alive(pid: u32) -> bool {
+    use nix::{sys::signal::kill, unistd::Pid};
+
+    match kill(Pid::from_raw(pid as i32), None) {
+        Ok(()) => true,
+        Err(nix::errno::Errno::ESRCH) => false,
+        // EPERM means the process exists but we can't signal it.
+        Err(_) => true,
+    }
+}
+
+#[cfg(windows)]
+pub(crate) fn is_pid_alive(pid: u32) -> bool {
+    // Untested AI slop
+    std::process::Command::new("tasklist")
+        .args(["/FI", &format!("PID eq {pid}"), "/NH"])
+        .output()
+        .map(|o| String::from_utf8_lossy(&o.stdout).contains(&pid.to_string()))
+        .unwrap_or(false)
+}
+
+/// Poll `watch_pid` until it exits, then clean up the given container and/or process.
+/// Runs as the `cleanup-guardian` hidden subcommand, fully detached from the terminal.
+#[cfg(unix)]
+pub fn run_cleanup_guardian(
+    watch_pid: u32,
+    container_runtime: Option<String>,
+    container_name: Option<String>,
+    process_pid: Option<u32>,
+) {
+    while is_pid_alive(watch_pid) {
+        std::thread::sleep(std::time::Duration::from_secs(1));
+    }
+
+    if let (Some(runtime), Some(name)) = (container_runtime, container_name) {
+        let _ = std::process::Command::new(&runtime)
+            .args(["rm", "-f", &name])
+            .output();
+    }
+
+    if let Some(pid) = process_pid {
+        let pid = nix::unistd::Pid::from_raw(pid as i32);
+        let _ = nix::sys::signal::kill(pid, nix::sys::signal::Signal::SIGTERM);
+        std::thread::sleep(std::time::Duration::from_secs(1));
+        let _ = nix::sys::signal::kill(pid, nix::sys::signal::Signal::SIGKILL);
+    }
+}
+
 /// Creates a listening socket using socket2
 /// to control the backlog and manage scenarios where
 /// the proxy is under heavy load.


### PR DESCRIPTION
### Summary
- Added a cleanup guardian process that watches the CLI's PID and removes the local Redis instance when it exits.
- Moved `is_pid_alive` and `cleanup guardian` logic from `db_branches.rs` and `local_redis.rs` to `util.rs` for reuse.

<!-- Thank you for contributing to mirrord! -->
<!-- Please use the checklist below as a guide for docs, tests and admin tasks for your PR -->
<!-- Feel free to ~strikethrough~ any items that you don't think apply -->

### Quality Checklist:

- [ ] I have documented new code sufficiently
- [ ] I have checked and updated the relevant existing docs in code, including removing outdated material
- [ ] I have written user-facing website docs for new features, or opened a (sub)issue to do so
- [ ] I have checked and updated existing website docs for changed features
- [ ] I have tested this change and know it succeeds and fails as expected
- [ ] I have written unit tests or purposefully omitted them
- [ ] I have written e2e tests or purposefully omitted them
- [ ] I have explained what this PR introduces and why, and linked to relevant context (e.g. linear issues, related PRs,
  documentation)
- [ ] I have introduced a short, clear and well-formatted changelog entry

<!-- need help with the changelog? see ../CONTRIBUTING.md#submitting-a-pull-request -->
<!-- Add more details of your changes below if needed -->