### PR TITLE
Fix install script broken pipe

### DIFF
--- a/changelog.d/+install-script.fixed.md
+++ b/changelog.d/+install-script.fixed.md
@@ -1,0 +1,1 @@
+Fixed broken pipe error in install script.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -17,7 +17,7 @@ file_issue_prompt() {
 }
 
 get_latest_version() {
-  local res=$(curl -fsSL https://github.com/metalbear-co/mirrord/raw/latest/Cargo.toml | grep -m 1 version | cut -d' ' -f3 | tr -d '\"')
+  local res=$(curl -fsSL https://github.com/metalbear-co/mirrord/raw/latest/Cargo.toml | grep version | head -n 1 | cut -d' ' -f3 | tr -d '\"')
   echo $res
 }
 


### PR DESCRIPTION
`grep -m 1` breaks the pipe and exit while curl still writing. Use `head -n 1` instead so curl can finish writing.

fix #4231 

<!-- Thank you for contributing to mirrord! -->
<!-- Please use the checklist below as a guide for docs, tests and admin tasks for your PR -->
<!-- Feel free to ~strikethrough~ any items that you don't think apply -->

### Quality Checklist:

- [ ] ~~I have documented new code sufficiently~~
- [ ] ~~I have checked and updated the relevant existing docs in code, including removing outdated material~~
- [ ] ~~I have written user-facing website docs for new features, or opened a (sub)issue to do so~~
- [ ] ~~I have checked and updated existing website docs for changed features~~
- [x] I have tested this change and know it succeeds and fails as expected
- [ ] ~~I have written unit tests or purposefully omitted them~~
- [ ] ~~I have written e2e tests or purposefully omitted them~~
- [x] I have explained what this PR introduces and why, and linked to relevant context (e.g. linear issues, related PRs,
  documentation)
- [x] I have introduced a short, clear and well-formatted changelog entry

<!-- need help with the changelog? see ../CONTRIBUTING.md#submitting-a-pull-request -->
<!-- Add more details of your changes below if needed -->