### PR TITLE
Ephemeral unix sock fix

### DIFF
--- a/changelog.d/+ephemeral-unix-outgoing.fixed.md
+++ b/changelog.d/+ephemeral-unix-outgoing.fixed.md
@@ -1,0 +1,1 @@
+Fixed outgoing connections to path-addressed Unix sockets failing with a "not found" error when the agent runs as an ephemeral container.

--- a/mirrord/agent/src/entrypoint.rs
+++ b/mirrord/agent/src/entrypoint.rs
@@ -383,7 +383,9 @@ impl ClientConnectionHandler {
 
         let pid = state.container_pid();
 
-        let file_manager = FileManager::new(pid.or_else(|| state.ephemeral.then_some(1)));
+        let file_pid = pid.or_else(|| state.ephemeral.then_some(1));
+
+        let file_manager = FileManager::new(file_pid);
 
         let tcp_mirror_api = bg_tasks
             .mirror_handle
@@ -397,7 +399,7 @@ impl ClientConnectionHandler {
         .await?;
         let dns_api = Self::create_dns_api(bg_tasks.dns);
         let reverse_dns_api = ReverseDnsApi::new(&state.network_runtime);
-        let tcp_outgoing_api = TcpOutgoingApi::new(&state.network_runtime);
+        let tcp_outgoing_api = TcpOutgoingApi::new(&state.network_runtime, file_pid);
         let udp_outgoing_api = UdpOutgoingApi::new(&state.network_runtime);
 
         let client_handler = Self {

--- a/mirrord/agent/src/outgoing.rs
+++ b/mirrord/agent/src/outgoing.rs
@@ -80,7 +80,12 @@ impl TcpOutgoingApi {
     /// # Params
     ///
     /// * `runtime` - tokio runtime to spawn the background task on.
-    pub(crate) fn new(runtime: &BgTaskRuntime) -> Self {
+    ///
+    /// * `fs_pid` - In targeted mode (both in pod and ephemeral), the
+    ///   PID of the main process. This will be passed to an
+    ///   [`InTargetPathResolver`](crate::util::path_resolver::InTargetPathResolver)
+    ///   to resolve unix socket paths.
+    pub(crate) fn new(runtime: &BgTaskRuntime, pid: Option<u64>) -> Self {
         // IMPORTANT: this makes tokio tasks spawn on `runtime`.
         // Do not remove this.
         let _rt = runtime.handle().enter();
@@ -88,7 +93,6 @@ impl TcpOutgoingApi {
         let (layer_tx, layer_rx) = mpsc::channel(1000);
         let (daemon_tx, daemon_rx) = mpsc::channel(1000);
 
-        let pid = runtime.target_pid();
         let task_status = tokio::spawn(TcpOutgoingTask::new(pid, layer_rx, daemon_tx).run())
             .into_status("TcpOutgoingTask");
 

--- a/mirrord/agent/src/outgoing.rs
+++ b/mirrord/agent/src/outgoing.rs
@@ -81,10 +81,10 @@ impl TcpOutgoingApi {
     ///
     /// * `runtime` - tokio runtime to spawn the background task on.
     ///
-    /// * `fs_pid` - In targeted mode (both in pod and ephemeral), the
-    ///   PID of the main process. This will be passed to an
-    ///   [`InTargetPathResolver`](crate::util::path_resolver::InTargetPathResolver)
-    ///   to resolve unix socket paths.
+    /// * `fs_pid` - In targeted mode (both in pod and ephemeral), the PID of the main process. This
+    ///   will be passed to an
+    ///   [`InTargetPathResolver`](crate::util::path_resolver::InTargetPathResolver) to resolve unix
+    ///   socket paths.
     pub(crate) fn new(runtime: &BgTaskRuntime, pid: Option<u64>) -> Self {
         // IMPORTANT: this makes tokio tasks spawn on `runtime`.
         // Do not remove this.

--- a/mirrord/agent/src/outgoing/udp.rs
+++ b/mirrord/agent/src/outgoing/udp.rs
@@ -47,8 +47,6 @@ struct UdpOutgoingTask {
     writers: HashMap<ConnectionId, (UdpFramed<BytesCodec, Arc<UdpSocket>>, SocketAddr)>,
     /// Reading halves of peer connections made on layer's requests.
     readers: StreamMap<ConnectionId, UdpReadStream>,
-    /// Optional pid of agent's target. Used in `SocketStream::connect`.
-    pid: Option<u64>,
     layer_rx: Receiver<LayerUdpOutgoing>,
     daemon_tx: Sender<Throttled<DaemonUdpOutgoing>>,
     throttler: Arc<Semaphore>,
@@ -67,7 +65,6 @@ impl fmt::Debug for UdpOutgoingTask {
             .field("next_connection_id", &self.next_connection_id)
             .field("writers", &self.writers.len())
             .field("readers", &self.readers.len())
-            .field("pid", &self.pid)
             .finish()
     }
 }
@@ -79,7 +76,6 @@ impl UdpOutgoingTask {
     const THROTTLE_PERMITS: usize = 512 * 1024;
 
     fn new(
-        pid: Option<u64>,
         layer_rx: Receiver<LayerUdpOutgoing>,
         daemon_tx: Sender<Throttled<DaemonUdpOutgoing>>,
     ) -> Self {
@@ -87,7 +83,6 @@ impl UdpOutgoingTask {
             next_connection_id: 0,
             writers: Default::default(),
             readers: Default::default(),
-            pid,
             layer_rx,
             daemon_tx,
             throttler: Arc::new(Semaphore::new(Self::THROTTLE_PERMITS)),
@@ -343,9 +338,8 @@ impl UdpOutgoingApi {
         let (layer_tx, layer_rx) = mpsc::channel(1000);
         let (daemon_tx, daemon_rx) = mpsc::channel(1000);
 
-        let task_status =
-            tokio::spawn(UdpOutgoingTask::new(runtime.target_pid(), layer_rx, daemon_tx).run())
-                .into_status("UdpOutgoingTask");
+        let task_status = tokio::spawn(UdpOutgoingTask::new(layer_rx, daemon_tx).run())
+            .into_status("UdpOutgoingTask");
 
         Self {
             task_status,


### PR DESCRIPTION
<!-- Thank you for contributing to mirrord! -->
<!-- Please use the checklist below as a guide for docs, tests and admin tasks for your PR -->
<!-- Feel free to ~strikethrough~ any items that you don't think apply -->

### Quality Checklist:

- [X] I have documented new code sufficiently
- [X] I have checked and updated the relevant existing docs in code, including removing outdated material
- [X] I have written user-facing website docs for new features, or opened a (sub)issue to do so
- [X] I have checked and updated existing website docs for changed features
- [X] I have tested this change and know it succeeds and fails as expected
- [X] I have written unit tests or purposefully omitted them
- [X] I have written e2e tests or purposefully omitted them
- [X] I have explained what this PR introduces and why, and linked to relevant context (e.g. linear issues, related PRs,
  documentation)
- [X] I have introduced a short, clear and well-formatted changelog entry

<!-- need help with the changelog? see ../CONTRIBUTING.md#submitting-a-pull-request -->
<!-- Add more details of your changes below if needed -->

When the agent runs as an ephemeral container, `BgTaskRuntime` is created without a target PID (it doesn't need to `setns`, since the ephemeral container already shares the target's namespaces), so `TcpOutgoingApi` was passing `pid: None` into `SocketStream::connect`. That made the agent connect to path-addressed Unix sockets in its own mount namespace instead of resolving them under the target container's root via `InTargetPathResolver`, so connects failed with `ENOENT` even though `FileManager` — which already takes the resolved PID from `state.container_pid()` — could `stat` the same socket fine. The fix passes that same PID into `TcpOutgoingApi::new` so outgoing Unix-socket connects resolve paths the same way file ops do. Also dropped the unused `pid` field from `UdpOutgoingTask` (UDP outgoing is IP-only).
