### PR TITLE
Disable bubblewrap for homebrew installation check in the release monitor

### DIFF
--- a/.github/workflows/releases-test.yaml
+++ b/.github/workflows/releases-test.yaml
@@ -269,7 +269,7 @@ jobs:
             {
               echo "HOMEBREW_PREFIX=/home/linuxbrew/.linuxbrew"
               echo "HOMEBREW_NO_AUTO_UPDATE=1"
-              echo "HOMEBREW_SANDBOX=0"
+              echo "HOMEBREW_NO_SANDBOX_LINUX=1"
               echo "PATH=/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:$PATH"
             } >> "$GITHUB_ENV"
           fi

--- a/.github/workflows/releases-test.yaml
+++ b/.github/workflows/releases-test.yaml
@@ -273,6 +273,13 @@ jobs:
             } >> "$GITHUB_ENV"
           fi
 
+          if command -v bwrap >/dev/null 2>&1; then
+            echo "Bubblewrap already installed on this Linux runner."
+          else
+            echo "Installing Bubblewrap on Linux"
+            sudo apt update && sudo apt install bubblewrap -y
+          fi
+
       - name: Test Homebrew install (Linux + macOS)
         id: brew
         shell: bash

--- a/.github/workflows/releases-test.yaml
+++ b/.github/workflows/releases-test.yaml
@@ -269,15 +269,9 @@ jobs:
             {
               echo "HOMEBREW_PREFIX=/home/linuxbrew/.linuxbrew"
               echo "HOMEBREW_NO_AUTO_UPDATE=1"
+              echo "HOMEBREW_SANDBOX=0"
               echo "PATH=/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:$PATH"
             } >> "$GITHUB_ENV"
-          fi
-
-          if command -v bwrap >/dev/null 2>&1; then
-            echo "Bubblewrap already installed on this Linux runner."
-          else
-            echo "Installing Bubblewrap on Linux"
-            sudo apt update && sudo apt install bubblewrap -y
           fi
 
       - name: Test Homebrew install (Linux + macOS)

--- a/.vale/styles/config/vocabularies/Metalbear/accept.txt
+++ b/.vale/styles/config/vocabularies/Metalbear/accept.txt
@@ -159,6 +159,7 @@ LTO
 jq
 jaq
 towncrier
+Bubblewrap
 
 # Cloud services
 SNS

--- a/changelog.d/+disable-bubblewrap.internal.md
+++ b/changelog.d/+disable-bubblewrap.internal.md
@@ -1,0 +1,1 @@
+Disabled Bubblewrap in Homebrew installation check in release monitor (Linux).


### PR DESCRIPTION
<!-- Thank you for contributing to mirrord! -->
<!-- Please use the checklist below as a guide for docs, tests and admin tasks for your PR -->
<!-- Feel free to ~strikethrough~ any items that you don't think apply -->

Missing Bubblewrap broke the installation on CI runner.

### Quality Checklist:

- ~[ ] I have documented new code sufficiently~
- ~[ ] I have checked and updated the relevant existing docs in code, including removing outdated material~
- ~[ ] I have written user-facing website docs for new features, or opened a (sub)issue to do so~
- ~[ ] I have checked and updated existing website docs for changed features~
- [x] I have tested this change and know it succeeds and fails as expected
- [x] I have written unit tests or purposefully omitted them
- [x] I have written e2e tests or purposefully omitted them
- [x] I have explained what this PR introduces and why, and linked to relevant context (e.g. linear issues, related PRs,
  documentation)
- [x] I have introduced a short, clear and well-formatted changelog entry

<!-- need help with the changelog? see ../CONTRIBUTING.md#submitting-a-pull-request -->
<!-- Add more details of your changes below if needed -->