### PR TITLE
Don't exclude loopback addresses from counting as indicator of v4/v6 stack availability

### DIFF
--- a/.vale/styles/config/vocabularies/Metalbear/accept.txt
+++ b/.vale/styles/config/vocabularies/Metalbear/accept.txt
@@ -111,6 +111,7 @@ darwin
 preload
 dylib
 intproxy
+loopback
 
 # Networking
 TCP

--- a/changelog.d/+ipv6-loopback-steal.fixed.md
+++ b/changelog.d/+ipv6-loopback-steal.fixed.md
@@ -1,0 +1,1 @@
+Agent now sets up ip6tables rules whenever the IPv6 stack is usable (including IPv4-only clusters that still have an IPv6 loopback), so traffic to `[::1]` is no longer silently excluded from steal/mirror.

--- a/mirrord/agent/src/entrypoint.rs
+++ b/mirrord/agent/src/entrypoint.rs
@@ -112,18 +112,8 @@ static IP_VERSION_AVAILABILITY: LazyLock<IpVersionAvailability> = LazyLock::new(
         let Some(addr) = addr.address else {
             continue;
         };
-        if let Some(v4) = addr.as_sockaddr_in()
-            && v4.ip().is_broadcast().not()
-            && v4.ip().is_unspecified().not()
-        {
-            has_v4 = true;
-        }
-
-        if let Some(v6) = addr.as_sockaddr_in6()
-            && v6.ip().is_unspecified().not()
-        {
-            has_v6 = true;
-        }
+        has_v4 |= addr.as_sockaddr_in().is_some();
+        has_v6 |= addr.as_sockaddr_in6().is_some();
     }
 
     if has_v4.not() && has_v6.not() {

--- a/mirrord/agent/src/entrypoint.rs
+++ b/mirrord/agent/src/entrypoint.rs
@@ -83,8 +83,16 @@ struct IpVersionAvailability {
     v6: bool,
 }
 
-/// Checks whether or not IPv4 and IPv6 addresses are present on any
-/// available network interfaces.
+/// Checks whether the IPv4 and IPv6 stacks are usable in the current network namespace,
+/// by looking for an assigned address of each family on any interface.
+///
+/// We deliberately count loopback (`127.0.0.1`/`::1`) here. The kernel assigns these
+/// automatically exactly when the corresponding stack is enabled, and removes them when it
+/// is disabled (e.g. `net.ipv6.conf.all.disable_ipv6=1`). So their presence is a reliable
+/// signal that `ip(6)tables` will work *and* that processes in the pod can talk to that
+/// family's loopback. The latter matters: in an IPv4-only cluster a pod still has `::1`, and
+/// Go's resolver in particular prefers `[::1]` for `localhost`, so without IPv6 rules that
+/// traffic would silently bypass mirrord's steal/mirror.
 static IP_VERSION_AVAILABILITY: LazyLock<IpVersionAvailability> = LazyLock::new(|| {
     let addrs = match nix::ifaddrs::getifaddrs() {
         Ok(addrs) => addrs,
@@ -105,7 +113,6 @@ static IP_VERSION_AVAILABILITY: LazyLock<IpVersionAvailability> = LazyLock::new(
             continue;
         };
         if let Some(v4) = addr.as_sockaddr_in()
-            && v4.ip().is_loopback().not()
             && v4.ip().is_broadcast().not()
             && v4.ip().is_unspecified().not()
         {
@@ -113,11 +120,7 @@ static IP_VERSION_AVAILABILITY: LazyLock<IpVersionAvailability> = LazyLock::new(
         }
 
         if let Some(v6) = addr.as_sockaddr_in6()
-            && v6.ip().is_loopback().not()
             && v6.ip().is_unspecified().not()
-            // these are automatically assigned, they don't mean
-            // anything
-            && v6.ip().is_unicast_link_local().not()
         {
             has_v6 = true;
         }


### PR DESCRIPTION

<!-- Thank you for contributing to mirrord! -->
<!-- Please use the checklist below as a guide for docs, tests and admin tasks for your PR -->
<!-- Feel free to ~strikethrough~ any items that you don't think apply -->

### Quality Checklist:

- [X] I have documented new code sufficiently
- [X] I have checked and updated the relevant existing docs in code, including removing outdated material
- [X] I have written user-facing website docs for new features, or opened a (sub)issue to do so
- [X] I have checked and updated existing website docs for changed features
- [X] I have tested this change and know it succeeds and fails as expected
- [X] I have written unit tests or purposefully omitted them
- [X] I have written e2e tests or purposefully omitted them
- [X] I have explained what this PR introduces and why, and linked to relevant context (e.g. linear issues, related PRs,
  documentation)
- [X] I have introduced a short, clear and well-formatted changelog entry

Just a slightly cleaner version of https://github.com/metalbear-co/mirrord/pull/4277
See code comments for explanation