### PR TITLE
docs(readme): rewrite intro and switch metalbear.co links to metalbear.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 [mirrord runs your local process inside a live Kubernetes cluster](https://metalbear.com/mirrord/).
 It works the same way for developers and for AI coding agents (Claude Code, Cursor, Codex, Copilot, Windsurf):
-your code runs on your machine, but mirrord routes its traffic, files, and environment through a target pod in the cluster.
+your code runs on your machine, but mirrord routes its traffic, files, and environment variables through a target pod in the cluster.
 
 That covers both halves of the software development loop. Read live cluster context while writing the code (real env vars, real service responses, real queue contents)
 so the change is grounded in what's actually deployed. Then run the code against those same services and data to confirm it works end-to-end.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Github CI](https://github.com/metalbear-co/mirrord/actions/workflows/ci.yaml/badge.svg)](https://github.com/metalbear-co/mirrord/actions/workflows/ci.yaml)
 [![License](https://img.shields.io/badge/license-MIT-green)](https://github.com/metalbear-co/mirrord/blob/main/LICENSE)
 [![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/metalbear-co/mirrord)](https://github.com/metalbear-co/mirrord/releases)
-[![Twitter Follow](https://img.shields.io/twitter/follow/metalbear?style=social)](https://twitter.com/metalbear)
+[![X Follow](https://img.shields.io/twitter/follow/metalbear?style=social)](https://x.com/metalbear)
 
 [mirrord runs your local process inside a live Kubernetes cluster](https://metalbear.com/mirrord/).
 It works the same way for a developer in an IDE and for an AI coding agent (Claude Code, Cursor, Codex, Copilot, Windsurf):

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Github CI](https://github.com/metalbear-co/mirrord/actions/workflows/ci.yaml/badge.svg)](https://github.com/metalbear-co/mirrord/actions/workflows/ci.yaml)
 [![License](https://img.shields.io/badge/license-MIT-green)](https://github.com/metalbear-co/mirrord/blob/main/LICENSE)
 [![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/metalbear-co/mirrord)](https://github.com/metalbear-co/mirrord/releases)
-[![Twitter Follow](https://img.shields.io/twitter/follow/metalbearco?style=social)](https://twitter.com/metalbearco)
+[![Twitter Follow](https://img.shields.io/twitter/follow/metalbear?style=social)](https://twitter.com/metalbear)
 
 [mirrord runs your local process inside a live Kubernetes cluster](https://metalbear.com/mirrord/).
 It works the same way for a developer in an IDE and for an AI coding agent (Claude Code, Cursor, Codex, Copilot, Windsurf):
@@ -172,7 +172,7 @@ mirrord works first-class with Claude Code, Cursor, Codex CLI, Gemini CLI, and o
 letting them run and verify generated code against real cluster services without deploying.
 
 For setup guides and ready-made workflow skills,
-see [metalbear-co/skills](https://github.com/metalbear-co/skills) or the [mirrord for AI Agents](https://metalbear.comm/mirrord/ai) page.
+see [metalbear-co/skills](https://github.com/metalbear-co/skills) or the [mirrord for AI Agents](https://metalbear.com/mirrord/ai) page.
 
 ## FAQ
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 [mirrord runs your local process inside a live Kubernetes cluster](https://metalbear.com/mirrord/).
 It works the same way for developers and for AI coding agents (Claude Code, Cursor, Codex, Copilot, Windsurf):
-your code stays on your machine, but mirrord routes its traffic, files, and environment through a target pod in the cluster.
+your code runs on your machine, but mirrord routes its traffic, files, and environment through a target pod in the cluster.
 
 That covers both halves of the loop. Read live cluster context while writing the code (real env vars, real service responses, real queue contents)
 so the change is grounded in what's actually deployed. Then run the code against those same services and data to confirm it works end-to-end.

--- a/README.md
+++ b/README.md
@@ -4,16 +4,21 @@
 
 </div>
 
-[![Community Slack](https://img.shields.io/badge/Join-e5f7f7?logo=slack&label=Community%20Slack)](https://metalbear.co/slack)
+[![Community Slack](https://img.shields.io/badge/Join-e5f7f7?logo=slack&label=Community%20Slack)](https://metalbear.com/slack)
 [![Github CI](https://github.com/metalbear-co/mirrord/actions/workflows/ci.yaml/badge.svg)](https://github.com/metalbear-co/mirrord/actions/workflows/ci.yaml)
 [![License](https://img.shields.io/badge/license-MIT-green)](https://github.com/metalbear-co/mirrord/blob/main/LICENSE)
 [![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/metalbear-co/mirrord)](https://github.com/metalbear-co/mirrord/releases)
 [![Twitter Follow](https://img.shields.io/twitter/follow/metalbearco?style=social)](https://twitter.com/metalbearco)
 
-[mirrord lets developers and AI coding agents run local processes in the context of their Kubernetes environment](https://metalbear.co/mirrord/).
-It’s meant to provide the benefits of running your service on a cloud environment (e.g. staging) without actually
-going through the hassle of deploying it there, and without disrupting the environment by deploying untested code.
-It comes as a Visual Studio Code extension, an IntelliJ plugin and a CLI tool. [You can read more about it here](https://metalbear.co/mirrord/docs/overview/introduction/).
+[mirrord runs your local process inside a live Kubernetes cluster](https://metalbear.com/mirrord/).
+It works the same way for a developer in an IDE and for an AI coding agent (Claude Code, Cursor, Codex, Copilot, Windsurf):
+your code stays on your machine, but mirrord routes its traffic, files, and environment through a target pod in the cluster.
+
+That covers both halves of the loop. Read live cluster context while writing the code (real env vars, real service responses, real queue contents)
+so the change is grounded in what's actually deployed. Then run the code against those same services and data to confirm it works end-to-end.
+
+You get the feedback of a deploy in seconds, without the deploy, and without disrupting the cluster for anyone else.
+mirrord ships as a VS Code extension, IntelliJ plugin, and CLI tool. [Read more](https://metalbear.com/mirrord/docs/overview/introduction/).
 
 **Adopted by**: monday.com, SurveyMonkey, Cadence, CoLab, Daylight Security, Zooplus, and [others](./ADOPTERS.md).
 
@@ -140,7 +145,7 @@ mirrord exec node app.js --target pod/my-pod
 When you select a pod to impersonate, mirrord launches a pod on the same node as the pod you selected.
 The new pod is then used to connect your local process and the impersonated pod: it mirrors incoming traffic from the pod to your process,
 routes outgoing traffic from your process through the pod, and does the same for file reads, file writes, and environment variables.
-[You can read more about it here](https://metalbear.co/mirrord/docs/overview/introduction/).
+[You can read more about it here](https://metalbear.com/mirrord/docs/overview/introduction/).
 
 ### Additional capabilities
 
@@ -150,7 +155,7 @@ Container run inside the pod launched by mirrord requires additional [Linux capa
 - `CAP_SYS_PTRACE` - for reading target pod environment
 - `CAP_SYS_ADMIN` - for joining target pod network namespace
 
-However, you can disable any subset of those in the [configuration](https://metalbear.co/mirrord/docs/reference/configuration/).
+However, you can disable any subset of those in the [configuration](https://metalbear.com/mirrord/docs/reference/configuration/).
 This will possibly limit mirrord functionalities or even make it unusable in some setups.
 
 ```bash
@@ -167,23 +172,23 @@ mirrord works first-class with Claude Code, Cursor, Codex CLI, Gemini CLI, and o
 letting them run and verify generated code against real cluster services without deploying.
 
 For setup guides and ready-made workflow skills,
-see [metalbear-co/skills](https://github.com/metalbear-co/skills) or the [mirrord for AI Agents](https://metalbear.com/mirrord/ai) page.
+see [metalbear-co/skills](https://github.com/metalbear-co/skills) or the [mirrord for AI Agents](https://metalbear.comm/mirrord/ai) page.
 
 ## FAQ
 
-[Our FAQ is available here](https://metalbear.co/mirrord/docs/faq/general/).
+[Our FAQ is available here](https://metalbear.com/mirrord/docs/faq/general/).
 If you have a question that's not on there, feel free to ask in our [Discussions](https://github.com/metalbear-co/mirrord/discussions)
-or on [Slack](https://metalbear.co/slack).
+or on [Slack](https://metalbear.com/slack).
 
 ## Contributing
 
 Contributions are very welcome.
 Start by checking out our [open issues](https://github.com/metalbear-co/mirrord/issues), and by going through our [contributing guide](CONTRIBUTING.md).
-We're available on [Slack](https://metalbear.co/slack) for any questions.
+We're available on [Slack](https://metalbear.com/slack) for any questions.
 
 ## Help and Community
 
-Join our [Slack](https://metalbear.co/slack) for questions, support and fun.
+Join our [Slack](https://metalbear.com/slack) for questions, support and fun.
 
 We always appreciate hearing how mirrord has made a difference for our users.  
 Check out our [ADOPTERS.md](./ADOPTERS.md) to see how others are using mirrord —  

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![X Follow](https://img.shields.io/twitter/follow/metalbear?style=social)](https://x.com/metalbear)
 
 [mirrord runs your local process inside a live Kubernetes cluster](https://metalbear.com/mirrord/).
-It works the same way for a developer in an IDE and for an AI coding agent (Claude Code, Cursor, Codex, Copilot, Windsurf):
+It works the same way for developers and for AI coding agents (Claude Code, Cursor, Codex, Copilot, Windsurf):
 your code stays on your machine, but mirrord routes its traffic, files, and environment through a target pod in the cluster.
 
 That covers both halves of the loop. Read live cluster context while writing the code (real env vars, real service responses, real queue contents)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 It works the same way for developers and for AI coding agents (Claude Code, Cursor, Codex, Copilot, Windsurf):
 your code runs on your machine, but mirrord routes its traffic, files, and environment through a target pod in the cluster.
 
-That covers both halves of the loop. Read live cluster context while writing the code (real env vars, real service responses, real queue contents)
+That covers both halves of the software development loop. Read live cluster context while writing the code (real env vars, real service responses, real queue contents)
 so the change is grounded in what's actually deployed. Then run the code against those same services and data to confirm it works end-to-end.
 
 You get the feedback of a deploy in seconds, without the deploy, and without disrupting the cluster for anyone else.

--- a/changelog.d/+readme-intro.changed.md
+++ b/changelog.d/+readme-intro.changed.md
@@ -1,0 +1,1 @@
+Rewrite README intro to name both halves of the developer + AI coding agent feedback loop. Update `metalbear.co` links to `metalbear.com`.


### PR DESCRIPTION
## Summary
Two changes:

**1. Rewrites the README intro for directness and the agent + developer loop.**
- Replaces wishy-washy phrasing ("It's meant to provide the benefits of... without actually going through the hassle of...") with a direct statement of what mirrord does and what the user gets.
- Names both audiences explicitly: developer in an IDE + AI coding agent (Claude Code, Cursor, Codex, Copilot, Windsurf).
- Surfaces both halves of the loop: reading live cluster context while writing code (real env vars, real service responses, real queue contents), then running code against those same services and data.

**2. Switches `metalbear.co` links to `metalbear.com`.**
- `metalbear.co` redirects to `.com` via the existing Cloudflare Worker, so this isn't a fix for a broken link, just a canonicalization. Avoids the redirect hop and reduces inconsistency between this README, the website, and other materials.
- Does not touch `metalbear-co` (the GitHub org slug); only the `.co` website domain.

## Why
The README is the first surface a technical evaluator hits on GitHub. The post-agent thesis is well-developed on /mirrord/ai but underweighted on the surfaces a build-vs-buy reviewer actually walks through first. This closes part of that gap, tightens the intro at the same time, and aligns the links with the canonical domain.

## Test plan
- [ ] GitHub renders the README correctly (no broken markdown)
- [ ] All `metalbear.com` links resolve (slack invite, /mirrord/, /mirrord/docs/*, /mirrord/ai)
- [ ] No `metalbear-co/` GitHub org slugs were modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)