### PR TITLE
fix: include IPv6 loopback in IP version availability check

### DIFF
--- a/mirrord/agent/src/entrypoint.rs
+++ b/mirrord/agent/src/entrypoint.rs
@@ -113,12 +113,15 @@ static IP_VERSION_AVAILABILITY: LazyLock<IpVersionAvailability> = LazyLock::new(
         }
 
         if let Some(v6) = addr.as_sockaddr_in6()
-            && v6.ip().is_loopback().not()
             && v6.ip().is_unspecified().not()
-            // these are automatically assigned, they don't mean
-            // anything
+            // link-local are automatically assigned, they don't mean
+            // anything for external connectivity
             && v6.ip().is_unicast_link_local().not()
         {
+            // Note: loopback (::1) is intentionally NOT excluded here.
+            // Even without global IPv6, processes can connect to [::1]:port
+            // (e.g. Go's HTTP client prefers IPv6 for "localhost").
+            // The OUTPUT chain ip6tables rules must capture this traffic.
             has_v6 = true;
         }
     }


### PR DESCRIPTION
## Summary

- **Bug**: In IPv4-only Kubernetes clusters (no global IPv6 addresses on pods), mirrord agent does not create ip6tables rules because `IP_VERSION_AVAILABILITY` excludes `::1` (loopback) from the IPv6 check, resulting in `has_v6 = false`.
- **Impact**: Processes inside the pod that connect to `[::1]:port` (IPv6 loopback) completely bypass mirrord's steal/mirror. This is common with Go's `net.Dialer`, which prefers IPv6 when resolving "localhost" — tools like `stripe listen`, gRPC health checks, and sidecar processes silently bypass mirrord.
- **Fix**: Remove the `is_loopback()` exclusion from the IPv6 availability check. When `::1` is present (virtually always on Linux), ip6tables OUTPUT chain rules are created to capture `[::1]` traffic. The ip6tables PREROUTING rules are harmless in IPv4-only clusters since no external IPv6 traffic arrives.

## Reproduction

1. Deploy a pod with a sidecar that calls `localhost:<port>` (e.g. `stripe listen --forward-to localhost:8080/...`)
2. The sidecar is written in Go (or any language whose resolver prefers IPv6)
3. Run `mirrord exec` in steal mode targeting the pod
4. Observe: sidecar's requests to localhost reach the pod's original app, NOT the local machine
5. `ss -tnp` inside the pod's netns shows connections from `[::1]` to `[::1]:8080`
6. `ip6tables -t nat -L -n` shows no mirrord chains — only IPv4 iptables has the rules

After this fix, ip6tables OUTPUT chain rules are created, and `[::1]:8080` traffic is properly redirected to the mirrord agent.

## Notes

- This was already partially recognized in the codebase: the IPv4 check also excluded loopback (`v4.ip().is_loopback().not()`), but IPv4 pods almost always have a non-loopback address so `has_v4 = true` regardless. IPv6 is different — many clusters have no global IPv6 at all, making loopback the only IPv6 address.
- The existing Windows connection pooling comment (`/// On Windows, connection pooling was previously disabled due to "channel closed" errors`) hints at similar symptoms that may have been IPv6-related.

## Test plan

- [ ] Verify ip6tables rules are created when pod only has `::1` (no global IPv6)
- [ ] Verify `[::1]:port` traffic is stolen/mirrored to local machine
- [ ] Verify no regression on pods with global IPv6 addresses
- [ ] Verify no regression on IPv4-only traffic