### PR TITLE
chaos: docs and UX for serializing rules

### DIFF
--- a/mirrord/cli/src/internal_proxy.rs
+++ b/mirrord/cli/src/internal_proxy.rs
@@ -113,6 +113,9 @@ fn print_addr(listener: &TcpListener) -> io::Result<()> {
 }
 
 /// Starts the session monitor API server if enabled.
+///
+/// `@analytics`: optionally, pass a reporter in to be used by the chaos router for chaos metrics
+/// reporting. If `None`, the chaos router will work as normal but will not report metrics.
 async fn start_session_monitor(
     config: &LayerConfig,
     is_operator: bool,

--- a/mirrord/config/src/feature/network/filter.rs
+++ b/mirrord/config/src/feature/network/filter.rs
@@ -103,7 +103,6 @@ impl AddressFilter {
             }
 
             AddressFilter::Name(hostname, port) if let Some(remote_hostname) = remote_hostname => {
-                tracing::info!(?hostname, ?port, ?remote_hostname, "Do we even get here?");
                 (self.port() == 0 || self.port() == *port) && remote_hostname.contains(hostname)
             }
             _ => false,

--- a/mirrord/config/src/feature/network/filter.rs
+++ b/mirrord/config/src/feature/network/filter.rs
@@ -141,6 +141,33 @@ impl From<nom::Err<nom::error::Error<&str>>> for AddressFilterError {
     }
 }
 
+impl std::fmt::Display for AddressFilter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AddressFilter::Port(port) => {
+                f.write_str(":")?;
+                f.write_str(&port.to_string())?;
+            }
+            AddressFilter::Socket(socket_addr) => {
+                f.write_str(&socket_addr.ip().to_string())?;
+                f.write_str(":")?;
+                f.write_str(&socket_addr.port().to_string())?;
+            }
+            AddressFilter::Name(name, port) => {
+                f.write_str(name)?;
+                f.write_str(":")?;
+                f.write_str(&port.to_string())?;
+            }
+            AddressFilter::Subnet(ip_net, port) => {
+                f.write_str(&ip_net.to_string())?;
+                f.write_str(":")?;
+                f.write_str(&port.to_string())?;
+            }
+        }
+        Ok(())
+    }
+}
+
 impl FromStr for AddressFilter {
     type Err = AddressFilterError;
 

--- a/mirrord/intproxy/src/session_monitor/chaos/analytics.rs
+++ b/mirrord/intproxy/src/session_monitor/chaos/analytics.rs
@@ -42,9 +42,7 @@ impl ChaosAnalyticsReporter {
     pub fn delete_rule(&mut self, rule: &ChaosRule) {
         match self.live_rules.remove(&rule.clone()) {
             Some(start_time) => {
-                let _ = self
-                    .dead_rules
-                    .insert(ChaosRuleInfo::from_rule(rule, start_time));
+                self.dead_rules.insert((rule, start_time).into());
             }
             None => {
                 tracing::debug!(
@@ -58,8 +56,7 @@ impl ChaosAnalyticsReporter {
     // converting each into a [`ChaosRuleInfo`].
     pub fn clear_session_rules(&mut self) {
         self.live_rules.drain().for_each(|(rule, start_time)| {
-            self.dead_rules
-                .insert(ChaosRuleInfo::from_rule(&rule, start_time));
+            self.dead_rules.insert((&rule, start_time).into());
         });
     }
 }
@@ -98,8 +95,9 @@ pub(crate) struct ChaosRuleInfo {
     rule_lifetime_secs: u32,
 }
 
-impl ChaosRuleInfo {
-    pub fn from_rule(rule: &ChaosRule, start_time: Instant) -> Self {
+impl From<(&ChaosRule, Instant)> for ChaosRuleInfo {
+    fn from(value: (&ChaosRule, Instant)) -> Self {
+        let (rule, start_time) = value;
         let rule_lifetime_secs = start_time
             .elapsed()
             .as_secs()
@@ -239,10 +237,7 @@ mod test {
         #[case] expected_json: Value,
     ) {
         let start_time = Instant::now().checked_sub(Duration::from_secs(14)).unwrap();
-        assert_eq!(
-            expected_rule_info,
-            ChaosRuleInfo::from_rule(&chaos_rule, start_time)
-        );
+        assert_eq!(expected_rule_info, (&chaos_rule, start_time).into());
 
         let mut analytics = Analytics::default();
         analytics.add("rule", expected_rule_info);

--- a/mirrord/intproxy/src/session_monitor/chaos/analytics.rs
+++ b/mirrord/intproxy/src/session_monitor/chaos/analytics.rs
@@ -1,3 +1,8 @@
+//! Defines types used to report mirrord chaos usage metrics with the [`AnalyticsReporter`] created
+//! during `internal_proxy::proxy()` in the CLI. The reporter is held in the session monitor
+//! [`AppState`](crate::session_monitor::api::AppState) and accessed during calls made to the
+//! [`chaos_router Router`](crate::session_monitor::chaos::api::chaos_router()).
+
 use std::{
     collections::{HashMap, HashSet},
     sync::atomic::Ordering,
@@ -8,6 +13,9 @@ use mirrord_analytics::{AnalyticValue, Analytics, AnalyticsReporter, CollectAnal
 
 use crate::session_monitor::chaos::rules::{ChaosRule, ChaosSelector};
 
+/// Wraps AnalyticsReporter for use reporting chaos rule analytics. Stores deleted rules instead of
+/// sending anaytics every time a rule is deleted. Sends all rules that were in effect over the
+/// whole session when the session ends.
 pub(crate) struct ChaosAnalyticsReporter {
     /// used to report analytics on session end
     inner: Option<AnalyticsReporter>,
@@ -19,9 +27,6 @@ pub(crate) struct ChaosAnalyticsReporter {
     dead_rules: HashSet<ChaosRuleInfo>,
 }
 
-/// Wraps AnalyticsReporter for use reporting chaos rule analytics. Stores deleted rules instead of
-/// sending anaytics every time a rule is deleted. Sends all rules that were in effect over the
-/// whole session when the session ends.
 impl ChaosAnalyticsReporter {
     pub fn new(inner: Option<AnalyticsReporter>) -> Self {
         Self {
@@ -31,14 +36,17 @@ impl ChaosAnalyticsReporter {
         }
     }
 
-    // Add a rule when it is created. Stores the rule with its creation time to allow us to
-    // calculate its lifetime on Drop.
+    /// Add a newly created chaos rule to `self.live_rules`. Stores a clone of the rule and its
+    /// creation time to allow us to calculate its lifetime on `Drop`.
     pub fn create_rule(&mut self, rule: &ChaosRule) {
         self.live_rules.insert(rule.clone(), Instant::now());
     }
 
-    // Remove a rule that was in effect from `self.live_rules`, and move it to `self.dead_rules`
-    // after converting it into a [`ChaosRuleInfo`]. This is what will be sent in analytics.
+    /// Remove a newly deleted rule that was in effect from `self.live_rules`, and move it to
+    /// `self.dead_rules` after converting it into a [`ChaosRuleInfo`]. This is the data that will
+    /// be sent in analytics.
+    ///
+    /// If the rule being deleted wasn't found in `self.live_rules`, log a `debug!` and ignore.
     pub fn delete_rule(&mut self, rule: &ChaosRule) {
         match self.live_rules.remove(&rule.clone()) {
             Some(start_time) => {
@@ -46,7 +54,8 @@ impl ChaosAnalyticsReporter {
             }
             None => {
                 tracing::debug!(
-                    "BUG: a rule got removed but we didn't have it stored in analytics. The rule will not be reported"
+                    ?rule.id,
+                    "a chaos rule got deleted but we didn't have it stored in analytics - the rule will not be reported"
                 );
             }
         };
@@ -69,7 +78,7 @@ impl Drop for ChaosAnalyticsReporter {
             .iter()
             .for_each(|(rule, _)| self.delete_rule(rule));
 
-        // report all the dead rules
+        // report all the dead rules to the AnalyticsReporter
         let rules_info: Vec<_> = self.dead_rules.drain().map(AnalyticValue::from).collect();
         if let Some(x) = self.inner.as_mut() {
             x.get_mut().add("rules", rules_info)

--- a/mirrord/intproxy/src/session_monitor/chaos/api.rs
+++ b/mirrord/intproxy/src/session_monitor/chaos/api.rs
@@ -153,6 +153,8 @@ async fn get_rule(
     Ok(Json(stored_rule))
 }
 
+/// Helper function to record a new rule creation in `AppState.reporter`, used in the router request
+/// handlers for POST and PUT.
 fn report_create_rule(state: &AppState, rule: &ChaosRule) {
     match state.reporter.try_write() {
         Ok(mut reporter) => reporter.create_rule(rule),
@@ -160,6 +162,8 @@ fn report_create_rule(state: &AppState, rule: &ChaosRule) {
     }
 }
 
+/// Helper function to record a rule deletion in `AppState.reporter`, used in the router request
+/// handlers for DELETE and PUT.
 fn report_delete_rule(state: &AppState, rule: &ChaosRule) {
     match state.reporter.try_write() {
         Ok(mut reporter) => reporter.delete_rule(rule),
@@ -167,6 +171,8 @@ fn report_delete_rule(state: &AppState, rule: &ChaosRule) {
     }
 }
 
+/// Helper function to record deletion of all active rules in `AppState.reporter`, used in the
+/// router request handler for DELETE.
 fn report_clear_session_rules(state: &AppState) {
     match state.reporter.try_write() {
         Ok(mut reporter) => reporter.clear_session_rules(),

--- a/mirrord/intproxy/src/session_monitor/chaos/rules.rs
+++ b/mirrord/intproxy/src/session_monitor/chaos/rules.rs
@@ -1,3 +1,11 @@
+//! Defines types that represent chaos rules ([`ChaosRule`]) and rule requests from the user
+//! ([`ChaosRuleRequest`]). A [`ChaosRuleRequest`] represents a request that has not yet been
+//! validated as a [`ChaosRule`].
+//!
+//! These types are separate for convenience, so we can change the API and implementation of chaos
+//! rules independently of each-other, and to allow for things like selector type
+//! ([`ChaosSelectorType`]) inference from requests.
+
 use std::{fmt::Display, str::FromStr, time::Duration};
 
 use anyhow::{Context, anyhow};
@@ -9,7 +17,7 @@ use mirrord_protocol::{
 use rand::{random_bool, random_range};
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
-use strum_macros::{EnumDiscriminants, EnumString};
+use strum_macros::{Display, EnumDiscriminants, EnumString};
 use thiserror::Error;
 use uuid::Uuid;
 
@@ -20,11 +28,12 @@ use crate::session_monitor::chaos::*;
 ///
 /// Chaos rules are used in the [`IntProxy`](crate::IntProxy) to purposefully inject faults into
 /// traffic coming from sources external to the user's process. They exist locally and are attached
-/// and applied to a single `mirrord` session. When outgoing traffic matches a rule, the `effect`
-/// specified by the user is applied, for example artificial latency or a connection error.
+/// and applied to a single `mirrord` session. When outgoing traffic matches a rule, the
+/// [`ChaosEffectType`] specified by the user is applied, for example artificial latency or a
+/// connection error.
 ///
 /// Rules can be applied to TCP, HTTP or FS traffic with a given percentage probability. The traffic
-/// type is inferred from the requested `selector`.
+/// type is inferred from a request's `selector` ([`ChaosSelectorRequest`]).
 ///
 /// For examples of requests and the rules they correspond to, see [`mod test`].
 ///
@@ -35,10 +44,14 @@ pub struct ChaosRule {
     /// The UUID of the rule (unrelated to the session ID that the rule is attached to). Created
     /// with [`Uuid::new_v4()`] via [`Self::new()`] or [`Self::default()`]. Cannot be specified
     /// by the user.
+    ///
+    /// We use only `id` to compare rules in `PartialEq`/ `Eq`. Although it is unique for live
+    /// rules, it is not necessarily unique among all rules past and present for the current
+    /// session.
     pub id: Uuid,
 
     /// Optional label specified by the user to identify the rule. If no name is given, defaults to
-    /// `None`.
+    /// `None`. No guarantee of uniqueness.
     pub name: Option<String>,
 
     /// An integer used to choose which rule to apply when multiple rules match the same request.
@@ -56,15 +69,17 @@ pub struct ChaosRule {
     pub selector: ChaosSelector,
 
     /// The number of times the rule has been applied, modified by the tasks where the rule is
-    /// applied. Cannot be specified by the user, starts at zero.
+    /// applied. Not necessarily equal to the number of times the matched against network traffic.
+    ///
+    /// Cannot be specified by the user, starts at zero. When a rule is edited via the PUT method,
+    /// the id stays the same but the hit_count resets to zero.
     #[serde(with = "atomic_u32_arc")]
     pub hit_count: Arc<AtomicU32>,
 }
 
 impl ChaosRule {
     /// Creates a new [`Self`](ChaosRule) with a new [`Uuid`]. If @name is `None`, it will be added
-    /// as `None` and skipped when serializing. If @priority is `None`, it will default to 0
-    /// also be skipped when serializing.
+    /// as `None` and skipped when serializing. If @priority is `None`, it will default to 0.
     pub fn new(name: Option<String>, priority: Option<u32>) -> Self {
         Self {
             id: Uuid::new_v4(),
@@ -74,7 +89,7 @@ impl ChaosRule {
         }
     }
 
-    #[tracing::instrument(level = Level::INFO, ret)]
+    /// Returns `true` if the rule `self` applies to `@remote_address`
     pub fn applies_to_address(
         &self,
         remote_address: &SocketAddress,
@@ -88,11 +103,19 @@ impl ChaosRule {
                 upstream.matches_socket_address(remote_address, remote_hostname)
                     && matches!(protocol, NetProtocol::Stream)
             }
-
-            ChaosSelector::Http { .. } | ChaosSelector::Fs { .. } | ChaosSelector::None => false,
+            unimpl @ ChaosSelector::Http { .. } | unimpl @ ChaosSelector::Fs { .. } => {
+                let error = ChaosRuleError::Unimplemented(format!(
+                    "{} selector",
+                    ChaosSelectorType::from(unimpl)
+                ));
+                tracing::error!(%error, "unimplemented selector used in chaos rule with id `{}`", self.id);
+                false
+            }
+            ChaosSelector::None => false,
         }
     }
 
+    /// Convenience method to get the `selector.percentage` for the rule `self`.
     pub fn selector_percentage(&self) -> Percentage {
         match self.selector {
             ChaosSelector::Tcp { percentage, .. }
@@ -102,6 +125,7 @@ impl ChaosRule {
         }
     }
 
+    /// Convenience method to get the `selector` (protocol) type for the rule `self`.
     pub fn selector_type(&self) -> ChaosSelectorType {
         match self.selector {
             ChaosSelector::Tcp { .. } => ChaosSelectorType::Tcp,
@@ -111,37 +135,15 @@ impl ChaosRule {
         }
     }
 
+    /// Convenience method to get the chaos `effect` type for the rule `self`.
     pub fn effect_type(&self) -> Option<ChaosEffectType> {
-        let string = match &self.selector {
-            ChaosSelector::Tcp { effect, .. } => effect.to_string(),
-            ChaosSelector::Http { effect, .. } => effect.to_string(),
-            ChaosSelector::Fs { effect, .. } => effect.to_string(),
-            ChaosSelector::None => {
-                return None;
-            }
-        };
-
-        ChaosEffectType::from_str(&string).ok()
+        self.selector.effect_type()
     }
 }
 
-// Note for devs: Avoid implementing `#[derive(Default)]` on `ChaosRule`: `Uuid::default()`
-// gives `Uuid::nil()`, which is just zero and will lead to conflicts.
+/// Note for devs: Avoid implementing `#[derive(Default)]` on `ChaosRule`: `Uuid::default()`
+/// gives `Uuid::nil()`, which is just zero and will lead to conflicts.
 impl Default for ChaosRule {
-    /// Use [`Self::new()`] instead.
-    ///
-    /// ```
-    /// let default_rule = ChaosRule::default();
-    /// // equivalent to calling ChaosRule::default()
-    /// let expected = ChaosRule {
-    ///     id: default_rule.id, // Uuid::new_v4()
-    ///     name: None,
-    ///     priority: 0,
-    ///     selector: ChaosSelector::None,
-    ///     hit_count: 0,
-    /// };
-    /// assert_eq!(default_rule, expected);
-    /// ```
     fn default() -> Self {
         Self {
             id: Uuid::new_v4(),
@@ -323,8 +325,9 @@ impl TryFrom<(Uuid, ChaosRuleRequest)> for ChaosRule {
     }
 }
 
-/// Represents a rule request from POST requests, corresponding to a rule that is not yet validated.
-/// In converting [`Self`](ChaosRuleRequest) to a [`ChaosRule`], the rule becomes validated.
+/// Represents a rule request from POST and PUT requests, corresponding to a rule that is not yet
+/// validated. In converting [`Self`](ChaosRuleRequest) to a [`ChaosRule`], the rule becomes
+/// validated.
 #[skip_serializing_none]
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub struct ChaosRuleRequest {
@@ -403,8 +406,9 @@ pub struct ChaosSelectorRequest {
     percentage: Option<u32>,
 }
 
+#[skip_serializing_none]
 #[derive(Clone, Serialize, Deserialize, Default, Debug, PartialEq, Hash, EnumDiscriminants)]
-#[strum_discriminants(derive(Serialize, Deserialize))]
+#[strum_discriminants(derive(Serialize, Deserialize, Display))]
 #[strum_discriminants(name(ChaosSelectorType))]
 #[repr(u8)]
 pub enum ChaosSelector {
@@ -428,8 +432,25 @@ pub enum ChaosSelector {
     None = 0,
 }
 
-// having separate enums per selector allows invalid effect/ selector combos to
-// be impossible
+impl ChaosSelector {
+    /// Convenience method to get the chaos `effect` type for the selector `self`. Conversion via
+    /// `String` is done due to `self.effect` having different types in different variants. Returns
+    /// an `Option` because there is no `None` variant of `ChaosEffectType`.
+    pub(crate) fn effect_type(&self) -> Option<ChaosEffectType> {
+        let string = match &self {
+            ChaosSelector::Tcp { effect, .. } => effect.to_string(),
+            ChaosSelector::Http { effect, .. } => effect.to_string(),
+            ChaosSelector::Fs { effect, .. } => effect.to_string(),
+            ChaosSelector::None => {
+                return None;
+            }
+        };
+
+        ChaosEffectType::from_str(&string).ok()
+    }
+}
+
+/// Possible effects for [`ChaosSelector::Tcp`].
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Hash, Default, strum_macros::Display)]
 pub enum TcpChaosEffect {
     Latency(ChaosEffectLatency),
@@ -440,6 +461,7 @@ pub enum TcpChaosEffect {
     Nothing,
 }
 
+/// Possible effects for [`ChaosSelector::Http`].
 #[derive(
     Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Hash, Default, strum_macros::Display,
 )]
@@ -451,6 +473,7 @@ pub enum HttpChaosEffect {
     Nothing,
 }
 
+/// Possible effects for [`ChaosSelector::Fs`].
 #[derive(
     Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Hash, Default, strum_macros::Display,
 )]
@@ -462,9 +485,10 @@ pub enum FsChaosEffect {
     Nothing,
 }
 
+/// An effect for [`ChaosEffectType::Latency`].
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Hash)]
 pub struct ChaosEffectLatency {
-    delay: Duration, // req
+    delay: Duration,
     jitter: Duration,
 }
 
@@ -485,19 +509,26 @@ impl ChaosEffectLatency {
     }
 }
 
+/// An effect for [`ChaosEffectType::ConnectionError`].
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Hash)]
 pub struct ChaosEffectConnectionError {
-    pub error_type: ConnectionErrorType, // req
+    pub error_type: ConnectionErrorType,
     pub after: Duration,
 }
 
+/// The type of error to be returned when [`ChaosEffectConnectionError`] is applied. Can be
+/// converted to/ from [`ErrorKindInternal`], and from [`RemoteIOError`].
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Hash, EnumString)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case", ascii_case_insensitive)]
 pub enum ConnectionErrorType {
+    /// Equivalent to [`ErrorKindInternal::ConnectionReset`].
     Reset,
+    /// Equivalent to [`ErrorKindInternal::TimedOut`].
     TimedOut,
+    /// Equivalent to [`ErrorKindInternal::ConnectionRefused`].
     Refused,
+    /// Equivalent to [`ErrorKindInternal::Unknown`].
     Unknown(String),
 }
 
@@ -538,8 +569,9 @@ impl From<ConnectionErrorType> for RemoteIOError {
 }
 
 /// Helper type for a number between 0 and 100 inclusive. Defaults to 100%. Values larger than 100%
-/// get rounded down to 100%.
+/// get rounded down to 100%. Serializes as the inner `u32`.
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Hash)]
+#[serde(transparent)]
 pub struct Percentage(u32);
 
 impl Percentage {

--- a/mirrord/intproxy/src/session_monitor/chaos/rules.rs
+++ b/mirrord/intproxy/src/session_monitor/chaos/rules.rs
@@ -16,7 +16,7 @@ use mirrord_protocol::{
 };
 use rand::{random_bool, random_range};
 use serde::{Deserialize, Serialize};
-use serde_with::skip_serializing_none;
+use serde_with::{DisplayFromStr, serde_as, skip_serializing_none};
 use strum_macros::{Display, EnumDiscriminants, EnumString};
 use thiserror::Error;
 use uuid::Uuid;
@@ -39,6 +39,7 @@ use crate::session_monitor::chaos::*;
 ///
 /// _WARNING: This type implements `PartialEq` for testing purposes - trying to compare rules
 /// without accounting for their unique `id`s will fail!_
+#[skip_serializing_none]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChaosRule {
     /// The UUID of the rule (unrelated to the session ID that the rule is attached to). Created
@@ -51,7 +52,7 @@ pub struct ChaosRule {
     pub id: Uuid,
 
     /// Optional label specified by the user to identify the rule. If no name is given, defaults to
-    /// `None`. No guarantee of uniqueness.
+    /// `None` and is not serialized. No guarantee of uniqueness.
     pub name: Option<String>,
 
     /// An integer used to choose which rule to apply when multiple rules match the same request.
@@ -406,20 +407,27 @@ pub struct ChaosSelectorRequest {
     percentage: Option<u32>,
 }
 
-#[skip_serializing_none]
+#[serde_as]
+#[serde_with::apply(
+    Option => #[serde(skip_serializing_if = "Option::is_none")]
+)]
 #[derive(Clone, Serialize, Deserialize, Default, Debug, PartialEq, Hash, EnumDiscriminants)]
 #[strum_discriminants(derive(Serialize, Deserialize, Display))]
 #[strum_discriminants(name(ChaosSelectorType))]
 #[repr(u8)]
+#[serde(tag = "type", rename_all = "snake_case")]
 pub enum ChaosSelector {
     Tcp {
+        #[serde_as(as = "DisplayFromStr")]
         upstream: AddressFilter, // req
         percentage: Percentage,
         effect: TcpChaosEffect,
     } = 1,
     Http {
+        #[serde_as(as = "DisplayFromStr")]
         upstream: AddressFilter, // req
         percentage: Percentage,
+        // #[serde(skip_serializing_if = "Option::is_none")]
         filter: Option<HttpFilter>, // ::Body and ::HeaderJq variants unused
         effect: HttpChaosEffect,
     } = 2,
@@ -452,6 +460,7 @@ impl ChaosSelector {
 
 /// Possible effects for [`ChaosSelector::Tcp`].
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Hash, Default, strum_macros::Display)]
+#[serde(rename_all = "snake_case")]
 pub enum TcpChaosEffect {
     Latency(ChaosEffectLatency),
     ConnectionError(ChaosEffectConnectionError),
@@ -465,6 +474,7 @@ pub enum TcpChaosEffect {
 #[derive(
     Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Hash, Default, strum_macros::Display,
 )]
+#[serde(rename_all = "snake_case")]
 pub enum HttpChaosEffect {
     Latency(ChaosEffectLatency),
     HttpOverride,
@@ -477,6 +487,7 @@ pub enum HttpChaosEffect {
 #[derive(
     Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Hash, Default, strum_macros::Display,
 )]
+#[serde(rename_all = "snake_case")]
 pub enum FsChaosEffect {
     Latency(ChaosEffectLatency),
     FsError,
@@ -486,9 +497,14 @@ pub enum FsChaosEffect {
 }
 
 /// An effect for [`ChaosEffectType::Latency`].
+#[serde_as]
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Hash)]
 pub struct ChaosEffectLatency {
+    #[serde_as(as = "serde_with::DurationMilliSeconds<u64>")]
+    #[serde(rename = "delay_ms")]
     delay: Duration,
+    #[serde_as(as = "serde_with::DurationMilliSeconds<u64>")]
+    #[serde(rename = "jitter_ms")]
     jitter: Duration,
 }
 
@@ -510,9 +526,12 @@ impl ChaosEffectLatency {
 }
 
 /// An effect for [`ChaosEffectType::ConnectionError`].
+#[serde_as]
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Hash)]
 pub struct ChaosEffectConnectionError {
     pub error_type: ConnectionErrorType,
+    #[serde_as(as = "serde_with::DurationMilliSeconds<u64>")]
+    #[serde(rename = "after_ms")]
     pub after: Duration,
 }
 

--- a/mirrord/intproxy/src/session_monitor/chaos/rules.rs
+++ b/mirrord/intproxy/src/session_monitor/chaos/rules.rs
@@ -98,8 +98,6 @@ impl ChaosRule {
         remote_hostname: Option<&String>,
     ) -> bool {
         match &self.selector {
-            // TODO(alex) [high]: We need to resolve the `AddressFilter::Name(name, port)` to an ip,
-            // so we can compare it with the `remote_address`.
             ChaosSelector::Tcp { upstream, .. } => {
                 upstream.matches_socket_address(remote_address, remote_hostname)
                     && matches!(protocol, NetProtocol::Stream)


### PR DESCRIPTION
- docs for analytics and rules
- switched a random `impl` into a `impl From`
- improved rule serialization to be less ugly and match the request more closely
    - `Duration` is displayed as `field_ms: number `
    - selector is tagged with "type" field instead of nested
    - `Percentage` is displayed as `u32`
    - `AddressFilter` uses `Display`/ `FromStr`

### Example rule in JSON
<img width="584" height="303" alt="Screenshot 2026-06-18 at 14 41 54" src="https://github.com/user-attachments/assets/784271ab-7456-48bd-8c7c-e49695219d54" />
