### PR TITLE
Re-extract apple utils binaries only on version change

### DIFF
--- a/changelog.d/+apple-utils-version.changed.md
+++ b/changelog.d/+apple-utils-version.changed.md
@@ -1,0 +1,1 @@
+The bundled Apple utilities are now re-extracted to `~/.mirrord/binaries` only when their version changes, tracked via `~/.mirrord/binaries_version`.

--- a/mirrord/sip/src/lib.rs
+++ b/mirrord/sip/src/lib.rs
@@ -66,7 +66,7 @@ mod main {
         },
     };
     use once_cell::sync::Lazy;
-    use tracing::{trace, warn};
+    use tracing::{debug, trace, warn};
     use which::which;
 
     use super::*;
@@ -91,6 +91,14 @@ mod main {
         concat!("mirrord-bin-ghu3278mz-", env!("CARGO_PKG_VERSION"));
 
     pub const FRAMEWORKS_ENV_VAR_NAME: &str = "DYLD_FALLBACK_FRAMEWORK_PATH";
+
+    /// Version of the apple utils bundle compiled into this binary. Recorded in
+    /// [`MIRRORD_BINARIES_VERSION_PATH_BUF`] on extraction so we can detect when an upgraded CLI
+    /// ships a newer bundle and needs to re-extract.
+    ///
+    /// Must be kept in sync with the version downloaded by `xtask` (see
+    /// `xtask/src/tasks/sip_binaries.rs`).
+    pub const APPLE_UTILS_VERSION: &str = "v7";
 
     /// The path of mirrord's internal temp binary dir, where we put SIP-patched binaries and
     /// scripts. Uses `temp_dir()`/mirrord/ because this is where the layer is extracted
@@ -122,6 +130,15 @@ mod main {
     /// String version of [`MIRRORD_BINARIES_DIR_PATH_BUF`], without a trailing `/`.
     pub static MIRRORD_BINARIES_DIR_STRING: Lazy<String> =
         Lazy::new(|| get_temp_bin_str_prefix(&MIRRORD_BINARIES_DIR_PATH_BUF));
+
+    /// Path to `~/.mirrord/binaries_version`, where we record the apple utils version that was last
+    /// extracted into [`MIRRORD_BINARIES_DIR_PATH_BUF`]. Used to decide whether the bundled
+    /// binaries need to be re-extracted after a CLI upgrade.
+    pub static MIRRORD_BINARIES_VERSION_PATH_BUF: Lazy<PathBuf> = Lazy::new(|| {
+        PathBuf::from(env::var("HOME").unwrap_or_default())
+            .join(".mirrord")
+            .join("binaries_version")
+    });
 
     /// Check if a cpu subtype (already parsed with the correct endianness) is arm64e, given its
     /// main cpu type is arm64. We only consider the lowest byte in the check.
@@ -849,15 +866,48 @@ mod main {
     }
 
     /// Extracts the bundled apple utils archive into `binaries_dir`.
-    /// No-op if the directory already exists and is non-empty.
+    ///
+    /// We record the last extracted version (see [`APPLE_UTILS_VERSION`]) in
+    /// [`MIRRORD_BINARIES_VERSION_PATH_BUF`] and only re-extract when it doesn't match (or when
+    /// nothing was extracted yet), so that upgrading the CLI refreshes stale binaries while
+    /// repeated runs of the same version stay cheap.
     pub fn extract_sip_binaries(binaries_dir: &Path, archive_bytes: &[u8]) -> Result<()> {
-        if binaries_dir.exists() && std::fs::read_dir(binaries_dir)?.next().is_some() {
-            return Ok(());
+        let version_path = &*MIRRORD_BINARIES_VERSION_PATH_BUF;
+        match std::fs::read_to_string(version_path) {
+            Ok(extracted) if extracted == APPLE_UTILS_VERSION => {
+                debug!(
+                    version = APPLE_UTILS_VERSION,
+                    "Apple utils binaries already match this version, skipping extraction"
+                );
+                return Ok(());
+            }
+            Ok(extracted) => {
+                debug!(
+                    extracted,
+                    expected = APPLE_UTILS_VERSION,
+                    "Apple utils binaries version mismatch, re-extracting"
+                );
+            }
+            Err(_) => {
+                debug!(
+                    version = APPLE_UTILS_VERSION,
+                    "No extracted apple utils binaries found, extracting"
+                );
+            }
+        }
+
+        if binaries_dir.exists() {
+            std::fs::remove_dir_all(binaries_dir)?;
         }
         std::fs::create_dir_all(binaries_dir)?;
         let gz = flate2::read::GzDecoder::new(Cursor::new(archive_bytes));
         let mut archive = tar::Archive::new(gz);
         archive.unpack(binaries_dir)?;
+
+        if let Some(parent) = version_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::write(version_path, APPLE_UTILS_VERSION)?;
         Ok(())
     }
 

--- a/xtask/src/tasks/sip_binaries.rs
+++ b/xtask/src/tasks/sip_binaries.rs
@@ -5,9 +5,11 @@ use std::{
 
 use anyhow::{Context, Result};
 
-const APPLE_UTILS_URL: &str =
-    "https://github.com/metalbear-co/appleutils/releases/download/v7/apple-utils-v7.tar.gz";
-const APPLE_UTILS_ARCHIVE_NAME: &str = "apple-utils-v7.tar.gz";
+/// Version of the apple utils release to download, used to build the download URL and archive name.
+///
+/// Must be kept in sync with `mirrord_sip::APPLE_UTILS_VERSION`, which the CLI uses at runtime to
+/// decide whether the binaries already extracted to `~/.mirrord/binaries` match this release.
+const APPLE_UTILS_VERSION: &str = "v7";
 
 /// Fetches the SIP utilities bundle once per workspace and reuses the cached archive afterwards.
 pub fn download() -> Result<PathBuf> {
@@ -22,7 +24,10 @@ pub fn download() -> Result<PathBuf> {
     }
 
     println!("Downloading SIP utilities bundle...");
-    let response = reqwest::blocking::get(APPLE_UTILS_URL)
+    let url = format!(
+        "https://github.com/metalbear-co/appleutils/releases/download/{APPLE_UTILS_VERSION}/apple-utils-{APPLE_UTILS_VERSION}.tar.gz"
+    );
+    let response = reqwest::blocking::get(&url)
         .context("Failed to download SIP utilities bundle")?
         .error_for_status()
         .context("SIP utilities download returned an error status")?;
@@ -39,5 +44,5 @@ pub fn download() -> Result<PathBuf> {
 fn sip_binaries_archive_path() -> PathBuf {
     Path::new("target")
         .join("sip")
-        .join(APPLE_UTILS_ARCHIVE_NAME)
+        .join(format!("apple-utils-{APPLE_UTILS_VERSION}.tar.gz"))
 }


### PR DESCRIPTION
## What

The apple utils (SIP) binaries bundled into the CLI were extracted to `~/.mirrord/binaries` only when that directory was empty — so after upgrading the CLI, stale binaries from an older bundle would silently be reused.

This change tracks the bundled version explicitly:

- `mirrord_sip::APPLE_UTILS_VERSION` is a `const` holding the bundled version (`v7`).
- On extraction, `extract_sip_binaries` writes that version to `~/.mirrord/binaries_version`.
- On each run it compares the compiled const against that file and re-extracts only when they differ (or when the file doesn't exist), clearing the dir first so stale files don't linger.
- A `debug!` log is emitted for each case: matching version (skip), version mismatch (re-extract), and no version file (extract).

`xtask` keeps its own `APPLE_UTILS_VERSION` const driving the download URL/archive name; both consts are cross-referenced in doc comments and must be bumped together (xtask can't depend on the macOS-gated `mirrord-sip` crate).

## Why

Closes COR-1580 — version the macOS utils binaries on the user side and replace them when the CLI ships a newer bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)