### PR TITLE
fix(cli): tolerate non-standard session.user in `mirrord ui`

### DIFF
--- a/changelog.d/+ui-preview-env-owner-fallback.fixed.md
+++ b/changelog.d/+ui-preview-env-owner-fallback.fixed.md
@@ -1,0 +1,1 @@
+`mirrord ui` no longer drops operator sessions whose `user` field doesn't match the `username/k8s_username@hostname` format. Falls back to the raw user string for both fields, so synthetic owners like preview environments surface in the session list.

--- a/mirrord/cli/src/ui.rs
+++ b/mirrord/cli/src/ui.rs
@@ -1206,6 +1206,15 @@ mod tests {
             assert_eq!(summary.owner.k8s_username, "alice@ex");
         }
 
+        #[test]
+        fn summary_from_session_accepts_preview_env_owner() {
+            let mut session = sample_session("preview-1", "han-preview");
+            session.user = "preview-env".to_owned();
+            let summary = OperatorSessionSummary::from_session(&session).unwrap();
+            assert_eq!(summary.owner.username, "preview-env");
+            assert_eq!(summary.owner.k8s_username, "preview-env");
+        }
+
         #[tokio::test]
         async fn operator_sessions_groups_by_key_with_none_bucket() {
             let (tx, _rx) = broadcast::channel::<SessionNotification>(16);


### PR DESCRIPTION
## Summary

`mirrord ui`'s operator-sessions watcher polls `MirrordOperator.status.sessions` and projects each entry into an `OperatorSessionSummary` served at `/api/operator-sessions`. The previous `parse_session_owner` strictly required the `username/k8s_username@hostname` wire format and returned `None` on any mismatch, which caused `from_session` to silently drop the entire summary.

Preview environment sessions carry `user = "preview-env"` (no `/`, no `@`), so they were filtered out before reaching the frontend, even though the frontend already special-cases the preview owner (`OperatorList.tsx`, `OperatorSessionDetail.tsx`). The fix falls back to using the raw `session.user` for both `username` and `k8s_username` when the strict parse fails. Standard-format users still parse identically.

## Test plan

- [x] `cargo xtask test-ut ui::tests::operator_sessions` (3 tests, including the new `summary_from_session_accepts_preview_env_owner` regression test)
- [x] Manual: started two `mirrord preview start` envs on the playground cluster, ran `mirrord ui` against the same kubeconfig context, confirmed `/api/operator-sessions` returns both with `owner.username = "preview-env"` and the UI renders them under the operator-sessions view.