### PR TITLE
feat(cli): suppress newsletter prompt in non-interactive sessions

### DIFF
--- a/changelog.d/+suppress-prompts-in-agent-context.changed.md
+++ b/changelog.d/+suppress-prompts-in-agent-context.changed.md
@@ -1,0 +1,1 @@
+Suppress the in-CLI newsletter prompt in non-interactive sessions (CI, AI agent runners, piped output). The session counter is not bumped either, so automated runs don't push human users past prompt thresholds.

--- a/mirrord/cli/src/interactive_session.rs
+++ b/mirrord/cli/src/interactive_session.rs
@@ -1,0 +1,41 @@
+//! Heuristic for whether the current `mirrord exec` run is interactive (a human at a terminal)
+//! or automated (CI pipeline, AI coding agent, piped output). Used to suppress marketing
+//! prompts in non-interactive contexts.
+
+use std::io::IsTerminal;
+
+const NON_INTERACTIVE_ENV_VARS: &[&str] = &[
+    "CI",
+    "GITHUB_ACTIONS",
+    "CIRCLECI",
+    "GITLAB_CI",
+    "BUILDKITE",
+    "JENKINS_URL",
+    "TRAVIS",
+    "TF_BUILD",
+    "CLAUDECODE",
+    "CURSOR_AGENT",
+    "AIDER_CHAT",
+];
+
+/// Returns `true` if the current mirrord run looks like an interactive human session.
+pub fn is_interactive_session() -> bool {
+    if let Ok(mode) = std::env::var("MIRRORD_PROGRESS_MODE") {
+        let mode = mode.to_lowercase();
+        if mode == "json" || mode == "off" {
+            return false;
+        }
+    }
+
+    if !std::io::stderr().is_terminal() {
+        return false;
+    }
+
+    for var in NON_INTERACTIVE_ENV_VARS {
+        if std::env::var(var).is_ok() {
+            return false;
+        }
+    }
+
+    true
+}

--- a/mirrord/cli/src/main.rs
+++ b/mirrord/cli/src/main.rs
@@ -325,6 +325,7 @@ mod execution;
 mod extension;
 mod external_proxy;
 mod extract;
+mod interactive_session;
 mod internal_proxy;
 #[cfg(target_os = "linux")]
 mod is_static;

--- a/mirrord/cli/src/newsletter.rs
+++ b/mirrord/cli/src/newsletter.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use mirrord_progress::Progress;
 use tracing::trace;
 
-use crate::user_data::UserData;
+use crate::{interactive_session::is_interactive_session, user_data::UserData};
 
 /// Link to the mirrord newsletter signup page (with UTM query params)
 const NEWSLETTER_SIGNUP_URL: &str =
@@ -24,6 +24,10 @@ const NEWSLETTER_COUNTER_PROMPT_AFTER_THIRD: u32 = 100;
 /// Called during normal execution, suggests newsletter signup if the user has run mirrord a certain
 /// number of times.
 pub async fn suggest_newsletter_signup<P: Progress>(user_data: &mut UserData, progress: &mut P) {
+    if !is_interactive_session() {
+        return;
+    }
+
     let newsletter_invites = HashMap::from([
         (
             NEWSLETTER_COUNTER_PROMPT_AFTER_FIRST,


### PR DESCRIPTION
## Summary

Suppresses the in-CLI newsletter prompt in non-interactive sessions (CI, AI agent runners, piped output). The session counter is not bumped either, so automated runs don't push human users past prompt thresholds before a human ever sees one.

Detected via `MIRRORD_PROGRESS_MODE`, stderr TTY status, and well-known CI / agent env vars (CI, GITHUB_ACTIONS, CIRCLECI, GITLAB_CI, BUILDKITE, JENKINS_URL, TRAVIS, TF_BUILD, CLAUDECODE, CURSOR_AGENT, AIDER_CHAT).

## Validation

Tested end-to-end against the staging cluster from a Claude Code agent session (`CLAUDECODE=1`, stderr piped). With `session_count` primed near a prompt threshold:

| Binary | Pre `session_count` | Post `session_count` | Verdict |
|---|---|---|---|
| This PR | 19 | 19 | counter not bumped, gate fires before prompt path |
| Installed 3.198.0 (no fix) | 4 | 5 | counter bumped, demonstrating the behavior this fix changes |

## Test plan
- [ ] CI passes
- [ ] Interactive `mirrord exec` → prompt fires when threshold reached
- [ ] `CI=true mirrord exec` → no prompt, no counter bump
- [ ] `mirrord exec | cat` → no prompt
- [ ] Subsequent interactive run shows the human's next threshold (counter wasn't inflated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)