### PR TITLE
COR-1614 Chaos latency delayed queue

### DIFF
--- a/changelog.d/+chaos-latency.changed.md
+++ b/changelog.d/+chaos-latency.changed.md
@@ -1,0 +1,2 @@
+Updated the chaos outgoing latency implementation so that busy connection's latency
+will not accumulate.

--- a/changelog.d/+chaos-latency.changed.md
+++ b/changelog.d/+chaos-latency.changed.md
@@ -1,2 +1,3 @@
 Updated the chaos outgoing latency implementation so that busy connection's latency
-will not accumulate.
+will not accumulate. Latency chaos rules will now add the specified latency amount
+more accurately.

--- a/mirrord/intproxy/src/proxies/outgoing/interceptor.rs
+++ b/mirrord/intproxy/src/proxies/outgoing/interceptor.rs
@@ -1,6 +1,7 @@
 //! [`BackgroundTask`] used by [`OutgoingProxy`](super::OutgoingProxy) to manage a single
 //! intercepted connection.
 
+mod delay_queue;
 pub(super) mod read_queue;
 pub(super) mod write_queue;
 

--- a/mirrord/intproxy/src/proxies/outgoing/interceptor/delay_queue.rs
+++ b/mirrord/intproxy/src/proxies/outgoing/interceptor/delay_queue.rs
@@ -1,0 +1,99 @@
+//! A FIFO queue of payloads that each become due at a deadline.
+//!
+//! Used by the outgoing interceptor's [read](super::read_queue) and [write](super::write_queue)
+//! queues to release messages after a chaos latency delay.
+//!
+//! This queue yields strictly in insertion order: it only ever waits on the *front* item's
+//! deadline. This is required because the chaos latency carries jitter. Releasing in deadline order
+//! would reorder the byte stream of an intercepted connection.
+
+use std::{
+    collections::VecDeque,
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use tokio::time::{Instant, Sleep, sleep_until};
+use tokio_stream::Stream;
+
+/// A payload paired with the [`Instant`] at which it becomes due to be sent.
+struct Delayed<T> {
+    payload: T,
+    deadline: Instant,
+}
+
+/// FIFO queue that yields each payload no earlier than its deadline, in insertion order.
+pub(super) struct DelayQueue<T> {
+    items: VecDeque<Delayed<T>>,
+
+    /// Timer that wakes the task at the current front item's deadline.
+    ///
+    /// Kept as state (rather than recreated on every poll) so the waker it registers survives
+    /// across polls.
+    timer: Option<Pin<Box<Sleep>>>,
+}
+
+impl<T> Default for DelayQueue<T> {
+    fn default() -> Self {
+        Self {
+            items: VecDeque::new(),
+            timer: None,
+        }
+    }
+}
+
+impl<T> DelayQueue<T> {
+    /// Enqueues `payload` to be yielded by [`Stream::poll_next`] once `deadline` is reached.
+    pub(super) fn push(&mut self, payload: T, deadline: Instant) {
+        self.items.push_back(Delayed { payload, deadline });
+    }
+
+    pub(super) fn is_empty(&self) -> bool {
+        self.items.is_empty()
+    }
+}
+
+impl<T: Unpin> Stream for DelayQueue<T> {
+    type Item = T;
+
+    /// Yields the front payload once its deadline has passed.
+    ///
+    /// An already-due front is popped and returned immediately, with no timer involved, so a burst
+    /// of due messages drains at line rate (this is what keeps the latency from accumulating per
+    /// message). A not-yet-due front arms a [`Sleep`] purely to register a wake at its deadline,
+    /// then returns [`Poll::Pending`].
+    ///
+    /// When empty, returns [`Poll::Ready`]`(None)` which does NOT mean end-of-stream. During the
+    /// live session callers guard against polling an empty queue (the sibling `select!` branch
+    /// feeding [`Self::push`] makes progress instead); the `None` is what terminates the final
+    /// drain once the input channel has closed.
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+
+        let deadline = match this.items.front() {
+            Some(front) => front.deadline,
+            None => {
+                this.timer = None;
+                return Poll::Ready(None);
+            }
+        };
+
+        if deadline <= Instant::now() {
+            this.timer = None;
+            match this.items.pop_front() {
+                Some(front) => return Poll::Ready(Some(front.payload)),
+                None => {
+                    return Poll::Ready(None);
+                }
+            };
+        }
+
+        let timer = this
+            .timer
+            .get_or_insert_with(|| Box::pin(sleep_until(deadline)));
+        let _ = timer.as_mut().poll(cx);
+
+        Poll::Pending
+    }
+}

--- a/mirrord/intproxy/src/proxies/outgoing/interceptor/read_queue.rs
+++ b/mirrord/intproxy/src/proxies/outgoing/interceptor/read_queue.rs
@@ -1,54 +1,74 @@
-use std::{ops::Not, time::Duration};
+use std::time::Duration;
 
 use bytes::Bytes;
-use tokio::{sync::mpsc, time::sleep};
+use tokio::{sync::mpsc, time::Instant};
+use tokio_stream::StreamExt;
 use tokio_util::task::AbortOnDropHandle;
 
-use super::Interceptor;
+use super::{Interceptor, delay_queue::DelayQueue};
 use crate::{
     background_tasks::TaskSender,
     proxies::outgoing::{InterceptorId, OutgoingProxy},
 };
 
-/// The [`Bytes`] that we're reading from the intercepted connection, with a delay before we send
-/// them to the layer that asked for it.
+/// The [`Bytes`] that we're reading from the intercepted connection, to be sent to the layer at
+/// [`Self::deadline`].
 struct QueuedInterceptorMessage {
     /// [`Bytes`] that can be read from this intercepted connection.
     bytes: Bytes,
 
-    /// How long to `sleep` for before sending the [`Self::bytes`].
-    delay: Duration,
+    /// When these [`Self::bytes`] become due to be sent to the layer.
+    /// Computed as `now + delay` at enqueue time.
+    deadline: Instant,
 }
 
 /// Holds the [`mpsc::Sender`] that we use to send [`QueuedInterceptorMessage`]s to the associated
 /// task.
 ///
 /// When a `ChaosSelector` matches some outgoing traffic, then we handle the bytes of read
-/// operations for this intercepted connection in the task with [`Self::handle`]. We have to do this
-/// to prevent blocking the main [`OutgoingProxy`] loop, and to keep the messages being sent in
+/// operations for this intercepted connection in the task spawned by [`Self::new`]. We have to do
+/// this to prevent blocking the main [`OutgoingProxy`] loop, and to keep the messages being sent in
 /// order.
 pub(crate) struct InterceptorReadQueue {
     /// [`mpsc::Sender`] for the [`QueuedInterceptorMessage`]s that are handled by the task.
     tx: mpsc::Sender<QueuedInterceptorMessage>,
 
-    /// Task that keeps calling [`mpsc::Receiver::recv`] on the receiver side of [`Self::tx`],
-    /// getting the [`QueuedInterceptorMessage`]s that should be sent to the agent, after maybe
-    /// sleeping according to the `ChaosRule`.
+    /// Task that moves [`QueuedInterceptorMessage`]s from [`Self::tx`] into a [`DelayQueue`] and
+    /// sends each one to the [`Interceptor`] once its [`QueuedInterceptorMessage::deadline`] is
+    /// reached.
     handle: AbortOnDropHandle<()>,
 }
 
 impl InterceptorReadQueue {
-    /// Creates the [`InterceptorReadQueue`] and starts the receiving task, see
+    /// Creates the [`InterceptorReadQueue`] and starts the background task, see
     /// [`InterceptorReadQueue::handle`].
     pub(crate) fn new(interceptor: TaskSender<Interceptor>) -> Self {
         let (tx, mut rx) = mpsc::channel::<QueuedInterceptorMessage>(OutgoingProxy::CHANNEL_SIZE);
 
         let handle = tokio::spawn(async move {
-            while let Some(QueuedInterceptorMessage { bytes, delay }) = rx.recv().await {
-                if delay.is_zero().not() {
-                    sleep(delay).await;
-                }
+            let mut queue = DelayQueue::<Bytes>::default();
 
+            loop {
+                tokio::select! {
+                    queued = rx.recv() => match queued {
+                        Some(QueuedInterceptorMessage { bytes, deadline }) => {
+                            queue.push(bytes, deadline);
+                        }
+                        // OutgoingProxy dropped the sender.
+                        None => break,
+                    },
+
+                    // `None` does NOT mean end of stream.
+                    // Guarded with is_empty so an empty queue doesn't cause a busy loop.
+                    Some(bytes) = queue.next(), if !queue.is_empty() => {
+                        interceptor.send(bytes).await;
+                    }
+                }
+            }
+
+            // Flush whatever is still queued (the final close sent by `finish`, plus any data
+            // enqueued before it), honoring each message's deadline, before ending.
+            while let Some(bytes) = queue.next().await {
                 interceptor.send(bytes).await;
             }
         });
@@ -59,11 +79,14 @@ impl InterceptorReadQueue {
         }
     }
 
-    /// Helper to send the `message` with `delay` on [`Self::tx`].
+    /// Helper to enqueue `bytes` with a release `delay` (counted from now) on [`Self::tx`].
     async fn send(&self, bytes: Bytes, delay: Duration) {
         let _ = self
             .tx
-            .send(QueuedInterceptorMessage { bytes, delay })
+            .send(QueuedInterceptorMessage {
+                bytes,
+                deadline: Instant::now() + delay,
+            })
             .await;
     }
 
@@ -75,7 +98,12 @@ impl InterceptorReadQueue {
     async fn finish(self, bytes: Bytes, delay: Duration) {
         let Self { tx, handle } = self;
 
-        let _ = tx.send(QueuedInterceptorMessage { bytes, delay }).await;
+        let _ = tx
+            .send(QueuedInterceptorMessage {
+                bytes,
+                deadline: Instant::now() + delay,
+            })
+            .await;
         drop(handle.detach());
     }
 }

--- a/mirrord/intproxy/src/proxies/outgoing/interceptor/write_queue.rs
+++ b/mirrord/intproxy/src/proxies/outgoing/interceptor/write_queue.rs
@@ -1,51 +1,71 @@
-use std::{ops::Not, time::Duration};
+use std::time::Duration;
 
 use mirrord_protocol::ClientMessage;
 use mirrord_protocol_io::{Client, TxHandle};
-use tokio::{sync::mpsc, time::sleep};
+use tokio::{sync::mpsc, time::Instant};
+use tokio_stream::StreamExt;
 use tokio_util::task::AbortOnDropHandle;
 
+use super::delay_queue::DelayQueue;
 use crate::proxies::outgoing::{InterceptorId, OutgoingProxy};
 
-/// The [`ClientMessage`] that we want to send with a potential `delay` to the agent.
+/// The [`ClientMessage`] that we want to send to the agent at [`Self::deadline`].
 ///
 /// We send these through the [`AgentWriteQueue`] if an outgoing connection should be handled by
 /// some `ChaosRule`.
 struct QueuedAgentMessage {
-    /// Regular [`ClientMessage`] to be sent to the agent, at some point.
+    /// Regular [`ClientMessage`] to be sent to the agent, at [`Self::deadline`].
     message: ClientMessage,
 
-    /// How long to `sleep` for before sending the [`Self::message`].
-    delay: Duration,
+    /// When this message becomes due to be sent to the agent.
+    /// Computed as `now + delay` at enqueue time.
+    deadline: Instant,
 }
 
 /// Holds the [`mpsc::Sender`] that we use to send [`QueuedAgentMessage`]s to the associated task.
 ///
 /// When a `ChaosSelector` matches some outgoing traffic, then we handle the [`ClientMessage`]s for
-/// this intercepted connection in the task with [`Self::handle`]. We have to do this to prevent
+/// this intercepted connection in the task spawned by [`Self::new`]. We have to do this to prevent
 /// blocking the main [`OutgoingProxy`] loop, and to keep the messages being sent in order.
 pub(crate) struct AgentWriteQueue {
     /// [`mpsc::Sender`] for the [`QueuedAgentMessage`]s that are handled by the task.
     tx: mpsc::Sender<QueuedAgentMessage>,
 
-    /// Task that keeps calling [`mpsc::Receiver::recv`] on the receiver side of [`Self::tx`],
-    /// getting the [`QueuedAgentMessage`]s that should be sent to the agent, after maybe sleeping
-    /// according to the `ChaosRule`.
+    /// Task that moves [`QueuedAgentMessage`]s from [`Self::tx`] into a [`DelayQueue`] and sends
+    /// each one to the agent once its [`QueuedAgentMessage::deadline`] is reached.
     handle: AbortOnDropHandle<()>,
 }
 
 impl AgentWriteQueue {
-    /// Creates the [`AgentWriteQueue`] and starts the receiving task, see
+    /// Creates the [`AgentWriteQueue`] and starts the background task, see
     /// [`AgentWriteQueue::handle`].
     pub(crate) fn new(agent_tx: TxHandle<Client>) -> Self {
         let (tx, mut rx) = mpsc::channel::<QueuedAgentMessage>(OutgoingProxy::CHANNEL_SIZE);
 
         let handle = tokio::spawn(async move {
-            while let Some(QueuedAgentMessage { message, delay }) = rx.recv().await {
-                if delay.is_zero().not() {
-                    sleep(delay).await;
-                }
+            let mut queue = DelayQueue::<ClientMessage>::default();
 
+            loop {
+                tokio::select! {
+                    queued = rx.recv() => match queued {
+                        Some(QueuedAgentMessage { message, deadline }) => {
+                            queue.push(message, deadline);
+                        }
+                        // OutgoingProxy dropped the sender.
+                        None => break,
+                    },
+
+                    // `None` does NOT mean end of stream.
+                    // Guarded with is_empty so an empty queue doesn't cause a busy loop.
+                    Some(message) = queue.next(), if !queue.is_empty() => {
+                        agent_tx.send(message).await;
+                    }
+                }
+            }
+
+            // Flush whatever is still queued (the final close sent by `finish`, plus any data
+            // enqueued before it), honoring each message's deadline, before ending.
+            while let Some(message) = queue.next().await {
                 agent_tx.send(message).await;
             }
         });
@@ -56,9 +76,15 @@ impl AgentWriteQueue {
         }
     }
 
-    /// Helper to send the `message` with `delay` on [`Self::tx`].
+    /// Helper to enqueue `message` with a release `delay` (counted from now) on [`Self::tx`].
     async fn send(&self, message: ClientMessage, delay: Duration) {
-        let _ = self.tx.send(QueuedAgentMessage { message, delay }).await;
+        let _ = self
+            .tx
+            .send(QueuedAgentMessage {
+                message,
+                deadline: Instant::now() + delay,
+            })
+            .await;
     }
 
     /// Sends one last `message` through [`Self::tx`] to the background task.
@@ -69,7 +95,12 @@ impl AgentWriteQueue {
     async fn finish(self, message: ClientMessage, delay: Duration) {
         let Self { tx, handle } = self;
 
-        let _ = tx.send(QueuedAgentMessage { message, delay }).await;
+        let _ = tx
+            .send(QueuedAgentMessage {
+                message,
+                deadline: Instant::now() + delay,
+            })
+            .await;
         drop(handle.detach());
     }
 }


### PR DESCRIPTION
<!-- Thank you for contributing to mirrord! -->
<!-- Please use the checklist below as a guide for docs, tests and admin tasks for your PR -->
<!-- Feel free to ~strikethrough~ any items that you don't think apply -->

### Problem
1. Chaos latency is cumulative.
2. When outgoing proxy to interceptor queue background task's channel is full, `send()` blocks, thus, blocking outgoing proxy's main event loop.

### Solution
Record each message's deadline at enqueue time. Use a delayed queue to keep insertion order, while honoring each message's deadline before releasing.

The current solution uses unbounded delayed queue. To handle layer-to-agent message back pressure, we can use a semaphore backed byte permits shared by interceptor background task and queue background task, so that when delayed queue capacity is full, stop reading from local socket connection.

But that can be a separate PR.


### Quality Checklist:

- [x] I have documented new code sufficiently
- [x] I have checked and updated the relevant existing docs in code, including removing outdated material
- [x] I have written user-facing website docs for new features, or opened a (sub)issue to do so
- [x] I have checked and updated existing website docs for changed features
- [x] I have tested this change and know it succeeds and fails as expected
- [ ] I have written unit tests or purposefully omitted them
- [ ] I have written e2e tests or purposefully omitted them
- [x] I have explained what this PR introduces and why, and linked to relevant context (e.g. linear issues, related PRs,
  documentation)
- [x] I have introduced a short, clear and well-formatted changelog entry

<!-- need help with the changelog? see ../CONTRIBUTING.md#submitting-a-pull-request -->
<!-- Add more details of your changes below if needed -->