### PR TITLE
Fix unix sockets

### DIFF
--- a/changelog.d/+unix-sockets.fixed.md
+++ b/changelog.d/+unix-sockets.fixed.md
@@ -1,0 +1,1 @@
+Fixed remote Unix socket connections failing for some applications, including when the socket lives in a directory mounted into the target pod.

--- a/mirrord/layer-lib/src/socket/ops.rs
+++ b/mirrord/layer-lib/src/socket/ops.rs
@@ -265,7 +265,7 @@ pub fn is_ignored_port(addr: &SocketAddr) -> bool {
 #[mirrord_layer_macro::instrument(level = "trace", skip(connect_fn), ret)]
 pub fn connect_common<F>(
     sockfd: SocketDescriptor,
-    remote_address: SockAddr,
+    mut remote_address: SockAddr,
     connect_fn: F,
 ) -> Detour<ConnectResult>
 where
@@ -315,6 +315,26 @@ where
     } else if remote_address.is_unix() {
         #[cfg(unix)]
         {
+            // Apps may pass `connect(2)` an `addrlen` larger than the actual
+            // `sun_path` length, padding the rest with null bytes — the kernel
+            // tolerates this. Rust's `SockAddr::as_pathname`, however, derives
+            // the path's length from `addrlen` rather than the first null, so
+            // the trailing nulls leak into the returned `&Path`. That breaks
+            // the layer's `unix_streams` `RegexSet` match, and on the agent
+            // side the path is later fed to a `CStr` conversion that rejects
+            // embedded nulls.
+            //
+            // Trim the trailing nulls by counting the non-null leading bytes
+            // of `sun_path` and shrinking `remote_address.len` to match.
+
+            if let Some(path) = remote_address.as_pathname() {
+                use std::os::unix::ffi::OsStrExt;
+                let bytes = path.as_os_str().as_bytes();
+                let nonzero = bytes.iter().take_while(|f| **f != 0).count();
+                let diff = bytes.len() - nonzero;
+                unsafe { remote_address.set_length(remote_address.len() - diff as u32) }
+            }
+
             let address = remote_address
                 .as_pathname()
                 .map(|path| path.to_string_lossy())

--- a/mirrord/layer-lib/src/socket/ops.rs
+++ b/mirrord/layer-lib/src/socket/ops.rs
@@ -265,7 +265,8 @@ pub fn is_ignored_port(addr: &SocketAddr) -> bool {
 #[mirrord_layer_macro::instrument(level = "trace", skip(connect_fn), ret)]
 pub fn connect_common<F>(
     sockfd: SocketDescriptor,
-    mut remote_address: SockAddr,
+    #[cfg(unix)] mut remote_address: SockAddr,
+    #[cfg(not(unix))] remote_address: SockAddr,
     connect_fn: F,
 ) -> Detour<ConnectResult>
 where

--- a/mirrord/layer-tests/tests/apps/unix_connect_addrlen/unix_connect_addrlen.c
+++ b/mirrord/layer-tests/tests/apps/unix_connect_addrlen/unix_connect_addrlen.c
@@ -1,0 +1,41 @@
+// Calls `connect(2)` on a unix socket twice with the same `sun_path` but
+// different `addrlen` values: first the exact length, then `sizeof(struct
+// sockaddr_un)` so `sun_path` carries trailing null bytes. The layer is
+// expected to send the same trimmed pathname to the agent in both cases.
+
+#include <stddef.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+static const char SOCKET_PATH[] = "/tmp/mirrord_test_uds_addrlen.sock";
+
+static void try_connect(socklen_t addrlen, const char *label) {
+    int fd = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (fd < 0) {
+        perror("socket");
+        return;
+    }
+
+    struct sockaddr_un addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.sun_family = AF_UNIX;
+    strncpy(addr.sun_path, SOCKET_PATH, sizeof(addr.sun_path) - 1);
+
+    int ret = connect(fd, (const struct sockaddr *)&addr, addrlen);
+    printf("[%s] connect ret=%d\n", label, ret);
+
+    close(fd);
+}
+
+int main(void) {
+    socklen_t exact = (socklen_t)(offsetof(struct sockaddr_un, sun_path)
+                                  + strlen(SOCKET_PATH) + 1);
+    try_connect(exact, "exact");
+
+    try_connect((socklen_t)sizeof(struct sockaddr_un), "padded");
+
+    return 0;
+}

--- a/mirrord/layer-tests/tests/common/mod.rs
+++ b/mirrord/layer-tests/tests/common/mod.rs
@@ -186,6 +186,9 @@ pub enum Application {
     DupListen,
     /// Rust app that listens on a socket twice
     DoubleListen,
+    /// C app that calls `connect(2)` on a unix socket with a too-large `addrlen`
+    /// so that `sun_path` carries trailing null bytes.
+    UnixConnectAddrlen,
 }
 
 impl Application {
@@ -379,6 +382,11 @@ impl Application {
                     "../../target/debug/double_listen"
                 )
             }
+            Application::UnixConnectAddrlen => format!(
+                "{}/{}",
+                env!("CARGO_MANIFEST_DIR"),
+                "tests/apps/unix_connect_addrlen/out.c_test_app",
+            ),
         }
     }
 
@@ -501,7 +509,8 @@ impl Application {
             | Application::DlopenCgo
             | Application::Connectx
             | Application::DoubleListen
-            | Application::DupListen => vec![],
+            | Application::DupListen
+            | Application::UnixConnectAddrlen => vec![],
             Application::RustOutgoingUdp => ["--udp", RUST_OUTGOING_LOCAL, RUST_OUTGOING_PEERS]
                 .into_iter()
                 .map(Into::into)
@@ -597,6 +606,7 @@ impl Application {
             | Application::NodeMakeConnections
             | Application::DoubleListen
             | Application::PythonSocketPair
+            | Application::UnixConnectAddrlen
             | Application::Connectx => unimplemented!("shouldn't get here"),
             Application::PythonSelfConnect => 1337,
             Application::RustIssue2058 => 1234,

--- a/mirrord/layer-tests/tests/configs/unix_streams.json
+++ b/mirrord/layer-tests/tests/configs/unix_streams.json
@@ -1,0 +1,9 @@
+{
+    "feature": {
+        "network": {
+            "outgoing": {
+                "unix_streams": "/tmp/mirrord_test_uds.*"
+            }
+        }
+    }
+}

--- a/mirrord/layer-tests/tests/unix_connect_addrlen.rs
+++ b/mirrord/layer-tests/tests/unix_connect_addrlen.rs
@@ -1,0 +1,65 @@
+#![cfg(target_family = "unix")]
+
+use std::{path::Path, time::Duration};
+
+use mirrord_protocol::{
+    ClientMessage, DaemonMessage, ResponseError,
+    outgoing::{
+        DaemonConnectV2, LayerConnectV2, SocketAddress, UnixAddr,
+        tcp::{DaemonTcpOutgoing, LayerTcpOutgoing},
+    },
+};
+use rstest::rstest;
+
+mod common;
+
+pub use common::*;
+
+/// Regression test for trailing nulls leaking into outgoing unix socket
+/// pathnames. The C app calls `connect(2)` twice with the same `sun_path`
+/// but different `addrlen` — first the exact length, then
+/// `sizeof(struct sockaddr_un)` so `sun_path` carries trailing null bytes.
+/// Without the layer-side trim, the second call's path arrives at the
+/// agent with embedded nulls, breaking remote unix connects (and the
+/// `unix_streams` regex match too — the second connect would be bypassed
+/// to local rather than handed to the intproxy).
+#[rstest]
+#[tokio::test]
+#[timeout(Duration::from_secs(60))]
+async fn unix_connect_addrlen_trims_trailing_nulls(
+    #[values(Application::UnixConnectAddrlen)] application: Application,
+    config_dir: &Path,
+) {
+    let config_path = config_dir.join("unix_streams.json");
+    let (mut test_process, mut intproxy) =
+        application.start_process(vec![], Some(&config_path)).await;
+
+    let expected_path = std::path::PathBuf::from("/tmp/mirrord_test_uds_addrlen.sock");
+
+    for label in ["exact", "padded"] {
+        let msg = intproxy.recv().await;
+        let ClientMessage::TcpOutgoing(LayerTcpOutgoing::ConnectV2(LayerConnectV2 {
+            uid,
+            remote_address: SocketAddress::Unix(UnixAddr::Pathname(path)),
+        })) = msg
+        else {
+            panic!("[{label}] unexpected message: {msg:?}");
+        };
+
+        assert_eq!(
+            path, expected_path,
+            "[{label}] layer forwarded a unix socket path with trailing nulls"
+        );
+
+        intproxy
+            .send(DaemonMessage::TcpOutgoing(DaemonTcpOutgoing::ConnectV2(
+                DaemonConnectV2 {
+                    uid,
+                    connect: Err(ResponseError::NotImplemented),
+                },
+            )))
+            .await;
+    }
+
+    test_process.wait_assert_success().await;
+}


### PR DESCRIPTION
<!-- Thank you for contributing to mirrord! -->
<!-- Please use the checklist below as a guide for docs, tests and admin tasks for your PR -->
<!-- Feel free to ~strikethrough~ any items that you don't think apply -->

### Quality Checklist:

- [X] I have documented new code sufficiently
- [X] I have checked and updated the relevant existing docs in code, including removing outdated material
- [X] I have written user-facing website docs for new features, or opened a (sub)issue to do so
- [X] I have checked and updated existing website docs for changed features
- [X] I have tested this change and know it succeeds and fails as expected
- [X] I have written unit tests or purposefully omitted them
- [X] I have written e2e tests or purposefully omitted them
- [X] I have explained what this PR introduces and why, and linked to relevant context (e.g. linear issues, related PRs,
  documentation)
- [X] I have introduced a short, clear and well-formatted changelog entry

<!-- need help with the changelog? see ../CONTRIBUTING.md#submitting-a-pull-request -->
<!-- Add more details of your changes below if needed -->

The unix socket address is passed to libc in a `libc::sockaddr_un`:

```c
struct sockaddr_un {
    sa_family_t  sun_family;  /* Address family */
    char         sun_path[108];  /* Socket pathname */
};
```

`sun_path` is 108 bytes long because that's the space remaining in a
`sockaddr_storage` after all the header stuff.

When calling `connect(2)`, the application provides a sockaddr* (which
is in reality pointing to an instance of sockaddr_un, C struct header
type punning stuff), and an `addrlen`. Now most apps will set
`addrlen` to the actual header size + `sun_path` length, but since
`sun_path` is a null-terminated, it's also technically possible to set
addrlen to something larger (like `sizeof(sockaddr_storage)`) and fill
the rest with null bytes -- this doesn't cause issues, at least not
with the kernel.

Rust (and the `socket2` crate) however treats this differently - when
we call `SockAddr::as_pathname`, the null byte are not used for
length calculation and `SockAddr::len` is used - which was passed to
us from the user app - and consequently the null bytes get pulled
along into the returned `&Path`. This causes two issues:

In the layer: the `unix_streams` `RegexSet` fails to match and we
try to do things locally.

In the agent: When the `&Path` gets converted into a `String` with the
null bytes and gets passed to the agent, the agent passes it verbatim
to Rust's unix connect functions. Before calling libc, these ensure
that the string passed to them is valid - and this includes checking
for null bytes (internally `CStr::from_bytes_with_nul` is used).
Needless to say this breaks and the agent returns an error.

To fix this, we count the non-null leading bytes in `sun_path`, and adjust
`remote_address.len` accordingly to trim the trailing nulls out.
