### PR TITLE
Bind agent to IPv6 dual stack, fallback to IPv4 if fails

### DIFF
--- a/changelog.d/+agent-ipv6-fallback.fixed.md
+++ b/changelog.d/+agent-ipv6-fallback.fixed.md
@@ -1,0 +1,1 @@
+Agent now falls back to an IPv4 client listener when setting up the dual-stack IPv6 one fails (e.g. on clusters with IPv6 disabled).

--- a/mirrord/agent/src/entrypoint.rs
+++ b/mirrord/agent/src/entrypoint.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::HashMap,
     mem,
-    net::{Ipv6Addr, SocketAddr},
+    net::{Ipv4Addr, Ipv6Addr, SocketAddr},
     ops::Not,
     path::PathBuf,
     sync::{
@@ -21,6 +21,7 @@ use mirrord_agent_iptables::{
     error::{IPTablesError, IPTablesResult},
 };
 use mirrord_protocol::{ClientMessage, DaemonMessage, GetEnvVarsRequest};
+use socket2::SockRef;
 use tokio::{
     net::{TcpListener, TcpSocket, TcpStream},
     process::Command,
@@ -868,14 +869,35 @@ async fn check_leftover_rules(
 #[tracing::instrument(level = Level::TRACE, ret, err)]
 async fn start_agent(args: Args) -> AgentResult<()> {
     let listener = {
-        let listener = TcpSocket::new_v6()?;
-        // SO_REUSEADDR is required to handle rapid agent restarts.
-        listener.set_reuseaddr(true)?;
-        listener.bind(SocketAddr::new(
-            Ipv6Addr::UNSPECIFIED.into(),
-            args.communicate_port,
-        ))?;
-        listener.listen(1024).map_err(AgentError::from)?
+        // Prefer a dual-stack IPv6 socket so both IPv4 and IPv6 clients can connect.
+        // If anything in that setup fails (e.g. IPv6 is disabled in the cluster),
+        // fall back to a plain IPv4 listener.
+        let create_dual_stack = || -> AgentResult<TcpListener> {
+            let listener = TcpSocket::new_v6()?;
+            // SO_REUSEADDR is required to handle rapid agent restarts.
+            listener.set_reuseaddr(true)?;
+            // Accept IPv4 clients on this socket as well, not only IPv6 ones.
+            SockRef::from(&listener).set_only_v6(false)?;
+            listener.bind(SocketAddr::new(
+                Ipv6Addr::UNSPECIFIED.into(),
+                args.communicate_port,
+            ))?;
+            listener.listen(1024).map_err(AgentError::from)
+        };
+
+        match create_dual_stack() {
+            Ok(listener) => listener,
+            Err(error) => {
+                warn!(%error, "Failed to set up an IPv6 client listener, falling back to IPv4.");
+                let listener = TcpSocket::new_v4()?;
+                listener.set_reuseaddr(true)?;
+                listener.bind(SocketAddr::new(
+                    Ipv4Addr::UNSPECIFIED.into(),
+                    args.communicate_port,
+                ))?;
+                listener.listen(1024).map_err(AgentError::from)?
+            }
+        }
     };
 
     let client_listener_address = listener.local_addr()?;


### PR DESCRIPTION
<!-- Thank you for contributing to mirrord! -->
<!-- Please use the checklist below as a guide for docs, tests and admin tasks for your PR -->
<!-- Feel free to ~strikethrough~ any items that you don't think apply -->

### Quality Checklist:

- [X] I have documented new code sufficiently
- [X] I have checked and updated the relevant existing docs in code, including removing outdated material
- [X] I have written user-facing website docs for new features, or opened a (sub)issue to do so
- [X] I have checked and updated existing website docs for changed features
- [X] I have tested this change and know it succeeds and fails as expected
- [X] I have written unit tests or purposefully omitted them
- [X] I have written e2e tests or purposefully omitted them
- [X] I have explained what this PR introduces and why, and linked to relevant context (e.g. linear issues, related PRs,
  documentation)
- [X] I have introduced a short, clear and well-formatted changelog entry

<!-- need help with the changelog? see ../CONTRIBUTING.md#submitting-a-pull-request -->
<!-- Add more details of your changes below if needed -->

Someone is running the agent in an environment where even creating an ipv6 socket fails (this is very unusual and not supposed to happen). Fallback to ipv4