### PR TITLE
Patch tmp binary permissions before signing as well - SIP

### DIFF
--- a/changelog.d/+santa-sip-patch-permissions.internal.md
+++ b/changelog.d/+santa-sip-patch-permissions.internal.md
@@ -1,1 +1,1 @@
-SIP-patching flow now sets tmp binary permissions twice - before and after signing. This is to enable transitive Santa rules.
+SIP-patching flow now sets permissions the temporary binary twice - before and after signing. This is to enable transitive Santa rules.

--- a/changelog.d/+santa-sip-patch-permissions.internal.md
+++ b/changelog.d/+santa-sip-patch-permissions.internal.md
@@ -1,1 +1,1 @@
-SIP-patching flow now sets permissions the temporary binary twice - before and after signing. This is to enable transitive Santa rules.
+SIP-patching flow now sets permissions for the temporary binary twice - before and after signing. This is to enable transitive Santa rules.

--- a/changelog.d/+santa-sip-patch-permissions.internal.md
+++ b/changelog.d/+santa-sip-patch-permissions.internal.md
@@ -1,0 +1,1 @@
+SIP-patching flow now sets tmp binary permissions twice - before and after signing. This is to enable transitive Santa rules.

--- a/mirrord/sip/src/lib.rs
+++ b/mirrord/sip/src/lib.rs
@@ -358,6 +358,7 @@ mod main {
             path, output
         );
         let data = std::fs::read(path)?;
+        let permissions = std::fs::metadata(path)?.permissions();
 
         // Propagate Err if the binary does not contain any supported architecture (x64/arm64).
         let binary_info = BinaryInfo::from_object_bytes(&data)?;
@@ -377,13 +378,22 @@ mod main {
             // Not stopping the SIP-patching as most binaries don't need the rpath fix.
         }
 
+        // Give the new file the same permissions as the old file.
+        // This needs to happen before the signing in case this machine uses Santa.
+        // We rely on transitive allowlist applied to /usr/bin/codesign.
+        // For Santa to pick up the creation of the signed binary,
+        // the binary must be executable.
+        trace!("Setting permissions for {temp_binary:?}");
+        temp_binary.as_file().set_permissions(permissions.clone())?;
+
         let signed_temp_file = tempfile::NamedTempFile::new()?;
+        trace!("Signing {temp_binary:?} and putting output at {signed_temp_file:?}");
         codesign::sign(&temp_binary, &signed_temp_file, path)?;
 
-        // Give the new file the same permissions as the old file.
-        // This needs to happen after the sign because it might change the permissions.
-        trace!("Setting permissions for {temp_binary:?}");
-        std::fs::set_permissions(&signed_temp_file, std::fs::metadata(path)?.permissions())?;
+        // Give the new signed file the same permissions as the old file.
+        // This needs to happen again because signing might change the permissions.
+        trace!("Setting permissions for {signed_temp_file:?}");
+        signed_temp_file.as_file().set_permissions(permissions)?;
 
         // Move the temp binary into its final location if no other process/thread already did.
         if let Err(err) = signed_temp_file.persist_noclobber(&output)


### PR DESCRIPTION
<!-- Thank you for contributing to mirrord! -->
<!-- Please use the checklist below as a guide for docs, tests and admin tasks for your PR -->
<!-- Feel free to ~strikethrough~ any items that you don't think apply -->

Context - with Santa we rely on the fact that /usr/bin/codesign is allow listed as a trusted compiler. Hence, binaries produced by it should automatically be trusted (Santa listens for close/rename events). However, I suspect that Santa actually ignores events for binaries that are not executable.

### Quality Checklist:

- [x] I have documented new code sufficiently
- [ ] I have checked and updated the relevant existing docs in code, including removing outdated material
- [ ] I have written user-facing website docs for new features, or opened a (sub)issue to do so
- [ ] I have checked and updated existing website docs for changed features
- [ ] I have tested this change and know it succeeds and fails as expected
- [x] I have written unit tests or purposefully omitted them
- [x] I have written e2e tests or purposefully omitted them
- [x] I have explained what this PR introduces and why, and linked to relevant context (e.g. linear issues, related PRs,
  documentation)
- [x] I have introduced a short, clear and well-formatted changelog entry

<!-- need help with the changelog? see ../CONTRIBUTING.md#submitting-a-pull-request -->
<!-- Add more details of your changes below if needed -->