### PR TITLE
Ipv6 outgoing fix

### DIFF
--- a/changelog.d/+dns-response-code.fixed.md
+++ b/changelog.d/+dns-response-code.fixed.md
@@ -1,0 +1,1 @@
+The agent no longer logs a spurious warning when a DNS server returns an error response code, and layer no longer logs bogus DNS errors with error level.

--- a/changelog.d/+ipv6-getaddrinfo.fixed.md
+++ b/changelog.d/+ipv6-getaddrinfo.fixed.md
@@ -1,0 +1,1 @@
+Fixed `getaddrinfo` truncating IPv6 addresses resolved through the agent.

--- a/mirrord/agent/src/dns.rs
+++ b/mirrord/agent/src/dns.rs
@@ -361,6 +361,9 @@ impl ProtocolConversion<ResolveErrorKindInternal> for &NetError {
             NetError::Dns(DnsError::NoRecordsFound(no_records)) => {
                 ResolveErrorKindInternal::NoRecordsFound(no_records.response_code.into())
             }
+            NetError::Dns(DnsError::ResponseCode(code)) => {
+                ResolveErrorKindInternal::Message(format!("DNS server error response: {code}"))
+            }
             NetError::Proto(proto_error) => {
                 ResolveErrorKindInternal::Message(format!("proto error: {proto_error}"))
             }

--- a/mirrord/layer-lib/src/socket/dns.rs
+++ b/mirrord/layer-lib/src/socket/dns.rs
@@ -25,7 +25,7 @@ use crate::{
 /// # Note
 ///
 /// This function updates the mapping in [`reverse_dns::REMOTE_DNS_REVERSE_MAPPING`].
-#[mirrord_layer_macro::instrument(level = Level::TRACE, ret, err)]
+#[mirrord_layer_macro::instrument(level = Level::TRACE, ret, err(level = Level::TRACE))]
 pub fn remote_getaddrinfo(
     node: String,
     service_port: u16,

--- a/mirrord/layer-lib/src/socket/dns/unix.rs
+++ b/mirrord/layer-lib/src/socket/dns/unix.rs
@@ -113,7 +113,8 @@ pub fn getaddrinfo(
             let ai_family = rawish_sock_addr.family() as _;
 
             // Must outlive this function, as it is stored as a pointer in `libc::addrinfo`.
-            let ai_addr = Box::into_raw(Box::new(unsafe { *rawish_sock_addr.as_ptr() }));
+            let ai_addr =
+                Box::into_raw(Box::new(rawish_sock_addr.as_storage())).cast::<libc::sockaddr>();
             let ai_canonname = CString::new(name).unwrap().into_raw();
 
             libc::addrinfo {

--- a/mirrord/layer/src/socket/hooks.rs
+++ b/mirrord/layer/src/socket/hooks.rs
@@ -388,7 +388,9 @@ unsafe extern "C" fn freeaddrinfo_detour(addrinfo: *mut libc::addrinfo) {
             let mut current = addrinfo;
             while !current.is_null() {
                 let current_box = Box::from_raw(current);
-                let ai_addr = Box::from_raw(current_box.ai_addr);
+                // `ai_addr` was allocated as a boxed `sockaddr_storage` in `getaddrinfo`, so it
+                // must be reclaimed with the same layout.
+                let ai_addr = Box::from_raw(current_box.ai_addr.cast::<libc::sockaddr_storage>());
                 let ai_canonname = CString::from_raw(current_box.ai_canonname);
 
                 current = (*current).ai_next;


### PR DESCRIPTION
<!-- Thank you for contributing to mirrord! -->
<!-- Please use the checklist below as a guide for docs, tests and admin tasks for your PR -->
<!-- Feel free to ~strikethrough~ any items that you don't think apply -->

### Quality Checklist:

- [X] I have documented new code sufficiently
- [X] I have checked and updated the relevant existing docs in code, including removing outdated material
- [X] I have written user-facing website docs for new features, or opened a (sub)issue to do so
- [X] I have checked and updated existing website docs for changed features
- [X] I have tested this change and know it succeeds and fails as expected
- [X] I have written unit tests or purposefully omitted them
- [X] I have written e2e tests or purposefully omitted them
- [X] I have explained what this PR introduces and why, and linked to relevant context (e.g. linear issues, related PRs,
  documentation)
- [X] I have introduced a short, clear and well-formatted changelog entry

<!-- need help with the changelog? see ../CONTRIBUTING.md#submitting-a-pull-request -->
<!-- Add more details of your changes below if needed -->



Fixes IPv6 DNS through mirrord plus DNS-error reporting cleanup:

- `getaddrinfo` IPv6 truncation: `ai_addr` was a boxed bare `sockaddr` (16 bytes) while `ai_addrlen` claimed 28, so every IPv6 result lost its lower 64 bits (`fd00:10:96::1` → `fd00:10:96::`), breaking outgoing connections in IPv6-only clusters (also causing UB lol). Now the full `sockaddr_storage` gets copied.
- Agent: handle some dns more errors explicitly instead of the "this is a bug" catch-all + `unknown error`. A non-success rcode is a routine resolution failure, not an agent bug.
- Layer: `remote_getaddrinfo`'s `#[instrument]` now logs errors at trace instead of error, like every other socket hook.
