### PR TITLE
Auto add volume and ConfigMap paths to `feature.fs.read_only`

### DIFF
--- a/.vale/styles/config/vocabularies/Metalbear/accept.txt
+++ b/.vale/styles/config/vocabularies/Metalbear/accept.txt
@@ -22,6 +22,7 @@ Linkerd
 # Container / cloud
 OCI
 PVC
+PVCs
 crio
 colima
 WSL

--- a/changelog.d/+auto-mount.added.md
+++ b/changelog.d/+auto-mount.added.md
@@ -1,0 +1,1 @@
+mirrord now automatically reads the target container's volume mounts (ConfigMaps, Secrets, PVCs) from the remote pod and serves those paths read-only from the remote, so the local process transparently sees its mounted files. Controlled by the new `feature.magic.auto_mount` flag, enabled by default.

--- a/mirrord-schema.json
+++ b/mirrord-schema.json
@@ -2812,6 +2812,14 @@
       "description": "Sensible default behaviors that help most users. Disable individual flags only if they conflict\nwith your setup.\n\n```json\n{\n  \"feature\": {\n    \"magic\": {\n      \"aws\": true\n    }\n  }\n}\n```",
       "type": "object",
       "properties": {
+        "auto_mount": {
+          "title": "feature.magic.auto_mount {#feature-magic-auto_mount}",
+          "description": "Kubernetes mounts ConfigMaps, Secrets, and volumes (e.g. PVCs) into the target container at\nfixed paths. When mirrord runs your process locally, those paths either don't exist or hold\nunrelated local data, so the process can't read the configuration or secrets it expects\nfrom the pod.\n\nWhen enabled, mirrord reads the target container's volume mounts from the remote pod spec\nand adds their mount paths to [`feature.fs.read_only`](#feature-fs-read_only), so the\nlocal process transparently reads those files from the remote pod while still writing\nlocally.\n\nThis matters when the file system mode is `localwithoverrides`: the mounted paths would\notherwise be served locally and not exist, so `auto_mount` forces them to be read from the\nremote pod. In the default `read` mode files are already read remotely, and in fully\n`local` mode all overrides are ignored, so `auto_mount` has no observable effect in\neither of those modes.\n\nPaths you've explicitly marked local via `feature.fs.local` are left untouched.\n\nDisable this only if you intentionally want the mounted paths served from the local file\nsystem.\n\nDefaults to `true`.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "aws": {
           "title": "feature.magic.aws {#feature-magic-aws}",
           "description": "The AWS CLI prefers local credentials (e.g. `~/.aws`, `AWS_PROFILE`) over the remote pod's\nidentity (IAM role, instance profile, IRSA). When those local credentials are present, the\npod's own identity is never used, which is rarely what you want in a mirrord session.\n\nWhen enabled, mirrord makes local AWS configuration unavailable to the process by:\n- Unsetting `AWS_PROFILE` and related AWS environment variables.\n- Mapping `~/.aws` to a temporary directory, so the AWS CLI cannot read local credentials\n  and also has a writable location for its credential cache (avoiding errors on cache\n  writes).\n\nThis allows the remote pod's IAM role / instance profile to be used as intended.\n\nDisable this only if you intentionally need local AWS credentials inside the local mirrord'\nprocess.\n\nDefaults to `true`.",

--- a/mirrord/cli/src/connection.rs
+++ b/mirrord/cli/src/connection.rs
@@ -152,7 +152,7 @@ where
 
         if layer_config.feature.magic.auto_mount {
             progress.warning(
-                "auto_mount: skipped in multi-cluster mode (target is resolved server-side",
+                "auto_mount: skipped in multi-cluster mode (target is resolved server-side)",
             );
         }
 

--- a/mirrord/cli/src/connection.rs
+++ b/mirrord/cli/src/connection.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashSet, time::Duration};
+use std::{collections::HashSet, ops::Not, time::Duration};
 
 use mirrord_analytics::Reporter;
 use mirrord_config::{
@@ -150,6 +150,12 @@ where
             .clone()
             .unwrap_or(Target::Targetless);
 
+        if layer_config.feature.magic.auto_mount {
+            progress.warning(
+                "auto_mount: skipped in multi-cluster mode (target is resolved server-side",
+            );
+        }
+
         api.connect_in_multi_cluster_session(
             &target_config,
             layer_config,
@@ -171,6 +177,10 @@ where
         )
         .await
         .map_err(CliError::OperatorTargetResolution)?;
+
+        if layer_config.feature.magic.auto_mount {
+            apply_auto_mount_for_target(layer_config, &target, api.client(), progress).await;
+        }
 
         api.connect_in_new_session(
             target,
@@ -236,6 +246,31 @@ pub(crate) async fn create_and_connect<P: Progress, R: Reporter>(
         .inspect_err(|fail| tracing::debug!(?fail, "Failed to detect OpenShift!"))
         .ok();
 
+    let auto_mount_target = config
+        .feature
+        .magic
+        .auto_mount
+        .then(|| config.target.path.clone())
+        .flatten()
+        .filter(|target| matches!(target, Target::Targetless).not());
+
+    if let Some(target_path) = auto_mount_target {
+        match ResolvedTarget::new(
+            k8s_api.client(),
+            &target_path,
+            config.target.namespace.as_deref(),
+        )
+        .await
+        {
+            Ok(target) => {
+                apply_auto_mount_for_target(config, &target, k8s_api.client(), progress).await
+            }
+            Err(error) => {
+                tracing::debug!(%error, "auto_mount: failed to resolve target, skipping")
+            }
+        }
+    }
+
     let agent_container_config = ContainerConfig::default();
 
     let agent_connect_info = tokio::time::timeout(
@@ -261,6 +296,27 @@ pub(crate) async fn create_and_connect<P: Progress, R: Reporter>(
     );
 
     Ok((AgentConnectInfo::DirectKubernetes(agent_connect_info), conn))
+}
+
+/// Resolves `target`'s pod spec and applies `feature.magic.auto_mount` to `config`, adding the
+/// target container's volume-mount paths to `feature.fs.read_only`.
+///
+/// auto_mount is a best-effort convenience, so any failure to resolve the pod spec is logged and
+/// ignored rather than aborting the session.
+async fn apply_auto_mount_for_target<P: Progress>(
+    config: &mut LayerConfig,
+    target: &ResolvedTarget<false>,
+    client: &kube::Client,
+    progress: &P,
+) {
+    match target.resolve_pod_spec(client).await {
+        Ok(Some(pod_spec)) => config.apply_auto_mount(pod_spec.as_ref(), target.container()),
+        Ok(None) => {}
+        Err(error) => {
+            tracing::warn!(?error, "failed to resolve target pod spec");
+            progress.warning("auto_mount: failed to resolve target pod spec, skipping")
+        }
+    }
 }
 
 /// Verifies and adjusts the [`LayerConfig`] after we've determined that this run does not use the

--- a/mirrord/config/src/feature/magic.rs
+++ b/mirrord/config/src/feature/magic.rs
@@ -41,10 +41,38 @@ pub struct MagicConfig {
     /// Defaults to `true`.
     #[config(default = true)]
     pub aws: bool,
+
+    /// #### feature.magic.auto_mount {#feature-magic-auto_mount}
+    ///
+    /// Kubernetes mounts ConfigMaps, Secrets, and volumes (e.g. PVCs) into the target container at
+    /// fixed paths. When mirrord runs your process locally, those paths either don't exist or hold
+    /// unrelated local data, so the process can't read the configuration or secrets it expects
+    /// from the pod.
+    ///
+    /// When enabled, mirrord reads the target container's volume mounts from the remote pod spec
+    /// and adds their mount paths to [`feature.fs.read_only`](#feature-fs-read_only), so the
+    /// local process transparently reads those files from the remote pod while still writing
+    /// locally.
+    ///
+    /// This matters when the file system mode is `localwithoverrides`: the mounted paths would
+    /// otherwise be served locally and not exist, so `auto_mount` forces them to be read from the
+    /// remote pod. In the default `read` mode files are already read remotely, and in fully
+    /// `local` mode all overrides are ignored, so `auto_mount` has no observable effect in
+    /// either of those modes.
+    ///
+    /// Paths you've explicitly marked local via `feature.fs.local` are left untouched.
+    ///
+    /// Disable this only if you intentionally want the mounted paths served from the local file
+    /// system.
+    ///
+    /// Defaults to `true`.
+    #[config(default = true)]
+    pub auto_mount: bool,
 }
 
 impl CollectAnalytics for &MagicConfig {
     fn collect_analytics(&self, analytics: &mut mirrord_analytics::Analytics) {
         analytics.add("aws", self.aws);
+        analytics.add("auto_mount", self.auto_mount);
     }
 }

--- a/mirrord/config/src/lib.rs
+++ b/mirrord/config/src/lib.rs
@@ -41,6 +41,7 @@ use feature::{
         outgoing::OutgoingFilterConfig,
     },
 };
+use k8s_openapi::api::core::v1::PodSpec;
 use mirrord_analytics::CollectAnalytics;
 use mirrord_config_derive::MirrordConfig;
 use mirrord_protocol::tcp::JsonPathQuery;
@@ -632,6 +633,88 @@ impl LayerConfig {
                     .or_insert(replacement);
             }
         }
+    }
+
+    /// Adds the target container's volume-mount paths to
+    /// [`feature.fs.read_only`](feature::fs::advanced::FsConfig), so files mounted into the remote
+    /// pod (ConfigMaps, Secrets, PVCs) are read from the remote pod while writes stay local.
+    ///
+    /// Mount paths the user has explicitly marked local via `feature.fs.local` are left untouched,
+    /// so auto_mount never overrides an intentional local override.
+    ///
+    /// Enabled by [`feature.magic.auto_mount`](feature::magic::MagicConfig). Unlike
+    /// [`apply_magic`](Self::apply_magic), this is not applied during [`resolve`](Self::resolve):
+    /// it needs the resolved target's pod spec, which is only available after the target is
+    /// fetched (well after config resolution). The caller fetches `pod_spec`; this is otherwise
+    /// a pure function of `pod_spec` and the target `container` (the name of the targeted
+    /// container, or [`None`] to fall back to the first container in the spec).
+    pub fn apply_auto_mount(&mut self, pod_spec: &PodSpec, container: Option<&str>) {
+        // Guard against accidental calls.
+        if self.feature.magic.auto_mount.not() {
+            tracing::warn!(
+                "apply_auto_mount called when `feature.magic.auto_mount` is disabled, please report this."
+            );
+            return;
+        }
+
+        let container = match container {
+            Some(name) => pod_spec.containers.iter().find(|c| c.name == name),
+            None => pod_spec.containers.first(),
+        };
+        let Some(container) = container else {
+            return;
+        };
+
+        // Paths the user has explicitly marked local win over auto_mount: skip any mount whose path
+        // matches `feature.fs.local`, so we don't override an intentional local override.
+        // (`read_only` is checked before `local` in the file filter, so without this an auto-added
+        // entry would shadow the user's choice.)
+        let local_overrides = self
+            .feature
+            .fs
+            .local
+            .as_ref()
+            .map(|patterns| Vec::from(patterns.clone()))
+            .and_then(|patterns| {
+                regex::RegexSetBuilder::new(patterns)
+                    .case_insensitive(true)
+                    .build()
+                    .ok()
+            });
+
+        let patterns = container
+            .volume_mounts
+            .iter()
+            .flatten()
+            .filter(|mount| {
+                local_overrides
+                    .as_ref()
+                    .is_none_or(|local| local.is_match(&mount.mount_path).not())
+            })
+            .map(|mount| {
+                let path = regex::escape(&mount.mount_path);
+                // A `subPath` mount points at a single file, so match it exactly. A plain mount is
+                // a directory, so match the directory and everything beneath it.
+                if mount.sub_path.is_some() {
+                    format!("^{path}$")
+                } else {
+                    format!("^{path}(/.*)?$")
+                }
+            })
+            .collect::<Vec<_>>();
+
+        if patterns.is_empty() {
+            return;
+        }
+
+        let existing = self
+            .feature
+            .fs
+            .read_only
+            .take()
+            .unwrap_or_else(|| VecOrSingle::Multiple(Vec::new()));
+
+        self.feature.fs.read_only = Some(append_dedup(existing, patterns));
     }
 
     /// Verifies that there are no conflicting settings in this config.

--- a/mirrord/config/src/lib.rs
+++ b/mirrord/config/src/lib.rs
@@ -1303,6 +1303,7 @@ mod tests {
         io::{Read, Write},
     };
 
+    use k8s_openapi::api::core::v1::{Container, VolumeMount};
     use rstest::*;
     use schemars::Schema;
     use tempfile::NamedTempFile;
@@ -2344,5 +2345,120 @@ mod tests {
             .find(|key| key.contains(r"\.aws"))
             .expect("magic.aws should produce a .aws mapping entry");
         assert_eq!(aws_pattern, r"^/Users/fake/\.aws(/.*)?");
+    }
+
+    /// Builds a [`PodSpec`] with a single named container that mounts the given paths. Each entry
+    /// is `(mount_path, sub_path)`.
+    fn pod_spec_with_mounts(container: &str, mounts: &[(&str, Option<&str>)]) -> PodSpec {
+        PodSpec {
+            containers: vec![Container {
+                name: container.to_owned(),
+                volume_mounts: Some(
+                    mounts
+                        .iter()
+                        .map(|(mount_path, sub_path)| VolumeMount {
+                            mount_path: (*mount_path).to_owned(),
+                            sub_path: sub_path.map(str::to_owned),
+                            ..Default::default()
+                        })
+                        .collect(),
+                ),
+                ..Default::default()
+            }],
+            ..Default::default()
+        }
+    }
+
+    fn default_config() -> LayerConfig {
+        LayerConfig::resolve(&mut ConfigContext::default().strict_env(true))
+            .expect("default config should resolve")
+    }
+
+    fn read_only(config: &LayerConfig) -> Vec<String> {
+        config
+            .feature
+            .fs
+            .read_only
+            .clone()
+            .map(Vec::from)
+            .unwrap_or_default()
+    }
+
+    #[test]
+    fn auto_mount_adds_volume_mount_paths_to_read_only() {
+        let pod_spec = pod_spec_with_mounts(
+            "app",
+            &[("/etc/config", None), ("/etc/secret/token", Some("token"))],
+        );
+        let mut config = default_config();
+        config.apply_auto_mount(&pod_spec, Some("app"));
+
+        // A directory mount matches the directory and everything under it.
+        assert!(read_only(&config).contains(&r"^/etc/config(/.*)?$".to_owned()));
+        // A `subPath` mount targets a single file, so it's matched exactly.
+        assert!(read_only(&config).contains(&r"^/etc/secret/token$".to_owned()));
+    }
+
+    #[test]
+    fn auto_mount_falls_back_to_first_container_when_none_given() {
+        let pod_spec = pod_spec_with_mounts("app", &[("/data", None)]);
+        let mut config = default_config();
+        config.apply_auto_mount(&pod_spec, None);
+
+        assert_eq!(read_only(&config), vec![r"^/data(/.*)?$".to_owned()]);
+    }
+
+    #[test]
+    fn auto_mount_disabled_is_noop() {
+        let pod_spec = pod_spec_with_mounts("app", &[("/etc/config", None)]);
+        let mut config = default_config();
+        config.feature.magic.auto_mount = false;
+        config.apply_auto_mount(&pod_spec, Some("app"));
+
+        assert!(config.feature.fs.read_only.is_none());
+    }
+
+    #[test]
+    fn auto_mount_dedups_against_existing_read_only() {
+        let pod_spec = pod_spec_with_mounts("app", &[("/etc/config", None)]);
+        let mut config = default_config();
+        config.feature.fs.read_only = Some(VecOrSingle::Multiple(vec![
+            r"^/etc/config(/.*)?$".to_owned(),
+        ]));
+        config.apply_auto_mount(&pod_spec, Some("app"));
+
+        assert_eq!(read_only(&config), vec![r"^/etc/config(/.*)?$".to_owned()]);
+    }
+
+    /// A specified-but-missing container is a no-op (the first-container fallback only applies when
+    /// no container is given).
+    #[test]
+    fn auto_mount_unknown_container_is_noop() {
+        let pod_spec = pod_spec_with_mounts("app", &[("/etc/config", None)]);
+        let mut config = default_config();
+        config.apply_auto_mount(&pod_spec, Some("does-not-exist"));
+
+        assert!(config.feature.fs.read_only.is_none());
+    }
+
+    /// Mounts the user explicitly marked local via `feature.fs.local` are left alone; others are
+    /// still added.
+    #[test]
+    fn auto_mount_respects_user_local_overrides() {
+        let pod_spec = pod_spec_with_mounts("app", &[("/etc/config", None), ("/etc/secret", None)]);
+        let mut config = default_config();
+        config.feature.fs.local = Some(VecOrSingle::Multiple(vec![
+            r"^/etc/secret(/.*)?$".to_owned(),
+        ]));
+        config.apply_auto_mount(&pod_spec, Some("app"));
+
+        let ro = read_only(&config);
+        assert!(ro.contains(&r"^/etc/config(/.*)?$".to_owned()));
+        assert!(ro.iter().all(|pattern| pattern.contains("secret").not()));
+    }
+
+    #[test]
+    fn magic_auto_mount_defaults_to_enabled() {
+        assert!(default_config().feature.magic.auto_mount);
     }
 }


### PR DESCRIPTION
<!-- Thank you for contributing to mirrord! -->
<!-- Please use the checklist below as a guide for docs, tests and admin tasks for your PR -->
<!-- Feel free to ~strikethrough~ any items that you don't think apply -->

### Quality Checklist:

- [X] I have documented new code sufficiently
- [X] I have checked and updated the relevant existing docs in code, including removing outdated material
- [X] I have written user-facing website docs for new features, or opened a (sub)issue to do so
- [X] I have checked and updated existing website docs for changed features
- [X] I have tested this change and know it succeeds and fails as expected
- [X] I have written unit tests or purposefully omitted them
- [X] I have written e2e tests or purposefully omitted them
- [X] I have explained what this PR introduces and why, and linked to relevant context (e.g. linear issues, related PRs,
  documentation)
- [X] I have introduced a short, clear and well-formatted changelog entry

<!-- need help with the changelog? see ../CONTRIBUTING.md#submitting-a-pull-request -->
<!-- Add more details of your changes below if needed -->

See https://linear.app/metalbear/issue/COR-1435/auto-add-volume-and-configmap-paths-to-featurefsread-only