### PR TITLE
mirrord-operator: add preview session count to operator status

### DIFF
--- a/changelog.d/+preview-in-operator-status.added.md
+++ b/changelog.d/+preview-in-operator-status.added.md
@@ -1,0 +1,1 @@
+Added the number of concurrent Preview Environment session to the output of `mirrord operator status`.

--- a/mirrord/cli/src/operator/status.rs
+++ b/mirrord/cli/src/operator/status.rs
@@ -278,10 +278,13 @@ Operator License
             println!("Operator Daily Users: {}", statistics.dau);
             println!("Operator Monthly Users: {}", statistics.mau);
 
+            println!("Operator Concurrent Sessions:");
+            println!("  CI Sessions: {}", statistics.active_ci_sessions_count?);
             println!(
-                "Operator Concurrent CI Sessions: {}",
-                statistics.active_ci_sessions_count?
+                "  Preview Environment Sessions: {}",
+                statistics.active_preview_sessions_count?
             );
+            println!();
 
             Some(())
         });

--- a/mirrord/operator/src/crd.rs
+++ b/mirrord/operator/src/crd.rs
@@ -377,6 +377,9 @@ pub struct MirrordOperatorStatusStatistics {
     ///   you may see a number in here that's higher than how many are actually being used (the
     ///   count is correct though, they're still alive).
     pub active_ci_sessions_count: Option<u64>,
+
+    /// Count of active preview environment sessions.
+    pub active_preview_sessions_count: Option<u64>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]


### PR DESCRIPTION
Prints the number of concurrent preview sessions in `mirrord operator status` by adding a field the the CR status. If the operator doesn't provide `active_preview_sessions_count` in the status (older versions), the line is not printed at all.

Matching PR in operator: [`todo!()`](https://github.com/metalbear-co/operator/pull/1733)

### Quality Checklist:

- [x] I have written user-facing website docs for new features, or opened a (sub)issue to do so
- [x] I have checked and updated existing website docs for changed features
- [x] I have tested this change and know it succeeds and fails as expected
- [x] I have explained what this PR introduces and why, and linked to relevant context (e.g. linear issues, related PRs,
  documentation)
- [x] I have introduced a short, clear and well-formatted changelog entry

<!-- need help with the changelog? see ../CONTRIBUTING.md#submitting-a-pull-request -->
<!-- Add more details of your changes below if needed -->

### Example Output

```
❯ mirrord-dev operator status
  ✓ Operator Status (cli version 3.213.0)
    ✓ fetched status
Operator version: 3.166.0
Operator default namespace: default
Operator License
    name: [...]
    organization: [...]
    expire at: [...]

No active copy targets.

Operator Daily Users: 1
Operator Monthly Users: 1
Operator Concurrent Sessions:
  CI Sessions: 1
  Preview Environment Sessions: 2

+------------------+-------------------+-----------+-------------------------------------+-------+------------------+
| Session ID       | Target            | Namespace | User                                | Ports | Session Duration |
+------------------+-------------------+-----------+-------------------------------------+-------+------------------+
| 38624A66D97731F9 | namespace/default | N/A       | Gemma Tipper/minikube-user@sentinel |       | 30s              |
+------------------+-------------------+-----------+-------------------------------------+-------+------------------+
```