### PR TITLE
Add database dump args config

### DIFF
--- a/changelog.d/+database-dump-args.added.md
+++ b/changelog.d/+database-dump-args.added.md
@@ -1,0 +1,1 @@
+Add `copy.dump_args` for PostgreSQL and MySQL database branches, allowing users to override the arguments passed to `pg_dump` and `mysqldump`.

--- a/mirrord-schema.json
+++ b/mirrord-schema.json
@@ -3013,11 +3013,20 @@
       ]
     },
     "MysqlBranchCopyConfig": {
-      "description": "Users can choose from the following copy mode to bootstrap their MySQL branch database:\n\n- Empty\n\n  Creates an empty database. If the source DB connection options are found from the chosen\n  target, mirrord operator extracts the database name and create an empty DB. Otherwise, mirrord\n  operator looks for the `name` field from the branch DB config object. This option is useful\n  for users that run DB migrations themselves before starting the application.\n\n- Schema\n\n  Creates an empty database and copies schema of all tables.\n\n- All\n\n  Copies both schema and data of all tables. This option shall only be used\n  when the data volume of the source database is minimal.",
+      "description": "Users can choose from the following copy mode to bootstrap their MySQL branch database.\n\nAll copy modes accept `dump_args`. When this field is set, it replaces the default\n`mysqldump` arguments. The defaults are `--single-transaction` and `--no-tablespaces`;\ninclude them explicitly when overriding if you want to preserve the default behavior. An\nempty list means no dump args.\n\n- Empty\n\n  Creates an empty database. If the source DB connection options are found from the chosen\n  target, mirrord operator extracts the database name and create an empty DB. Otherwise, mirrord\n  operator looks for the `name` field from the branch DB config object. This option is useful\n  for users that run DB migrations themselves before starting the application.\n\n- Schema\n\n  Creates an empty database and copies schema of all tables.\n\n- All\n\n  Copies both schema and data of all tables. This option shall only be used when the data volume\n  of the source database is minimal.",
       "oneOf": [
         {
           "type": "object",
           "properties": {
+            "dump_args": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
+            },
             "mode": {
               "type": "string",
               "const": "empty"
@@ -3040,6 +3049,15 @@
         {
           "type": "object",
           "properties": {
+            "dump_args": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
+            },
             "mode": {
               "type": "string",
               "const": "schema"
@@ -3062,6 +3080,15 @@
         {
           "type": "object",
           "properties": {
+            "dump_args": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
+            },
             "mode": {
               "type": "string",
               "const": "all"
@@ -3209,11 +3236,20 @@
       ]
     },
     "PgBranchCopyConfig": {
-      "description": "Users can choose from the following copy mode to bootstrap their PostgreSQL branch database:\n\n- Empty\n\n  Creates an empty database. If the source DB connection options are found from the chosen\n  target, mirrord operator extracts the database name and create an empty DB. Otherwise, mirrord\n  operator looks for the `name` field from the branch DB config object. This option is useful\n  for users that run DB migrations themselves before starting the application.\n\n- Schema\n\n  Creates an empty database and copies schema of all tables.\n\n- All\n\n  Copies both schema and data of all tables. This option shall only be used\n  when the data volume of the source database is minimal.",
+      "description": "Users can choose from the following copy mode to bootstrap their PostgreSQL branch database.\n\nAll copy modes accept `dump_args`. When this field is set, it replaces the default `pg_dump`\narguments. The defaults are `--no-owner` and `--no-acl`; include them explicitly when\noverriding if you want to preserve the default behavior. An empty list means no dump args.\n\n- Empty\n\n  Creates an empty database. If the source DB connection options are found from the chosen\n  target, mirrord operator extracts the database name and create an empty DB. Otherwise, mirrord\n  operator looks for the `name` field from the branch DB config object. This option is useful\n  for users that run DB migrations themselves before starting the application.\n\n- Schema\n\n  Creates an empty database and copies schema of all tables.\n\n- All\n\n  Copies both schema and data of all tables. This option shall only be used when the data volume\n  of the source database is minimal.",
       "oneOf": [
         {
           "type": "object",
           "properties": {
+            "dump_args": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
+            },
             "mode": {
               "type": "string",
               "const": "empty"
@@ -3236,6 +3272,15 @@
         {
           "type": "object",
           "properties": {
+            "dump_args": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
+            },
             "mode": {
               "type": "string",
               "const": "schema"
@@ -3258,6 +3303,15 @@
         {
           "type": "object",
           "properties": {
+            "dump_args": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
+            },
             "mode": {
               "type": "string",
               "const": "all"

--- a/mirrord/config/src/feature/database_branches.rs
+++ b/mirrord/config/src/feature/database_branches.rs
@@ -744,6 +744,8 @@ pub fn default_creation_timeout_secs() -> u64 {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
     use super::*;
 
     #[test]
@@ -968,6 +970,97 @@ mod tests {
         let json = serde_json::to_string(&source).unwrap();
         let deserialized: ConnectionSource = serde_json::from_str(&json).unwrap();
         assert_eq!(source, deserialized);
+    }
+
+    #[test]
+    fn mysql_copy_dump_args_parse_for_all_modes() {
+        let empty: MysqlBranchCopyConfig = serde_json::from_str(
+            r#"{
+                "mode": "empty",
+                "tables": {
+                    "users": { "filter": "active = true" }
+                },
+                "dump_args": ["--single-transaction"]
+            }"#,
+        )
+        .unwrap();
+        assert_eq!(
+            empty,
+            MysqlBranchCopyConfig::Empty {
+                tables: Some(BTreeMap::from([(
+                    "users".to_owned(),
+                    BranchItemCopyConfig {
+                        filter: Some("active = true".to_owned())
+                    }
+                )])),
+                dump_args: Some(vec!["--single-transaction".to_owned()])
+            }
+        );
+
+        let schema: MysqlBranchCopyConfig =
+            serde_json::from_str(r#"{ "mode": "schema", "dump_args": [] }"#).unwrap();
+        assert_eq!(
+            schema,
+            MysqlBranchCopyConfig::Schema {
+                tables: None,
+                dump_args: Some(vec![])
+            }
+        );
+
+        let all: MysqlBranchCopyConfig =
+            serde_json::from_str(r#"{ "mode": "all", "dump_args": ["--no-tablespaces"] }"#)
+                .unwrap();
+        assert_eq!(
+            all,
+            MysqlBranchCopyConfig::All {
+                dump_args: Some(vec!["--no-tablespaces".to_owned()])
+            }
+        );
+    }
+
+    #[test]
+    fn pg_copy_dump_args_parse_for_all_modes() {
+        let empty: PgBranchCopyConfig = serde_json::from_str(
+            r#"{
+                "mode": "empty",
+                "tables": {
+                    "users": { "filter": "active = true" }
+                },
+                "dump_args": ["--no-owner"]
+            }"#,
+        )
+        .unwrap();
+        assert_eq!(
+            empty,
+            PgBranchCopyConfig::Empty {
+                tables: Some(BTreeMap::from([(
+                    "users".to_owned(),
+                    BranchItemCopyConfig {
+                        filter: Some("active = true".to_owned())
+                    }
+                )])),
+                dump_args: Some(vec!["--no-owner".to_owned()])
+            }
+        );
+
+        let schema: PgBranchCopyConfig =
+            serde_json::from_str(r#"{ "mode": "schema", "dump_args": [] }"#).unwrap();
+        assert_eq!(
+            schema,
+            PgBranchCopyConfig::Schema {
+                tables: None,
+                dump_args: Some(vec![])
+            }
+        );
+
+        let all: PgBranchCopyConfig =
+            serde_json::from_str(r#"{ "mode": "all", "dump_args": ["--no-acl"] }"#).unwrap();
+        assert_eq!(
+            all,
+            PgBranchCopyConfig::All {
+                dump_args: Some(vec!["--no-acl".to_owned()])
+            }
+        );
     }
 
     #[test]

--- a/mirrord/config/src/feature/database_branches/mysql.rs
+++ b/mirrord/config/src/feature/database_branches/mysql.rs
@@ -24,7 +24,12 @@ pub struct MysqlBranchConfig {
     pub iam_auth: Option<IamAuthConfig>,
 }
 
-/// Users can choose from the following copy mode to bootstrap their MySQL branch database:
+/// Users can choose from the following copy mode to bootstrap their MySQL branch database.
+///
+/// All copy modes accept `dump_args`. When this field is set, it replaces the default
+/// `mysqldump` arguments. The defaults are `--single-transaction` and `--no-tablespaces`;
+/// include them explicitly when overriding if you want to preserve the default behavior. An
+/// empty list means no dump args.
 ///
 /// - Empty
 ///
@@ -39,26 +44,34 @@ pub struct MysqlBranchConfig {
 ///
 /// - All
 ///
-///   Copies both schema and data of all tables. This option shall only be used
-///   when the data volume of the source database is minimal.
+///   Copies both schema and data of all tables. This option shall only be used when the data volume
+///   of the source database is minimal.
 #[derive(Clone, Debug, Eq, PartialEq, JsonSchema, Serialize, Deserialize)]
 #[serde(tag = "mode", rename_all = "lowercase", deny_unknown_fields)]
 pub enum MysqlBranchCopyConfig {
     Empty {
         tables: Option<BTreeMap<String, MysqlBranchTableCopyConfig>>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        dump_args: Option<Vec<String>>,
     },
 
     Schema {
         tables: Option<BTreeMap<String, MysqlBranchTableCopyConfig>>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        dump_args: Option<Vec<String>>,
     },
 
-    All,
+    All {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        dump_args: Option<Vec<String>>,
+    },
 }
 
 impl Default for MysqlBranchCopyConfig {
     fn default() -> Self {
         MysqlBranchCopyConfig::Empty {
             tables: Default::default(),
+            dump_args: None,
         }
     }
 }

--- a/mirrord/config/src/feature/database_branches/pg.rs
+++ b/mirrord/config/src/feature/database_branches/pg.rs
@@ -24,7 +24,11 @@ pub struct PgBranchConfig {
     pub iam_auth: Option<IamAuthConfig>,
 }
 
-/// Users can choose from the following copy mode to bootstrap their PostgreSQL branch database:
+/// Users can choose from the following copy mode to bootstrap their PostgreSQL branch database.
+///
+/// All copy modes accept `dump_args`. When this field is set, it replaces the default `pg_dump`
+/// arguments. The defaults are `--no-owner` and `--no-acl`; include them explicitly when
+/// overriding if you want to preserve the default behavior. An empty list means no dump args.
 ///
 /// - Empty
 ///
@@ -39,26 +43,34 @@ pub struct PgBranchConfig {
 ///
 /// - All
 ///
-///   Copies both schema and data of all tables. This option shall only be used
-///   when the data volume of the source database is minimal.
+///   Copies both schema and data of all tables. This option shall only be used when the data volume
+///   of the source database is minimal.
 #[derive(Clone, Debug, Eq, PartialEq, JsonSchema, Serialize, Deserialize)]
 #[serde(tag = "mode", rename_all = "lowercase", deny_unknown_fields)]
 pub enum PgBranchCopyConfig {
     Empty {
         tables: Option<BTreeMap<String, PgBranchTableCopyConfig>>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        dump_args: Option<Vec<String>>,
     },
 
     Schema {
         tables: Option<BTreeMap<String, PgBranchTableCopyConfig>>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        dump_args: Option<Vec<String>>,
     },
 
-    All,
+    All {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        dump_args: Option<Vec<String>>,
+    },
 }
 
 impl Default for PgBranchCopyConfig {
     fn default() -> Self {
         PgBranchCopyConfig::Empty {
             tables: Default::default(),
+            dump_args: None,
         }
     }
 }

--- a/mirrord/operator/src/crd/db_branching/branch_database.rs
+++ b/mirrord/operator/src/crd/db_branching/branch_database.rs
@@ -237,6 +237,10 @@ pub struct SqlBranchCopyConfig {
     /// Per-table copy filters. Only compatible with Empty and Schema modes.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub items: Option<BTreeMap<String, ItemCopyConfig>>,
+    /// Arguments passed to the database dump tool. When this field is set,
+    /// it replaces the operator's dump defaults. An empty list means no dump args.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dump_args: Option<Vec<String>>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, strum_macros::AsRefStr)]
@@ -253,6 +257,7 @@ impl Default for SqlBranchCopyConfig {
         Self {
             mode: SqlBranchCopyMode::Empty,
             items: None,
+            dump_args: None,
         }
     }
 }
@@ -346,17 +351,20 @@ impl From<&PgIamAuthConfig> for IamAuthConfig {
 impl From<PgBranchCopyConfig> for SqlBranchCopyConfig {
     fn from(config: PgBranchCopyConfig) -> Self {
         match config {
-            PgBranchCopyConfig::Empty { tables } => SqlBranchCopyConfig {
+            PgBranchCopyConfig::Empty { tables, dump_args } => SqlBranchCopyConfig {
                 mode: SqlBranchCopyMode::Empty,
                 items: convert_item_copy_configs(tables),
+                dump_args,
             },
-            PgBranchCopyConfig::Schema { tables } => SqlBranchCopyConfig {
+            PgBranchCopyConfig::Schema { tables, dump_args } => SqlBranchCopyConfig {
                 mode: SqlBranchCopyMode::Schema,
                 items: convert_item_copy_configs(tables),
+                dump_args,
             },
-            PgBranchCopyConfig::All => SqlBranchCopyConfig {
+            PgBranchCopyConfig::All { dump_args } => SqlBranchCopyConfig {
                 mode: SqlBranchCopyMode::All,
                 items: None,
+                dump_args,
             },
         }
     }
@@ -365,17 +373,20 @@ impl From<PgBranchCopyConfig> for SqlBranchCopyConfig {
 impl From<MysqlBranchCopyConfig> for SqlBranchCopyConfig {
     fn from(config: MysqlBranchCopyConfig) -> Self {
         match config {
-            MysqlBranchCopyConfig::Empty { tables } => SqlBranchCopyConfig {
+            MysqlBranchCopyConfig::Empty { tables, dump_args } => SqlBranchCopyConfig {
                 mode: SqlBranchCopyMode::Empty,
                 items: convert_item_copy_configs(tables),
+                dump_args,
             },
-            MysqlBranchCopyConfig::Schema { tables } => SqlBranchCopyConfig {
+            MysqlBranchCopyConfig::Schema { tables, dump_args } => SqlBranchCopyConfig {
                 mode: SqlBranchCopyMode::Schema,
                 items: convert_item_copy_configs(tables),
+                dump_args,
             },
-            MysqlBranchCopyConfig::All => SqlBranchCopyConfig {
+            MysqlBranchCopyConfig::All { dump_args } => SqlBranchCopyConfig {
                 mode: SqlBranchCopyMode::All,
                 items: None,
+                dump_args,
             },
         }
     }
@@ -387,14 +398,17 @@ impl From<MssqlBranchCopyConfig> for SqlBranchCopyConfig {
             MssqlBranchCopyConfig::Empty { tables } => SqlBranchCopyConfig {
                 mode: SqlBranchCopyMode::Empty,
                 items: convert_item_copy_configs(tables),
+                dump_args: None,
             },
             MssqlBranchCopyConfig::Schema { tables } => SqlBranchCopyConfig {
                 mode: SqlBranchCopyMode::Schema,
                 items: convert_item_copy_configs(tables),
+                dump_args: None,
             },
             MssqlBranchCopyConfig::All => SqlBranchCopyConfig {
                 mode: SqlBranchCopyMode::All,
                 items: None,
+                dump_args: None,
             },
         }
     }
@@ -444,5 +458,39 @@ impl From<BranchItemCopyConfig> for ItemCopyConfig {
         ItemCopyConfig {
             filter: config.filter,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sql_copy_config_preserves_pg_dump_args() {
+        let copy = SqlBranchCopyConfig::from(PgBranchCopyConfig::Schema {
+            tables: None,
+            dump_args: Some(vec!["--no-comments".to_owned()]),
+        });
+
+        assert!(matches!(copy.mode, SqlBranchCopyMode::Schema));
+        assert!(copy.items.is_none());
+        assert_eq!(copy.dump_args, Some(vec!["--no-comments".to_owned()]));
+    }
+
+    #[test]
+    fn sql_copy_config_preserves_mysql_empty_dump_args() {
+        let copy = SqlBranchCopyConfig::from(MysqlBranchCopyConfig::Empty {
+            tables: Some(BTreeMap::from([(
+                "users".to_owned(),
+                BranchItemCopyConfig {
+                    filter: Some("active = true".to_owned()),
+                },
+            )])),
+            dump_args: Some(vec![]),
+        });
+
+        assert!(matches!(copy.mode, SqlBranchCopyMode::Empty));
+        assert!(copy.items.is_some());
+        assert_eq!(copy.dump_args, Some(vec![]));
     }
 }

--- a/mirrord/operator/src/crd/db_branching/mysql.rs
+++ b/mirrord/operator/src/crd/db_branching/mysql.rs
@@ -75,7 +75,7 @@ impl Default for BranchCopyConfig {
 impl From<MysqlBranchCopyConfig> for BranchCopyConfig {
     fn from(config: MysqlBranchCopyConfig) -> Self {
         match config {
-            MysqlBranchCopyConfig::Empty { tables } => BranchCopyConfig {
+            MysqlBranchCopyConfig::Empty { tables, .. } => BranchCopyConfig {
                 mode: BranchCopyMode::Empty,
                 tables: tables.map(|t| {
                     t.into_iter()
@@ -83,7 +83,7 @@ impl From<MysqlBranchCopyConfig> for BranchCopyConfig {
                         .collect()
                 }),
             },
-            MysqlBranchCopyConfig::Schema { tables } => BranchCopyConfig {
+            MysqlBranchCopyConfig::Schema { tables, .. } => BranchCopyConfig {
                 mode: BranchCopyMode::Schema,
                 tables: tables.map(|t| {
                     t.into_iter()
@@ -91,7 +91,7 @@ impl From<MysqlBranchCopyConfig> for BranchCopyConfig {
                         .collect()
                 }),
             },
-            MysqlBranchCopyConfig::All => BranchCopyConfig {
+            MysqlBranchCopyConfig::All { .. } => BranchCopyConfig {
                 mode: BranchCopyMode::All,
                 tables: None,
             },

--- a/mirrord/operator/src/crd/db_branching/pg.rs
+++ b/mirrord/operator/src/crd/db_branching/pg.rs
@@ -80,7 +80,7 @@ impl Default for BranchCopyConfig {
 impl From<PgBranchCopyConfig> for BranchCopyConfig {
     fn from(config: PgBranchCopyConfig) -> Self {
         match config {
-            PgBranchCopyConfig::Empty { tables } => BranchCopyConfig {
+            PgBranchCopyConfig::Empty { tables, .. } => BranchCopyConfig {
                 mode: BranchCopyMode::Empty,
                 tables: tables.map(|t| {
                     t.into_iter()
@@ -88,7 +88,7 @@ impl From<PgBranchCopyConfig> for BranchCopyConfig {
                         .collect()
                 }),
             },
-            PgBranchCopyConfig::Schema { tables } => BranchCopyConfig {
+            PgBranchCopyConfig::Schema { tables, .. } => BranchCopyConfig {
                 mode: BranchCopyMode::Schema,
                 tables: tables.map(|t| {
                     t.into_iter()
@@ -96,7 +96,7 @@ impl From<PgBranchCopyConfig> for BranchCopyConfig {
                         .collect()
                 }),
             },
-            PgBranchCopyConfig::All => BranchCopyConfig {
+            PgBranchCopyConfig::All { .. } => BranchCopyConfig {
                 mode: BranchCopyMode::All,
                 tables: None,
             },


### PR DESCRIPTION
## Summary
- Add `copy.dump_args` to Postgres and MySQL database branch copy configs for `empty`, `schema`, and `all` modes.
- Preserve the distinction between omitted args, custom args, and an explicit empty list.
- Regenerate `mirrord-schema.json` and update CRD conversion coverage.


Refs INT-448, INT-455.