### PR TITLE
Make `OperatorApi` return an established connection as a plain `Stream+Sink` type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5254,7 +5254,6 @@ dependencies = [
  "mirrord-kube",
  "mirrord-progress",
  "mirrord-protocol",
- "mirrord-protocol-io",
  "rand 0.9.2",
  "rstest",
  "schemars 1.2.1",

--- a/changelog.d/+mirrord-protocol-api-prep.internal.md
+++ b/changelog.d/+mirrord-protocol-api-prep.internal.md
@@ -1,0 +1,1 @@
+`OperatorApi` now returns an established `mirrord-protocol` connection as a named `Stream+Sink` type.

--- a/mirrord/cli/src/connection.rs
+++ b/mirrord/cli/src/connection.rs
@@ -219,7 +219,7 @@ pub(crate) async fn create_and_connect<P: Progress, R: Reporter>(
         }
         return Ok((
             AgentConnectInfo::Operator(connection.session),
-            connection.conn,
+            Connection::from_channel(connection.conn),
         ));
     }
 
@@ -258,8 +258,7 @@ pub(crate) async fn create_and_connect<P: Progress, R: Reporter>(
             .map_err(|error| {
                 CliError::friendlier_error_or_else(error, CliError::AgentConnectionFailed)
             })?,
-    )
-    .await;
+    );
 
     Ok((AgentConnectInfo::DirectKubernetes(agent_connect_info), conn))
 }

--- a/mirrord/cli/src/error.rs
+++ b/mirrord/cli/src/error.rs
@@ -746,7 +746,6 @@ impl From<OperatorApiError> for CliError {
                 operation: operation.to_string(),
             },
             OperatorApiError::InvalidBackoff(fail) => Self::InvalidBackoff(fail.to_string()),
-            OperatorApiError::ProtocolError(error) => Self::from(error),
             OperatorApiError::ApiKey(fail) => Self::ApiKey(fail),
             OperatorApiError::SerdeJson(fail) => Self::JsonSerializeError(fail),
             OperatorApiError::TargetResolutionFailed(msg) => {

--- a/mirrord/intproxy/src/agent_conn.rs
+++ b/mirrord/intproxy/src/agent_conn.rs
@@ -172,7 +172,7 @@ impl AgentConnection {
                     OperatorApi::connect_in_existing_session(config, session.clone(), analytics)
                         .await?;
                 (
-                    connection.conn,
+                    Connection::from_channel(connection.conn),
                     if session.allow_reconnect {
                         ReconnectFlow::ConnectInfo {
                             config: Box::new(config.clone()),
@@ -196,7 +196,7 @@ impl AgentConnection {
 
                 let conn = match tls_pem {
                     Some(tls_pem) => tls::wrap_raw_connection(stream, tls_pem.as_path()).await?,
-                    None => Connection::from_stream(stream).await,
+                    None => Connection::from_stream(stream),
                 };
 
                 (conn, ReconnectFlow::Break(kind))
@@ -229,7 +229,7 @@ impl AgentConnection {
 
     pub async fn new_for_raw_address(address: SocketAddr) -> Result<Self, AgentConnectionError> {
         let stream = TcpStream::connect(address).await?;
-        let connection = Connection::<Client>::from_stream(stream).await;
+        let connection = Connection::<Client>::from_stream(stream);
 
         Ok(Self {
             connection,

--- a/mirrord/intproxy/src/agent_conn/portforward.rs
+++ b/mirrord/intproxy/src/agent_conn/portforward.rs
@@ -18,7 +18,7 @@ pub async fn create_connection(
         .await
         .map_err(AgentConnectionError::Kube)?;
 
-    Ok(Connection::from_stream(convert(stream)).await)
+    Ok(Connection::from_stream(convert(stream)))
 }
 
 // If I don't do this stuff rustc complains about some cursed lifetime

--- a/mirrord/intproxy/src/agent_conn/tls.rs
+++ b/mirrord/intproxy/src/agent_conn/tls.rs
@@ -42,5 +42,5 @@ pub async fn wrap_raw_connection(
         .await
         .map_err(ConnectionTlsError::ConnectionError)?;
 
-    Ok(Connection::from_stream(stream).await)
+    Ok(Connection::from_stream(stream))
 }

--- a/mirrord/operator/Cargo.toml
+++ b/mirrord/operator/Cargo.toml
@@ -32,7 +32,6 @@ client = [
   "dep:mirrord-kube",
   "dep:mirrord-progress",
   "dep:mirrord-protocol",
-  "dep:mirrord-protocol-io",
   "dep:rand",
   "dep:tokio",
   "dep:tokio-tungstenite",
@@ -61,7 +60,6 @@ mirrord-config = { path = "../config", optional = true }
 mirrord-kube = { path = "../kube", optional = true }
 mirrord-progress = { path = "../progress", optional = true }
 mirrord-protocol = { path = "../protocol", optional = true }
-mirrord-protocol-io = { path = "../protocol-io", optional = true}
 
 base64 = { workspace = true, optional = true }
 dotenvy = { workspace = true, optional = true }

--- a/mirrord/operator/src/client.rs
+++ b/mirrord/operator/src/client.rs
@@ -4,7 +4,6 @@ use base64::{Engine, engine::general_purpose};
 use chrono::{DateTime, Utc};
 use connect_params::{BranchDbNames, ConnectParams};
 use error::{OperatorApiError, OperatorApiResult, OperatorOperation};
-use futures::{SinkExt, StreamExt, future::Either};
 use http::{HeaderName, HeaderValue, request::Request};
 use k8s_openapi::api::apps::v1::Deployment;
 use kube::{
@@ -34,20 +33,20 @@ use mirrord_kube::{
     retry::retry_policy_from_config,
 };
 use mirrord_progress::Progress;
-use mirrord_protocol::{ClientMessage, DaemonMessage};
-use mirrord_protocol_io::{Client as ProtocolClient, Connection};
 use semver::Version;
 use serde::{Deserialize, Serialize};
-use tokio_tungstenite::tungstenite;
 use tower::{buffer::BufferLayer, retry::RetryLayer};
 use tracing::Level;
 
 use crate::{
-    client::database_branches::{
-        DatabaseBranchParams, UnifiedDatabaseBranchParams, create_branches,
-        create_mongodb_branches, create_mysql_branches, create_pg_branches, list_existing_branches,
-        list_reusable_mongodb_branches, list_reusable_mysql_branches, list_reusable_pg_branches,
-        wait_for_pending_branches,
+    client::{
+        connection::OperatorConnection,
+        database_branches::{
+            DatabaseBranchParams, UnifiedDatabaseBranchParams, create_branches,
+            create_mongodb_branches, create_mysql_branches, create_pg_branches,
+            list_existing_branches, list_reusable_mongodb_branches, list_reusable_mysql_branches,
+            list_reusable_pg_branches, wait_for_pending_branches,
+        },
     },
     crd::{
         MirrordClusterOperatorUserCredential, MirrordOperatorCrd, NewOperatorFeature,
@@ -66,6 +65,7 @@ use crate::{
 };
 
 pub mod connect_params;
+pub mod connection;
 mod credentials;
 pub mod database_branches;
 mod discovery;
@@ -141,7 +141,6 @@ pub struct OperatorSession {
     /// Version of the operator, right now only for [`fmt::Debug`] implementation.
     operator_version: Version,
     /// Version of [`mirrord_protocol`] used by the operator.
-    /// Used to create [`Connection`].
     pub operator_protocol_version: Option<Version>,
     /// Allow the layer to attempt reconnection
     pub allow_reconnect: bool,
@@ -183,15 +182,14 @@ impl fmt::Debug for OperatorSession {
 /// Connection to an operator target.
 pub struct OperatorSessionConnection {
     pub session: Box<OperatorSession>,
-    pub conn: Connection<ProtocolClient>,
+    pub conn: OperatorConnection,
 }
 
 impl fmt::Debug for OperatorSessionConnection {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("OperatorSessionConnection")
-            .field("session", &self.session)
-            .field("closed", &self.conn.is_closed())
-            .finish()
+        f.debug_tuple("OperatorSessionConnection")
+            .field(&self.session)
+            .finish_non_exhaustive()
     }
 }
 
@@ -1926,7 +1924,7 @@ impl OperatorApi<PreparedClientCert> {
     async fn connect_target(
         client: &Client,
         session: &OperatorSession,
-    ) -> OperatorApiResult<Connection<ProtocolClient>> {
+    ) -> OperatorApiResult<OperatorConnection> {
         let request_builder = Request::builder()
             .uri(&session.connect_url)
             .header(SESSION_ID_HEADER, session.id.to_string());
@@ -1945,59 +1943,13 @@ impl OperatorApi<PreparedClientCert> {
             .body(vec![])
             .map_err(OperatorApiError::ConnectRequestBuildError)?;
 
-        #[derive(thiserror::Error, Debug)]
-        enum OperatorClientError {
-            #[error(transparent)]
-            DecodeError(#[from] bincode::error::DecodeError),
-            #[error(transparent)]
-            WsError(#[from] Box<tungstenite::Error>),
-            #[error("invalid message: {0:?}")]
-            InvalidMessage(Box<tungstenite::Message>),
-        }
-
-        impl From<tungstenite::Error> for OperatorClientError {
-            fn from(error: tungstenite::Error) -> Self {
-                Self::WsError(Box::new(error))
-            }
-        }
-
-        let ws = upgrade::connect_ws(client, request)
+        upgrade::connect_ws(client, request)
             .await
             .map_err(|error| OperatorApiError::KubeError {
                 error,
                 operation: OperatorOperation::WebsocketConnection,
-            })?
-            .with(|outbound: Vec<u8>| {
-                let ws_message = tungstenite::Message::Binary(outbound);
-                std::future::ready(Ok::<_, OperatorClientError>(ws_message))
             })
-            .map(|inbound| match inbound? {
-                tungstenite::Message::Binary(payload) => Ok(payload),
-                other => Err(OperatorClientError::InvalidMessage(Box::new(other))),
-            });
-
-        let operator_protocol_version = session.operator_protocol_version.clone();
-
-        let conn = Connection::<ProtocolClient>::from_channel(
-            ws,
-            // Mock protocol version negotiation if the operator does not support it.
-            Some(move |msg| match msg {
-                ClientMessage::SwitchProtocolVersion(version) => match &operator_protocol_version {
-                    Some(operator_protocol_version) => {
-                        Either::Left(ClientMessage::SwitchProtocolVersion(
-                            operator_protocol_version.min(&version).clone(),
-                        ))
-                    }
-                    _ => Either::Right(DaemonMessage::SwitchProtocolVersionResponse(
-                        semver::Version::new(1, 2, 1),
-                    )),
-                },
-                other => Either::Left(other),
-            }),
-        )
-        .await?;
-
-        Ok(conn)
+            .map(OperatorConnection)
     }
 }
 

--- a/mirrord/operator/src/client.rs
+++ b/mirrord/operator/src/client.rs
@@ -1967,11 +1967,12 @@ impl OperatorApi<PreparedClientCert> {
                 error,
                 operation: OperatorOperation::WebsocketConnection,
             })?
-            .with(|e: Vec<u8>| async {
-                Ok::<_, OperatorClientError>(tungstenite::Message::Binary(e))
+            .with(|outbound: Vec<u8>| {
+                let ws_message = tungstenite::Message::Binary(outbound);
+                std::future::ready(Ok::<_, OperatorClientError>(ws_message))
             })
-            .map(|i| match i.map_err(OperatorClientError::from)? {
-                tungstenite::Message::Binary(pl) => Ok(pl),
+            .map(|inbound| match inbound? {
+                tungstenite::Message::Binary(payload) => Ok(payload),
                 other => Err(OperatorClientError::InvalidMessage(Box::new(other))),
             });
 

--- a/mirrord/operator/src/client/connection.rs
+++ b/mirrord/operator/src/client/connection.rs
@@ -1,0 +1,120 @@
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use futures::{Sink, SinkExt, Stream, StreamExt};
+use hyper::upgrade::Upgraded;
+use hyper_util::rt::TokioIo;
+use mirrord_protocol::{ClientMessage, DaemonMessage};
+use thiserror::Error;
+use tokio_tungstenite::{
+    WebSocketStream,
+    tungstenite::{self, Message},
+};
+
+/// [`mirrord_protocol`] connection established with the operator.
+///
+/// Implements:
+/// 1. [`Stream`] of [`DaemonMessage`]s
+/// 2. [`Sink`] of [`ClientMessage`]s
+/// 3. [`Sink`] of [`Vec<u8>`]s ([`ClientMessage`]s pre-encoded with [`bincode`]) - mostly to fit
+///    into the existing interfaces. Encoded messages are not verified in any way.
+pub struct OperatorConnection(pub(super) WebSocketStream<TokioIo<Upgraded>>);
+
+impl Stream for OperatorConnection {
+    type Item = Result<DaemonMessage, OperatorConnectionError>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+
+        let item = match std::task::ready!(this.0.poll_next_unpin(cx)) {
+            Some(Ok(Message::Binary(msg))) => {
+                match bincode::decode_from_slice(&msg, bincode::config::standard()) {
+                    Ok((message, _)) => Some(Ok(message)),
+                    Err(error) => Some(Err(OperatorConnectionError::DecodeError(error))),
+                }
+            }
+            // Operator only sends binary messages.
+            Some(Ok(unexpected)) => Some(Err(OperatorConnectionError::InvalidMessage(
+                unexpected.into(),
+            ))),
+            Some(Err(error)) => Some(Err(OperatorConnectionError::WsError(error.into()))),
+            None => None,
+        };
+
+        Poll::Ready(item)
+    }
+}
+
+impl Sink<ClientMessage> for OperatorConnection {
+    type Error = OperatorConnectionError;
+
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.get_mut().0.poll_close_unpin(cx).map_err(From::from)
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.get_mut().0.poll_flush_unpin(cx).map_err(From::from)
+    }
+
+    fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.get_mut().0.poll_ready_unpin(cx).map_err(From::from)
+    }
+
+    fn start_send(self: Pin<&mut Self>, item: ClientMessage) -> Result<(), Self::Error> {
+        let item = bincode::encode_to_vec(&item, bincode::config::standard())?;
+        self.get_mut()
+            .0
+            .start_send_unpin(Message::Binary(item))
+            .map_err(From::from)
+    }
+}
+
+impl Sink<Vec<u8>> for OperatorConnection {
+    type Error = OperatorConnectionError;
+
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.get_mut().0.poll_close_unpin(cx).map_err(From::from)
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.get_mut().0.poll_flush_unpin(cx).map_err(From::from)
+    }
+
+    fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.get_mut().0.poll_ready_unpin(cx).map_err(From::from)
+    }
+
+    fn start_send(self: Pin<&mut Self>, item: Vec<u8>) -> Result<(), Self::Error> {
+        self.get_mut()
+            .0
+            .start_send_unpin(Message::Binary(item))
+            .map_err(From::from)
+    }
+}
+
+/// Errors that can occur when working with [`OperatorConnection`].
+#[derive(Error, Debug)]
+pub enum OperatorConnectionError {
+    #[error("bincode decode: {0}")]
+    /// Failed to decode a [`DaemonMessage`] with [`bincode::de`].
+    DecodeError(#[from] bincode::error::DecodeError),
+    /// Failed to encode a [`ClientMessage`] with [`bincode::enc`].
+    #[error("bincode encode: {0}")]
+    EncodeError(#[from] bincode::error::EncodeError),
+    /// [`tungstenite`] WebSocket connection failed.
+    #[error("tungstenite: {0}")]
+    WsError(#[from] Box<tungstenite::Error>),
+    /// Received an unexpected [`Message`] from the WebSocket connection.
+    ///
+    /// Only [`Message::Binary`] messages are expected.
+    #[error("unexpected message: {0:?}")]
+    InvalidMessage(Box<Message>),
+}
+
+impl From<tungstenite::Error> for OperatorConnectionError {
+    fn from(error: tungstenite::Error) -> Self {
+        Self::WsError(Box::new(error))
+    }
+}

--- a/mirrord/operator/src/client/error.rs
+++ b/mirrord/operator/src/client/error.rs
@@ -3,7 +3,6 @@ use std::{fmt, num::ParseIntError};
 pub use http::Error as HttpError;
 use mirrord_auth::error::ApiKeyError;
 use mirrord_kube::error::KubeApiError;
-use mirrord_protocol_io::ProtocolError;
 use thiserror::Error;
 use tower::retry::backoff::InvalidBackoff;
 
@@ -103,9 +102,6 @@ pub enum OperatorApiError {
 
     #[error(transparent)]
     InvalidBackoff(#[from] InvalidBackoff),
-
-    #[error("protocol error: {0}")]
-    ProtocolError(#[from] ProtocolError),
 
     #[error(transparent)]
     ApiKey(#[from] ApiKeyError),

--- a/mirrord/protocol-api/src/client/config.rs
+++ b/mirrord/protocol-api/src/client/config.rs
@@ -1,7 +1,7 @@
 use std::{num::NonZeroUsize, time::Duration};
 
 /// Configuration for a new [`MirrordClient`](crate::client::MirrordClient).
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ClientConfig {
     /// How often should ping messages be sent
     pub ping_pong_interval: Duration,

--- a/mirrord/protocol-api/src/client/connector.rs
+++ b/mirrord/protocol-api/src/client/connector.rs
@@ -4,7 +4,7 @@ use futures::{Sink, Stream};
 use mirrord_protocol::{ClientMessage, DaemonMessage};
 
 /// Trait for mirrord-protocol client->server connection provider.
-pub trait ProtocolConnector: 'static + Send + Sync + fmt::Debug {
+pub trait ProtocolConnector: 'static + Send + fmt::Debug {
     /// Type of error that can occur when connecting to the server or working with an established
     /// connection.
     type Error: 'static + std::error::Error + Send + Sync;

--- a/mirrord/protocol-io/src/lib.rs
+++ b/mirrord/protocol-io/src/lib.rs
@@ -14,9 +14,8 @@ use std::{
 };
 
 use actix_codec::{AsyncRead, AsyncWrite, Decoder, Encoder, Framed};
-use bincode::error::DecodeError;
-use bytes::{BufMut, BytesMut};
-use futures::{Sink, SinkExt, Stream, StreamExt, future::Either};
+use bytes::BytesMut;
+use futures::{Sink, SinkExt, Stream, StreamExt};
 use mirrord_protocol::{ClientMessage, DaemonMessage, ProtocolCodec};
 use rand::seq::IteratorRandom;
 use tokio::{
@@ -86,8 +85,7 @@ impl<I: bincode::Decode<()>> Decoder for Codec<I> {
 impl<I> Encoder<Vec<u8>> for Codec<I> {
     type Error = io::Error;
     fn encode(&mut self, encoded: Vec<u8>, dst: &mut BytesMut) -> Result<(), Self::Error> {
-        dst.reserve(encoded.len());
-        dst.put(&encoded[..]);
+        dst.extend_from_slice(&encoded);
         Ok(())
     }
 }
@@ -112,17 +110,15 @@ pub struct Connection<Type: ProtocolEndpoint> {
 }
 
 impl<Type: ProtocolEndpoint> Connection<Type> {
-    /// Create a new connection running over a byte stream, i.e.
-    /// `AsyncRead` + `AsyncWrite`.
-    pub async fn from_stream<IO>(inner: IO) -> Self
+    /// Create a new connection running over a bidirectional byte stream ([`AsyncRead`] +
+    /// [`AsyncWrite`]).
+    pub fn from_stream<IO>(inner: IO) -> Self
     where
         IO: AsyncIO,
     {
         let framed = Framed::new(inner, Codec::<Type::InMsg>(PhantomData));
-
         let (inbound_tx, inbound_rx) = mpsc::channel(64);
-
-        let shared_state = Arc::new(SharedState::new(inbound_tx.downgrade(), None));
+        let shared_state = Arc::new(SharedState::new(inbound_tx.downgrade()));
 
         tokio::spawn(io_task::<_, Type>(
             framed,
@@ -136,49 +132,34 @@ impl<Type: ProtocolEndpoint> Connection<Type> {
         }
     }
 
-    /// Create a new connection, running over a `Sink` + `Stream` of `Vec<u8>`s.
-    /// Used for connecting to the operator over a websocket connection.
-    pub async fn from_channel<C, Filter>(
-        channel: C,
-        filter: Option<Filter>,
-    ) -> Result<Self, ProtocolError>
+    /// Create a new connection, running over a [`Sink`] + [`Stream`] of byte [`Vec`]s.
+    ///
+    /// Used for connecting to the operator over a WebSocket connection.
+    pub fn from_channel<C>(channel: C) -> Self
     where
-        C: Transport<Vec<u8>, Vec<u8>>,
-        Filter: Fn(Type::OutMsg) -> Either<Type::OutMsg, Type::InMsg> + Send + Sync + 'static,
-        C::Error: From<DecodeError> + std::error::Error + Send + 'static,
+        C: Transport<Type::InMsg, Vec<u8>>,
+        C::Error: std::error::Error + Send + 'static,
     {
-        let framed = channel.map(|msg| {
-            msg.and_then(|e| {
-                bincode::decode_from_slice::<Type::InMsg, _>(&e, bincode::config::standard())
-                    .map(|(msg, _)| msg)
-                    .map_err(<C::Error as From<DecodeError>>::from)
-            })
-        });
-
         let (inbound_tx, inbound_rx) = mpsc::channel(64);
-
-        let shared_state = Arc::new(SharedState::new(
-            inbound_tx.downgrade(),
-            filter.map(|f| Box::new(f) as _),
-        ));
+        let shared_state = Arc::new(SharedState::new(inbound_tx.downgrade()));
 
         tokio::spawn(io_task::<_, Type>(
-            framed,
+            channel,
             Arc::clone(&shared_state),
             inbound_tx,
         ));
 
-        Ok(Self {
+        Self {
             rx: inbound_rx,
             shared_state,
-        })
+        }
     }
 
     /// Create a dummy instance, mainly used for tests.
     pub fn dummy() -> (Self, mpsc::Sender<Type::InMsg>, ConnectionOutput<Type>) {
         let (inbound_tx, inbound_rx) = mpsc::channel(32);
 
-        let shared_state = Arc::new(SharedState::new(inbound_tx.downgrade(), None));
+        let shared_state = Arc::new(SharedState::new(inbound_tx.downgrade()));
 
         let connection = Connection {
             rx: inbound_rx,
@@ -370,8 +351,6 @@ struct OutQueue {
     free: Arc<Notify>,
 }
 
-type FilterFn<I, O> = dyn Fn(O) -> Either<O, I> + Send + Sync;
-
 #[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
 struct QueueId(usize);
 
@@ -391,12 +370,6 @@ struct SharedState<Type: ProtocolEndpoint> {
     /// task is dead.
     in_tx: mpsc::WeakSender<Type::InMsg>,
 
-    /// Used for doing a sort of filter_map and message faking. If
-    /// Some, all outgoing messages are passed to this function, and
-    /// the return value is either injected as an incoming message
-    /// (left), or enqueued for sending (right).
-    out_filter: Option<Box<FilterFn<Type::InMsg, Type::OutMsg>>>,
-
     next_queue_id: AtomicUsize,
 }
 
@@ -412,10 +385,8 @@ impl<Type: ProtocolEndpoint> fmt::Debug for SharedState<Type> {
 
 impl<Type: ProtocolEndpoint> SharedState<Type> {
     const MAX_CAPACITY: usize = 1024 * 16;
-    fn new(
-        in_tx: mpsc::WeakSender<Type::InMsg>,
-        out_filter: Option<Box<FilterFn<Type::InMsg, Type::OutMsg>>>,
-    ) -> Self {
+
+    fn new(in_tx: mpsc::WeakSender<Type::InMsg>) -> Self {
         Self {
             queues: Mutex::new(Queues {
                 queues: HashMap::new(),
@@ -423,7 +394,6 @@ impl<Type: ProtocolEndpoint> SharedState<Type> {
             }),
             nonempty: Arc::new(Notify::new()),
             in_tx,
-            out_filter,
             // 0 is reserved for the Connection struct
             next_queue_id: 1.into(),
         }
@@ -471,26 +441,7 @@ impl<Type: ProtocolEndpoint> SharedState<Type> {
     /// Push a message into the given queue, creating it if necessary.
     /// Will wait for the queue to free up if necessary, resolves only
     /// when the message has been successfully pushed.
-    async fn push(&self, id: QueueId, mut msg: Type::OutMsg) {
-        if let Some(filter) = &self.out_filter {
-            match filter(msg) {
-                Either::Left(out) => msg = out,
-                Either::Right(inj) => {
-                    match self.in_tx.upgrade() {
-                        Some(tx) => {
-                            let _ = tx.send(inj).await;
-                        }
-                        None => {
-                            tracing::warn!(
-                                "Cannot inject response to filtered message because the IO task has closed. Dropping."
-                            )
-                        }
-                    }
-                    return;
-                }
-            }
-        }
-
+    async fn push(&self, id: QueueId, msg: Type::OutMsg) {
         let mut encoded = bincode::encode_to_vec(msg, bincode::config::standard()).unwrap();
 
         loop {


### PR DESCRIPTION
<!-- Thank you for contributing to mirrord! -->
<!-- Please use the checklist below as a guide for docs, tests and admin tasks for your PR -->
<!-- Feel free to ~strikethrough~ any items that you don't think apply -->

Preparation for integrating `mirrord-protocol-api` into the mirrord CLI

1. `OperatorApi` now returns the `mirrord-protocol` connection with the operator as a plain `Stream+Sink` type (so it can be used with both `mirrord-protocol-io` and `mirrord-protocol-api`.
2. Fixed some trait bounds and derives in `mirrord-protocol-api`.
3. For simplicity, removed the mechanism of filtering outbound messages in `mirrord-protocol-io`:
    * It was only used to handle operator instances that do not support protocol version switch
    * Version switch was introduced in `1.3.0`, a long time ago (2 years)

### Quality Checklist:

- [x] I have documented new code sufficiently
- [x] I have checked and updated the relevant existing docs in code, including removing outdated material
- ~[ ] I have written user-facing website docs for new features, or opened a (sub)issue to do so~
- ~[ ] I have checked and updated existing website docs for changed features~
- [ ] I have tested this change and know it succeeds and fails as expected
- [x] I have written unit tests or purposefully omitted them
- [x] I have written e2e tests or purposefully omitted them
- [x] I have explained what this PR introduces and why, and linked to relevant context (e.g. linear issues, related PRs,
  documentation)
- [x] I have introduced a short, clear and well-formatted changelog entry

<!-- need help with the changelog? see ../CONTRIBUTING.md#submitting-a-pull-request -->
<!-- Add more details of your changes below if needed -->