### PR TITLE
chore: improve mirrord maintenance path

### DIFF
--- a/tests/src/env.rs
+++ b/tests/src/env.rs
@@ -7,7 +7,7 @@ mod env_tests {
     use rstest::*;
 
     use crate::utils::{
-        application::{env::EnvApp, GoVersion},
+        application::{GoVersion, env::EnvApp},
         kube_service::KubeService,
         services::basic_service,
     };
@@ -47,7 +47,6 @@ mod env_tests {
             None,
         )
         .await;
-        let res = process.wait().await;
-        assert!(res.success());
+        process.wait_assert_success().await;
     }
 }

--- a/tests/src/ls.rs
+++ b/tests/src/ls.rs
@@ -29,12 +29,16 @@ pub async fn mirrord_ls() {
     .await;
 
     let mut process = run_ls(&namespace, cfg!(feature = "operator")).await;
-    let res = process.wait().await;
-    assert!(res.success(), "mirrord ls command failed");
+    process.wait_assert_success().await;
 
     let stdout = process.get_stdout().await;
     let targets: Vec<String> =
         serde_json::from_str(&stdout).expect("mirrord ls output should be a valid JSON");
+
+    assert!(
+        !targets.is_empty(),
+        "mirrord ls returned an empty target list"
+    );
 
     let types = [
         "pod",


### PR DESCRIPTION
Summary:
- Add or tighten focused edge-case tests or type assertions in tests/src/ls.rs, tests/src/env.rs related to runtime safety, error handling, performance, tests; avoid docs-only changes and broad refactors.
- Keep the change narrow so it is straightforward to review.

Notes:
- I kept this scoped to the relevant implementation and tests.