### PR TITLE
Enforce LF line endings for Rust sources via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# rustfmt.toml sets `newline_style = "Unix"`, so enforce LF for Rust sources at the git level
+# as well. Otherwise Windows checkouts (core.autocrlf=true) get CRLF working trees that
+# `cargo fmt` rewrites back to LF, leaving line-ending-only noise in `git status`.
+*.rs text eol=lf

--- a/changelog.d/+rust-lf-gitattributes.internal.md
+++ b/changelog.d/+rust-lf-gitattributes.internal.md
@@ -1,0 +1,1 @@
+Added a `.gitattributes` file enforcing LF line endings for Rust sources, matching `newline_style = "Unix"` in `rustfmt.toml`.


### PR DESCRIPTION
## What

Adds a `.gitattributes` file with `*.rs text eol=lf`, plus an `internal` changelog fragment.

## Why

`rustfmt.toml` declares `newline_style = Unix`, but git itself doesn't enforce anything. On Windows checkouts with `core.autocrlf=true` (the Git for Windows installer default), git produces CRLF working trees that `cargo fmt` then rewrites back to LF — leaving line-ending-only noise across the whole repo in `git status`.

Enforcing LF for `*.rs` at the git level makes git and rustfmt agree regardless of the contributor's `core.autocrlf` setting.

No renormalization is needed: every `.rs` file in the index is already LF (`git ls-files --eol`), so this is purely additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)