### PR TITLE
mirrord UI command UX

### DIFF
--- a/changelog.d/+ui-qol.changed.md
+++ b/changelog.d/+ui-qol.changed.md
@@ -1,0 +1,4 @@
+- added `--no-browser` flag to prevent the browser opening automatically
+- UI now respects `BROWSER` env var for selecting which browser to open with
+- UI auth token can be set as `x-auth-token` header
+- `mirrord exec` now includes session ID in progress printout

--- a/mirrord/cli/src/config.rs
+++ b/mirrord/cli/src/config.rs
@@ -249,7 +249,7 @@ pub(super) enum Commands {
     #[command(hide = true)]
     Pitm(PitmArgs),
 
-    /// Launch the mirrord local UI.
+    /// Launch the mirrord local UI. Respects the `$BROWSER` env var.
     ///
     /// Watches active mirrord sessions and displays a web dashboard showing
     /// real-time events (file operations, DNS queries, HTTP requests, etc.)

--- a/mirrord/cli/src/config.rs
+++ b/mirrord/cli/src/config.rs
@@ -1573,6 +1573,10 @@ pub struct UiArgs {
     /// Port to serve the UI on.
     #[arg(short = 'p', long, default_value_t = UI_DEFAULT_PORT)]
     pub port: u16,
+
+    /// Run the command, including the UI, but do not automatically open the browser.
+    #[arg(long)]
+    pub no_browser: bool,
 }
 
 /// Arguments for the `mirrord session` command.

--- a/mirrord/cli/src/execution.rs
+++ b/mirrord/cli/src/execution.rs
@@ -590,6 +590,7 @@ impl MirrordExecution {
             _ => uuid::Uuid::new_v4().to_string(),
         };
         proxy_command.env("MIRRORD_SESSION_ID", &session_id);
+        progress.info(&format!("session ID: {session_id}"));
 
         #[cfg(unix)]
         unsafe {

--- a/mirrord/cli/src/ui.rs
+++ b/mirrord/cli/src/ui.rs
@@ -979,38 +979,60 @@ fn claim_token_file_at(lock_path: PathBuf, token_path: PathBuf) -> Result<TokenC
 
 /// Outcome of [`setup_ui`].
 pub enum UiSetup {
-    /// This invocation owns the UI; `server` runs it and `url` opens it.
+    /// This invocation owns the UI; `server` runs it.
     Started {
         server: futures::future::BoxFuture<'static, Result<(), CliError>>,
+
+        /// Clickable link to show the user to where the frontend web UI is served, including auth token query param eg. "http://localhost:59281?token=..."
         url: String,
+
+        /// The auth token from `~/.mirrord/token`, to be passed as a query param in requests (also
+        /// gets saved as a cookie in the browser).
+        token: String,
     },
-    /// Another `mirrord ui` is already running; `url` opens the existing instance.
-    AlreadyRunning { url: String },
+    /// Another `mirrord ui` is already running.
+    AlreadyRunning { url: String, token: String },
 }
 
 pub async fn ui_command(args: UiArgs) -> Result<(), CliError> {
     match setup_ui(args.port).await? {
-        UiSetup::AlreadyRunning { url } => {
-            eprintln!();
-            eprintln!("  mirrord session monitor is already running");
-            eprintln!("    Web UI:             {url}");
-            eprintln!();
+        UiSetup::AlreadyRunning { url, token } => {
+            ui_printout(true, &url, &token);
             Ok(())
         }
-        UiSetup::Started { server, url } => {
+        UiSetup::Started { server, url, token } => {
             if !args.no_browser {
                 if let Err(err) = opener::open_browser(&url) {
                     warn!(?err, "Failed to open browser");
                 }
             }
 
-            eprintln!();
-            eprintln!("  mirrord session monitor");
-            eprintln!("    Web UI:             {url}");
-            eprintln!();
-
+            ui_printout(false, &url, &token);
             server.await
         }
+    }
+}
+
+#[tracing::instrument(level = "trace", skip(token), ret)]
+fn ui_printout(already_running: bool, url: &str, token: &str) {
+    println!("");
+    if already_running {
+        println!("* Another session monitor is already running");
+    } else {
+        println!("* New mirrord session monitor started");
+    }
+
+    println!("");
+    println!("* Web UI:");
+    println!(" -> {url}");
+    println!("* API token:");
+    println!(" -> {token}");
+
+    println!("");
+    if already_running {
+        println!("* mirrord session monitor unchanged");
+    } else {
+        println!("* mirrord session monitor ready!");
     }
 }
 
@@ -1018,7 +1040,7 @@ pub async fn setup_ui(port: u16) -> Result<UiSetup, CliError> {
     let (guard, token) = match claim_token_file()? {
         TokenClaim::AlreadyRunning { token } => {
             let url = format!("http://{}:{port}?token={token}", Ipv4Addr::LOCALHOST);
-            return Ok(UiSetup::AlreadyRunning { url });
+            return Ok(UiSetup::AlreadyRunning { url, token });
         }
         TokenClaim::Claimed { guard, token } => (guard, token),
     };
@@ -1065,7 +1087,7 @@ pub async fn setup_ui(port: u16) -> Result<UiSetup, CliError> {
             .map_err(|e| CliError::UiError(format!("server error: {e}")))
     });
 
-    Ok(UiSetup::Started { server, url })
+    Ok(UiSetup::Started { server, url, token })
 }
 
 #[cfg(test)]

--- a/mirrord/cli/src/ui.rs
+++ b/mirrord/cli/src/ui.rs
@@ -1009,10 +1009,10 @@ pub async fn ui_command(args: UiArgs) -> Result<(), CliError> {
             Ok(())
         }
         UiSetup::Started { server, url, token } => {
-            if !args.no_browser {
-                if let Err(err) = opener::open_browser(&url) {
-                    warn!(?err, "Failed to open browser");
-                }
+            if !args.no_browser
+                && let Err(err) = opener::open_browser(&url)
+            {
+                warn!(?err, "Failed to open browser");
             }
 
             ui_printout(false, &url, &token);

--- a/mirrord/cli/src/ui.rs
+++ b/mirrord/cli/src/ui.rs
@@ -998,8 +998,10 @@ pub async fn ui_command(args: UiArgs) -> Result<(), CliError> {
             Ok(())
         }
         UiSetup::Started { server, url } => {
-            if let Err(err) = opener::open(&url) {
-                warn!(?err, "Failed to open browser");
+            if !args.no_browser {
+                if let Err(err) = opener::open(&url) {
+                    warn!(?err, "Failed to open browser");
+                }
             }
 
             eprintln!();

--- a/mirrord/cli/src/ui.rs
+++ b/mirrord/cli/src/ui.rs
@@ -999,7 +999,7 @@ pub async fn ui_command(args: UiArgs) -> Result<(), CliError> {
         }
         UiSetup::Started { server, url } => {
             if !args.no_browser {
-                if let Err(err) = opener::open(&url) {
+                if let Err(err) = opener::open_browser(&url) {
                     warn!(?err, "Failed to open browser");
                 }
             }

--- a/mirrord/cli/src/ui.rs
+++ b/mirrord/cli/src/ui.rs
@@ -56,6 +56,8 @@ mod chaos;
 
 const MAX_EVENTS_PER_SESSION: usize = 500;
 
+const TOKEN_HEADER_NAME: &str = "x-auth-token";
+
 #[cfg(not(debug_assertions))]
 #[derive(Embed)]
 #[folder = "../../packages/monitor/dist/"]
@@ -258,11 +260,12 @@ struct TokenQuery {
 }
 
 /// Middleware that validates the request carries a valid auth token, either via the `mirrord_token`
-/// cookie or the `?token=` query parameter.
+/// cookie, the `?token=` query parameter or the `x-auth-token` header.
 async fn token_auth(
     State(state): State<AppState>,
     jar: CookieJar,
     Query(query): Query<TokenQuery>,
+    headers: HeaderMap,
     request: Request,
     next: Next,
 ) -> Response {
@@ -272,8 +275,13 @@ async fn token_auth(
         return next.run(request).await;
     }
 
-    if let Some(token) = &query.token
-        && token == &state.token
+    if query.token.as_ref() == Some(&state.token)
+        || headers
+            .get(TOKEN_HEADER_NAME)
+            .map(HeaderValue::to_str)
+            .transpose()
+            .unwrap_or_default()
+            == Some(&state.token)
     {
         let mut response = next.run(request).await;
         let cookie = Cookie::build(("mirrord_token", state.token.clone()))
@@ -1026,7 +1034,7 @@ fn ui_printout(already_running: bool, url: &str, token: &str) {
     println!("* Web UI:");
     println!(" -> {url}");
     println!("* API token:");
-    println!(" -> {token}");
+    println!(" -> {TOKEN_HEADER_NAME}: {token}");
 
     println!("");
     if already_running {

--- a/mirrord/cli/src/up.rs
+++ b/mirrord/cli/src/up.rs
@@ -89,8 +89,8 @@ async fn run_up(args: UpArgs, analytics: &mut AnalyticsReporter) -> Result<(), U
     if args.ui {
         tokio::spawn(async move {
             let (server, url) = match crate::ui::setup_ui(UI_DEFAULT_PORT).await {
-                Ok(crate::ui::UiSetup::Started { server, url }) => (server, url),
-                Ok(crate::ui::UiSetup::AlreadyRunning { url }) => {
+                Ok(crate::ui::UiSetup::Started { server, url, .. }) => (server, url),
+                Ok(crate::ui::UiSetup::AlreadyRunning { url, .. }) => {
                     tracing::info!(%url, "local UI already running, not starting another");
                     return;
                 }


### PR DESCRIPTION
### Summary

Various QOL improvements for the `mirrord UI` command:
- added `--no-browser` flag to prevent the browser opening automatically
- UI now respects `BROWSER` env var for selecting which browser to open with
- printed messages tweaked slightly
- UI auth token can be set as `x-auth-token` header 

Also:
- `mirrord exec` now includes session ID in progress printout

### UI command output

<img width="907" height="194" alt="fresh_start" src="https://github.com/user-attachments/assets/e5891044-3d63-442b-9e47-e760651b02c4" />
<img width="920" height="175" alt="already_running" src="https://github.com/user-attachments/assets/ab6e71bf-d0c0-48c4-9fad-edfb8d2e4f49" />
