### PR TITLE
🇧🇷 win-117 🇧🇷 ﹏ improve `feature.fs` documentation for windows 

### DIFF
--- a/changelog.d/+windows-docs.added.md
+++ b/changelog.d/+windows-docs.added.md
@@ -1,0 +1,1 @@
+Added clarifications for Windows-specific fs mapping and fs filter quirks

--- a/changelog.d/+windows-docs.added.md
+++ b/changelog.d/+windows-docs.added.md
@@ -1,1 +1,1 @@
-Added clarifications for Windows-specific fs mapping and fs filter quirks
+Added clarifications for Windows-specific `fs` mapping and `fs` filter quirks

--- a/mirrord-schema.json
+++ b/mirrord-schema.json
@@ -268,7 +268,7 @@
       "properties": {
         "local": {
           "title": "feature.fs.local {#feature-fs-local}",
-          "description": "Specify file path patterns that if matched will be opened locally.",
+          "description": "Specify file path patterns that if matched will be opened locally.\n\n##### Windows\n\nPatterns are matched against a unix-style form of the requested path, not the raw\nWindows path. Before matching, the drive letter is stripped and backslashes are\nconverted to forward slashes, so `D:\\Workspaces\\myapp\\app.json` is matched as\n`/Workspaces/myapp/app.json`.\n\nPatterns must therefore be written with forward slashes. Backslashes in the regex\n(e.g. `\"\\\\\\\\Workspaces\\\\\\\\\"`) will never match anything, because the input string the\nregex sees contains no backslashes at all — they were stripped during translation.",
           "anyOf": [
             {
               "$ref": "#/$defs/VecOrSingle"
@@ -280,7 +280,7 @@
         },
         "mapping": {
           "title": "feature.fs.mapping {#feature-fs-mapping}",
-          "description": "Specify map of patterns that if matched will replace the path according to specification.\n\n*Capture groups are allowed.*\n\nExample:\n```json\n{\n  \"^/home/(?<user>\\\\S+)/dev/tomcat\": \"/etc/tomcat\"\n  \"^/home/(?<user>\\\\S+)/dev/config/(?<app>\\\\S+)\": \"/mnt/configs/${user}-$app\"\n}\n```\nWill do the next replacements for any io operation\n\n`/home/johndoe/dev/tomcat/context.xml` => `/etc/tomcat/context.xml`\n`/home/johndoe/dev/config/api/app.conf` => `/mnt/configs/johndoe-api/app.conf`\n\n- Relative paths: this feature (currently) does not apply mappings to relative paths, e.g.\n  `../dev`.",
+          "description": "Specify map of patterns that if matched will replace the path according to specification.\n\n*Capture groups are allowed.* Matching is case-insensitive and uses\n[`Regex::replace`](https://docs.rs/regex/latest/regex/struct.Regex.html#method.replace),\nso the replacement value supports `$1` / `${name}` substitutions.\n\n##### Unix (Linux, macOS)\n\nPatterns are matched against the path exactly as the application requested it.\n\nExample:\n```json\n{\n  \"^/home/(?<user>\\\\S+)/dev/tomcat\": \"/etc/tomcat\",\n  \"^/home/(?<user>\\\\S+)/dev/config/(?<app>\\\\S+)\": \"/mnt/configs/${user}-$app\"\n}\n```\n\nWill produce the following replacements for any io operation:\n\n`/home/johndoe/dev/tomcat/context.xml` => `/etc/tomcat/context.xml`\n`/home/johndoe/dev/config/api/app.conf` => `/mnt/configs/johndoe-api/app.conf`\n\n##### Windows\n\nPatterns are matched against a unix-style form of the requested path, not the raw\nWindows path. Before matching, the drive letter is stripped and backslashes are\nconverted to forward slashes, so:\n\n`D:\\Workspaces\\myapp\\config\\app.json` is matched as `/Workspaces/myapp/config/app.json`\n\nPatterns must therefore be written with forward slashes. Backslashes in the regex\n(e.g. `\"\\\\\\\\Workspaces\\\\\\\\\"`) will never match anything, because the input string the\nregex sees contains no backslashes at all — they were stripped during translation.\n\nThe replacement value is sent to the agent as-is and is what the remote (Linux) pod\nwill see on disk, so it should also use forward slashes.\n\nExample:\n```json\n{\n  \"^/Workspaces/(?<app>[^/]+)/config/(?<file>.+)\": \"/etc/${app}/$file\"\n}\n```\n\nWill produce the following replacement:\n\n`D:\\Workspaces\\myapp\\config\\app.json` => `/etc/myapp/app.json`\n\n##### Caveats\n\n- Relative paths: this feature (currently) does not apply mappings to relative paths, e.g.\n  `../dev`.",
           "type": [
             "object",
             "null"
@@ -302,7 +302,7 @@
         },
         "not_found": {
           "title": "feature.fs.not_found {#feature-fs-not_found}",
-          "description": "Specify file path patterns that if matched will be treated as non-existent.",
+          "description": "Specify file path patterns that if matched will be treated as non-existent.\n\n##### Windows\n\nPatterns are matched against a unix-style form of the requested path, not the raw\nWindows path. Before matching, the drive letter is stripped and backslashes are\nconverted to forward slashes, so `D:\\Workspaces\\myapp\\app.json` is matched as\n`/Workspaces/myapp/app.json`.\n\nPatterns must therefore be written with forward slashes. Backslashes in the regex\n(e.g. `\"\\\\\\\\Workspaces\\\\\\\\\"`) will never match anything, because the input string the\nregex sees contains no backslashes at all — they were stripped during translation.",
           "anyOf": [
             {
               "$ref": "#/$defs/VecOrSingle"
@@ -314,7 +314,7 @@
         },
         "read_only": {
           "title": "feature.fs.read_only {#feature-fs-read_only}",
-          "description": "Specify file path patterns that if matched will be read from the remote.\nif file matching the pattern is opened for writing or read/write it will be opened locally.",
+          "description": "Specify file path patterns that if matched will be read from the remote.\nif file matching the pattern is opened for writing or read/write it will be opened locally.\n\n##### Windows\n\nPatterns are matched against a unix-style form of the requested path, not the raw\nWindows path. Before matching, the drive letter is stripped and backslashes are\nconverted to forward slashes, so `D:\\Workspaces\\myapp\\app.json` is matched as\n`/Workspaces/myapp/app.json`.\n\nPatterns must therefore be written with forward slashes. Backslashes in the regex\n(e.g. `\"\\\\\\\\Workspaces\\\\\\\\\"`) will never match anything, because the input string the\nregex sees contains no backslashes at all — they were stripped during translation.",
           "anyOf": [
             {
               "$ref": "#/$defs/VecOrSingle"
@@ -326,7 +326,7 @@
         },
         "read_write": {
           "title": "feature.fs.read_write {#feature-fs-read_write}",
-          "description": "Specify file path patterns that if matched will be read and written to the remote.",
+          "description": "Specify file path patterns that if matched will be read and written to the remote.\n\n##### Windows\n\nPatterns are matched against a unix-style form of the requested path, not the raw\nWindows path. Before matching, the drive letter is stripped and backslashes are\nconverted to forward slashes, so `D:\\Workspaces\\myapp\\app.json` is matched as\n`/Workspaces/myapp/app.json`.\n\nPatterns must therefore be written with forward slashes. Backslashes in the regex\n(e.g. `\"\\\\\\\\Workspaces\\\\\\\\\"`) will never match anything, because the input string the\nregex sees contains no backslashes at all — they were stripped during translation.",
           "anyOf": [
             {
               "$ref": "#/$defs/VecOrSingle"

--- a/mirrord/config/src/feature/fs/advanced.rs
+++ b/mirrord/config/src/feature/fs/advanced.rs
@@ -105,6 +105,17 @@ pub struct FsConfig {
     /// #### feature.fs.read_write {#feature-fs-read_write}
     ///
     /// Specify file path patterns that if matched will be read and written to the remote.
+    ///
+    /// ##### Windows
+    ///
+    /// Patterns are matched against a unix-style form of the requested path, not the raw
+    /// Windows path. Before matching, the drive letter is stripped and backslashes are
+    /// converted to forward slashes, so `D:\Workspaces\myapp\app.json` is matched as
+    /// `/Workspaces/myapp/app.json`.
+    ///
+    /// Patterns must therefore be written with forward slashes. Backslashes in the regex
+    /// (e.g. `"\\\\Workspaces\\\\"`) will never match anything, because the input string the
+    /// regex sees contains no backslashes at all — they were stripped during translation.
     #[config(env = "MIRRORD_FILE_READ_WRITE_PATTERN")]
     pub read_write: Option<VecOrSingle<String>>,
 
@@ -112,36 +123,104 @@ pub struct FsConfig {
     ///
     /// Specify file path patterns that if matched will be read from the remote.
     /// if file matching the pattern is opened for writing or read/write it will be opened locally.
+    ///
+    /// ##### Windows
+    ///
+    /// Patterns are matched against a unix-style form of the requested path, not the raw
+    /// Windows path. Before matching, the drive letter is stripped and backslashes are
+    /// converted to forward slashes, so `D:\Workspaces\myapp\app.json` is matched as
+    /// `/Workspaces/myapp/app.json`.
+    ///
+    /// Patterns must therefore be written with forward slashes. Backslashes in the regex
+    /// (e.g. `"\\\\Workspaces\\\\"`) will never match anything, because the input string the
+    /// regex sees contains no backslashes at all — they were stripped during translation.
     pub read_only: Option<VecOrSingle<String>>,
 
     /// #### feature.fs.local {#feature-fs-local}
     ///
     /// Specify file path patterns that if matched will be opened locally.
+    ///
+    /// ##### Windows
+    ///
+    /// Patterns are matched against a unix-style form of the requested path, not the raw
+    /// Windows path. Before matching, the drive letter is stripped and backslashes are
+    /// converted to forward slashes, so `D:\Workspaces\myapp\app.json` is matched as
+    /// `/Workspaces/myapp/app.json`.
+    ///
+    /// Patterns must therefore be written with forward slashes. Backslashes in the regex
+    /// (e.g. `"\\\\Workspaces\\\\"`) will never match anything, because the input string the
+    /// regex sees contains no backslashes at all — they were stripped during translation.
     #[config(env = "MIRRORD_FILE_LOCAL_PATTERN")]
     pub local: Option<VecOrSingle<String>>,
 
     /// #### feature.fs.not_found {#feature-fs-not_found}
     ///
     /// Specify file path patterns that if matched will be treated as non-existent.
+    ///
+    /// ##### Windows
+    ///
+    /// Patterns are matched against a unix-style form of the requested path, not the raw
+    /// Windows path. Before matching, the drive letter is stripped and backslashes are
+    /// converted to forward slashes, so `D:\Workspaces\myapp\app.json` is matched as
+    /// `/Workspaces/myapp/app.json`.
+    ///
+    /// Patterns must therefore be written with forward slashes. Backslashes in the regex
+    /// (e.g. `"\\\\Workspaces\\\\"`) will never match anything, because the input string the
+    /// regex sees contains no backslashes at all — they were stripped during translation.
     pub not_found: Option<VecOrSingle<String>>,
 
     /// #### feature.fs.mapping {#feature-fs-mapping}
     ///
     /// Specify map of patterns that if matched will replace the path according to specification.
     ///
-    /// *Capture groups are allowed.*
+    /// *Capture groups are allowed.* Matching is case-insensitive and uses
+    /// [`Regex::replace`](https://docs.rs/regex/latest/regex/struct.Regex.html#method.replace),
+    /// so the replacement value supports `$1` / `${name}` substitutions.
+    ///
+    /// ##### Unix (Linux, macOS)
+    ///
+    /// Patterns are matched against the path exactly as the application requested it.
     ///
     /// Example:
     /// ```json
     /// {
-    ///   "^/home/(?<user>\\S+)/dev/tomcat": "/etc/tomcat"
+    ///   "^/home/(?<user>\\S+)/dev/tomcat": "/etc/tomcat",
     ///   "^/home/(?<user>\\S+)/dev/config/(?<app>\\S+)": "/mnt/configs/${user}-$app"
     /// }
     /// ```
-    /// Will do the next replacements for any io operation
+    ///
+    /// Will produce the following replacements for any io operation:
     ///
     /// `/home/johndoe/dev/tomcat/context.xml` => `/etc/tomcat/context.xml`
     /// `/home/johndoe/dev/config/api/app.conf` => `/mnt/configs/johndoe-api/app.conf`
+    ///
+    /// ##### Windows
+    ///
+    /// Patterns are matched against a unix-style form of the requested path, not the raw
+    /// Windows path. Before matching, the drive letter is stripped and backslashes are
+    /// converted to forward slashes, so:
+    ///
+    /// `D:\Workspaces\myapp\config\app.json` is matched as `/Workspaces/myapp/config/app.json`
+    ///
+    /// Patterns must therefore be written with forward slashes. Backslashes in the regex
+    /// (e.g. `"\\\\Workspaces\\\\"`) will never match anything, because the input string the
+    /// regex sees contains no backslashes at all — they were stripped during translation.
+    ///
+    /// The replacement value is sent to the agent as-is and is what the remote (Linux) pod
+    /// will see on disk, so it should also use forward slashes.
+    ///
+    /// Example:
+    /// ```json
+    /// {
+    ///   "^/Workspaces/(?<app>[^/]+)/config/(?<file>.+)": "/etc/${app}/$file"
+    /// }
+    /// ```
+    ///
+    /// Will produce the following replacement:
+    ///
+    /// `D:\Workspaces\myapp\config\app.json` => `/etc/myapp/app.json`
+    ///
+    /// ##### Caveats
     ///
     /// - Relative paths: this feature (currently) does not apply mappings to relative paths, e.g.
     ///   `../dev`.


### PR DESCRIPTION
<img width="225" height="225" alt="image" src="https://github.com/user-attachments/assets/2397c4a5-9ed4-41cb-a547-93b97b49cdaf" />

## Linear
https://linear.app/metalbear/issue/WIN-116/add-windows-fs-mapping-examples-to-documentation

## Summary

This change introduces clarifications about ***current*** Windows `feature.fs.mapping` + `feature.fs.read_write`, `feature.fs.read_only`, `feature.fs.local` and `feature.fs.not_found` quirks.

This has been way long overdue and has caused multiple customer threads. My bad!

### Quality Checklist:

- [x] I have checked and updated the relevant existing docs in code, including removing outdated material
- [x] I have written user-facing website docs for new features, or opened a (sub)issue to do so
- [x] I have checked and updated existing website docs for changed features
- [ ] I have tested this change and know it succeeds and fails as expected
- [x] I have explained what this PR introduces and why, and linked to relevant context (e.g. linear issues, related PRs,
  documentation)
- [x] I have introduced a short, clear and well-formatted changelog entry