### PR TITLE
Make test binary path absolute so e2e tests can locate it

### DIFF
--- a/changelog.d/+xtask-test-binary-absolute-path.internal.md
+++ b/changelog.d/+xtask-test-binary-absolute-path.internal.md
@@ -1,0 +1,1 @@
+Make the test binary path absolute in `xtask` so e2e tests can locate it when running from a non-workspace-root directory.

--- a/xtask/src/tasks/test.rs
+++ b/xtask/src/tasks/test.rs
@@ -98,13 +98,16 @@ fn resolve_artifacts(
         }
         (None, Some(l)) => {
             let l = validate_path(&l, "MIRRORD_LAYER_FILE", "mirrord layer")?;
-            let b = build_binary_for_host(&l)?;
+            // Need this to be absolute because tests (e2e in
+            // particular) don't run from workspace root won't be able
+            // to resolve binary otherwise
+            let b = std::path::absolute(build_binary_for_host(&l)?)?;
             Ok((b, l))
         }
         (None, None) => {
             println!("No mirrord artifacts provided — building from source...");
             let l = build_layer_for_host()?;
-            let b = build_binary_for_host(&l)?;
+            let b = std::path::absolute(build_binary_for_host(&l)?)?;
             Ok((b, l))
         }
     }


### PR DESCRIPTION
E2E tests don't run from the workspace root (they run from `tests/`), but currently the mirrord cli path is specified relative to workspace root. Thus the tests cant find it and stuff breaks : (

PR makes the paths absolute so it always works