### PR TITLE
frontend: update build-monitor xtask to warn user if corepack not installed

### DIFF
--- a/changelog.d/+xtask-corepack-warn.internal.md
+++ b/changelog.d/+xtask-corepack-warn.internal.md
@@ -1,0 +1,2 @@
+Added a warning to `cargo xtask build-monitor` if `corepack` is not found in PATH.
+Not using `corepack` can cause issues with `pnpm 10`/ `pnpm 11` version compatibility.

--- a/xtask/src/tasks/monitor.rs
+++ b/xtask/src/tasks/monitor.rs
@@ -20,7 +20,7 @@ pub fn build_monitor() -> Result<PathBuf> {
         anyhow::bail!("Monitor directory not found at {}.", monitor_dir.display());
     }
 
-    if !pnpm_available() {
+    if !pnpm_available_with_corepack_warning() {
         anyhow::bail!(
             "`pnpm` not found on PATH. Install it before building the monitor frontend \
              (for example with `corepack enable pnpm`)."
@@ -85,8 +85,21 @@ pub fn build_monitor() -> Result<PathBuf> {
     Ok(dist_dir)
 }
 
-fn pnpm_available() -> bool {
+fn pnpm_available_with_corepack_warning() -> bool {
+    if !corepack_available() {
+        eprintln!(
+            "[WARNING] - `corepack` not found in PATH: this may cause builds to fail if a compatible version of `pnpm` is not available"
+        )
+    }
+
     Command::new(pnpm_command())
+        .arg("--version")
+        .output()
+        .is_ok_and(|out| out.status.success())
+}
+
+fn corepack_available() -> bool {
+    Command::new("corepack")
         .arg("--version")
         .output()
         .is_ok_and(|out| out.status.success())


### PR DESCRIPTION
Running `cargo xtask build-monitor` was failing on my machine due to pnpm being installed directly with brew. The version installed was `pnpm 11`, whereas mirrord's `packkage.lock` file specifies `pnpm 10`. The error message was unspecific, so emitting a warning might be more helpful in the future, even when we upgrade to using `pnpm 11`.

Related: [internal slack thread](https://metalbear.slack.com/archives/C08TYT624SV/p1781254058559749)

### Quality Checklist:

- [x] I have tested this change and know it succeeds and fails as expected
- [x] I have explained what this PR introduces and why, and linked to relevant context (e.g. linear issues, related PRs,
  documentation)
- [x] I have introduced a short, clear and well-formatted changelog entry
