### PR TITLE
mirrord ui: rename "Signed in as" to "Running as" (PRO-122)

### DIFF
--- a/changelog.d/+running-as-label.changed.md
+++ b/changelog.d/+running-as-label.changed.md
@@ -1,0 +1,1 @@
+Renamed the mirrord UI identity label from "Signed in as" to "Running as", since it reflects the active cluster identity queried by the CLI rather than an authenticated session.

--- a/changelog.d/+running-as-label.changed.md
+++ b/changelog.d/+running-as-label.changed.md
@@ -1,1 +1,1 @@
-Renamed the mirrord UI identity label from "Signed in as" to "Running as", since it reflects the active cluster identity queried by the CLI rather than an authenticated session.
+Renamed the mirrord UI identity label to "Running as" (previously "Signed in as") to reflect that it shows the active cluster identity queried by the CLI rather than an authenticated session.

--- a/packages/monitor/src/components/AppHeader.tsx
+++ b/packages/monitor/src/components/AppHeader.tsx
@@ -134,7 +134,7 @@ export default function AppHeader({
                 <div className="absolute right-0 top-full mt-1.5 z-50 min-w-[220px] rounded-lg border border-border bg-popover text-popover-foreground shadow-lg p-2 flex flex-col">
                   {currentUser && (
                     <div className="px-2 py-1.5">
-                      <div className="text-caps text-muted-foreground">Signed in as</div>
+                      <div className="text-caps text-muted-foreground">Running as</div>
                       <div className="font-mono text-meta text-foreground truncate" title={currentUser}>
                         {currentUser}
                       </div>


### PR DESCRIPTION
## Summary

In the mirrord UI user menu, the identity label said **"Signed in as"**. That identity is the active cluster identity that the CLI queries, not an authenticated session, so the label wrongly implied a sign-in/sign-out flow that does not exist in the UI. This renames it to **"Running as"**, which describes what the value actually is.

Per [PRO-122](https://linear.app/metalbear/issue/PRO-122) (Liron's suggestion, agreed by Aviram).

Before / after (user menu):
```
Signed in as        ->    Running as
alice@cluster             alice@cluster
```

## Test plan

- Open the mirrord UI, click the user menu in the header, confirm the label now reads "Running as" above the identity.
- One-word JSX text change in `packages/monitor/src/components/AppHeader.tsx`; no logic or types touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)