### PR TITLE
Fix macOS 26 Turbopack worker crashes (DNS segfault + EOPNOTSUPP flood)

### DIFF
--- a/changelog.d/+eopnotsupp-soft-error.fixed.md
+++ b/changelog.d/+eopnotsupp-soft-error.fixed.md
@@ -1,0 +1,1 @@
+Stopped the layer from reporting `EOPNOTSUPP` ("Operation not supported on socket") socket errors as hard layer errors, which flooded logs and could kill processes such as Turbopack workers.

--- a/changelog.d/+macos26-dns-configuration-segfault.fixed.md
+++ b/changelog.d/+macos26-dns-configuration-segfault.fixed.md
@@ -1,0 +1,1 @@
+Fixed a segfault in the macOS DNS configuration hook (`dns_configuration_free`) that crashed short-lived Node workers (e.g. Next.js/Turbopack) on macOS 26 when remote DNS config could not be built.

--- a/mirrord/layer-lib/src/error.rs
+++ b/mirrord/layer-lib/src/error.rs
@@ -39,19 +39,24 @@ mod ignore_codes {
     ///
     /// Prefer using [`is_ignored_code`] instead of relying on this constant.
     #[cfg(unix)]
-    const IGNORE_ERROR_CODES: [i32; 4] = [
+    const IGNORE_ERROR_CODES: [i32; 5] = [
         libc::EINPROGRESS,
         libc::EAFNOSUPPORT,
         libc::EADDRINUSE,
         libc::EPERM,
+        // Some sockets (e.g. the loopback IPC sockets that Turbopack's Node workers use) reject
+        // operations the layer performs on them with `EOPNOTSUPP`. That's a property of the
+        // socket, not a problem in the layer, so don't surface it as a hard error.
+        libc::EOPNOTSUPP,
     ];
 
     #[cfg(windows)]
-    const IGNORE_ERROR_CODES: [i32; 4] = [
+    const IGNORE_ERROR_CODES: [i32; 5] = [
         winapi::um::winsock2::WSAEINPROGRESS,
         winapi::um::winsock2::WSAEAFNOSUPPORT,
         winapi::um::winsock2::WSAEADDRINUSE,
         winapi::um::winsock2::WSAEACCES, // Using EACCES as equivalent to EPERM
+        winapi::um::winsock2::WSAEOPNOTSUPP,
     ];
 
     /// Checks if an error code from some function should be treated as a hard error, or

--- a/mirrord/layer/src/socket/hooks.rs
+++ b/mirrord/layer/src/socket/hooks.rs
@@ -583,10 +583,16 @@ pub(super) unsafe extern "C" fn sendmsg_nocancel_detour(
 
 /// Not a faithful reproduction of what [`FN_DNS_CONFIGURATION_COPY`] is supposed to do, see
 /// [`remote_dns_configuration_copy`].
+///
+/// We must always hand back a non-null, [`Box`]-allocated [`dns_config_t`], even when we can't
+/// build a real one: a `Bypass` or an `Error` from [`remote_dns_configuration_copy`] both fall back
+/// to an empty config. Returning null here would make callers (e.g. c-ares'
+/// `ares_init_by_sysconfig`) pass that null straight to [`dns_configuration_free_detour`], which
+/// would then dereference it and crash.
 #[cfg(target_os = "macos")]
 #[hook_guard_fn]
 unsafe extern "C" fn dns_configuration_copy_detour() -> *mut dns_config_t {
-    remote_dns_configuration_copy().unwrap_or_bypass_with(|_| {
+    let empty_config = || {
         Box::into_raw(Box::new(dns_config_t {
             n_resolver: 0,
             resolver: std::ptr::null_mut(),
@@ -594,7 +600,12 @@ unsafe extern "C" fn dns_configuration_copy_detour() -> *mut dns_config_t {
             scoped_resolver: std::ptr::null_mut(),
             reserved: [0; 5],
         }))
-    })
+    };
+
+    match remote_dns_configuration_copy() {
+        Detour::Success(config) => config,
+        Detour::Bypass(_) | Detour::Error(_) => empty_config(),
+    }
 }
 
 /// Because we create our pointers with boxes and not alloc ourselfs the easies way to safely
@@ -603,6 +614,13 @@ unsafe extern "C" fn dns_configuration_copy_detour() -> *mut dns_config_t {
 #[cfg(target_os = "macos")]
 #[hook_guard_fn]
 unsafe extern "C" fn dns_configuration_free_detour(config: *mut dns_config_t) {
+    // Callers are allowed to pass null (and c-ares on macOS 26 does), in which case there's
+    // nothing to free. Reconstructing boxes from a null pointer would dereference near-null and
+    // segfault.
+    if config.is_null() {
+        return;
+    }
+
     unsafe {
         // It should drop it automatically after recreating the boxes and vecs
 

--- a/mirrord/layer/src/socket/ops.rs
+++ b/mirrord/layer/src/socket/ops.rs
@@ -1307,11 +1307,13 @@ pub(super) unsafe fn free_dns_resolver_t(resolver: *mut dns_resolver_t) {
 #[cfg(target_os = "macos")]
 #[mirrord_layer_macro::instrument(level = "trace", ret)]
 pub(super) fn remote_dns_configuration_copy() -> Detour<*mut dns_config_t> {
+    tracing::debug!("remote_dns_configuration_copy called");
     let remote = read_remote_resolv_conf()?;
 
     // TODO: possibly create a different error rather than the almost correct
     // [`HookError::DNSNoName`]
     let resolv_conf = resolv_conf::Config::parse(remote).map_err(|_error| HookError::DNSNoName)?;
+    tracing::debug!("remote_dns_configuration_copy resolv_conf done");
 
     let options = CString::new(format!(
         "ndots:{ndots} attempts:{attempts}",
@@ -1351,6 +1353,7 @@ pub(super) fn remote_dns_configuration_copy() -> Detour<*mut dns_config_t> {
         reserved: [0; 5],
     }));
 
+    tracing::debug!("remote_dns_configuration_copy success");
     Detour::Success(config)
 }
 


### PR DESCRIPTION
## Summary

Two issues crash short-lived Node workers (e.g. Next.js / Turbopack PostCSS workers) running under mirrord on **macOS 26 (Tahoe)**. Both are addressed here.

### A) SIGSEGV in the DNS hook (`KERN_INVALID_ADDRESS at 0x4`)

`dns_configuration_copy_detour` returned **NULL** on the `Detour::Error` path: `unwrap_or_bypass_with` only routes `Bypass` through the empty-config fallback, while `Error` went through `impl From<HookError> for *mut dns_config_t`, which returns `null_mut()`. This `Error` happens when `remote_dns_configuration_copy()` can't build a config — e.g. the remote `/etc/resolv.conf` read fails, which races during the bootstrap of short-lived workers.

c-ares (`ares_init_by_sysconfig`) then called `dns_configuration_free(NULL)`, and the free detour read `.resolver` at offset 4 of a null pointer → segfault at `0x4`.

Fix:
- `dns_configuration_copy_detour` now returns the empty `dns_config_t` box on **both** `Bypass` and `Error` — never null.
- `dns_configuration_free_detour` null-checks `config` before reconstructing boxes (defensive; c-ares on macOS 26 can also pass null directly).

### B) `EOPNOTSUPP` flagged as a hard error

The layer surfaced `EOPNOTSUPP` (code 102, "Operation not supported on socket") on the worker's loopback socket as a hard error, flooding logs with `Error occured in Layer >> IO(...)`. Added `EOPNOTSUPP` / `WSAEOPNOTSUPP` to `IGNORE_ERROR_CODES` so it's treated as a soft, pass-through errno like `EADDRINUSE`/`EPERM` already are.

## Testing

- `cargo check`, `cargo clippy -- --deny warnings`, and `cargo fmt` clean on `mirrord-layer` and `mirrord-layer-lib`.

Refs COR-1583 (follow-up to the Turbopack "magic" turbo feature, which did not resolve the macOS 26 crashes).