### PR TITLE
feat(monitor): auto-configure the browser extension from `mirrord ui`

### DIFF
--- a/changelog.d/+mirrord-ui-extension-config.added.md
+++ b/changelog.d/+mirrord-ui-extension-config.added.md
@@ -1,0 +1,1 @@
+`mirrord ui` now configures the browser extension automatically — it hands the extension its backend and token (re-using the cached token on a bare revisit) and prints the token so it can also be pasted in manually. The "install the extension" prompt links to the extension landing page.

--- a/mirrord/cli/src/ui.rs
+++ b/mirrord/cli/src/ui.rs
@@ -841,11 +841,14 @@ fn build_router(state: Arc<AppState>) -> Router {
     // PostHog origin must be listed in both `script-src` (for the recorder bundle) and
     // `connect-src` (for `/e/` event capture and `/s/` session replay ingest). Without these,
     // telemetry is silently dropped by the browser's CSP enforcement.
+    // NOTE: no `ws://[::1]:*` source — the server binds `Ipv4Addr::LOCALHOST` only, so the
+    // IPv6 loopback is never used; listing it is dead config (and some browsers reject the
+    // bracketed IPv6 host, spamming the page console).
     let csp_value = HeaderValue::from_static(
         "default-src 'self'; script-src 'self' https://hog.metalbear.com; \
          style-src 'self' 'unsafe-inline'; \
          connect-src 'self' https://hog.metalbear.com \
-         ws://localhost:* ws://127.0.0.1:* ws://[::1]:*; \
+         ws://localhost:* ws://127.0.0.1:*; \
          img-src 'self' data:; object-src 'none'; frame-ancestors 'none'",
     );
 
@@ -975,25 +978,29 @@ fn claim_token_file_at(lock_path: PathBuf, token_path: PathBuf) -> Result<TokenC
 
 /// Outcome of [`setup_ui`].
 pub enum UiSetup {
-    /// This invocation owns the UI; `server` runs it and `url` opens it.
+    /// This invocation owns the UI; `server` runs it and `url` opens it. `token` authenticates
+    /// requests and can be pasted into the browser extension manually.
     Started {
         server: futures::future::BoxFuture<'static, Result<(), CliError>>,
         url: String,
+        token: String,
     },
-    /// Another `mirrord ui` is already running; `url` opens the existing instance.
-    AlreadyRunning { url: String },
+    /// Another `mirrord ui` is already running; `url` opens the existing instance and `token`
+    /// is the one it published.
+    AlreadyRunning { url: String, token: String },
 }
 
 pub async fn ui_command(args: UiArgs) -> Result<(), CliError> {
     match setup_ui(args.port).await? {
-        UiSetup::AlreadyRunning { url } => {
+        UiSetup::AlreadyRunning { url, token } => {
             eprintln!();
             eprintln!("  mirrord session monitor is already running");
             eprintln!("    Web UI:             {url}");
+            eprintln!("    Token:              {token}");
             eprintln!();
             Ok(())
         }
-        UiSetup::Started { server, url } => {
+        UiSetup::Started { server, url, token } => {
             if let Err(err) = opener::open(&url) {
                 warn!(?err, "Failed to open browser");
             }
@@ -1001,6 +1008,7 @@ pub async fn ui_command(args: UiArgs) -> Result<(), CliError> {
             eprintln!();
             eprintln!("  mirrord session monitor");
             eprintln!("    Web UI:             {url}");
+            eprintln!("    Token:              {token}");
             eprintln!();
 
             server.await
@@ -1012,7 +1020,7 @@ pub async fn setup_ui(port: u16) -> Result<UiSetup, CliError> {
     let (guard, token) = match claim_token_file()? {
         TokenClaim::AlreadyRunning { token } => {
             let url = format!("http://{}:{port}?token={token}", Ipv4Addr::LOCALHOST);
-            return Ok(UiSetup::AlreadyRunning { url });
+            return Ok(UiSetup::AlreadyRunning { url, token });
         }
         TokenClaim::Claimed { guard, token } => (guard, token),
     };
@@ -1059,7 +1067,7 @@ pub async fn setup_ui(port: u16) -> Result<UiSetup, CliError> {
             .map_err(|e| CliError::UiError(format!("server error: {e}")))
     });
 
-    Ok(UiSetup::Started { server, url })
+    Ok(UiSetup::Started { server, url, token })
 }
 
 #[cfg(test)]

--- a/mirrord/cli/src/up.rs
+++ b/mirrord/cli/src/up.rs
@@ -89,8 +89,8 @@ async fn run_up(args: UpArgs, analytics: &mut AnalyticsReporter) -> Result<(), U
     if args.ui {
         tokio::spawn(async move {
             let (server, url) = match crate::ui::setup_ui(UI_DEFAULT_PORT).await {
-                Ok(crate::ui::UiSetup::Started { server, url }) => (server, url),
-                Ok(crate::ui::UiSetup::AlreadyRunning { url }) => {
+                Ok(crate::ui::UiSetup::Started { server, url, .. }) => (server, url),
+                Ok(crate::ui::UiSetup::AlreadyRunning { url, .. }) => {
                     tracing::info!(%url, "local UI already running, not starting another");
                     return;
                 }

--- a/packages/monitor/src/App.tsx
+++ b/packages/monitor/src/App.tsx
@@ -13,6 +13,7 @@ import EmptySessionState from './components/EmptySessionState'
 import FunnelHero from './components/FunnelHero'
 import ConnectOperatorModal from './components/ConnectOperatorModal'
 import OperatorSessionDetail from './components/OperatorSessionDetail'
+import ExtensionConfiguredToast from './components/ExtensionConfiguredToast'
 import { applyDark, loadTheme, resolveDark, saveTheme, type ThemePref } from './theme'
 import {
   initAnalytics,
@@ -321,6 +322,7 @@ export default function App() {
 
   return (
     <div className="h-screen flex flex-col bg-background text-foreground">
+      <ExtensionConfiguredToast />
       <AppHeader
         connected={connected}
         isDarkMode={isDarkMode}

--- a/packages/monitor/src/api.ts
+++ b/packages/monitor/src/api.ts
@@ -13,6 +13,16 @@ if (typeof window !== 'undefined') {
   }
 }
 
+/**
+ * The poller auth token this page is using for its API calls — resolved from the `?token=`
+ * launch param and cached in `sessionStorage`. Exposed so the extension-configure flow hands
+ * the extension the same token, including on a bare revisit where the param is no longer in the
+ * URL (App strips it after first load).
+ */
+export function getAuthToken(): string | null {
+  return authToken
+}
+
 function withToken(path: string): string {
   if (!authToken) return path
   const sep = path.includes('?') ? '&' : '?'

--- a/packages/monitor/src/components/ExtensionConfiguredToast.tsx
+++ b/packages/monitor/src/components/ExtensionConfiguredToast.tsx
@@ -1,0 +1,51 @@
+import { useEffect, useState } from 'react'
+import { CheckCircle2, X } from 'lucide-react'
+import {
+  EXTENSION_CONFIGURED_EVENT,
+  isExtensionConfigured,
+} from '../extensionConfigure'
+
+const AUTO_DISMISS_MS = 6000
+
+/**
+ * Confirmation banner shown once the browser extension acknowledges that this `mirrord ui`
+ * page handed it the backend + token. Self-contained: listens for the configure event (and
+ * checks the module flag on mount, in case the ack landed before render), auto-dismisses, and
+ * can be closed manually.
+ */
+export default function ExtensionConfiguredToast() {
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    const show = () => setVisible(true)
+    if (isExtensionConfigured()) show()
+    window.addEventListener(EXTENSION_CONFIGURED_EVENT, show)
+    return () => window.removeEventListener(EXTENSION_CONFIGURED_EVENT, show)
+  }, [])
+
+  useEffect(() => {
+    if (!visible) return
+    const timer = setTimeout(() => setVisible(false), AUTO_DISMISS_MS)
+    return () => clearTimeout(timer)
+  }, [visible])
+
+  if (!visible) return null
+
+  return (
+    <div
+      role="status"
+      className="fixed bottom-4 right-4 z-50 flex items-center gap-2 rounded-md border border-border bg-card px-4 py-2 text-sm text-foreground shadow-lg"
+    >
+      <CheckCircle2 className="h-4 w-4 text-green-500" />
+      <span>Browser extension configured</span>
+      <button
+        type="button"
+        aria-label="Dismiss"
+        onClick={() => setVisible(false)}
+        className="ml-2 text-muted-foreground hover:text-foreground"
+      >
+        <X className="h-4 w-4" />
+      </button>
+    </div>
+  )
+}

--- a/packages/monitor/src/components/JoinBar.tsx
+++ b/packages/monitor/src/components/JoinBar.tsx
@@ -7,7 +7,7 @@ import {
   LogIn,
   LogOut,
 } from 'lucide-react'
-import { CHROME_WEB_STORE_URL, type ExtensionState } from '../extensionBridge'
+import { EXTENSION_INSTALL_URL, type ExtensionState } from '../extensionBridge'
 import { strings } from '../strings'
 
 interface JoinBarProps {
@@ -51,7 +51,7 @@ export default function JoinBar({
         <div className="text-xs leading-relaxed flex-1">
           Install the{' '}
           <a
-            href={CHROME_WEB_STORE_URL}
+            href={EXTENSION_INSTALL_URL}
             target="_blank"
             rel="noreferrer"
             className="text-primary hover:underline font-semibold"
@@ -62,7 +62,7 @@ export default function JoinBar({
           and ride along.
         </div>
         <Button asChild variant="outline" size="sm">
-          <a href={CHROME_WEB_STORE_URL} target="_blank" rel="noreferrer">
+          <a href={EXTENSION_INSTALL_URL} target="_blank" rel="noreferrer">
             Install <ExternalLink className="h-3 w-3 ml-1" />
           </a>
         </Button>

--- a/packages/monitor/src/extensionBridge.ts
+++ b/packages/monitor/src/extensionBridge.ts
@@ -60,6 +60,17 @@ function send<T = unknown>(
   })
 }
 
+/**
+ * Public name for the extension messaging transport. The extension is reachable directly via
+ * Chrome's `externally_connectable`, so this is a thin wrapper over `send`.
+ */
+export function sendExtensionMessage<T = unknown>(
+  message: unknown,
+  timeoutMs = REQUEST_TIMEOUT_MS
+): Promise<T | null> {
+  return send<T>(message, timeoutMs)
+}
+
 export async function pingExtension(): Promise<ExtensionState> {
   const response = await send<{
     type?: string
@@ -125,5 +136,8 @@ export async function leaveViaExtension(): Promise<{ ok: boolean; error?: string
   return { ok: response.ok ?? false, error: response.error }
 }
 
-export const CHROME_WEB_STORE_URL =
-  'https://chromewebstore.google.com/detail/mirrord/bijejadnnfgjkfdocgocklekjhnhkhkf'
+// Cross-browser extension landing page (routes the visitor to the right store). UTM params
+// attribute installs that originate from the local `mirrord ui` install prompt.
+export const EXTENSION_INSTALL_URL =
+  'https://metalbear.com/mirrord/extension' +
+  '?utm_source=mirrord_ui&utm_medium=install_banner&utm_campaign=browser_extension'

--- a/packages/monitor/src/extensionConfigure.ts
+++ b/packages/monitor/src/extensionConfigure.ts
@@ -1,40 +1,65 @@
-const EXTENSION_ID = 'bijejadnnfgjkfdocgocklekjhnhkhkf'
+import { getAuthToken } from './api'
+import { sendExtensionMessage } from './extensionBridge'
 
-type ChromeRuntime = {
-    sendMessage: (
-        extensionId: string,
-        message: unknown,
-        callback?: (response: unknown) => void
-    ) => void
-    lastError?: { message?: string }
+const CONFIGURE_TYPE = 'mirrord-ui-configure'
+const CONFIGURE_TIMEOUT_MS = 500
+// The extension's background service worker may be cold when the page first loads, so its
+// message listener might not be ready yet. Retry a few times (the message is idempotent) until
+// the extension acknowledges with `{ ok: true }`.
+const CONFIGURE_ATTEMPTS = 5
+const CONFIGURE_RETRY_MS = 400
+
+/**
+ * Dispatched on `window` once the extension acknowledges configuration. The React app
+ * listens for it (and checks `isExtensionConfigured()` on mount, in case the ack landed
+ * before it rendered) to show a confirmation banner.
+ */
+export const EXTENSION_CONFIGURED_EVENT = 'mirrord:extension-configured'
+
+let extensionConfigured = false
+
+/** Whether the extension has acknowledged configuration during this page load. */
+export function isExtensionConfigured(): boolean {
+  return extensionConfigured
 }
 
-type ChromeGlobal = {
-    runtime?: ChromeRuntime
+function markConfigured(): void {
+  if (extensionConfigured) return
+  extensionConfigured = true
+  window.dispatchEvent(new CustomEvent(EXTENSION_CONFIGURED_EVENT))
 }
 
+/**
+ * Push the current `mirrord ui` backend + token to the browser extension so it can
+ * talk to this poller without the user re-entering anything. The extension receives it via
+ * Chrome's `externally_connectable`. No-op when the extension isn't installed (the send
+ * simply times out).
+ *
+ * Uses the same token the API client resolved (`?token=` launch param, cached in
+ * `sessionStorage`), so a bare revisit — where the param is no longer in the URL — still
+ * auto-configures an installed extension.
+ */
 export function autoConfigureExtension(): void {
-    const token = new URLSearchParams(window.location.search).get('token')
-    if (!token) return
+  const token = getAuthToken()
+  if (!token) return
 
-    const chromeGlobal = (window as unknown as { chrome?: ChromeGlobal }).chrome
-    const sendMessage = chromeGlobal?.runtime?.sendMessage
-    if (!sendMessage) return
+  const message = {
+    type: CONFIGURE_TYPE,
+    backend: window.location.origin,
+    token,
+  }
 
-    try {
-        sendMessage.call(
-            chromeGlobal!.runtime!,
-            EXTENSION_ID,
-            {
-                type: 'mirrord-ui-configure',
-                backend: window.location.origin,
-                token,
-            },
-            () => {
-                void chromeGlobal!.runtime!.lastError
-            }
-        )
-    } catch {
+  void (async () => {
+    for (let attempt = 0; attempt < CONFIGURE_ATTEMPTS; attempt++) {
+      const response = await sendExtensionMessage<{ ok?: boolean }>(
+        message,
+        CONFIGURE_TIMEOUT_MS
+      )
+      if (response && response.ok) {
+        markConfigured()
         return
+      }
+      await new Promise((r) => setTimeout(r, CONFIGURE_RETRY_MS))
     }
+  })()
 }


### PR DESCRIPTION
## What

`mirrord ui` now configures the browser extension automatically, so users don't have to copy/paste anything:

- **Hands the extension its backend + token** over Chrome's `externally_connectable` (`extensionConfigure.ts`), retrying a few times to cover service-worker cold start. Reuses the token the API client already resolved (`getAuthToken` in `api.ts`), so a **bare revisit** — where `?token=` is no longer in the URL — still auto-configures an installed extension.
- **Prints the token** in the `mirrord ui` CLI output (`ui.rs`/`up.rs`) so it can also be pasted in manually.
- **Confirmation toast** once the extension acknowledges (`ExtensionConfiguredToast`).
- The "install the extension" prompt links to the extension **landing page** (with UTM attribution) instead of the Chrome Web Store directly (`JoinBar`, `EXTENSION_INSTALL_URL`).
- Drops the unused `ws://[::1]:*` CSP source (the server binds IPv4 loopback only).

## Scope

This is the **Chrome-only** slice — messaging goes directly to the extension via `externally_connectable`; there is no `window.postMessage` content-script bridge here. (Firefox support, which needs that bridge, is tracked separately in #4383.)

## Test plan

- `mirrord ui` → extension auto-configures; revisit the page without `?token=` and it still configures.
- Token line appears in CLI output and can be pasted manually.
- Install prompt links to the landing page; toast shows on configure.
- Monitor typechecks (`tsc -b`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)