### PR TITLE
Bump apple-utils to v7

### DIFF
--- a/changelog.d/+bump-apple-utils.internal.md
+++ b/changelog.d/+bump-apple-utils.internal.md
@@ -1,0 +1,1 @@
+Bumped `apple-utils` to v7.

--- a/xtask/src/tasks/sip_binaries.rs
+++ b/xtask/src/tasks/sip_binaries.rs
@@ -6,8 +6,8 @@ use std::{
 use anyhow::{Context, Result};
 
 const APPLE_UTILS_URL: &str =
-    "https://github.com/metalbear-co/appleutils/releases/download/v6/apple-utils-v6.tar.gz";
-const APPLE_UTILS_ARCHIVE_NAME: &str = "apple-utils-v6.tar.gz";
+    "https://github.com/metalbear-co/appleutils/releases/download/v7/apple-utils-v7.tar.gz";
+const APPLE_UTILS_ARCHIVE_NAME: &str = "apple-utils-v7.tar.gz";
 
 /// Fetches the SIP utilities bundle once per workspace and reuses the cached archive afterwards.
 pub fn download() -> Result<PathBuf> {


### PR DESCRIPTION
## Summary
Bumps the `apple-utils` SIP bundle downloaded by `xtask` from `v6` to `v7`.

- Updated the release URL and cached archive name in `xtask/src/tasks/sip_binaries.rs`.
- Added an internal changelog fragment.

## ⚠️ Merge dependency
Do **not** merge until the appleutils v7 release build succeeds:
https://github.com/metalbear-co/appleutils/actions/runs/27756800021/job/82120589269

🤖 Generated with [Claude Code](https://claude.com/claude-code)