### PR TITLE
ci: build the mirrord CLI once and reuse it across e2e jobs

### DIFF
--- a/.github/workflows/build-e2e-cli.yaml
+++ b/.github/workflows/build-e2e-cli.yaml
@@ -1,0 +1,42 @@
+name: Build E2E CLI
+
+# Builds the mirrord CLI + layer once (zigbuild + wizard, exactly how the e2e
+# job used to build them inline) and uploads them as the `mirrord-e2e-cli`
+# artifact. The e2e matrix legs download this instead of each recompiling the
+# CLI on the critical path. See DEV-64.
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  build-e2e-cli:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: 22
+      - name: Enable corepack (pnpm-only; leave npm alone for wizard build)
+        run: corepack enable pnpm
+      - uses: metalbear-co/setup-rust-toolchain@a8d42d5aa259519dac1faeee20e37c1fb43453a3
+        with:
+          cache-shared-key: mirrord-${{ runner.os }}-${{ runner.arch }}
+      - uses: metalbear-co/setup-protoc@770e54d44679c8e1d8fdc06d1d9268fa79fbefb4
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
+      - run: uv tool install cargo-zigbuild==0.22.1
+      - run: uv tool install ziglang==0.15.2 --with-executables-from ziglang
+      - run: ln -sf "$(command -v python-zig)" "$HOME/.local/bin/zig"
+      - run: cargo xtask build-cli
+      - name: Upload mirrord CLI + layer
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: mirrord-e2e-cli
+          path: |
+            target/x86_64-unknown-linux-gnu/debug/mirrord
+            target/x86_64-unknown-linux-gnu/debug/libmirrord_layer.so
+          if-no-files-found: error

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -234,6 +234,14 @@ jobs:
     if: ${{ needs.plan.outputs.rs_changed == 'true' || needs.plan.outputs.ci_changed == 'true' || needs.plan.outputs.dockerfile_changed == 'true' }}
     uses: ./.github/workflows/build-cli-image.yaml
 
+  # Build the mirrord CLI + layer once so the e2e matrix legs download them
+  # instead of each recompiling (zigbuild + wizard) on the critical path. DEV-64.
+  build_e2e_cli:
+    needs: plan
+    if: ${{ needs.plan.outputs.rs_changed == 'true' || needs.plan.outputs.ci_changed == 'true' }}
+    uses: ./.github/workflows/build-e2e-cli.yaml
+    secrets: inherit
+
   # ── tests ───────────────────────────────────────────────────────────
 
   test_agent:
@@ -270,7 +278,7 @@ jobs:
     secrets: inherit
 
   e2e:
-    needs: [plan, test_agent_image]
+    needs: [plan, test_agent_image, build_e2e_cli]
     if: ${{ needs.plan.outputs.rs_changed == 'true' || needs.plan.outputs.ci_changed == 'true' }}
     uses: ./.github/workflows/test-e2e.yaml
     secrets: inherit
@@ -316,6 +324,7 @@ jobs:
         vscode_e2e_on_release_branch,
         test_agent_image,
         test_cli_image,
+        build_e2e_cli,
         macos_tests,
         integration_tests,
         e2e,

--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -35,11 +35,6 @@ jobs:
           docker-images: true
           swap-storage: true
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
-        with:
-          node-version: 22
-      - name: Enable corepack (pnpm-only; leave npm alone for wizard build)
-        run: corepack enable pnpm
       - uses: metalbear-co/setup-rust-toolchain@a8d42d5aa259519dac1faeee20e37c1fb43453a3
         with:
           cache-shared-key: mirrord-${{ runner.os }}-${{ runner.arch }}
@@ -62,12 +57,14 @@ jobs:
       - uses: metalbear-co/setup-protoc@770e54d44679c8e1d8fdc06d1d9268fa79fbefb4
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
-      - run: uv --version
-      - run: uv tool install cargo-zigbuild==0.22.1
-      - run: uv tool install ziglang==0.15.2 --with-executables-from ziglang
-      - run: ln -sf "$(command -v python-zig)" "$HOME/.local/bin/zig"
-      - run: cargo xtask build-cli
+      # The mirrord CLI + layer are built once in the `build_e2e_cli` job and
+      # downloaded here, instead of compiling them in each e2e matrix leg.
+      - name: Download mirrord CLI + layer (built once upstream)
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: mirrord-e2e-cli
+          path: target/x86_64-unknown-linux-gnu/debug
+      - run: chmod +x target/x86_64-unknown-linux-gnu/debug/mirrord
       - name: Run cli E2E tests
         if: ${{ matrix.container-runtime == 'docker' }}
         run: |

--- a/changelog.d/+e2e-build-cli-once.internal.md
+++ b/changelog.d/+e2e-build-cli-once.internal.md
@@ -1,0 +1,1 @@
+Speed up CI by building the mirrord CLI and layer once and sharing them with the e2e jobs as an artifact, instead of recompiling them (zigbuild + wizard) in every e2e matrix leg.


### PR DESCRIPTION
> 🚧 **Verifying — please don't merge yet.** CI is running to confirm the speed-up; I'll fill in the Results section below (measured before/after + graphs + run links) once it completes.

## TL;DR

Both `e2e` matrix legs (`docker/kind` and `containerd/minikube`) currently recompile the mirrord CLI + layer from scratch before running tests. This builds them **once** in a new `build_e2e_cli` job and has the e2e legs download the prebuilt binaries — moving ~4 min of compile **off the e2e critical path** and eliminating the duplicate build.

## Background — why the per-leg build is slow

Profiling a recent `main` run ([run #27764028886](https://github.com/metalbear-co/mirrord/actions/runs/27764028886)), each e2e leg spends **~4 min in `cargo xtask build-cli`**, compiling ~630 crates — even though the rust-cache reports a **full hit** and restores 1.5 GB.

The catch: a cache *key* hit is not an *artifact* hit. `build-cli` cross-compiles via `cargo-zigbuild` to a glibc-pinned target (`x86_64-unknown-linux-gnu.2.17`) **with the `wizard` feature** (the `mirrord wizard` web-server stack — axum/tower/hyper/tungstenite/…). That's a different build configuration than the native, non-wizard builds that populate the shared cache, so the fingerprints miss and it recompiles almost everything. Jobs that build natively (e.g. `integration`) reuse the same cache fine — so this is specific to the e2e build, not a general cache problem.

And because it's in the matrix, that ~4 min cold build happens **twice per run**, both on the critical path (`plan` → `build-agent-image` → `e2e`).

## What this PR does

- **New `build-e2e-cli.yaml`** reusable workflow: runs `cargo xtask build-cli` once (same env as before — node/pnpm for the wizard, zigbuild for the target) and uploads `mirrord` + `libmirrord_layer.so` as the `mirrord-e2e-cli` artifact.
- **New `build_e2e_cli` job** in `ci.yaml`: runs in parallel with `build-agent-image`. The `e2e` job already waits on `build-agent-image` (which is longer), so this adds nothing to the critical path.
- **`test-e2e.yaml`**: downloads the artifact, `chmod +x`'s the binary, and drops the per-leg `cargo xtask build-cli` (plus the now-unused node/corepack/uv/zigbuild setup). `cargo xtask test-e2e` already accepts `--binary`/`--layer`, so it consumes the prebuilt artifacts and compiles only the `mirrord-tests` crate.

This mirrors the pattern the operator repo already uses (build once → upload artifact → test jobs download). The agent image is already handled this way in this repo; this extends it to the CLI binary.

## Expected impact

- CLI compiled **once per run instead of twice**.
- ~4 min of cold compile removed from each e2e leg → e2e job ~17 min → ~13 min.
- Critical path ~27 min → ~22–23 min (exact numbers in Results below once CI confirms).
- Net **cost** savings too: one fewer full `build-cli` per run.

## Risk / things to check in review

- The downloaded binary needs `chmod +x` (artifacts drop the executable bit) — handled.
- The artifact must be the **wizard** build (the `mirrord wizard` e2e step runs it) — `build_e2e_cli` builds with wizard.
- No behavior change to the tests themselves; only *where* the CLI is built.

## Results

⏳ _CI in progress — will update with the measured e2e job time (before vs after), total wall-clock, and links to the runs._

---

Refs DEV-64.
