### PR TITLE
Updated test guide on CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,11 +29,56 @@ The following guide details the steps to setup a local development environment f
 - [GCC](https://gcc.gnu.org/) - only on Linux, GCC is needed for Go dynamic linking
 - [Rust](https://www.rust-lang.org/)
 - [NodeJS](https://nodejs.org/en/), [ExpressJS](https://expressjs.com/), [portfinder](https://www.npmjs.com/package/portfinder)
-- [Python](https://www.python.org/), [Flask](https://flask.palletsprojects.com/en/2.1.x/), [FastAPI](https://fastapi.tiangolo.com/), [Uvicorn](https://www.uvicorn.org/)
+- [Python (recommended 3.13+)](https://www.python.org/), [Flask](https://flask.palletsprojects.com/en/2.1.x/), [FastAPI](https://fastapi.tiangolo.com/), [Uvicorn](https://www.uvicorn.org/)
 - [Go](https://go.dev/)
 - Kubernetes Cluster (local/remote)
 - [Argo Rollouts CRD](https://argoproj.github.io/argo-rollouts/) - required for rollout-related E2E tests (`kubectl create namespace argo-rollouts && kubectl apply -n argo-rollouts -f https://github.com/argoproj/argo-rollouts/releases/latest/download/install.yaml`)
 
+### Building mirrord layer and binary
+
+If you run integration or e2e tests, both are automatically built.
+To build it from scratch, run `cargo xtask build-layer`. 
+This will result in a `target/<arch>/debug/<layer binary name>` 
+Then, build the project with `MIRRORD_LAYER_FILE=$(pwd)/target/<arch>/debug/<layer binary name> cargo build --all` 
+On macOS always use `universal-apple-darwin` arch (rather than e.g. `aarch64-apple-darwin`) whenever an explicit path to the layer binary is required.
+
+<layer binary name> is OS specific:
+- Linux: libmirrord_layer.so
+- macOS: libmirrord_layer.dylib
+- Windows: mirrord_layer_win.dll
+
+### Compiling Rust test binaries
+
+There are a couple rough edges which are tested with standalone Rust binaries.
+For more info on these, check the respective GitHub issues.
+`rustc` is used rather than `cargo` for faster and lighter compilation
+
+```rust
+    cd mirrord/layer-tests/tests/apps
+    rustc issue1123/issue1123.rs --out-dir target
+    rustc issue1054/issue1054.rs --out-dir target
+    rustc issue1458/issue1458.rs --out-dir target
+    rustc issue1458portnot53/issue1458portnot53.rs --out-dir target
+    rustc issue2058/issue2058.rs --out-dir target
+    rustc issue2204/issue2204.rs --out-dir target
+```
+
+### Build Go and C test apps
+
+Both E2E and integration run tests with simple C, Go, Python and Node.js apps.
+C and Go need to be built before testing. ([this should be automated in the future](https://github.com/metalbear-co/mirrord/issues/982)).
+
+Build Go test apps:
+```bash
+./scripts/build_go_apps.sh 24
+./scripts/build_go_apps.sh 25
+./scripts/build_go_apps.sh 26
+```
+
+Build C test apps: (script uses clang, but feel free to use another compiler);
+```bash
+./scripts/build_c_apps.sh
+```
 ### Setup a Kubernetes cluster
 
 For E2E tests and testing mirrord manually you will need a working Kubernetes cluster. A minimal cluster can be easily setup locally using either of the following:
@@ -90,29 +135,33 @@ kubectl config use-context minikube
 
 ## E2E Tests
 
-The E2E tests create Kubernetes resources in the cluster that kubectl is configured to use and then run sample apps
-with the mirrord CLI. The mirrord CLI spawns an agent for the target on the cluster, and runs the test app, with the
-layer injected into it. Some test apps need to be compiled before they can be used in the tests
-([this should be automated in the future](https://github.com/metalbear-co/mirrord/issues/982)).
+The E2E tests create Kubernetes resources in the cluster that kubectl is configured to use and then run sample apps with the mirrord CLI. The mirrord CLI spawns an agent for the target on the cluster, and runs the test app, with the layer injected into it. 
 
-> **Note:** `//go:build linux` prevents certain Go test apps from being built on macOS. When using
-> `scripts/build_go_apps.sh`, make the change below so the script continues building all other apps.
-> ```bash
-> go build -o "$1.go_test_app" || echo "Failed to build $directory/$1.go_test_app"
-> ```
+Both E2E and integration tests require a mirrord binary and a layer binary. These can be provided as arguments:  
 
-The basic command to run the E2E tests is:
 ```bash
-cargo xtask test-e2e
+cargo xtask test-e2e \
+--binary $(pwd)/target/<arch>/debug/mirrord \
+--layer $(pwd)/target/<arch>/debug/<layer binary name>
+```
+... or as environment variables: 
+
+```bash
+MIRRORD_TESTS_USE_BINARY=$(pwd)/target/<arch>/debug/mirrord \
+MIRRORD_LAYER_FILE=$(pwd)/target/<arch>/debug/<layer binary name> \ 
+cargo xtask test-e2e 
 ```
 
-If no binary or layer is provided, xtask builds them from source automatically. To use
-pre-built artifacts instead, pass `--binary` / `--layer` or set `MIRRORD_TESTS_USE_BINARY` /
-`MIRRORD_LAYER_FILE`:
+For each binary, arguments have precedence over environment variables. If neither is passed in for that binary, then it is built from source:
+
+Ex1:
 ```bash
-MIRRORD_TESTS_USE_BINARY=target/universal-apple-darwin/debug/mirrord \
-MIRRORD_LAYER_FILE=target/universal-apple-darwin/debug/libmirrord_layer.dylib \
-cargo xtask test-e2e
+cargo xtask test-e2e # builds both mirrord binary and layer binary from source
+```
+
+Ex2:
+```bash
+cargo xtask test-e2e --binary <path to mirrord binary> # builds only layer binary from source, takes mirrord binary from arg
 ```
 
 If new tests are added, decorate them with `cfg_attr` attribute macro to define what the tests target.
@@ -120,6 +169,7 @@ For example, a test which only tests sanity of the ephemeral container feature s
 `#[cfg_attr(not(feature = "ephemeral"), ignore)]`
 
 On Linux, running tests may exhaust a large amount of RAM and crash the machine. To prevent this, limit the number of concurrent jobs by running the command with e.g. `-j 4`
+If running on a laptop, you might want to pass the `--no-fail-fast` flag, as some tests can timeout. This is applicable to both integration and e2e.
 
 ### IPv6
 
@@ -160,7 +210,8 @@ IPv6 tests (they currently don't run in the CI):
 The Kubernetes resources created by the E2E tests are automatically deleted when the test exits. However, you can preserve resources from failed tests for debugging. To do this, set the `MIRRORD_E2E_PRESERVE_FAILED` variable to any value.
 
 ```bash
-MIRRORD_E2E_PRESERVE_FAILED=y cargo xtask test-e2e
+MIRRORD_E2E_PRESERVE_FAILED=y \
+cargo xtask test-e2e
 ```
 
 All test resources share a common label `mirrord-e2e-test-resource=true`. To delete them, simply run:
@@ -183,20 +234,8 @@ Therefore, whenever possible we create integration tests, and only resort to E2E
 
 ### Running the Integration Tests
 
-Some test apps need to be compiled before they can be used in the tests
-([this should be automated in the future](https://github.com/metalbear-co/mirrord/issues/982)).
-
 The basic command to run the integration tests is:
 ```bash
-cargo xtask test-integration
-```
-
-If no binary or layer is provided, xtask builds them from source automatically. To use
-pre-built artifacts instead, pass `--binary` / `--layer` or set `MIRRORD_TESTS_USE_BINARY` /
-`MIRRORD_LAYER_FILE`:
-```bash
-MIRRORD_TESTS_USE_BINARY=target/x86_64-unknown-linux-gnu/debug/mirrord \
-MIRRORD_LAYER_FILE=target/x86_64-unknown-linux-gnu/debug/libmirrord_layer.so \
 cargo xtask test-integration
 ```
 

--- a/changelog.d/+improve-contributing-guide.internal.md
+++ b/changelog.d/+improve-contributing-guide.internal.md
@@ -1,0 +1,1 @@
+Fix CONTRIBUTING.md faulty integration and e2e instructions

--- a/scripts/build_go_apps.sh
+++ b/scripts/build_go_apps.sh
@@ -11,6 +11,8 @@ then
     exit 1
 fi
 
+app_name=$1
+
 # Let Go download the toolchain a module's `go` directive asks for, instead of
 # failing under the GOTOOLCHAIN=local that newer setup-go versions export.
 export GOTOOLCHAIN=auto
@@ -22,9 +24,21 @@ do
     directory=$(dirname $go_mod)
     cd $directory
 
-    1>&2 echo "Building test app $directory/$1.go_test_app"
-    go build -o "$1.go_test_app"
+    package_info=$(go list -e -f '{{len .GoFiles}} {{len .CgoFiles}} {{len .IgnoredGoFiles}}' .)
+    set -- $package_info
+    go_files=$1
+    cgo_files=$2
+    ignored_go_files=$3
 
+    if [ "$go_files" -eq 0 ] && [ "$cgo_files" -eq 0 ] && [ "$ignored_go_files" -gt 0 ]
+    then
+        1>&2 echo "Skipping test app $directory/$app_name.go_test_app: no buildable Go files for $(go env GOOS)/$(go env GOARCH)"
+        cd - 1>/dev/null
+        continue
+    fi
+
+    1>&2 echo "Building test app $directory/$app_name.go_test_app"
+    go build -o "$app_name.go_test_app"
     cd - 1>/dev/null
 done
 

--- a/xtask/src/tasks/test.rs
+++ b/xtask/src/tasks/test.rs
@@ -73,8 +73,8 @@ pub fn run(
 
 /// Resolves the mirrord binary and layer paths.
 ///
-/// Uses CLI args first, then env vars. If neither is set for a given artifact, builds it from
-/// source using the current host platform.
+/// Uses CLI args take precendence over envvars. If neither is provided, then build automatically
+/// from source. test-appropriate defaults.
 fn resolve_artifacts(
     binary_arg: Option<PathBuf>,
     layer_arg: Option<PathBuf>,
@@ -82,35 +82,20 @@ fn resolve_artifacts(
     let binary_from_env = env::var_os("MIRRORD_TESTS_USE_BINARY").map(PathBuf::from);
     let layer_from_env = env::var_os("MIRRORD_LAYER_FILE").map(PathBuf::from);
 
-    let binary = binary_arg.or(binary_from_env);
-    let layer = layer_arg.or(layer_from_env);
+    let layer = match layer_arg.or(layer_from_env) {
+        Some(layer) => validate_path(&layer, "MIRRORD_LAYER_FILE", "mirrord layer")?,
+        None => build_layer_for_tests()?,
+    };
 
-    match (binary, layer) {
-        (Some(b), Some(l)) => {
-            let b = validate_path(&b, "MIRRORD_TESTS_USE_BINARY", "mirrord binary")?;
-            let l = validate_path(&l, "MIRRORD_LAYER_FILE", "mirrord layer")?;
-            Ok((b, l))
-        }
-        (Some(b), None) => {
-            let b = validate_path(&b, "MIRRORD_TESTS_USE_BINARY", "mirrord binary")?;
-            let l = build_layer_for_host()?;
-            Ok((b, l))
-        }
-        (None, Some(l)) => {
-            let l = validate_path(&l, "MIRRORD_LAYER_FILE", "mirrord layer")?;
-            let b = build_binary_for_host(&l)?;
-            Ok((b, l))
-        }
-        (None, None) => {
-            println!("No mirrord artifacts provided — building from source...");
-            let l = build_layer_for_host()?;
-            let b = build_binary_for_host(&l)?;
-            Ok((b, l))
-        }
-    }
+    let binary = match binary_arg.or(binary_from_env) {
+        Some(binary) => validate_path(&binary, "MIRRORD_TESTS_USE_BINARY", "mirrord binary")?,
+        None => build_binary_for_tests(&layer)?,
+    };
+
+    Ok((binary, layer))
 }
 
-fn host_target() -> Result<Target> {
+fn host_cli_target() -> Result<Target> {
     match (env::consts::OS, env::consts::ARCH) {
         ("macos", "x86_64") => Ok(Target::MacosX86_64),
         ("macos", "aarch64") => Ok(Target::MacosAarch64),
@@ -121,15 +106,47 @@ fn host_target() -> Result<Target> {
     }
 }
 
-fn build_layer_for_host() -> Result<PathBuf> {
-    let target = host_target()?;
-    layer::build_layer(target, false, &[])
+fn test_layer_target() -> Result<Target> {
+    match (env::consts::OS, env::consts::ARCH) {
+        ("macos", _) => Ok(Target::MacosUniversal),
+        ("linux", "x86_64") => Ok(Target::LinuxX86_64),
+        ("linux", "aarch64") => Ok(Target::LinuxAarch64),
+        ("windows", _) => Ok(Target::Windows),
+        (os, arch) => bail!("Unsupported host platform: {os} {arch}"),
+    }
 }
 
-fn build_binary_for_host(layer_path: &Path) -> Result<PathBuf> {
-    let target = host_target()?;
+fn build_layer_for_tests() -> Result<PathBuf> {
+    let target = test_layer_target()?;
+    let layer = layer::build_layer(target, false, &[])?;
+    canonicalize_built_artifact(&layer, "built mirrord layer")
+}
+
+fn build_binary_for_tests(layer_path: &Path) -> Result<PathBuf> {
+    let target = host_cli_target()?;
+    ensure_macos_arm64_layer(target, false)?;
     super::monitor::build_monitor()?;
-    super::cli::build_cli(target, false, layer_path, None, &[])
+    let binary = super::cli::build_cli(target, false, layer_path, None, &[])?;
+    canonicalize_built_artifact(&binary, "built mirrord binary")
+}
+
+fn ensure_macos_arm64_layer(target: Target, release: bool) -> Result<()> {
+    if !matches!(target, Target::MacosX86_64 | Target::MacosAarch64) {
+        return Ok(());
+    }
+
+    let arm64_layer = Target::MacosAarch64.layer_file(release);
+
+    if !arm64_layer.is_file() {
+        layer::build_layer(Target::MacosAarch64, release, &[])?;
+    }
+
+    Ok(())
+}
+
+fn canonicalize_built_artifact(path: &Path, description: &str) -> Result<PathBuf> {
+    path.canonicalize()
+        .with_context(|| format!("Failed to canonicalize {description}: {}", path.display()))
 }
 
 /// Runs CLI unit tests with placeholder embedded assets.


### PR DESCRIPTION
* e2e and integration tests now build binary and layer automatically when no args or envvars are presented
* Fix CONTRIBUTING.md to accuratelly describe the steps needed for integration and e2e testing
* Fix scripts/build_go_apps.sh to now always runs to completion even if linux only go apps fail on mac.
Previously, the contributor had to add that by hand

<!-- Thank you for contributing to mirrord! -->
<!-- Please use the checklist below as a guide for docs, tests and admin tasks for your PR -->
<!-- Feel free to ~strikethrough~ any items that you don't think apply -->

### Quality Checklist:

- [X] I have documented new code sufficiently
- [X] I have checked and updated the relevant existing docs in code, including removing outdated material
- [X] I have written user-facing website docs for new features, or opened a (sub)issue to do so
- [X] I have checked and updated existing website docs for changed features
- [X] I have tested this change and know it succeeds and fails as expected
- [X] I have written unit tests or purposefully omitted them
- [X] I have written e2e tests or purposefully omitted them
- [X] I have explained what this PR introduces and why, and linked to relevant context (e.g. linear issues, related PRs,
  documentation)
- [X] I have introduced a short, clear and well-formatted changelog entry

<!-- need help with the changelog? see ../CONTRIBUTING.md#submitting-a-pull-request -->
<!-- Add more details of your changes below if needed -->