### PR TITLE
chaos metrics: chaos rules usage analytics reporting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5026,6 +5026,7 @@ name = "mirrord-intproxy"
 version = "3.217.1"
 dependencies = [
  "anyhow",
+ "assert-json-diff",
  "axum 0.8.8",
  "bytes",
  "futures",

--- a/mirrord/analytics/src/lib.rs
+++ b/mirrord/analytics/src/lib.rs
@@ -34,6 +34,7 @@ pub enum AnalyticValue {
     Uuid(Uuid),
     Nested(Analytics),
     Hash(AnalyticsHash),
+    List(Vec<AnalyticValue>),
 }
 
 #[derive(Default, Debug, Serialize, Deserialize, Clone, Copy)]
@@ -203,6 +204,12 @@ impl From<Analytics> for AnalyticValue {
 impl From<AnalyticsHash> for AnalyticValue {
     fn from(hash: AnalyticsHash) -> Self {
         AnalyticValue::Hash(hash)
+    }
+}
+
+impl From<Vec<AnalyticValue>> for AnalyticValue {
+    fn from(vec: Vec<AnalyticValue>) -> Self {
+        AnalyticValue::List(vec)
     }
 }
 

--- a/mirrord/cli/src/internal_proxy.rs
+++ b/mirrord/cli/src/internal_proxy.rs
@@ -116,6 +116,7 @@ fn print_addr(listener: &TcpListener) -> io::Result<()> {
 async fn start_session_monitor(
     config: &LayerConfig,
     is_operator: bool,
+    analytics: Option<AnalyticsReporter>,
 ) -> (MonitorTx, ChaosWatcherRx) {
     use tokio::sync::watch;
 
@@ -188,6 +189,7 @@ async fn start_session_monitor(
             api_monitor_rx,
             shutdown,
             ChaosWatcherTx::new(chaos_tx),
+            analytics,
         )
         .await
         {
@@ -304,7 +306,7 @@ pub(crate) async fn proxy(
     let process_logging_interval =
         Duration::from_secs(config.internal_proxy.process_logging_interval);
 
-    let (monitor_tx, chaos_rx) = start_session_monitor(&config, is_operator).await;
+    let (monitor_tx, chaos_rx) = start_session_monitor(&config, is_operator, Some(analytics)).await;
 
     IntProxy::new_with_connection(
         agent_conn,

--- a/mirrord/intproxy/Cargo.toml
+++ b/mirrord/intproxy/Cargo.toml
@@ -70,6 +70,7 @@ futures.workspace = true
 tempfile.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
 tokio-util = { workspace = true }
+assert-json-diff.workspace = true
 
 [lib]
 doctest = false

--- a/mirrord/intproxy/src/proxies/outgoing/chaos.rs
+++ b/mirrord/intproxy/src/proxies/outgoing/chaos.rs
@@ -64,7 +64,7 @@ impl OutgoingProxy {
                 })
                 .max_by_key(|rule| rule.priority)?;
 
-            if rule.get_selector_percentage().roll_for_hit().not() {
+            if rule.selector_percentage().roll_for_hit().not() {
                 return None;
             }
 
@@ -129,7 +129,7 @@ impl OutgoingProxy {
                 })
                 .max_by_key(|rule| rule.priority)?;
 
-            if rule.get_selector_percentage().roll_for_hit().not() {
+            if rule.selector_percentage().roll_for_hit().not() {
                 return None;
             }
 

--- a/mirrord/intproxy/src/session_monitor/api.rs
+++ b/mirrord/intproxy/src/session_monitor/api.rs
@@ -29,6 +29,7 @@ use axum::{
     },
     routing::{get, post},
 };
+use mirrord_analytics::AnalyticsReporter;
 use mirrord_session_monitor_protocol::{PortSubscription, ProcessInfo, SessionInfo};
 use tokio::sync::{RwLock, broadcast::error::RecvError};
 use tokio_stream::{StreamExt, wrappers::BroadcastStream};
@@ -174,6 +175,7 @@ pub async fn start_api_server(
     monitor_rx: tokio::sync::broadcast::Receiver<MonitorEvent>,
     shutdown: CancellationToken,
     chaos_tx: ChaosWatcherTx,
+    analytics: Option<AnalyticsReporter>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let session_id = session_info.session_id.clone();
 
@@ -189,17 +191,12 @@ pub async fn start_api_server(
         fs::set_permissions(&sessions_dir, fs::Permissions::from_mode(0o700))?;
     }
 
-    let reporter = || {
-        // AnalyticsReporter::new(enabled, execution_kind, watch, machine_id)
-        todo!()
-    };
-
     let state = AppState {
         session_info: Arc::new(RwLock::new(session_info)),
         monitor_tx,
         shutdown: shutdown.clone(),
         chaos_tx,
-        reporter: Arc::new(RwLock::new(ChaosAnalyticsReporter::new(reporter()))),
+        reporter: Arc::new(RwLock::new(ChaosAnalyticsReporter::new(analytics))),
     };
 
     tokio::spawn(update_session_info_from_events(state.clone(), monitor_rx));

--- a/mirrord/intproxy/src/session_monitor/api.rs
+++ b/mirrord/intproxy/src/session_monitor/api.rs
@@ -36,7 +36,9 @@ use tokio_util::sync::CancellationToken;
 use tower_http::trace::TraceLayer;
 
 use super::{MonitorEvent, MonitorTx};
-use crate::session_monitor::chaos::{ChaosWatcherTx, api::chaos_router};
+use crate::session_monitor::chaos::{
+    ChaosWatcherTx, analytics::ChaosAnalyticsReporter, api::chaos_router,
+};
 
 #[cfg(unix)]
 #[path = "transport_unix.rs"]
@@ -59,6 +61,7 @@ pub(crate) struct AppState {
     monitor_tx: MonitorTx,
     shutdown: CancellationToken,
     pub(crate) chaos_tx: ChaosWatcherTx,
+    pub(crate) reporter: Arc<RwLock<ChaosAnalyticsReporter>>,
 }
 
 async fn health() -> impl IntoResponse {
@@ -186,11 +189,17 @@ pub async fn start_api_server(
         fs::set_permissions(&sessions_dir, fs::Permissions::from_mode(0o700))?;
     }
 
+    let reporter = || {
+        // AnalyticsReporter::new(enabled, execution_kind, watch, machine_id)
+        todo!()
+    };
+
     let state = AppState {
         session_info: Arc::new(RwLock::new(session_info)),
         monitor_tx,
         shutdown: shutdown.clone(),
         chaos_tx,
+        reporter: Arc::new(RwLock::new(ChaosAnalyticsReporter::new(reporter()))),
     };
 
     tokio::spawn(update_session_info_from_events(state.clone(), monitor_rx));

--- a/mirrord/intproxy/src/session_monitor/chaos.rs
+++ b/mirrord/intproxy/src/session_monitor/chaos.rs
@@ -13,6 +13,7 @@ use tokio::sync::watch;
 use tracing::Level;
 use uuid::Uuid;
 
+pub mod analytics;
 pub mod api;
 pub mod rules;
 

--- a/mirrord/intproxy/src/session_monitor/chaos/analytics.rs
+++ b/mirrord/intproxy/src/session_monitor/chaos/analytics.rs
@@ -136,3 +136,162 @@ impl CollectAnalytics for ChaosRuleInfo {
         analytics.add("rule_lifetime_secs", rule_lifetime_secs);
     }
 }
+
+#[cfg(test)]
+mod test {
+    use std::{
+        sync::{Arc, atomic::AtomicU32},
+        time::{Duration, Instant},
+    };
+
+    use assert_json_diff::assert_json_eq;
+    use mirrord_analytics::{AnalyticValue, Analytics};
+    use mirrord_config::feature::network::filter::AddressFilter;
+    use rstest::rstest;
+    use serde_json::{Value, json};
+    use uuid::Uuid;
+
+    use crate::session_monitor::chaos::{
+        analytics::ChaosRuleInfo,
+        rules::{
+            ChaosEffectConnectionError, ChaosEffectLatency, ChaosEffectType, ChaosRule,
+            ChaosSelector, ChaosSelectorType, ConnectionErrorType, Percentage, TcpChaosEffect,
+        },
+    };
+
+    #[rstest]
+    #[case::tcp_latency(ChaosRule {
+        id: Uuid::default(),
+        name: Some("rust-connect-slow".to_owned()),
+        selector: ChaosSelector::Tcp {
+            upstream: AddressFilter::Name("rust-lang.org".to_owned(), 0),
+            percentage: Percentage::from(100),
+            effect: TcpChaosEffect::Latency(ChaosEffectLatency::new(
+                Duration::from_millis(200),
+                Duration::from_millis(50),)
+            ),
+        },
+        priority: 0,
+        hit_count: Arc::new(AtomicU32::from(33)),
+    }, ChaosRuleInfo {
+        effect_type: ChaosEffectType::Latency as u8,
+        selector_type: ChaosSelectorType::Tcp as u8,
+        custom_http_filter_set: false,
+        selector_percentage: 100,
+        final_hit_count: 33,
+        rule_lifetime_secs: 14
+    },
+    json!({
+        "rule": {
+            "effect_type": ChaosEffectType::Latency as u8,
+            "selector_type": ChaosSelectorType::Tcp as u8,
+            "custom_http_filter_set": false,
+            "selector_percentage": 100,
+            "final_hit_count": 33,
+            "rule_lifetime_secs": 14
+        }
+    }))]
+    #[case::tcp_conn_error(ChaosRule {
+        id: Uuid::default(),
+        name: None,
+        priority: 100,
+        selector: ChaosSelector::Tcp {
+            upstream: AddressFilter::Name(
+                "https://www.gov.pl/web/baza-wiedzy/phishing-jako-najczesciej-spotykana-forma-cyberatakow".to_owned(),
+                3030
+            ),
+            percentage: Percentage::from(75),
+            effect: TcpChaosEffect::ConnectionError(ChaosEffectConnectionError {
+                error_type: ConnectionErrorType::TimedOut,
+                after: Duration::from_millis(750)
+            }),
+        },
+        hit_count: Arc::new(AtomicU32::from(0)),
+    }, ChaosRuleInfo {
+        effect_type: ChaosEffectType::ConnectionError as u8,
+        selector_type: ChaosSelectorType::Tcp as u8,
+        custom_http_filter_set: false,
+        selector_percentage: 75,
+        final_hit_count: 0,
+        rule_lifetime_secs: 14
+    },
+    json!({
+        "rule": {
+            "effect_type": ChaosEffectType::ConnectionError as u8,
+            "selector_type": ChaosSelectorType::Tcp as u8,
+            "custom_http_filter_set": false,
+            "selector_percentage": 75,
+            "final_hit_count": 0,
+            "rule_lifetime_secs": 14
+        }
+    }))]
+    fn get_analytics_on_rule(
+        #[case] chaos_rule: ChaosRule,
+        #[case] expected_rule_info: ChaosRuleInfo,
+        #[case] expected_json: Value,
+    ) {
+        let start_time = Instant::now().checked_sub(Duration::from_secs(14)).unwrap();
+        assert_eq!(
+            expected_rule_info,
+            ChaosRuleInfo::from_rule(&chaos_rule, start_time)
+        );
+
+        let mut analytics = Analytics::default();
+        analytics.add("rule", expected_rule_info);
+
+        assert_json_eq!(analytics, expected_json)
+    }
+
+    #[rstest]
+    #[case(vec![
+        ChaosRuleInfo {
+            effect_type: ChaosEffectType::Latency as u8,
+            selector_type: ChaosSelectorType::Tcp as u8,
+            custom_http_filter_set: false,
+            selector_percentage: 100,
+            final_hit_count: 33,
+            rule_lifetime_secs: 14
+        },
+        ChaosRuleInfo {
+            effect_type: ChaosEffectType::ConnectionError as u8,
+            selector_type: ChaosSelectorType::Tcp as u8,
+            custom_http_filter_set: false,
+            selector_percentage: 75,
+            final_hit_count: 0,
+            rule_lifetime_secs: 14
+        }
+    ],
+    json!({
+        "rules": [
+            {
+                "effect_type": ChaosEffectType::Latency as u8,
+                "selector_type": ChaosSelectorType::Tcp as u8,
+                "custom_http_filter_set": false,
+                "selector_percentage": 100,
+                "final_hit_count": 33,
+                "rule_lifetime_secs": 14
+            },
+            {
+                "effect_type": ChaosEffectType::ConnectionError as u8,
+                "selector_type": ChaosSelectorType::Tcp as u8,
+                "custom_http_filter_set": false,
+                "selector_percentage": 75,
+                "final_hit_count": 0,
+                "rule_lifetime_secs": 14
+            }
+        ]
+    }))]
+    fn get_analytics_on_vec_rules(
+        #[case] chaos_rules_info: Vec<ChaosRuleInfo>,
+        #[case] expected_json: Value,
+    ) {
+        let mut analytics = Analytics::default();
+        let chaos_rules: Vec<_> = chaos_rules_info
+            .into_iter()
+            .map(AnalyticValue::from)
+            .collect();
+        analytics.add("rules", chaos_rules);
+
+        assert_json_eq!(analytics, expected_json)
+    }
+}

--- a/mirrord/intproxy/src/session_monitor/chaos/analytics.rs
+++ b/mirrord/intproxy/src/session_monitor/chaos/analytics.rs
@@ -1,0 +1,103 @@
+use std::{
+    collections::{HashMap, HashSet},
+    sync::atomic::Ordering,
+    time::Instant,
+};
+
+use mirrord_analytics::{AnalyticsReporter, Reporter};
+
+use crate::session_monitor::chaos::rules::{ChaosRule, ChaosSelector};
+
+pub(crate) struct ChaosAnalyticsReporter {
+    /// used to report analytics on session end
+    inner: AnalyticsReporter,
+
+    /// rules that are currently in use, and the `Instant` they were created
+    live_rules: HashMap<ChaosRule, Instant>,
+
+    /// rules that have been stopped, and how long they were live for
+    dead_rules: HashSet<ChaosRuleInfo>,
+}
+
+/// Wraps AnalyticsReporter for use reporting chaos rule analytics. Stores deleted rules instead of
+/// sending anaytics every time a rule is deleted. Sends all rules that were in effect over the
+/// whole session when the session ends.
+impl ChaosAnalyticsReporter {
+    pub fn new(inner: AnalyticsReporter) -> Self {
+        Self {
+            inner,
+            live_rules: HashMap::default(),
+            dead_rules: HashSet::default(),
+        }
+    }
+
+    pub fn add_live_rule(&mut self, rule: ChaosRule) {
+        self.live_rules.insert(rule, Instant::now());
+    }
+
+    pub fn kill_live_rule(&mut self, rule: ChaosRule) {
+        match self.live_rules.remove(&rule) {
+            Some(start_time) => {
+                let _ = self
+                    .dead_rules
+                    .insert(ChaosRuleInfo::from_rule(rule, start_time));
+            }
+            None => {
+                tracing::debug!(
+                    "BUG: a rule got removed but we didn't have it stored in analytics. The rule will not be reported"
+                );
+            }
+        };
+    }
+}
+
+impl Drop for ChaosAnalyticsReporter {
+    fn drop(&mut self) {
+        // kill all the live rules we have
+        self.live_rules
+            .clone()
+            .into_iter()
+            .for_each(|(rule, _)| self.kill_live_rule(rule));
+
+        // report all the dead rules
+        let rules_info: Vec<_> = self.dead_rules.drain().collect();
+        self.inner.get_mut().add("rules", rules_info);
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub(crate) struct ChaosRuleInfo {
+    effect_type: u8,              // ChaosEffectType
+    selector_type: u8,            // ChaosSelectorType
+    custom_http_filter_set: bool, // selector.http_filter != *
+    selector_percentage: u32,     // selector.percentage != 100
+    final_hit_count: u32,         // hit count
+    rule_lifetime_secs: u32,      // lifetime in seconds
+}
+
+impl ChaosRuleInfo {
+    pub fn from_rule(rule: ChaosRule, start_time: Instant) -> Self {
+        let rule_lifetime_secs = start_time
+            .elapsed()
+            .as_secs()
+            .try_into()
+            .unwrap_or(u32::MAX);
+
+        let selector_percentage = rule.selector_percentage().as_percentage();
+        let effect_type = rule.effect_type().map(|t| t as u8).unwrap_or(u8::MAX);
+        let selector_type = rule.selector_type() as u8;
+        let custom_http_filter_set = match rule.selector {
+            ChaosSelector::Http { filter, .. } => filter.is_some(),
+            ChaosSelector::Tcp { .. } | ChaosSelector::Fs { .. } | ChaosSelector::None => false,
+        };
+
+        ChaosRuleInfo {
+            effect_type,
+            selector_type,
+            custom_http_filter_set,
+            selector_percentage,
+            final_hit_count: rule.hit_count.load(Ordering::Relaxed),
+            rule_lifetime_secs,
+        }
+    }
+}

--- a/mirrord/intproxy/src/session_monitor/chaos/analytics.rs
+++ b/mirrord/intproxy/src/session_monitor/chaos/analytics.rs
@@ -33,13 +33,13 @@ impl ChaosAnalyticsReporter {
 
     // Add a rule when it is created. Stores the rule with its creation time to allow us to
     // calculate its lifetime on Drop.
-    pub fn add_live_rule(&mut self, rule: &ChaosRule) {
+    pub fn create_rule(&mut self, rule: &ChaosRule) {
         self.live_rules.insert(rule.clone(), Instant::now());
     }
 
     // Remove a rule that was in effect from `self.live_rules`, and move it to `self.dead_rules`
     // after converting it into a [`ChaosRuleInfo`]. This is what will be sent in analytics.
-    pub fn kill_live_rule(&mut self, rule: &ChaosRule) {
+    pub fn delete_rule(&mut self, rule: &ChaosRule) {
         match self.live_rules.remove(&rule.clone()) {
             Some(start_time) => {
                 let _ = self
@@ -56,7 +56,7 @@ impl ChaosAnalyticsReporter {
 
     // Remove all live rules from `self.live_rules`, and move them to `self.dead_rules` after
     // converting each into a [`ChaosRuleInfo`].
-    pub fn kill_all_live_rules(&mut self) {
+    pub fn clear_session_rules(&mut self) {
         self.live_rules.drain().for_each(|(rule, start_time)| {
             self.dead_rules
                 .insert(ChaosRuleInfo::from_rule(&rule, start_time));
@@ -70,7 +70,7 @@ impl Drop for ChaosAnalyticsReporter {
         self.live_rules
             .clone()
             .iter()
-            .for_each(|(rule, _)| self.kill_live_rule(rule));
+            .for_each(|(rule, _)| self.delete_rule(rule));
 
         // report all the dead rules
         let rules_info: Vec<_> = self.dead_rules.drain().map(AnalyticValue::from).collect();
@@ -80,14 +80,22 @@ impl Drop for ChaosAnalyticsReporter {
     }
 }
 
+/// The type used to report chaos rule analytics with [`AnalyticsReporter`]. Doesn't contain any
+/// identifying information, just metadata about field usage etc.
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub(crate) struct ChaosRuleInfo {
-    effect_type: u8,              // ChaosEffectType
-    selector_type: u8,            // ChaosSelectorType
-    custom_http_filter_set: bool, // selector.http_filter != *
-    selector_percentage: u32,     // selector.percentage != 100
-    final_hit_count: u32,         // hit count
-    rule_lifetime_secs: u32,      // lifetime in seconds
+    /// `ChaosEffectType`'s repr(u8)
+    effect_type: u8,
+    /// `ChaosSelectorType`'s repr(u8)
+    selector_type: u8,
+    /// If a custom http filter was set - `true` if selector.http_filter is `Some`
+    custom_http_filter_set: bool,
+    /// Value of selector.percentage
+    selector_percentage: u32,
+    /// Final hit count i.e. times a rule was applied
+    final_hit_count: u32,
+    /// Total rule lifetime in seconds
+    rule_lifetime_secs: u32,
 }
 
 impl ChaosRuleInfo {

--- a/mirrord/intproxy/src/session_monitor/chaos/analytics.rs
+++ b/mirrord/intproxy/src/session_monitor/chaos/analytics.rs
@@ -4,7 +4,7 @@ use std::{
     time::Instant,
 };
 
-use mirrord_analytics::{AnalyticsReporter, Reporter};
+use mirrord_analytics::{AnalyticValue, Analytics, AnalyticsReporter, CollectAnalytics, Reporter};
 
 use crate::session_monitor::chaos::rules::{ChaosRule, ChaosSelector};
 
@@ -60,7 +60,7 @@ impl Drop for ChaosAnalyticsReporter {
             .for_each(|(rule, _)| self.kill_live_rule(rule));
 
         // report all the dead rules
-        let rules_info: Vec<_> = self.dead_rules.drain().collect();
+        let rules_info: Vec<_> = self.dead_rules.drain().map(AnalyticValue::from).collect();
         self.inner.get_mut().add("rules", rules_info);
     }
 }
@@ -99,5 +99,25 @@ impl ChaosRuleInfo {
             final_hit_count: rule.hit_count.load(Ordering::Relaxed),
             rule_lifetime_secs,
         }
+    }
+}
+
+impl CollectAnalytics for ChaosRuleInfo {
+    fn collect_analytics(&self, analytics: &mut Analytics) {
+        let &Self {
+            effect_type,
+            selector_type,
+            custom_http_filter_set,
+            custom_percentage_set,
+            final_hit_count,
+            rule_lifetime_secs,
+        } = self;
+
+        analytics.add("effect_type", effect_type as u32);
+        analytics.add("selector_type", selector_type as u32);
+        analytics.add("custom_http_filter_set", custom_http_filter_set);
+        analytics.add("custom_percentage_set", custom_percentage_set);
+        analytics.add("final_hit_count", final_hit_count);
+        analytics.add("rule_lifetime_secs", rule_lifetime_secs);
     }
 }

--- a/mirrord/intproxy/src/session_monitor/chaos/analytics.rs
+++ b/mirrord/intproxy/src/session_monitor/chaos/analytics.rs
@@ -10,7 +10,7 @@ use crate::session_monitor::chaos::rules::{ChaosRule, ChaosSelector};
 
 pub(crate) struct ChaosAnalyticsReporter {
     /// used to report analytics on session end
-    inner: AnalyticsReporter,
+    inner: Option<AnalyticsReporter>,
 
     /// rules that are currently in use, and the `Instant` they were created
     live_rules: HashMap<ChaosRule, Instant>,
@@ -23,7 +23,7 @@ pub(crate) struct ChaosAnalyticsReporter {
 /// sending anaytics every time a rule is deleted. Sends all rules that were in effect over the
 /// whole session when the session ends.
 impl ChaosAnalyticsReporter {
-    pub fn new(inner: AnalyticsReporter) -> Self {
+    pub fn new(inner: Option<AnalyticsReporter>) -> Self {
         Self {
             inner,
             live_rules: HashMap::default(),
@@ -31,12 +31,16 @@ impl ChaosAnalyticsReporter {
         }
     }
 
-    pub fn add_live_rule(&mut self, rule: ChaosRule) {
-        self.live_rules.insert(rule, Instant::now());
+    // Add a rule when it is created. Stores the rule with its creation time to allow us to
+    // calculate its lifetime on Drop.
+    pub fn add_live_rule(&mut self, rule: &ChaosRule) {
+        self.live_rules.insert(rule.clone(), Instant::now());
     }
 
-    pub fn kill_live_rule(&mut self, rule: ChaosRule) {
-        match self.live_rules.remove(&rule) {
+    // Remove a rule that was in effect from `self.live_rules`, and move it to `self.dead_rules`
+    // after converting it into a [`ChaosRuleInfo`]. This is what will be sent in analytics.
+    pub fn kill_live_rule(&mut self, rule: &ChaosRule) {
+        match self.live_rules.remove(&rule.clone()) {
             Some(start_time) => {
                 let _ = self
                     .dead_rules
@@ -49,6 +53,15 @@ impl ChaosAnalyticsReporter {
             }
         };
     }
+
+    // Remove all live rules from `self.live_rules`, and move them to `self.dead_rules` after
+    // converting each into a [`ChaosRuleInfo`].
+    pub fn kill_all_live_rules(&mut self) {
+        self.live_rules.drain().for_each(|(rule, start_time)| {
+            self.dead_rules
+                .insert(ChaosRuleInfo::from_rule(&rule, start_time));
+        });
+    }
 }
 
 impl Drop for ChaosAnalyticsReporter {
@@ -56,16 +69,18 @@ impl Drop for ChaosAnalyticsReporter {
         // kill all the live rules we have
         self.live_rules
             .clone()
-            .into_iter()
+            .iter()
             .for_each(|(rule, _)| self.kill_live_rule(rule));
 
         // report all the dead rules
         let rules_info: Vec<_> = self.dead_rules.drain().map(AnalyticValue::from).collect();
-        self.inner.get_mut().add("rules", rules_info);
+        self.inner
+            .as_mut()
+            .map(|x| x.get_mut().add("rules", rules_info));
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Hash)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub(crate) struct ChaosRuleInfo {
     effect_type: u8,              // ChaosEffectType
     selector_type: u8,            // ChaosSelectorType
@@ -76,7 +91,7 @@ pub(crate) struct ChaosRuleInfo {
 }
 
 impl ChaosRuleInfo {
-    pub fn from_rule(rule: ChaosRule, start_time: Instant) -> Self {
+    pub fn from_rule(rule: &ChaosRule, start_time: Instant) -> Self {
         let rule_lifetime_secs = start_time
             .elapsed()
             .as_secs()
@@ -86,7 +101,7 @@ impl ChaosRuleInfo {
         let selector_percentage = rule.selector_percentage().as_percentage();
         let effect_type = rule.effect_type().map(|t| t as u8).unwrap_or(u8::MAX);
         let selector_type = rule.selector_type() as u8;
-        let custom_http_filter_set = match rule.selector {
+        let custom_http_filter_set = match &rule.selector {
             ChaosSelector::Http { filter, .. } => filter.is_some(),
             ChaosSelector::Tcp { .. } | ChaosSelector::Fs { .. } | ChaosSelector::None => false,
         };
@@ -108,7 +123,7 @@ impl CollectAnalytics for ChaosRuleInfo {
             effect_type,
             selector_type,
             custom_http_filter_set,
-            custom_percentage_set,
+            selector_percentage,
             final_hit_count,
             rule_lifetime_secs,
         } = self;
@@ -116,7 +131,7 @@ impl CollectAnalytics for ChaosRuleInfo {
         analytics.add("effect_type", effect_type as u32);
         analytics.add("selector_type", selector_type as u32);
         analytics.add("custom_http_filter_set", custom_http_filter_set);
-        analytics.add("custom_percentage_set", custom_percentage_set);
+        analytics.add("selector_percentage", selector_percentage);
         analytics.add("final_hit_count", final_hit_count);
         analytics.add("rule_lifetime_secs", rule_lifetime_secs);
     }

--- a/mirrord/intproxy/src/session_monitor/chaos/analytics.rs
+++ b/mirrord/intproxy/src/session_monitor/chaos/analytics.rs
@@ -74,9 +74,9 @@ impl Drop for ChaosAnalyticsReporter {
 
         // report all the dead rules
         let rules_info: Vec<_> = self.dead_rules.drain().map(AnalyticValue::from).collect();
-        self.inner
-            .as_mut()
-            .map(|x| x.get_mut().add("rules", rules_info));
+        if let Some(x) = self.inner.as_mut() {
+            x.get_mut().add("rules", rules_info)
+        }
     }
 }
 

--- a/mirrord/intproxy/src/session_monitor/chaos/api.rs
+++ b/mirrord/intproxy/src/session_monitor/chaos/api.rs
@@ -64,7 +64,6 @@ pub(crate) fn chaos_router() -> Router<AppState> {
         )
 }
 
-// TODO: creating a rule has to return the new rule after creation
 async fn post_create_rule(
     Path(_): Path<SessionId>,
     State(state): State<AppState>,
@@ -73,16 +72,12 @@ async fn post_create_rule(
     let new_rule = ChaosRule::try_from(new_rule)?;
     let rule_id = new_rule.id;
 
-    // report new rule
-    state
-        .reporter
-        .blocking_write()
-        .add_live_rule(new_rule.clone());
-
     let created_rule = state
         .chaos_tx
         .create_rule(new_rule)
         .ok_or(ChaosApiError::RuleAlreadyPresent(rule_id))?;
+
+    report_add(&state, &created_rule);
 
     Ok(Json(created_rule))
 }
@@ -99,6 +94,9 @@ async fn delete_clear_session_rules(
     State(state): State<AppState>,
 ) -> ChaosResult<()> {
     state.chaos_tx.clear_session_rules();
+
+    report_remove_all(&state);
+
     Ok(())
 }
 
@@ -107,10 +105,14 @@ async fn put_update_rule(
     State(state): State<AppState>,
     Json(new_rule): Json<ChaosRuleRequest>,
 ) -> ChaosResult<Json<ChaosRule>> {
+    let new_rule = ChaosRule::try_from((rule_id, new_rule))?;
+    report_add(&state, &new_rule);
+
     let replaced_rule = state
         .chaos_tx
-        .update_rule(ChaosRule::try_from((rule_id, new_rule))?)
+        .update_rule(new_rule)
         .ok_or(ChaosApiError::RuleNotFound(rule_id))?;
+    report_remove(&state, &replaced_rule);
 
     Ok(Json(replaced_rule))
 }
@@ -123,6 +125,8 @@ async fn delete_rule(
         .chaos_tx
         .delete_rule(rule_id)
         .ok_or(ChaosApiError::RuleNotFound(rule_id))?;
+
+    report_remove(&state, &stored_rule);
 
     Ok(Json(stored_rule))
 }
@@ -137,4 +141,25 @@ async fn get_rule(
         .ok_or(ChaosApiError::RuleNotFound(rule_id))?;
 
     Ok(Json(stored_rule))
+}
+
+fn report_add(state: &AppState, rule: &ChaosRule) {
+    match state.reporter.try_write() {
+        Ok(mut reporter) => reporter.add_live_rule(rule),
+        Err(error) => tracing::trace!("failed to get write lock on analytics reporter: {error}"),
+    }
+}
+
+fn report_remove(state: &AppState, rule: &ChaosRule) {
+    match state.reporter.try_write() {
+        Ok(mut reporter) => reporter.kill_live_rule(rule),
+        Err(error) => tracing::trace!("failed to get write lock on analytics reporter: {error}"),
+    }
+}
+
+fn report_remove_all(state: &AppState) {
+    match state.reporter.try_write() {
+        Ok(mut reporter) => reporter.kill_all_live_rules(),
+        Err(error) => tracing::trace!("failed to get write lock on analytics reporter: {error}"),
+    }
 }

--- a/mirrord/intproxy/src/session_monitor/chaos/api.rs
+++ b/mirrord/intproxy/src/session_monitor/chaos/api.rs
@@ -145,21 +145,21 @@ async fn get_rule(
 
 fn report_add(state: &AppState, rule: &ChaosRule) {
     match state.reporter.try_write() {
-        Ok(mut reporter) => reporter.add_live_rule(rule),
+        Ok(mut reporter) => reporter.create_rule(rule),
         Err(error) => tracing::trace!("failed to get write lock on analytics reporter: {error}"),
     }
 }
 
 fn report_remove(state: &AppState, rule: &ChaosRule) {
     match state.reporter.try_write() {
-        Ok(mut reporter) => reporter.kill_live_rule(rule),
+        Ok(mut reporter) => reporter.delete_rule(rule),
         Err(error) => tracing::trace!("failed to get write lock on analytics reporter: {error}"),
     }
 }
 
 fn report_remove_all(state: &AppState) {
     match state.reporter.try_write() {
-        Ok(mut reporter) => reporter.kill_all_live_rules(),
+        Ok(mut reporter) => reporter.clear_session_rules(),
         Err(error) => tracing::trace!("failed to get write lock on analytics reporter: {error}"),
     }
 }

--- a/mirrord/intproxy/src/session_monitor/chaos/api.rs
+++ b/mirrord/intproxy/src/session_monitor/chaos/api.rs
@@ -73,6 +73,12 @@ async fn post_create_rule(
     let new_rule = ChaosRule::try_from(new_rule)?;
     let rule_id = new_rule.id;
 
+    // report new rule
+    state
+        .reporter
+        .blocking_write()
+        .add_live_rule(new_rule.clone());
+
     let created_rule = state
         .chaos_tx
         .create_rule(new_rule)

--- a/mirrord/intproxy/src/session_monitor/chaos/rules.rs
+++ b/mirrord/intproxy/src/session_monitor/chaos/rules.rs
@@ -9,7 +9,7 @@ use mirrord_protocol::{
 use rand::{random_bool, random_range};
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
-use strum_macros::EnumString;
+use strum_macros::{EnumDiscriminants, EnumString};
 use thiserror::Error;
 use uuid::Uuid;
 
@@ -93,13 +93,35 @@ impl ChaosRule {
         }
     }
 
-    pub fn get_selector_percentage(&self) -> Percentage {
+    pub fn selector_percentage(&self) -> Percentage {
         match self.selector {
             ChaosSelector::Tcp { percentage, .. }
             | ChaosSelector::Http { percentage, .. }
             | ChaosSelector::Fs { percentage, .. } => percentage,
             ChaosSelector::None => Percentage::default(),
         }
+    }
+
+    pub fn selector_type(&self) -> ChaosSelectorType {
+        match self.selector {
+            ChaosSelector::Tcp { .. } => ChaosSelectorType::Tcp,
+            ChaosSelector::Http { .. } => ChaosSelectorType::Http,
+            ChaosSelector::Fs { .. } => ChaosSelectorType::Fs,
+            ChaosSelector::None => ChaosSelectorType::None,
+        }
+    }
+
+    pub fn effect_type(&self) -> Option<ChaosEffectType> {
+        let string = match &self.selector {
+            ChaosSelector::Tcp { effect, .. } => effect.to_string(),
+            ChaosSelector::Http { effect, .. } => effect.to_string(),
+            ChaosSelector::Fs { effect, .. } => effect.to_string(),
+            ChaosSelector::None => {
+                return None;
+            }
+        };
+
+        ChaosEffectType::from_str(&string).ok()
     }
 }
 
@@ -328,27 +350,30 @@ pub struct ChaosRuleRequest {
 /// The type of effect that a [`ChaosRule`] should apply. Can only be used with a compatible
 /// `selector`, as checked in [`ChaosRule::try_from<ChaosRuleRequest>()`].
 #[skip_serializing_none]
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, EnumDiscriminants)]
 #[serde(rename_all = "snake_case")]
+#[strum_discriminants(name(ChaosEffectType))]
+#[strum_discriminants(derive(EnumString))]
+#[repr(u8)]
 pub enum ChaosEffectRequest {
     Latency {
         delay_ms: u64,
         jitter_ms: Option<u64>,
-    },
+    } = 0,
     ConnectionError {
         #[serde(rename = "type")]
         error_type: String,
         after_ms: Option<u64>,
-    },
+    } = 1,
     #[serde(skip)]
     // Reinstate when required protocol implemented
-    Degradation,
+    Degradation = 2,
     #[serde(skip)]
     // Reinstate when required protocol implemented
-    HttpOverride,
+    HttpOverride = 3,
     #[serde(skip)]
     // Reinstate when required protocol implemented
-    FsError,
+    FsError = 4,
 }
 
 /// The traffic to which a [`ChaosRule`] should apply. The (protocol) type of selector (see
@@ -378,52 +403,79 @@ pub struct ChaosSelectorRequest {
     percentage: Option<u32>,
 }
 
-#[derive(Clone, Serialize, Deserialize, Default, Debug, PartialEq, Hash)]
+impl ChaosSelectorRequest {
+    pub fn tcp_port(port: u16, percentage: Option<u32>) -> Self {
+        Self {
+            upstream: Some(format!(":{port}")),
+            percentage,
+            ..Default::default()
+        }
+    }
+
+    pub fn name() -> Self {
+        Self {
+            upstream: Some(format!("google.com:443")),
+            ..Default::default()
+        }
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize, Default, Debug, PartialEq, Hash, EnumDiscriminants)]
+#[strum_discriminants(derive(Serialize, Deserialize))]
+#[strum_discriminants(name(ChaosSelectorType))]
+#[repr(u8)]
 pub enum ChaosSelector {
     Tcp {
         upstream: AddressFilter, // req
         percentage: Percentage,
         effect: TcpChaosEffect,
-    },
+    } = 1,
     Http {
         upstream: AddressFilter, // req
         percentage: Percentage,
-        filter: HttpFilter, // ::Body and ::HeaderJq variants unused
+        filter: Option<HttpFilter>, // ::Body and ::HeaderJq variants unused
         effect: HttpChaosEffect,
-    },
+    } = 2,
     Fs {
         file_path: Vec<String>, // req
         percentage: Percentage,
         effect: FsChaosEffect,
-    },
+    } = 3,
     #[default]
-    None,
+    None = 0,
 }
 
 // having separate enums per selector allows invalid effect/ selector combos to
 // be impossible
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Hash, Default)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Hash, Default, strum_macros::Display)]
 pub enum TcpChaosEffect {
     Latency(ChaosEffectLatency),
     ConnectionError(ChaosEffectConnectionError),
     Degradation,
     #[default]
+    #[strum(disabled)]
     Nothing,
 }
 
-#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Hash, Default)]
+#[derive(
+    Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Hash, Default, strum_macros::Display,
+)]
 pub enum HttpChaosEffect {
     Latency(ChaosEffectLatency),
     HttpOverride,
     #[default]
+    #[strum(disabled)]
     Nothing,
 }
 
-#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Hash, Default)]
+#[derive(
+    Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Hash, Default, strum_macros::Display,
+)]
 pub enum FsChaosEffect {
     Latency(ChaosEffectLatency),
     FsError,
     #[default]
+    #[strum(disabled)]
     Nothing,
 }
 
@@ -688,7 +740,7 @@ mod test {
         name: Some("http-connect-slow".to_owned()),
         selector: ChaosSelector::Http {
             upstream: AddressFilter::Name("jadwiga-wawel.pl".to_owned(), 0),
-            filter: HttpFilter::Path(Filter::new("^/api/".to_owned()).unwrap()),
+            filter: Some(HttpFilter::Path(Filter::new("^/api/".to_owned()).unwrap())),
             percentage: Percentage::from(100),
             effect: HttpChaosEffect::Latency(ChaosEffectLatency {
                 delay: Duration::from_millis(200),

--- a/mirrord/intproxy/src/session_monitor/chaos/rules.rs
+++ b/mirrord/intproxy/src/session_monitor/chaos/rules.rs
@@ -414,7 +414,7 @@ impl ChaosSelectorRequest {
 
     pub fn name() -> Self {
         Self {
-            upstream: Some(format!("google.com:443")),
+            upstream: Some("google.com:443".to_owned()),
             ..Default::default()
         }
     }

--- a/mirrord/intproxy/src/session_monitor/chaos/rules.rs
+++ b/mirrord/intproxy/src/session_monitor/chaos/rules.rs
@@ -403,23 +403,6 @@ pub struct ChaosSelectorRequest {
     percentage: Option<u32>,
 }
 
-impl ChaosSelectorRequest {
-    pub fn tcp_port(port: u16, percentage: Option<u32>) -> Self {
-        Self {
-            upstream: Some(format!(":{port}")),
-            percentage,
-            ..Default::default()
-        }
-    }
-
-    pub fn name() -> Self {
-        Self {
-            upstream: Some("google.com:443".to_owned()),
-            ..Default::default()
-        }
-    }
-}
-
 #[derive(Clone, Serialize, Deserialize, Default, Debug, PartialEq, Hash, EnumDiscriminants)]
 #[strum_discriminants(derive(Serialize, Deserialize))]
 #[strum_discriminants(name(ChaosSelectorType))]

--- a/mirrord/intproxy/src/session_monitor/chaos/rules.rs
+++ b/mirrord/intproxy/src/session_monitor/chaos/rules.rs
@@ -486,6 +486,9 @@ pub struct ChaosEffectLatency {
 }
 
 impl ChaosEffectLatency {
+    pub fn new(delay: Duration, jitter: Duration) -> Self {
+        Self { delay, jitter }
+    }
     pub fn latency_duration(&self) -> Duration {
         if self.jitter.is_zero() {
             return self.delay;

--- a/mirrord/intproxy/tests/session_monitor_round_trip.rs
+++ b/mirrord/intproxy/tests/session_monitor_round_trip.rs
@@ -115,6 +115,7 @@ impl StartedServer {
                     rx,
                     shutdown,
                     ChaosWatcherTx::new(chaos_tx),
+                    None,
                 )
                 .await
             }
@@ -389,6 +390,7 @@ async fn invalid_session_id_with_path_traversal_returns_error() {
         rx,
         shutdown,
         ChaosWatcherTx::new(chaos_tx),
+        None,
     )
     .await;
 


### PR DESCRIPTION
### Architecture

<img width="1597" height="835" alt="Screenshot 2026-06-17 at 15 45 12" src="https://github.com/user-attachments/assets/ac1b82b8-0460-4fca-b412-2a1419d872c4" />

### Summary

- Added convenience methods to get effect and selector types from a `ChaosRule`
- Added a new type `ChaosAnalyticsReporter` that contains an `AnalyticsReporter`
- Rules are recorded when calls are made to the session monitor API
- Lifetimes are calculated on `Drop`/ rule deletion
- Rules are turned into anonymised `ChaosRuleInfo`
- On `Drop`, the `ChaosAnalyticsReporter` reports info for all the rules it has stored under `"rules"`