### PR TITLE
Make preview environments resilient to crashes and evictions

### DIFF
--- a/changelog.d/+preview-env-autodelete.changed.md
+++ b/changelog.d/+preview-env-autodelete.changed.md
@@ -1,0 +1,2 @@
+Preview sessions are now deleted automatically when their TTL expires, and failed sessions are cleaned up automatically after the retention window configured by `operator.preview.cleanupAfterMins` in the chart configuration.
+Alongside this change, `mirrord preview status` now only shows active sessions by default, and a new `--failed` flag lets you inspect failed sessions that haven't been cleaned up yet.

--- a/changelog.d/+preview-env-restarts.added.md
+++ b/changelog.d/+preview-env-restarts.added.md
@@ -1,0 +1,1 @@
+Preview environments are now resilient to pod crashes and evictions.

--- a/mirrord/cli/src/config.rs
+++ b/mirrord/cli/src/config.rs
@@ -1380,6 +1380,12 @@ pub(super) struct PreviewStatusArgs {
     /// Query all namespaces.
     #[arg(short = 'A', long = "all-namespaces", conflicts_with = "namespace")]
     pub all_namespaces: bool,
+
+    /// Show only failed sessions.
+    ///
+    /// By default, `mirrord preview status` only shows active sessions.
+    #[arg(long)]
+    pub failed: bool,
 }
 
 impl PreviewStatusArgs {

--- a/mirrord/cli/src/port_forward.rs
+++ b/mirrord/cli/src/port_forward.rs
@@ -617,7 +617,7 @@ impl ReversePortForwarder {
             let message_id = i as u64;
             let layer_id = LayerId(1);
             let req = IncomingRequest::PortSubscribe(PortSubscribe {
-                listening_on: SocketAddr::new(Ipv4Addr::LOCALHOST.into(), local),
+                listening_on: SocketAddr::new(Ipv4Addr::LOCALHOST.into(), local).into(),
                 subscription,
             });
             incoming

--- a/mirrord/cli/src/preview.rs
+++ b/mirrord/cli/src/preview.rs
@@ -400,7 +400,8 @@ async fn preview_start(
 
 /// Handle `mirrord preview status` command.
 ///
-/// Lists preview environments, optionally filtered by key and namespace.
+/// Lists preview environments, optionally filtered by key, namespace, and whether failed
+/// sessions should be shown.
 #[tracing::instrument(level = Level::TRACE, ret, skip_all)]
 async fn preview_status(
     args: PreviewStatusArgs,
@@ -443,6 +444,32 @@ async fn preview_status(
         })?
         .items;
 
+    let sessions: Vec<_> = sessions
+        .iter()
+        .filter(|session| {
+            let Some(status) = session.status.as_ref() else {
+                return false;
+            };
+
+            // Older operators reused the `Failed` phase with a specific failure message
+            // when the preview TTL elapsed instead of deleting them, so we need to handle
+            // that to hide expired preview sessions in a backwards compatible way.
+            // See https://github.com/metalbear-co/operator/blob/17e4c645d59affefc672f597a10e2880c405f043/crates/operator-preview-env/src/task.rs#L774-L775
+            let (failed, expired) = match (status.phase, status.failure_message.as_deref()) {
+                (PreviewSessionPhase::Failed, Some("preview session TTL expired")) => (false, true),
+                (PreviewSessionPhase::Failed, _) => (true, false),
+                _ => (false, false),
+            };
+
+            if args.failed {
+                failed
+            } else {
+                // Not failed and not expired = alive
+                !failed && !expired
+            }
+        })
+        .collect();
+
     if sessions.is_empty() {
         subtask.success(Some("no preview sessions found"));
         progress.success(None);
@@ -478,7 +505,7 @@ async fn preview_status(
                 .and_then(|s| s.pod_name.as_deref())
                 .unwrap_or("<unknown>");
 
-            let status = match session.status.as_ref().map(|s| &s.phase) {
+            let status = match session.status.as_ref().map(|status| status.phase) {
                 Some(PreviewSessionPhase::Initializing) => "initializing".to_owned(),
                 Some(PreviewSessionPhase::Waiting) => "waiting".to_owned(),
                 Some(PreviewSessionPhase::Ready) => {
@@ -502,14 +529,12 @@ async fn preview_status(
                         }
                     }
                 }
-                Some(PreviewSessionPhase::Failed) => {
-                    let msg = session
-                        .status
-                        .as_ref()
-                        .and_then(|s| s.failure_message.as_deref())
-                        .unwrap_or("unknown");
-                    format!("stopped ({msg})")
-                }
+                Some(PreviewSessionPhase::Failed) => session
+                    .status
+                    .as_ref()
+                    .and_then(|status| status.failure_message.as_deref())
+                    .unwrap_or("unknown")
+                    .to_owned(),
                 Some(PreviewSessionPhase::Unknown) => "unknown".to_owned(),
                 None => "pending".to_owned(),
             };
@@ -537,7 +562,6 @@ async fn preview_status(
 
     Ok(())
 }
-
 /// Handle `mirrord preview stop` command.
 ///
 /// Deletes preview environments matching the given key and, optionally, a target filter and

--- a/mirrord/cli/src/preview.rs
+++ b/mirrord/cli/src/preview.rs
@@ -253,7 +253,7 @@ async fn preview_start(
 
     let session = PreviewSession {
         metadata: ObjectMeta {
-            name: Some(session_name),
+            name: Some(session_name.clone()),
             labels: Some(session_labels),
             annotations,
             ..Default::default()
@@ -295,7 +295,7 @@ async fn preview_start(
 
     let mut last_known_phase: &str = "unknown";
 
-    let pod_name = loop {
+    loop {
         tokio::select! {
             _ = &mut timeout => {
                 if let Err(err) = delete::delete_and_finalize(api, &session.name_any(), &DeleteParams::default()).await {
@@ -328,8 +328,8 @@ async fn preview_start(
                                     last_known_phase = "waiting for preview pod to be ready";
                                 }
                                 PreviewSessionPhase::Ready => {
-                                    subtask.success(Some("preview pod is ready"));
-                                    break status.pod_name.clone().expect("Ready session must have pod_name");
+                                    subtask.success(Some("preview session is ready"));
+                                    break;
                                 }
                                 PreviewSessionPhase::Failed => {
                                     let failure_message = status.failure_message.clone().expect("Failed session must have failure_message");
@@ -370,7 +370,7 @@ async fn preview_start(
                 }
             }
         }
-    };
+    }
 
     // Display summary of the created preview environment.
 
@@ -393,7 +393,9 @@ async fn preview_start(
     progress
         .subtask(&format!("namespace: {namespace}"))
         .success(None);
-    progress.subtask(&format!("pod: {pod_name}")).success(None);
+    progress
+        .subtask(&format!("session: {session_name}"))
+        .success(None);
 
     Ok(())
 }
@@ -486,24 +488,20 @@ async fn preview_status(
 
     // Display sessions grouped by key.
 
-    let mut grouped: BTreeMap<&str, Vec<&PreviewSession>> = BTreeMap::new();
+    let mut sessions_by_key: BTreeMap<&str, Vec<&PreviewSession>> = BTreeMap::new();
 
     for session in &sessions {
-        grouped
+        sessions_by_key
             .entry(session.spec.key.as_str())
             .or_default()
             .push(session);
     }
 
-    for (key, sessions) in grouped {
+    for (key, sessions) in sessions_by_key {
         println!("  {key}:",);
 
         for session in sessions.iter() {
-            let pod_name = session
-                .status
-                .as_ref()
-                .and_then(|s| s.pod_name.as_deref())
-                .unwrap_or("<unknown>");
+            let session_name = session.metadata.name.as_deref().unwrap_or("<unknown>");
 
             let status = match session.status.as_ref().map(|status| status.phase) {
                 Some(PreviewSessionPhase::Initializing) => "initializing".to_owned(),
@@ -541,7 +539,7 @@ async fn preview_status(
 
             println!(
                 "    * {} ({} @ {}): {}",
-                pod_name,
+                session_name,
                 session.spec.target,
                 session.metadata.namespace.as_deref().unwrap_or("<unknown>"),
                 status

--- a/mirrord/intproxy/protocol/src/lib.rs
+++ b/mirrord/intproxy/protocol/src/lib.rs
@@ -204,15 +204,51 @@ pub struct ConnMetadataResponse {
     pub local_address: IpAddr,
 }
 
+/// Where the internal proxy should forward traffic for a [`PortSubscribe`].
+///
+/// [`Self::Socket`] is used by the regular layer (the layer hooked `listen()` and the user
+/// application is bound to that address). [`Self::Hostname`] is used by preview environments,
+/// where the operator creates a headless Service for the preview pods and passes its DNS name.
+/// Using a hostname spreads load across the backing pods and avoids burning a ClusterIP per
+/// session, which matters in clusters that exhaust their service CIDR.
+#[derive(Encode, Decode, Debug, Clone, PartialEq, Eq, Hash)]
+pub enum ListeningOn {
+    Socket(SocketAddr),
+    Hostname { host: String, port: u16 },
+}
+
+impl ListeningOn {
+    /// Port the layer / preview environment subscribed on.
+    pub fn port(&self) -> u16 {
+        match self {
+            Self::Socket(addr) => addr.port(),
+            Self::Hostname { port, .. } => *port,
+        }
+    }
+}
+
+impl From<SocketAddr> for ListeningOn {
+    fn from(addr: SocketAddr) -> Self {
+        Self::Socket(addr)
+    }
+}
+
+impl fmt::Display for ListeningOn {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Socket(addr) => write!(f, "{addr}"),
+            Self::Hostname { host, port } => write!(f, "{host}:{port}"),
+        }
+    }
+}
+
 /// A request to start proxying incoming connections.
 ///
-/// For each connection incoming to the remote port,
-/// the internal proxy will initiate a new connection to the local port specified in `listening_on`.
+/// For each connection incoming to the remote port, the internal proxy will initiate a new
+/// connection to the destination described by [`PortSubscribe::listening_on`].
 #[derive(Encode, Decode, Debug, Clone, PartialEq, Eq)]
 pub struct PortSubscribe {
-    /// Local address on which the layer is listening.
-    pub listening_on: SocketAddr,
-    /// Instructions on how to execute mirroring.
+    pub listening_on: ListeningOn,
     pub subscription: PortSubscription,
 }
 
@@ -228,10 +264,8 @@ pub enum PortSubscription {
 /// A request to stop proxying incoming connections.
 #[derive(Encode, Decode, Debug, PartialEq, Eq)]
 pub struct PortUnsubscribe {
-    /// Port on the remote pod that layer mirrored.
     pub port: Port,
-    /// Local address on which the layer was listening.
-    pub listening_on: SocketAddr,
+    pub listening_on: ListeningOn,
 }
 
 /// Messages sent by the internal proxy and handled by the layer.

--- a/mirrord/intproxy/src/lib.rs
+++ b/mirrord/intproxy/src/lib.rs
@@ -1247,7 +1247,10 @@ mod test {
                 message_id: 0,
                 inner: LayerToProxyMessage::Incoming(IncomingRequest::PortSubscribe(
                     PortSubscribe {
-                        listening_on: "0.0.0.0:42069".parse().unwrap(),
+                        listening_on: "0.0.0.0:42069"
+                            .parse::<std::net::SocketAddr>()
+                            .unwrap()
+                            .into(),
                         subscription: PortSubscription::Steal(StealType::All(42069)),
                     },
                 )),
@@ -1536,7 +1539,7 @@ mod test {
                 message_id: 0,
                 inner: LayerToProxyMessage::Incoming(IncomingRequest::PortSubscribe(
                     PortSubscribe {
-                        listening_on: addr,
+                        listening_on: addr.into(),
                         subscription: PortSubscription::Steal(StealType::All(80)),
                     },
                 )),

--- a/mirrord/intproxy/src/proxies/incoming.rs
+++ b/mirrord/intproxy/src/proxies/incoming.rs
@@ -57,7 +57,7 @@ mod bound_socket;
 pub mod http;
 mod http_gateway;
 mod metadata_store;
-mod port_subscription_ext;
+pub mod port_subscription_ext;
 mod subscriptions;
 pub mod tasks;
 mod tcp_proxy;

--- a/mirrord/intproxy/src/proxies/incoming.rs
+++ b/mirrord/intproxy/src/proxies/incoming.rs
@@ -24,7 +24,7 @@ use metadata_store::MetadataStore;
 use mirrord_config::feature::network::incoming::tls_delivery::LocalTlsDelivery;
 use mirrord_intproxy_protocol::{
     ConnMetadataRequest, ConnMetadataResponse, IncomingRequest, IncomingResponse, LayerId,
-    MessageId, PortSubscription, ProxyToLayerMessage,
+    ListeningOn, MessageId, PortSubscription, ProxyToLayerMessage,
 };
 use mirrord_protocol::{
     ClientMessage, ConnectionId, RequestId, ResponseError,
@@ -35,6 +35,7 @@ use mirrord_protocol::{
         NewTcpConnectionV2,
     },
 };
+use rand::seq::IndexedRandom;
 use semver::Version;
 use tasks::{HttpGatewayId, HttpOut, InProxyTask, InProxyTaskError, InProxyTaskMessage};
 use tcp_proxy::{LocalTcpConnection, TcpProxyTask};
@@ -321,15 +322,15 @@ impl IncomingProxy {
             port: request.port,
             version: request.version(),
         };
-        let server_addr = normalize_connection_address(subscription.listening_on);
-        tracing::info!("Using server address {} for connection", server_addr);
+        let listening_on = subscription.listening_on.clone();
+        tracing::info!(%listening_on, "Forwarding HTTP request");
 
         let tx = self.tasks.as_mut().unwrap().register(
             HttpGatewayTask::new(
                 request,
                 self.client_store.clone(),
                 is_steal.then_some(self.response_mode),
-                server_addr,
+                listening_on,
                 transport,
             ),
             if is_steal {
@@ -394,24 +395,33 @@ impl IncomingProxy {
             return Ok(());
         };
 
-        let socket = BoundTcpSocket::bind_specified_or_localhost(subscription.listening_on.ip())
+        let peer_address = subscription
+            .listening_on
+            .resolve_addr()
+            .await
+            .map_err(IncomingProxyError::SocketSetupFailed)?;
+        let peer_address = normalize_connection_address(peer_address);
+
+        let socket = BoundTcpSocket::bind_specified_or_localhost(peer_address.ip())
             .map_err(IncomingProxyError::SocketSetupFailed)?;
 
-        let peer_address = normalize_connection_address(subscription.listening_on);
-
-        self.metadata_store.expect(
-            ConnMetadataRequest {
-                listener_address: subscription.listening_on,
-                peer_address: socket
-                    .local_addr()
-                    .map_err(IncomingProxyError::SocketSetupFailed)?,
-            },
-            connection_id,
-            ConnMetadataResponse {
-                remote_source: SocketAddr::new(remote_address, source_port),
-                local_address,
-            },
-        );
+        // Hostname subscriptions have no layer making `accept()` calls, so there's nothing to
+        // satisfy with a [`ConnMetadataResponse`].
+        if let ListeningOn::Socket(listener_address) = &subscription.listening_on {
+            self.metadata_store.expect(
+                ConnMetadataRequest {
+                    listener_address: *listener_address,
+                    peer_address: socket
+                        .local_addr()
+                        .map_err(IncomingProxyError::SocketSetupFailed)?,
+                },
+                connection_id,
+                ConnMetadataResponse {
+                    remote_source: SocketAddr::new(remote_address, source_port),
+                    local_address,
+                },
+            );
+        }
 
         let id = if is_steal {
             InProxyTask::StealTcpProxy(connection_id)
@@ -1007,5 +1017,33 @@ fn normalize_connection_address(listen_addr: SocketAddr) -> SocketAddr {
             SocketAddr::new(Ipv6Addr::LOCALHOST.into(), listen_addr.port())
         }
         _ => listen_addr,
+    }
+}
+
+pub trait ListeningOnExt {
+    /// Returns a concrete [`SocketAddr`] to forward traffic to.
+    ///
+    /// For [`ListeningOn::Hostname`], resolves it via DNS and picks one of the returned addresses
+    /// at random. Call this per request / per new connection so load gets spread across the
+    /// backing pods of a headless Service.
+    fn resolve_addr(&self) -> impl Future<Output = io::Result<SocketAddr>>;
+}
+
+impl ListeningOnExt for ListeningOn {
+    async fn resolve_addr(&self) -> io::Result<SocketAddr> {
+        match self {
+            Self::Socket(addr) => Ok(*addr),
+            Self::Hostname { host, port } => {
+                let addrs = tokio::net::lookup_host((host.as_str(), *port))
+                    .await?
+                    .collect::<Vec<_>>();
+                addrs.choose(&mut rand::rng()).copied().ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::AddrNotAvailable,
+                        format!("DNS lookup for {host}:{port} returned no addresses"),
+                    )
+                })
+            }
+        }
     }
 }

--- a/mirrord/intproxy/src/proxies/incoming/http_gateway.rs
+++ b/mirrord/intproxy/src/proxies/incoming/http_gateway.rs
@@ -3,13 +3,13 @@ use std::{
     convert::Infallible,
     error::Report,
     fmt,
-    net::SocketAddr,
     ops::ControlFlow,
     time::{Duration, Instant},
 };
 
 use http_body_util::BodyExt;
 use hyper::{StatusCode, body::Incoming, http::response::Parts};
+use mirrord_intproxy_protocol::ListeningOn;
 use mirrord_protocol::{
     ClientMessage, Payload,
     batched_body::BatchedBody,
@@ -24,6 +24,7 @@ use tokio_retry::strategy::ExponentialBackoff;
 use tracing::Level;
 
 use super::{
+    ListeningOnExt,
     http::{ClientStore, LocalHttpError, ResponseMode, StreamingBody, mirrord_error_response},
     tasks::{HttpOut, InProxyTaskMessage},
 };
@@ -43,8 +44,9 @@ pub struct HttpGatewayTask {
     ///
     /// [`None`] if this is a mirrored request and we should discard the response.
     response_mode: Option<ResponseMode>,
-    /// Address of the HTTP server in the user application.
-    server_addr: SocketAddr,
+    /// Forward destination, resolved on every send attempt so hostname subscriptions spread
+    /// load across the backing pods.
+    listening_on: ListeningOn,
     /// How to transport the HTTP request to the server.
     transport: IncomingTrafficTransportType,
 }
@@ -54,7 +56,7 @@ impl fmt::Debug for HttpGatewayTask {
         f.debug_struct("HttpGatewayTask")
             .field("request", &self.request)
             .field("response_mode", &self.response_mode)
-            .field("server_addr", &self.server_addr)
+            .field("listening_on", &self.listening_on)
             .field("transport", &self.transport)
             .finish()
     }
@@ -66,14 +68,14 @@ impl HttpGatewayTask {
         request: HttpRequest<StreamingBody>,
         client_store: ClientStore,
         response_mode: Option<ResponseMode>,
-        server_addr: SocketAddr,
+        listening_on: ListeningOn,
         transport: IncomingTrafficTransportType,
     ) -> Self {
         Self {
             request,
             client_store,
             response_mode,
-            server_addr,
+            listening_on,
             transport,
         }
     }
@@ -227,10 +229,15 @@ impl HttpGatewayTask {
     /// sending [`ChunkedResponse::Start`]. The agent would get a duplicated response.
     #[tracing::instrument(level = Level::DEBUG, skip_all, err(level = Level::WARN))]
     async fn send_attempt(&self, message_bus: &mut MessageBus<Self>) -> Result<(), LocalHttpError> {
+        let server_addr = self
+            .listening_on
+            .resolve_addr()
+            .await
+            .map_err(LocalHttpError::ConnectTcpFailed)?;
         let mut client = self
             .client_store
             .get(
-                self.server_addr,
+                server_addr,
                 self.request.version(),
                 &self.transport,
                 &self.request.internal_request.uri,
@@ -672,7 +679,7 @@ mod test {
                     LocalTlsSetup::from_config(Default::default()),
                 ),
                 is_steal.then_some(ResponseMode::Basic),
-                local_destination,
+                ListeningOn::Socket(local_destination),
                 if use_tls {
                     IncomingTrafficTransportType::Tls {
                         alpn_protocol: Some(b"http/1.1".to_vec()),
@@ -841,7 +848,7 @@ mod test {
                 request,
                 ClientStore::new_with_timeout(Duration::from_secs(1), Default::default()),
                 response_mode,
-                addr,
+                ListeningOn::Socket(addr),
                 IncomingTrafficTransportType::Tcp,
             ),
             (),
@@ -1002,7 +1009,7 @@ mod test {
                 request,
                 client_store.clone(),
                 Some(ResponseMode::Basic),
-                addr,
+                ListeningOn::Socket(addr),
                 IncomingTrafficTransportType::Tcp,
             ),
             (),
@@ -1082,7 +1089,7 @@ mod test {
                 request.clone(),
                 client_store.clone(),
                 Some(ResponseMode::Basic),
-                addr,
+                ListeningOn::Socket(addr),
                 IncomingTrafficTransportType::Tcp,
             ),
             0,
@@ -1093,7 +1100,7 @@ mod test {
                 request.clone(),
                 client_store.clone(),
                 Some(ResponseMode::Basic),
-                addr,
+                ListeningOn::Socket(addr),
                 IncomingTrafficTransportType::Tcp,
             ),
             1,

--- a/mirrord/intproxy/src/proxies/incoming/subscriptions.rs
+++ b/mirrord/intproxy/src/proxies/incoming/subscriptions.rs
@@ -1,11 +1,9 @@
-use std::{
-    collections::{HashMap, hash_map::Entry},
-    net::SocketAddr,
-};
+use std::collections::{HashMap, hash_map::Entry};
 
 use futures::future::Either;
 use mirrord_intproxy_protocol::{
-    IncomingResponse, LayerId, MessageId, PortSubscribe, PortUnsubscribe, ProxyToLayerMessage,
+    IncomingResponse, LayerId, ListeningOn, MessageId, PortSubscribe, PortUnsubscribe,
+    ProxyToLayerMessage,
 };
 use mirrord_protocol::{BlockedAction, ClientMessage, Port, RemoteResult, ResponseError};
 use semver::Version;
@@ -124,15 +122,15 @@ impl Subscription {
 
     /// Removed a source from this subscription.
     /// If this source is the last one, returns [`Err`] with a message to be sent to the agent.
-    fn remove_source(mut self, listening_on: SocketAddr) -> Result<Self, Box<ClientMessage>> {
+    fn remove_source(mut self, listening_on: &ListeningOn) -> Result<Self, Box<ClientMessage>> {
         let queue_size = self.queued_sources.len();
         self.queued_sources
-            .retain(|source| source.request.listening_on != listening_on);
+            .retain(|source| source.request.listening_on != *listening_on);
         if queue_size != self.queued_sources.len() {
             return Ok(self);
         }
 
-        if self.active_source.request.listening_on != listening_on {
+        if self.active_source.request.listening_on != *listening_on {
             return Ok(self);
         }
 
@@ -170,7 +168,7 @@ impl Subscription {
 ///    subscription request
 #[derive(Default)]
 pub struct SubscriptionsManager {
-    remote_ports: RemoteResources<(Port, SocketAddr)>,
+    remote_ports: RemoteResources<(Port, ListeningOn)>,
     subscriptions: HashMap<Port, Subscription>,
 }
 
@@ -198,7 +196,7 @@ impl SubscriptionsManager {
     ) -> Option<Either<ProxyMessage, ClientMessage>> {
         self.remote_ports.add(
             layer_id,
-            (request.subscription.port(), request.listening_on),
+            (request.subscription.port(), request.listening_on.clone()),
         );
 
         let port = request.subscription.port();
@@ -231,14 +229,14 @@ impl SubscriptionsManager {
     ) -> Option<ClientMessage> {
         let closed_in_all_forks = self
             .remote_ports
-            .remove(layer_id, (request.port, request.listening_on));
+            .remove(layer_id, (request.port, request.listening_on.clone()));
         if !closed_in_all_forks {
             return None;
         }
 
         let subscription = self.subscriptions.remove(&request.port)?;
 
-        match subscription.remove_source(request.listening_on) {
+        match subscription.remove_source(&request.listening_on) {
             Ok(subscription) => {
                 self.subscriptions.insert(request.port, subscription);
                 None
@@ -322,7 +320,7 @@ impl SubscriptionsManager {
             .remove_all(layer_id)
             .filter_map(|(port, listening_on)| {
                 let subscription = self.subscriptions.remove(&port)?;
-                match subscription.remove_source(listening_on) {
+                match subscription.remove_source(&listening_on) {
                     Ok(subscription) => {
                         self.subscriptions.insert(port, subscription);
                         None
@@ -352,8 +350,14 @@ mod test {
 
     #[test]
     fn with_double_subscribe() {
-        let listener_1 = "127.0.0.1:1111".parse().unwrap();
-        let listener_2 = "127.0.0.1:2222".parse().unwrap();
+        let listener_1: ListeningOn = "127.0.0.1:1111"
+            .parse::<std::net::SocketAddr>()
+            .unwrap()
+            .into();
+        let listener_2: ListeningOn = "127.0.0.1:2222"
+            .parse::<std::net::SocketAddr>()
+            .unwrap()
+            .into();
 
         let mut manager = SubscriptionsManager::default();
 
@@ -361,7 +365,7 @@ mod test {
             LayerId(0),
             0,
             PortSubscribe {
-                listening_on: listener_1,
+                listening_on: listener_1.clone(),
                 subscription: PortSubscription::Mirror(MirrorType::All(80)),
             },
             None,
@@ -380,7 +384,7 @@ mod test {
             LayerId(0),
             1,
             PortSubscribe {
-                listening_on: listener_2,
+                listening_on: listener_2.clone(),
                 subscription: PortSubscription::Mirror(MirrorType::All(80)),
             },
             None,
@@ -434,7 +438,10 @@ mod test {
 
     #[test]
     fn with_fork() {
-        let listening_on = "127.0.0.1:1111".parse().unwrap();
+        let listening_on: ListeningOn = "127.0.0.1:1111"
+            .parse::<std::net::SocketAddr>()
+            .unwrap()
+            .into();
 
         let mut manager = SubscriptionsManager::default();
 
@@ -442,7 +449,7 @@ mod test {
             LayerId(0),
             0,
             PortSubscribe {
-                listening_on,
+                listening_on: listening_on.clone(),
                 subscription: PortSubscription::Mirror(MirrorType::All(80)),
             },
             None,
@@ -479,7 +486,7 @@ mod test {
             LayerId(0),
             PortUnsubscribe {
                 port: 80,
-                listening_on,
+                listening_on: listening_on.clone(),
             },
         );
         assert!(response.is_none(), "{response:?}");
@@ -501,7 +508,10 @@ mod test {
 
     #[test]
     fn with_double_response() {
-        let listening_on = "127.0.0.1:1111".parse().unwrap();
+        let listening_on: ListeningOn = "127.0.0.1:1111"
+            .parse::<std::net::SocketAddr>()
+            .unwrap()
+            .into();
 
         let mut manager = SubscriptionsManager::default();
 
@@ -509,7 +519,7 @@ mod test {
             LayerId(0),
             0,
             PortSubscribe {
-                listening_on,
+                listening_on: listening_on.clone(),
                 subscription: PortSubscription::Mirror(MirrorType::All(80)),
             },
             None,

--- a/mirrord/intproxy/src/proxies/incoming/tests.rs
+++ b/mirrord/intproxy/src/proxies/incoming/tests.rs
@@ -84,7 +84,7 @@ async fn http_request_terminates_on_remote_close(#[case] steal_type: StealType) 
             0,
             LayerId(0),
             IncomingRequest::PortSubscribe(PortSubscribe {
-                listening_on: local_addr,
+                listening_on: local_addr.into(),
                 subscription: PortSubscription::Steal(steal_type.clone()),
             }),
         ))

--- a/mirrord/layer-lib/src/socket.rs
+++ b/mirrord/layer-lib/src/socket.rs
@@ -218,7 +218,7 @@ impl UserSocket {
             } => {
                 let _ = make_proxy_request_no_response(PortUnsubscribe {
                     port: bound.requested_address.port(),
-                    listening_on: bound.address,
+                    listening_on: bound.address.into(),
                 });
             }
             Self {

--- a/mirrord/layer-win/src/hooks/socket/mod.rs
+++ b/mirrord/layer-win/src/hooks/socket/mod.rs
@@ -504,7 +504,7 @@ unsafe extern "system" fn listen_detour(s: SOCKET, backlog: INT) -> INT {
 
     // Make the request to the agent
     match make_proxy_request_with_response(PortSubscribe {
-        listening_on: bound_state.address,
+        listening_on: bound_state.address.into(),
         subscription: setup().incoming_mode().subscription(mapped_port),
     }) {
         Ok(Ok(_)) => {

--- a/mirrord/layer/src/socket/ops.rs
+++ b/mirrord/layer/src/socket/ops.rs
@@ -358,7 +358,7 @@ pub(super) fn listen(sockfd: RawFd, backlog: c_int) -> Detour<i32> {
                 .unwrap_or_else(|| requested_address.port());
 
             make_proxy_request_with_response(PortSubscribe {
-                listening_on: address,
+                listening_on: address.into(),
                 subscription: setup.incoming_mode().subscription(mapped_port),
             })??;
 

--- a/mirrord/operator/src/crd/preview.rs
+++ b/mirrord/operator/src/crd/preview.rs
@@ -86,6 +86,11 @@ impl PreviewSessionSpec {
     pub fn has_infinite_ttl(&self) -> bool {
         self.ttl_secs >= PreviewTtl::INFINITE_TTL_SECS
     }
+
+    /// Returns `true` when `ttl_secs` should _not_ be treated as infinite.
+    pub fn has_ttl(&self) -> bool {
+        self.ttl_secs < PreviewTtl::INFINITE_TTL_SECS
+    }
 }
 
 impl PreviewSession {
@@ -203,8 +208,8 @@ impl PreviewStatusUpdate {
     }
 
     /// Sets `.status.expiresAt`.
-    pub fn expires_at(mut self, expires_at: MicroTime) -> Self {
-        self.expires_at = Some(expires_at);
+    pub fn expires_at(mut self, expires_at: Option<MicroTime>) -> Self {
+        self.expires_at = expires_at;
         self
     }
 

--- a/mirrord/operator/src/crd/preview.rs
+++ b/mirrord/operator/src/crd/preview.rs
@@ -2,8 +2,8 @@
 //!
 //! The CLI creates a [`PreviewSession`] resource in the cluster, and the operator reconciles
 //! it by spawning a preview pod and routing traffic to it. The CR's status subresource
-//! tracks the session lifecycle (`Initializing` → `Waiting` → `Ready` / `Failed`), which
-//! the CLI watches to report progress back to the user.
+//! tracks the session lifecycle (`Initializing` → `Waiting` → `Ready` / `Failed`), which the
+//! CLI watches to report progress back to the user.
 
 use std::{collections::BTreeMap, time::Duration};
 
@@ -110,18 +110,15 @@ pub struct PreviewSessionStatus {
     /// Timestamp of when the operator started processing this session.
     pub started_at: MicroTime,
 
-    /// Name of the preview pod created for this session.
-    ///
-    /// Set once the pod is created (from the `Waiting` phase onward). `None` during
-    /// `Initializing` or if pod creation failed before a name was assigned.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub pod_name: Option<String>,
-
     /// Human-readable description of why the session failed.
     ///
     /// Only set when `phase` is `Failed`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub failure_message: Option<String>,
+
+    /// Timestamp of when the session entered the `Failed` phase.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub failed_at: Option<MicroTime>,
 
     /// Timestamp when the session's TTL expires.
     ///
@@ -135,8 +132,8 @@ pub struct PreviewSessionStatus {
 
 /// Phase of a preview session's lifecycle.
 ///
-/// Progresses through `Initializing` → `Waiting` → `Ready`. Any phase may transition to
-/// `Failed` on error.
+/// The session will transition linearly through each of these phases.
+/// Any phase may transition to `Failed` on error.
 #[derive(Clone, Copy, Debug, Deserialize, Serialize, JsonSchema, Eq, PartialEq)]
 pub enum PreviewSessionPhase {
     /// Operator is setting up — the preview pod has not been created yet.
@@ -166,10 +163,10 @@ pub struct PreviewStatusUpdate {
     started_at: Option<MicroTime>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pod_name: Option<String>,
+    failure_message: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    failure_message: Option<String>,
+    failed_at: Option<MicroTime>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     expires_at: Option<MicroTime>,
@@ -193,15 +190,15 @@ impl PreviewStatusUpdate {
         self
     }
 
-    /// Sets `.status.podName`.
-    pub fn pod_name(mut self, pod_name: String) -> Self {
-        self.pod_name = Some(pod_name);
-        self
-    }
-
     /// Sets `.status.failureMessage`.
     pub fn failure_message(mut self, failure_message: String) -> Self {
         self.failure_message = Some(failure_message);
+        self
+    }
+
+    /// Sets `.status.failedAt`.
+    pub fn failed_at(mut self, failed_at: MicroTime) -> Self {
+        self.failed_at = Some(failed_at);
         self
     }
 


### PR DESCRIPTION
## Summary

See the operator PR :)

## Issues

- [Operator should monitor preview pod health and reschedule within TTL window](https://linear.app/metalbear/issue/COR-1400/operator-should-monitor-preview-pod-health-and-reschedule-within-ttl)
- [Show only live previews in mirrord preview status](https://linear.app/metalbear/issue/COR-1388/show-only-live-previews-in-mirrord-preview-status)

## Related PRs

- https://github.com/metalbear-co/operator/pull/1527

<!-- Thank you for contributing to mirrord! -->
<!-- Please use the checklist below as a guide for docs, tests and admin tasks for your PR -->
<!-- Feel free to ~strikethrough~ any items that you don't think apply -->

### Quality Checklist:

- [x] I have documented new code sufficiently
- [x] I have checked and updated the relevant existing docs in code, including removing outdated material
- [x] I have written user-facing website docs for new features, or opened a (sub)issue to do so
- [x] I have checked and updated existing website docs for changed features
- [x] I have tested this change and know it succeeds and fails as expected
- [x] I have written unit tests or purposefully omitted them
- [x] I have written e2e tests or purposefully omitted them
- [x] I have explained what this PR introduces and why, and linked to relevant context (e.g. linear issues, related PRs,
  documentation)
- [x] I have introduced a short, clear and well-formatted changelog entry

<!-- need help with the changelog? see ../CONTRIBUTING.md#submitting-a-pull-request -->
<!-- Add more details of your changes below if needed -->
