### PR TITLE
Fix Windows mirror/steal HTTP forwarding to wildcard-bound servers

### DIFF
--- a/.vale/styles/config/vocabularies/Metalbear/accept.txt
+++ b/.vale/styles/config/vocabularies/Metalbear/accept.txt
@@ -125,6 +125,7 @@ TTL
 RTT
 VPN
 URI
+loopback
 
 # File formats
 YAML

--- a/changelog.d/+win-e2e-http-forward-loopback.fixed.md
+++ b/changelog.d/+win-e2e-http-forward-loopback.fixed.md
@@ -1,0 +1,1 @@
+Fixed mirrored/stolen HTTP traffic failing to reach a local server bound to a wildcard address (e.g. `0.0.0.0`) on Windows: the intproxy HTTP gateway now normalizes the forward address to loopback before connecting, matching the raw-TCP path.

--- a/changelog.d/+win-e2e-http-forward-loopback.fixed.md
+++ b/changelog.d/+win-e2e-http-forward-loopback.fixed.md
@@ -1,1 +1,1 @@
-Fixed mirrored/stolen HTTP traffic failing to reach a local server bound to a wildcard address (e.g. `0.0.0.0`) on Windows: the intproxy HTTP gateway now normalizes the forward address to loopback before connecting, matching the raw-TCP path.
+Fixed mirrored/stolen HTTP traffic failing to reach a local server bound to a wildcard address such as `0.0.0.0` on Windows: the intproxy HTTP gateway now normalizes the forward address to loopback before connecting, matching the raw-TCP path.

--- a/mirrord/intproxy/src/proxies/incoming.rs
+++ b/mirrord/intproxy/src/proxies/incoming.rs
@@ -395,12 +395,12 @@ impl IncomingProxy {
             return Ok(());
         };
 
+        // `resolve_addr` already normalizes a wildcard listen address to loopback.
         let peer_address = subscription
             .listening_on
             .resolve_addr()
             .await
             .map_err(IncomingProxyError::SocketSetupFailed)?;
-        let peer_address = normalize_connection_address(peer_address);
 
         let socket = BoundTcpSocket::bind_specified_or_localhost(peer_address.ip())
             .map_err(IncomingProxyError::SocketSetupFailed)?;
@@ -1021,29 +1021,37 @@ fn normalize_connection_address(listen_addr: SocketAddr) -> SocketAddr {
 }
 
 pub trait ListeningOnExt {
-    /// Returns a concrete [`SocketAddr`] to forward traffic to.
+    /// Returns a concrete, connectable [`SocketAddr`] to forward traffic to.
     ///
     /// For [`ListeningOn::Hostname`], resolves it via DNS and picks one of the returned addresses
     /// at random. Call this per request / per new connection so load gets spread across the
     /// backing pods of a headless Service.
+    ///
+    /// The returned address is always connectable: a wildcard listen address (`0.0.0.0` / `::`) is
+    /// normalized to loopback (see [`normalize_connection_address`]). Centralizing that here keeps
+    /// every caller on a connectable address — the raw-TCP and HTTP-gateway paths drifted apart
+    /// once (regressed in #4264, restored in #4302), and folding it in is what stops that
+    /// recurring.
     fn resolve_addr(&self) -> impl Future<Output = io::Result<SocketAddr>>;
 }
 
 impl ListeningOnExt for ListeningOn {
     async fn resolve_addr(&self) -> io::Result<SocketAddr> {
-        match self {
-            Self::Socket(addr) => Ok(*addr),
+        let addr = match self {
+            Self::Socket(addr) => *addr,
             Self::Hostname { host, port } => {
                 let addrs = tokio::net::lookup_host((host.as_str(), *port))
                     .await?
                     .collect::<Vec<_>>();
-                addrs.choose(&mut rand::rng()).copied().ok_or_else(|| {
+                *addrs.choose(&mut rand::rng()).ok_or_else(|| {
                     io::Error::new(
                         io::ErrorKind::AddrNotAvailable,
                         format!("DNS lookup for {host}:{port} returned no addresses"),
                     )
-                })
+                })?
             }
-        }
+        };
+
+        Ok(normalize_connection_address(addr))
     }
 }

--- a/mirrord/intproxy/src/proxies/incoming/http_gateway.rs
+++ b/mirrord/intproxy/src/proxies/incoming/http_gateway.rs
@@ -26,7 +26,6 @@ use tracing::Level;
 use super::{
     ListeningOnExt,
     http::{ClientStore, LocalHttpError, ResponseMode, StreamingBody, mirrord_error_response},
-    normalize_connection_address,
     tasks::{HttpOut, InProxyTaskMessage},
 };
 use crate::background_tasks::{BackgroundTask, MessageBus};
@@ -230,16 +229,14 @@ impl HttpGatewayTask {
     /// sending [`ChunkedResponse::Start`]. The agent would get a duplicated response.
     #[tracing::instrument(level = Level::DEBUG, skip_all, err(level = Level::WARN))]
     async fn send_attempt(&self, message_bus: &mut MessageBus<Self>) -> Result<(), LocalHttpError> {
-        // Normalize a wildcard listen address (e.g. `0.0.0.0`) to loopback before connecting,
-        // matching the raw-TCP path in `IncomingProxy`. Connecting to `0.0.0.0` happens to route
-        // to loopback on Linux but fails on Windows, so without this the HTTP gateway can't reach
-        // a server bound to the wildcard address.
-        let server_addr = normalize_connection_address(
-            self.listening_on
-                .resolve_addr()
-                .await
-                .map_err(LocalHttpError::ConnectTcpFailed)?,
-        );
+        // `resolve_addr` returns a connectable address, normalizing a wildcard listen address
+        // (e.g. `0.0.0.0`) to loopback. That matters on Windows, where connecting to `0.0.0.0`
+        // fails outright (on Linux it happens to route to loopback).
+        let server_addr = self
+            .listening_on
+            .resolve_addr()
+            .await
+            .map_err(LocalHttpError::ConnectTcpFailed)?;
         let mut client = self
             .client_store
             .get(

--- a/mirrord/intproxy/src/proxies/incoming/http_gateway.rs
+++ b/mirrord/intproxy/src/proxies/incoming/http_gateway.rs
@@ -26,6 +26,7 @@ use tracing::Level;
 use super::{
     ListeningOnExt,
     http::{ClientStore, LocalHttpError, ResponseMode, StreamingBody, mirrord_error_response},
+    normalize_connection_address,
     tasks::{HttpOut, InProxyTaskMessage},
 };
 use crate::background_tasks::{BackgroundTask, MessageBus};
@@ -229,11 +230,16 @@ impl HttpGatewayTask {
     /// sending [`ChunkedResponse::Start`]. The agent would get a duplicated response.
     #[tracing::instrument(level = Level::DEBUG, skip_all, err(level = Level::WARN))]
     async fn send_attempt(&self, message_bus: &mut MessageBus<Self>) -> Result<(), LocalHttpError> {
-        let server_addr = self
-            .listening_on
-            .resolve_addr()
-            .await
-            .map_err(LocalHttpError::ConnectTcpFailed)?;
+        // Normalize a wildcard listen address (e.g. `0.0.0.0`) to loopback before connecting,
+        // matching the raw-TCP path in `IncomingProxy`. Connecting to `0.0.0.0` happens to route
+        // to loopback on Linux but fails on Windows, so without this the HTTP gateway can't reach
+        // a server bound to the wildcard address.
+        let server_addr = normalize_connection_address(
+            self.listening_on
+                .resolve_addr()
+                .await
+                .map_err(LocalHttpError::ConnectTcpFailed)?,
+        );
         let mut client = self
             .client_store
             .get(


### PR DESCRIPTION
## What

The intproxy HTTP gateway connected to the *resolved* `listening_on` address directly. #4264 (`3817ef2c`) dropped the `normalize_connection_address` call on this path while the raw-TCP path kept it. Connecting to a wildcard address (`0.0.0.0`) routes to loopback on Linux but **fails on Windows**, so every mirrored/stolen HTTP request to a wildcard-bound server failed there.

Rather than just re-add the call on the HTTP path (leaving the two paths free to drift again), normalization is folded into `ListeningOnExt::resolve_addr`: the resolver now always returns a *connectable* address, normalizing a wildcard listen address (`0.0.0.0` / `::`) to loopback. Both callers — the raw-TCP path in `IncomingProxy` and the HTTP gateway — drop their manual `normalize_connection_address` calls, so the two forwarding paths share one source of truth and can't diverge again.

## How this was found

windows-e2e last passed at #4213 and was failing on `main`. Bisecting the 46 commits in between (CI probes at evenly-spaced commits) isolated the regression to **#4264** — id 44 passed, id 45 (#4264) failed. The failing tests are all incoming HTTP (`http::mirror_http_traffic`, `traffic::mirror::mirror_with_http_header_filter::*`, `traffic::steal::steal_tests::*`), matching exactly the gateway forwarding path.

## Notes

- `windows-e2e` label so the Windows e2e suite runs.
- Normalization is now centralized in `ListeningOnExt::resolve_addr` (the follow-up previously noted here is done in this PR), so the TCP and HTTP forwarding paths can't regress independently.