### PR TITLE
Preview: Support configuring the number of replicas in a session

### DIFF
--- a/changelog.d/+preview-env-replicas.added.md
+++ b/changelog.d/+preview-env-replicas.added.md
@@ -1,0 +1,1 @@
+Preview environments can now control the number of pod replicas in a session through the new `feature.preview.replicas` option.

--- a/mirrord-schema.json
+++ b/mirrord-schema.json
@@ -3254,6 +3254,15 @@
             "null"
           ]
         },
+        "replicas": {
+          "title": "feature.preview.replicas {#feature-preview-replicas}",
+          "description": "Number of preview pods to deploy.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "int32"
+        },
         "ttl_mins": {
           "title": "feature.preview.ttl_mins {#feature-preview-ttl_mins}",
           "description": "How long (in minutes) the preview session is allowed to live after creation.\nThe operator will terminate the session when this time elapses.\n\nSet to `\"infinite\"` to disable TTL.\n\nMutually exclusive with [`ttl_secs`](#feature-preview-ttl_secs); when neither is set,\ndefaults to 60 minutes.",

--- a/mirrord/cli/src/preview.rs
+++ b/mirrord/cli/src/preview.rs
@@ -213,6 +213,7 @@ async fn preview_start(
         key: layer_config.key.as_str().to_owned(),
         target: session_target,
         ttl_secs: layer_config.feature.preview.resolved_ttl_secs(),
+        replicas: layer_config.feature.preview.replicas,
         incoming: PreviewIncomingConfig::from_config(
             &layer_config.feature.network.incoming,
             layer_config.key.as_str(),

--- a/mirrord/config/src/feature/preview.rs
+++ b/mirrord/config/src/feature/preview.rs
@@ -67,6 +67,12 @@ pub struct PreviewConfig {
     #[config(env = "MIRRORD_PREVIEW_CREATION_TIMEOUT_SECS", default = 60)]
     pub creation_timeout_secs: u64,
 
+    /// #### feature.preview.replicas {#feature-preview-replicas}
+    ///
+    /// Number of preview pods to deploy.
+    #[config(env = "MIRRORD_PREVIEW_REPLICAS", default = 1)]
+    pub replicas: i32,
+
     /// #### feature.preview.config_mounts {#feature-preview-config_mounts}
     ///
     /// Files to mount into the preview pod at session start.
@@ -244,6 +250,12 @@ impl PreviewConfig {
             ));
         }
 
+        if self.replicas < 0 {
+            return Err(ConfigError::Conflict(
+                "`feature.preview.replicas` cannot be negative.".to_owned(),
+            ));
+        }
+
         for (idx, config_mount) in self.config_mounts.iter().enumerate() {
             match (&config_mount.payload, &config_mount.from_file) {
                 (Some(_), Some(_)) => {
@@ -369,6 +381,7 @@ mod tests {
             ttl_mins,
             ttl_secs,
             creation_timeout_secs: 60,
+            replicas: 1,
             config_mounts: vec![],
         }
     }
@@ -412,6 +425,7 @@ mod tests {
             ttl_mins: None,
             ttl_secs: None,
             creation_timeout_secs: 60,
+            replicas: 1,
             config_mounts: vec![mount],
         }
     }

--- a/mirrord/operator/src/crd/preview.rs
+++ b/mirrord/operator/src/crd/preview.rs
@@ -55,6 +55,10 @@ pub struct PreviewSessionSpec {
     /// Values >= `u32::MAX` are treated as infinite.
     pub ttl_secs: u64,
 
+    /// Number of replicas created by the deployment.
+    #[serde(default = "PreviewSessionSpec::default_replicas")]
+    pub replicas: i32,
+
     /// Incoming traffic configuration for the preview environment.
     ///
     /// Specifies which ports to steal/mirror traffic from and optional HTTP filters.
@@ -81,6 +85,10 @@ pub struct PreviewSessionSpec {
 }
 
 impl PreviewSessionSpec {
+    fn default_replicas() -> i32 {
+        1
+    }
+
     /// Convert the [`SessionTarget`] into a [`mirrord_config::target::Target`].
     pub fn config_target(&self) -> Option<Target> {
         self.target.clone().into_config()


### PR DESCRIPTION
<!-- Thank you for contributing to mirrord! -->
<!-- Please use the checklist below as a guide for docs, tests and admin tasks for your PR -->
<!-- Feel free to ~strikethrough~ any items that you don't think apply -->

## Summary

Allows configuring the amount of replicas in the preview environment's deployment! Yay!

## Related PRs

- https://github.com/metalbear-co/operator/pull/1643

### Quality Checklist:

- [x] I have documented new code sufficiently
- [x] I have checked and updated the relevant existing docs in code, including removing outdated material
- ~[ ] I have written user-facing website docs for new features, or opened a (sub)issue to do so~
- ~[ ] I have checked and updated existing website docs for changed features~
- [x] I have tested this change and know it succeeds and fails as expected
- [x] I have written unit tests or purposefully omitted them
- [x] I have written e2e tests or purposefully omitted them
- ~[ ] I have explained what this PR introduces and why, and linked to relevant context (e.g. linear issues, related PRs,~
  documentation)
- [x] I have introduced a short, clear and well-formatted changelog entry

<!-- need help with the changelog? see ../CONTRIBUTING.md#submitting-a-pull-request -->
<!-- Add more details of your changes below if needed -->
