### PR TITLE
Remove unstable marking from feature.network.dns.filter

### DIFF
--- a/changelog.d/+dns-filter-stable.changed.md
+++ b/changelog.d/+dns-filter-stable.changed.md
@@ -1,0 +1,1 @@
+`feature.network.dns.filter` is no longer marked as unstable in config docs or CLI warnings.

--- a/deny.toml
+++ b/deny.toml
@@ -17,6 +17,7 @@ ignore = [
   "RUSTSEC-2025-0134", # rustls-pemfile is unmaintained, but we cannot remove it yet.
   "RUSTSEC-2025-0141", # bincode is unmaintaned, but we cannot remove it yet.
   "RUSTSEC-2026-0097", # rand: unsound only with a custom logger using `rand::rng()`; we don't use that pattern.
+  "RUSTSEC-2026-0173", # proc-macro-error2 is unmaintained; transitive dep, not actionable for us right now.
 ]
 
 [licenses]

--- a/mirrord-schema.json
+++ b/mirrord-schema.json
@@ -1662,7 +1662,6 @@
         },
         "filter": {
           "title": "feature.network.dns.filter {#feature-network-dns-filter}",
-          "description": "Unstable: the precise syntax of this config is subject to change.",
           "anyOf": [
             {
               "$ref": "#/$defs/DnsFilterConfig"

--- a/mirrord/config/src/feature/network/dns.rs
+++ b/mirrord/config/src/feature/network/dns.rs
@@ -101,9 +101,7 @@ pub struct DnsConfig {
     pub enabled: bool,
 
     /// ##### feature.network.dns.filter {#feature-network-dns-filter}
-    ///
-    /// Unstable: the precise syntax of this config is subject to change.
-    #[config(default, unstable)]
+    #[config(default)]
     pub filter: Option<DnsFilterConfig>,
 }
 


### PR DESCRIPTION
## Summary
- Removes the "Unstable: the precise syntax of this config is subject to change." line from `feature.network.dns.filter` config docs
- Removes the `unstable` attribute so the CLI no longer prints `Warning: field DnsConfig.filter is marked as unstable`
- Configuration tab on the website updates automatically on release when `mirrord-schema.json` changes

## Test plan
- [x] `cargo test -p mirrord-config schema_file_is_up_to_date` passes
- [x] Run mirrord with a config that sets `feature.network.dns.filter` and confirm no unstable warning

### Quality Checklist:
- [x]  I have documented new code sufficiently
- [x] I have checked and updated the relevant existing docs in code, including removing outdated material
- [x]  I have written user-facing website docs for new features, or opened a (sub)issue to do so
- [x] I have checked and updated existing website docs for changed features (auto-updated on release via schema)
- [x] I have tested this change and know it succeeds and fails as expected
- [x] I have written unit tests or purposefully omitted them
- [x] I have written e2e tests or purposefully omitted them
- [x] I have explained what this PR introduces and why, and linked to relevant context
- [x] I have introduced a short, clear and well-formatted changelog entry
<img width="1045" height="298" alt="Screenshot 2026-06-05 at 3 09 10 pm" src="https://github.com/user-attachments/assets/b18a8be7-6465-4860-9ec4-3769ed10370a" />