### PR TITLE
Use absolute paths in xtask

### DIFF
--- a/changelog.d/+absolute-xtask-paths.internal.md
+++ b/changelog.d/+absolute-xtask-paths.internal.md
@@ -1,0 +1,1 @@
+Use absolute paths when building layer and CLI in xtask so that tasks can be run from subdirectories of the project.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,6 +1,9 @@
 mod tasks;
 
-use std::process::Command;
+use std::{
+    path::{Path, PathBuf},
+    process::Command,
+};
 
 use anyhow::Result;
 use clap::{Parser, Subcommand};
@@ -317,4 +320,13 @@ fn main() -> Result<()> {
     }
 
     Ok(())
+}
+
+fn relative_to_root(path: &Path) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        // Take the parent because here `CARGO_MANIFEST_DIR` is
+        // the xtask/ subdirectory
+        .parent()
+        .unwrap()
+        .join(path)
 }

--- a/xtask/src/tasks/layer.rs
+++ b/xtask/src/tasks/layer.rs
@@ -6,6 +6,8 @@ use std::{
 use anyhow::{Context, Result};
 use which::which;
 
+use crate::relative_to_root;
+
 use super::signing;
 
 /// Target platform for building
@@ -97,7 +99,7 @@ pub fn build_layer(target: Target, release: bool, cargo_args: &[String]) -> Resu
         anyhow::bail!("cargo build failed for {}", target.triple());
     }
 
-    let layer_path = target.layer_file(release);
+    let layer_path = relative_to_root(&target.layer_file(release));
     println!("✓ Layer built: {}", layer_path.display());
     Ok(layer_path)
 }

--- a/xtask/src/tasks/layer.rs
+++ b/xtask/src/tasks/layer.rs
@@ -6,9 +6,8 @@ use std::{
 use anyhow::{Context, Result};
 use which::which;
 
-use crate::relative_to_root;
-
 use super::signing;
+use crate::relative_to_root;
 
 /// Target platform for building
 #[derive(Debug, Clone, Copy)]

--- a/xtask/src/tasks/monitor.rs
+++ b/xtask/src/tasks/monitor.rs
@@ -17,10 +17,7 @@ pub fn build_monitor() -> Result<PathBuf> {
     let monitor_dir = &relative_to_root(Path::new("packages/monitor"));
 
     if !monitor_dir.exists() {
-        anyhow::bail!(
-            "Monitor directory not found at {}.",
-            monitor_dir.display()
-        );
+        anyhow::bail!("Monitor directory not found at {}.", monitor_dir.display());
     }
 
     if !pnpm_available() {

--- a/xtask/src/tasks/monitor.rs
+++ b/xtask/src/tasks/monitor.rs
@@ -5,6 +5,8 @@ use std::{
 
 use anyhow::{Context, Result};
 
+use crate::relative_to_root;
+
 /// Builds the monitor frontend (pnpm install + build).
 ///
 /// The CLI embeds these assets, so a missing `pnpm` means the resulting binary would have a
@@ -12,11 +14,11 @@ use anyhow::{Context, Result};
 pub fn build_monitor() -> Result<PathBuf> {
     println!("Building monitor frontend...");
 
-    let monitor_dir = Path::new("packages/monitor");
+    let monitor_dir = &relative_to_root(Path::new("packages/monitor"));
 
     if !monitor_dir.exists() {
         anyhow::bail!(
-            "Monitor directory not found at {}. Are you in the mirrord repository root?",
+            "Monitor directory not found at {}.",
             monitor_dir.display()
         );
     }

--- a/xtask/src/tasks/release.rs
+++ b/xtask/src/tasks/release.rs
@@ -3,9 +3,8 @@ use std::{env, ops::Not, path::PathBuf};
 use anyhow::{Context, Result};
 use layer::Target;
 
-use crate::relative_to_root;
-
 use super::{cli, layer, monitor, wizard};
+use crate::relative_to_root;
 
 #[derive(Debug, Clone, Copy)]
 pub enum Platform {

--- a/xtask/src/tasks/release.rs
+++ b/xtask/src/tasks/release.rs
@@ -3,6 +3,8 @@ use std::{env, ops::Not, path::PathBuf};
 use anyhow::{Context, Result};
 use layer::Target;
 
+use crate::relative_to_root;
+
 use super::{cli, layer, monitor, wizard};
 
 #[derive(Debug, Clone, Copy)]
@@ -204,6 +206,8 @@ pub fn build_release_cli(options: BuildOptions) -> Result<PathBuf> {
             .context("Failed to build CLI")?
         }
     };
+
+    let cli_path = relative_to_root(&cli_path);
 
     if options.quiet.not() {
         println!();

--- a/xtask/src/tasks/test.rs
+++ b/xtask/src/tasks/test.rs
@@ -1,6 +1,6 @@
 use std::{
     env,
-    path::{Path, PathBuf, absolute},
+    path::{Path, PathBuf},
     process::Command,
 };
 
@@ -123,15 +123,13 @@ fn host_target() -> Result<Target> {
 
 fn build_layer_for_host() -> Result<PathBuf> {
     let target = host_target()?;
-    let path = layer::build_layer(target, false, &[])?;
-    Ok(absolute(path)?)
+    layer::build_layer(target, false, &[])
 }
 
 fn build_binary_for_host(layer_path: &Path) -> Result<PathBuf> {
     let target = host_target()?;
     super::monitor::build_monitor()?;
-    let path = super::cli::build_cli(target, false, layer_path, None, &[])?;
-    Ok(absolute(path)?)
+    super::cli::build_cli(target, false, layer_path, None, &[])
 }
 
 /// Runs CLI unit tests with placeholder embedded assets.

--- a/xtask/src/tasks/wizard.rs
+++ b/xtask/src/tasks/wizard.rs
@@ -5,17 +5,16 @@ use std::{
 
 use anyhow::{Context, Result};
 
+use crate::relative_to_root;
+
 /// Builds the wizard frontend (npm install + build)
 pub fn build_wizard() -> Result<PathBuf> {
     println!("Building wizard frontend...");
 
-    let wizard_dir = Path::new("packages/wizard");
+    let wizard_dir = &relative_to_root(Path::new("packages/wizard"));
 
     if !wizard_dir.exists() {
-        anyhow::bail!(
-            "Wizard directory not found at {}. Are you in the mirrord repository root?",
-            wizard_dir.display()
-        );
+        anyhow::bail!("Wizard directory not found at {}.", wizard_dir.display());
     }
 
     // npm install


### PR DESCRIPTION
Allows running `run-cli`/`build-cli`/`test-*` etc from subdirectories