### PR TITLE
README: surface adopters and AI coding agents section

### DIFF
--- a/.vale/styles/config/vocabularies/Metalbear/accept.txt
+++ b/.vale/styles/config/vocabularies/Metalbear/accept.txt
@@ -222,4 +222,7 @@ uutils
 teardown
 portforward
 portforwards
+
+# Customer / company names
+Zooplus
 ```

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -17,7 +17,13 @@ We're proud to be used by the most innovative teams around the world! If you're 
 | [BforeAI](https://bfore.ai) | [User Story](https://metalbear.com/mirrord/stories/bfore-ai/) |
 | [Utila](https://utila.io) | [User Story](https://metalbear.com/mirrord/stories/utila/) |
 | [Savvy Security](https://www.savvy.security) | [User Story](https://metalbear.com/mirrord/stories/savvy/) |
-| [HM Courts & Tribunal Service](https://www.gov.uk/government/organisations/hm-courts-and-tribunals-service) | [Use Case](https://github.com/hmcts/civil-citizen-ui/blob/master/README.md#development--debugging-environment---preview-with-mirrord) | 
+| [monday.com](https://monday.com) | [Case Study](https://metalbear.com/mirrord/case-study/monday/) |
+| [SurveyMonkey](https://www.surveymonkey.com) | [Case Study](https://metalbear.com/mirrord/case-study/surveymonkey/) |
+| [Cadence](https://www.cadence.com) | [Case Study](https://metalbear.com/mirrord/case-study/cadence/) |
+| [CoLab](https://www.colabsoftware.com) | [Case Study](https://metalbear.com/mirrord/case-study/colab/) |
+| [Daylight Security](https://www.daylight.security) | [Case Study](https://metalbear.com/mirrord/case-study/daylight/) |
+| [Zooplus](https://www.zooplus.com) | [Case Study](https://metalbear.com/mirrord/case-study/zooplus/) |
+| [HM Courts & Tribunal Service](https://www.gov.uk/government/organisations/hm-courts-and-tribunals-service) | [Use Case](https://github.com/hmcts/civil-citizen-ui/blob/master/README.md#development--debugging-environment---preview-with-mirrord) |
 
 \* Optional: link to a blog post, tweet, internal write-up, or leave blank.
 

--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@
 [![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/metalbear-co/mirrord)](https://github.com/metalbear-co/mirrord/releases)
 [![Twitter Follow](https://img.shields.io/twitter/follow/metalbearco?style=social)](https://twitter.com/metalbearco)
 
-[mirrord lets developers run local processes in the context of their Kubernetes environment](https://metalbear.co/mirrord/).
+[mirrord lets developers and AI coding agents run local processes in the context of their Kubernetes environment](https://metalbear.co/mirrord/).
 It’s meant to provide the benefits of running your service on a cloud environment (e.g. staging) without actually
 going through the hassle of deploying it there, and without disrupting the environment by deploying untested code.
 It comes as a Visual Studio Code extension, an IntelliJ plugin and a CLI tool. [You can read more about it here](https://metalbear.co/mirrord/docs/overview/introduction/).
 
-Or maybe you're just Looking for the [KubeCon Atlanta raffle password](#kubecon-atlanta-raffle).
+**Adopted by**: monday.com, SurveyMonkey, Cadence, CoLab, Daylight Security, Zooplus, and [others](./ADOPTERS.md).
 
 # Contents
 
@@ -32,6 +32,7 @@ Or maybe you're just Looking for the [KubeCon Atlanta raffle password](#kubecon-
     - [How To Use](#how-to-use-2)
   - [How It Works](#how-it-works)
     - [Additional capabilities](#additional-capabilities)
+  - [Using mirrord with AI coding agents](#using-mirrord-with-ai-coding-agents)
   - [FAQ](#faq)
   - [Contributing](#contributing)
   - [Help and Community](#help-and-community)
@@ -160,6 +161,14 @@ MIRRORD_AGENT_DISABLED_CAPABILITIES=CAP_NET_RAW,CAP_SYS_PTRACE mirrord exec node
   <img src="./images/how_it_works.svg" alt="How It Works"/>
 </p>
 
+## Using mirrord with AI coding agents
+
+mirrord works first-class with Claude Code, Cursor, Codex CLI, Gemini CLI, and other AI coding agents,
+letting them run and verify generated code against real cluster services without deploying.
+
+For setup guides and ready-made workflow skills,
+see [metalbear-co/skills](https://github.com/metalbear-co/skills) or the [mirrord for AI Agents](https://metalbear.com/mirrord/ai) page.
+
 ## FAQ
 
 [Our FAQ is available here](https://metalbear.co/mirrord/docs/faq/general/).
@@ -179,11 +188,6 @@ Join our [Slack](https://metalbear.co/slack) for questions, support and fun.
 We always appreciate hearing how mirrord has made a difference for our users.  
 Check out our [ADOPTERS.md](./ADOPTERS.md) to see how others are using mirrord —  
 and [open a pull request](https://github.com/metalbear-co/mirrord/pulls) to add your organization if you’d like to share how mirrord has been useful to you.
-
-## KubeCon Atlanta Raffle
-
-The password is: **"The blind rooster crows at midnight."**
-Say it to one of our team members at Booth #1560.
 
 ## Code of Conduct
 

--- a/changelog.d/+readme-adopters-ai-agents.internal.md
+++ b/changelog.d/+readme-adopters-ai-agents.internal.md
@@ -1,0 +1,1 @@
+README: refresh description to mention AI coding agents, add an "Adopted by" line citing case-study customers, add a "Using mirrord with AI coding agents" section pointing at `metalbear-co/skills`, and remove the stale KubeCon Atlanta raffle section. Append 6 case-study customers to ADOPTERS.md.


### PR DESCRIPTION
## Summary

Four small README/ADOPTERS edits to close LLM-citation and discoverability gaps surfaced by a recent visibility audit.

## Changes

**README.md:**

1. **Description refresh.** Adds "and AI coding agents" to the opening sentence so the README reflects who the audience actually is.
2. **"Adopted by" line above the fold.** Replaces the stale KubeCon Atlanta raffle teaser. Lists 6 case-study customers (monday.com, SurveyMonkey, Cadence, CoLab, Daylight Security, Zooplus) and links to ADOPTERS.md for the full list.
3. **New "Using mirrord with AI coding agents" section** before FAQ, pointing at [metalbear-co/skills](https://github.com/metalbear-co/skills) and the [mirrord for AI Agents](https://metalbear.com/mirrord/ai) page.
4. **Removes the stale KubeCon Atlanta Raffle section.**

**ADOPTERS.md:**

Appends 6 case-study customers (each linked to their case study on metalbear.com) to bring the public adopters list into rough parity with the customer page on the marketing site.

## Why

Audit found that LLM training scrapers heavily weight the README, but the current one mentions zero customers and doesn't reflect the AI-coding-agent audience that's grown in the last 12 months. These additions stay within OSS-README norms (no comparison tables, no marketing copy) while addressing the gaps.

Companion to merged llms.txt changes ([metalbear-co/metalbear.co#386](https://github.com/metalbear-co/metalbear.co/pull/386)) and merged awesome-agent-skills listing ([VoltAgent/awesome-agent-skills#523](https://github.com/VoltAgent/awesome-agent-skills/pull/523)).
