### PR TITLE
ci: refresh Rust dependency cache instead of freezing a stale snapshot

### DIFF
--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -35,6 +35,15 @@ jobs:
           docker-images: true
           swap-storage: true
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      # Read-only consumer of the Rust dependency cache that the integration job
+      # populates on main (identical key scheme). e2e never writes the cache, so
+      # it can't proliferate entries; it just warm-starts `cargo xtask build-cli`
+      # on the critical path. See test-integration.yaml for the key rationale.
+      - name: Compute Rust dependency cache key
+        id: rustdeps
+        run: |
+          hash=$(awk 'BEGIN{RS="";ORS="\n\n"} { if ($0 ~ /(^|\n)source = /) {print} else {b=$0; gsub(/\nversion = "[^"]*"/,"",b); print b} }' Cargo.lock | sha256sum | cut -d" " -f1)
+          echo "key=rs1-mirrord-${{ runner.os }}-${{ runner.arch }}-$hash" >> "$GITHUB_OUTPUT"
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: 22
@@ -42,7 +51,17 @@ jobs:
         run: corepack enable pnpm
       - uses: metalbear-co/setup-rust-toolchain@a8d42d5aa259519dac1faeee20e37c1fb43453a3
         with:
-          cache-shared-key: mirrord-${{ runner.os }}-${{ runner.arch }}
+          cache: false
+      - name: Restore Rust dependency cache
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ steps.rustdeps.outputs.key }}
+          restore-keys: |
+            rs1-mirrord-${{ runner.os }}-${{ runner.arch }}-
       - uses: ./.github/actions/e2e-setup
         with:
           container-runtime: ${{ matrix.container-runtime }}

--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -17,10 +17,32 @@ jobs:
       MIRRORD_LAYER_FILE: ${{ github.workspace }}/target/x86_64-unknown-linux-gnu/debug/libmirrord_layer.so
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      # The Rust cache key hashes Cargo.lock with the workspace crates' own
+      # version lines stripped out. Release commits rewrite every workspace
+      # crate's version every few days without touching a single third-party
+      # dependency; stripping those lines keeps the key stable across releases
+      # so it only rotates on real dependency changes (~weekly). restore-keys
+      # warm-starts each new key from the previous build, and only main writes
+      # the cache (see the save step below).
+      - name: Compute Rust dependency cache key
+        id: rustdeps
+        run: |
+          hash=$(awk 'BEGIN{RS="";ORS="\n\n"} { if ($0 ~ /(^|\n)source = /) {print} else {b=$0; gsub(/\nversion = "[^"]*"/,"",b); print b} }' Cargo.lock | sha256sum | cut -d" " -f1)
+          echo "key=rs1-mirrord-${{ runner.os }}-${{ runner.arch }}-$hash" >> "$GITHUB_OUTPUT"
       - uses: metalbear-co/setup-rust-toolchain@a8d42d5aa259519dac1faeee20e37c1fb43453a3
         with:
-          cache-shared-key: mirrord-${{ runner.os }}-${{ runner.arch }}
+          cache: false
           target: x86_64-unknown-linux-gnu
+      - name: Restore Rust dependency cache
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ steps.rustdeps.outputs.key }}
+          restore-keys: |
+            rs1-mirrord-${{ runner.os }}-${{ runner.arch }}-
       - run: |
           cd mirrord/layer-tests/tests/apps/issue1123
           rustc issue1123.rs --out-dir target
@@ -142,6 +164,25 @@ jobs:
         run: cargo test --target x86_64-unknown-linux-gnu -p mirrord-protocol-io
       - name: mirrord jaq UT
         run: cargo test --target x86_64-unknown-linux-gnu -p mirrord-jaq
+      # Drop the workspace crates' own artifacts before saving so the cache holds
+      # only third-party dependencies (the workspace crates change every commit
+      # and recompile regardless, so caching them just bloats the entry). Only
+      # main saves, so PRs never mint a cache and can't evict each other.
+      - name: Prune workspace crates from cache (keep dependencies only)
+        if: ${{ github.ref == 'refs/heads/main' }}
+        run: |
+          cargo metadata --format-version=1 --no-deps 2>/dev/null \
+            | jq -r '.packages[].name' \
+            | while read -r p; do cargo clean -p "$p" --target x86_64-unknown-linux-gnu 2>/dev/null || true; done
+      - name: Save Rust dependency cache
+        if: ${{ github.ref == 'refs/heads/main' }}
+        uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ steps.rustdeps.outputs.key }}
       - name: save intproxy logs
         continue-on-error: true
         if: ${{ always() }}

--- a/changelog.d/+ci-rust-cache.internal.md
+++ b/changelog.d/+ci-rust-cache.internal.md
@@ -1,0 +1,1 @@
+CI Rust dependency cache now refreshes on real dependency changes instead of freezing on a stale snapshot, cutting redundant recompilation in the integration and e2e jobs.


### PR DESCRIPTION
## TL;DR

mirrord's Rust CI cache is keyed on a fixed string with no `Cargo.lock` component, so it never refreshes. The live Linux-x64 cache has been **frozen since 2026-04-15 (~2 months)** even though dependencies have changed dozens of times since — so every run recompiles all that drift. This PR keys the cache on a *normalized* `Cargo.lock` hash, warm-starts new keys from the previous cache via `restore-keys`, and saves only on `main`. `integration` writes the cache; `e2e` reads it (so the critical path benefits too).

## Why this makes sense (from the data)

- The cache key is literally `v0-rust-mirrord-Linux-X64-Linux-x64` — no lockfile/source hash — and on a hit it never re-saves (`Cache hit … not saving cache`). `gh cache list` shows it `created=2026-04-15`, still in use today.
- A single `integration` run compiles **113 distinct crates (86 third-party) out of 956** in the lockfile. The workspace crates always recompile, but a large share of those 86 deps is pure staleness — they changed on `main` after the cache froze and now recompile every run, on every branch, indefinitely.

## How much time this saves

- A CLI compile with **no** rust-cache (the Docker image build) takes ~13.6 min vs ~4.2 min warm — caching is worth ~3× / ~9 min per compile. A *stale* cache only gives back part of that; a fresh one recovers the drift portion of `e2e`'s ~4.2 min `cargo xtask build-cli`, which sits on the critical path (`build-agent-image` → `e2e` ≈ 26 min). Expect a couple of minutes off the critical path plus real runner-minute savings in `integration`.
- This PR deliberately does **not** touch the larger structural levers (build the CLI once and share it; cache the agent Docker build). Those are follow-ups with bigger wins.

## Why this won't cause too many evictions

- **Normalized key.** 7 of the last 10 `Cargo.lock` changes were "Prepare release" commits that bump only workspace crate versions — zero third-party deps. Hashing the raw lockfile would rotate the key ~5×/week and mint a near-duplicate ~1.5 GB cache each time. Stripping the workspace `version =` lines drops that to **real dependency changes only (~1–2×/week)**. Verified against history: a release bump leaves the normalized hash identical, while `+http 1.4.0` changes it.
- **Save on `main` only.** PR runs never write the cache, so open PRs can't proliferate ~1.5 GB entries or evict each other.
- **Prune before save.** Workspace crates (which recompile every commit regardless) are dropped before saving, keeping the entry lean (~1.5 GB), matching the upstream rust-cache behavior we'd otherwise lose by controlling the key directly.
- **Headroom.** The repo's Actions cache is ~7.9 / 10 GB. This adds one ~1.5 GB entry (→ ~9.4 GB) while `lint`/`macOS`/`Windows` keep the old key for now — under the cap, no forced eviction.

## Scope

`integration` (writer) + `e2e` (reader) on Linux x64 only, as a reviewable first step. `lint` (x64), `macOS`, and `Windows` still use the old wrapper cache; once this is validated they migrate to the same scheme and the old `v0-rust-mirrord-*` caches age out. Reclaiming the ~2.3 GB of churning CodeQL caches (separate) frees additional headroom.

## First-run behaviour

This PR's own CI runs **cold** for the new `rs1-` cache namespace (it starts empty), and the save step is `main`-only — so `integration`/`e2e` won't be faster *on this PR* and won't write a cache. The benefit starts after merge, once one `main` run populates the cache; subsequent PR and `main` runs then restore it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
