### PR TITLE
agent: return 503 for bypassed requests with no local listener

### DIFF
--- a/mirrord/agent/src/http/error.rs
+++ b/mirrord/agent/src/http/error.rs
@@ -9,25 +9,53 @@ use super::BoxResponse;
 
 /// HTTP response produced by the agent when it fails to serve a redirected request.
 ///
-/// 1. Always uses [`StatusCode::BAD_GATEWAY`].
-/// 2. Body always starts with `mirrord-agent: `.
+/// The body always starts with `mirrord-agent v<version>: `.
 pub struct MirrordErrorResponse {
     version: Version,
+    status: StatusCode,
     body: Bytes,
 }
 
 impl MirrordErrorResponse {
+    /// Generic failure response. Uses [`StatusCode::BAD_GATEWAY`].
     pub fn new<M: fmt::Display>(version: Version, message: M) -> Self {
+        Self::with_status(version, StatusCode::BAD_GATEWAY, message)
+    }
+
+    /// Response for a request that was bypassed (did not match any steal filter)
+    /// but had no local application listening to serve it.
+    ///
+    /// This is the expected outcome on a copy-target pod, where the target container
+    /// is a placeholder with no real application: only requests matching the steal
+    /// filter are served by the stealing client, and everything else is passed
+    /// through to `localhost`, where nothing is listening.
+    pub fn bypassed(version: Version, port: u16) -> Self {
+        Self::with_status(
+            version,
+            StatusCode::SERVICE_UNAVAILABLE,
+            format_args!(
+                "request to port {port} did not match the steal filter, and no \
+                 application is listening locally to serve it. Use a steal-all \
+                 session, or expect filtered-out requests to fail."
+            ),
+        )
+    }
+
+    fn with_status<M: fmt::Display>(version: Version, status: StatusCode, message: M) -> Self {
         let body = format!("mirrord-agent v{}: {message}\n", env!("CARGO_PKG_VERSION")).into();
 
-        Self { version, body }
+        Self {
+            version,
+            status,
+            body,
+        }
     }
 }
 
 impl From<MirrordErrorResponse> for BoxResponse {
     fn from(value: MirrordErrorResponse) -> Self {
         Response::builder()
-            .status(StatusCode::BAD_GATEWAY)
+            .status(value.status)
             .version(value.version)
             .body(Full::new(value.body).map_err(|_| unreachable!()).boxed())
             .unwrap()

--- a/mirrord/agent/src/incoming/connection/http_task.rs
+++ b/mirrord/agent/src/incoming/connection/http_task.rs
@@ -1,4 +1,4 @@
-use std::{error::Report, future::Future, sync::Arc};
+use std::{error::Report, future::Future, io, sync::Arc};
 
 use bytes::{Bytes, BytesMut};
 use futures::StreamExt;
@@ -142,11 +142,28 @@ impl HttpTask<PassthroughConnection> {
             let mut response = match Self::send_request(&info, hyper_request).await {
                 Ok(response) => response,
                 Err(error) => {
-                    let message = format!(
-                        "failed to pass the request to its original destination: {}",
-                        Report::new(&error).pretty(true)
-                    );
-                    let error_response = MirrordErrorResponse::new(version, message);
+                    let error_response = match &error {
+                        // Nothing is listening on the local passthrough target. The
+                        // expected case is a copy-target placeholder pod, where bypassed
+                        // (filtered-out) requests are forwarded to a `localhost` with no
+                        // application behind it. Return a clear 503 instead of a cryptic
+                        // gateway error.
+                        ConnError::TcpConnectError(source)
+                            if source.kind() == io::ErrorKind::ConnectionRefused =>
+                        {
+                            MirrordErrorResponse::bypassed(
+                                version,
+                                info.original_destination.port(),
+                            )
+                        }
+                        _ => {
+                            let message = format!(
+                                "failed to pass the request to its original destination: {}",
+                                Report::new(&error).pretty(true),
+                            );
+                            MirrordErrorResponse::new(version, message)
+                        }
+                    };
                     let _ = request.response_tx.send(error_response.into());
                     return Err(error);
                 }


### PR DESCRIPTION
When a filtered steal passes a non-matching request through to its original destination and the local connection is refused, the agent returned a generic 502 with a cryptic "connection refused (os error 111)". This is the expected case on a copy-target placeholder pod, where there is no real app to serve bypassed traffic.

Return a clear 503 with an actionable message instead. Adds a configurable status to MirrordErrorResponse plus a `bypassed()` constructor, and branches the passthrough-failure path on ConnectionRefused.

HTTP only — raw TCP passthrough has no response to inject, so non-HTTP bypass still resets

<!-- Thank you for contributing to mirrord! -->
<!-- Please use the checklist below as a guide for docs, tests and admin tasks for your PR -->
<!-- Feel free to ~strikethrough~ any items that you don't think apply -->

### Quality Checklist:

- [ ] I have documented new code sufficiently
- [ ] I have checked and updated the relevant existing docs in code, including removing outdated material
- [ ] I have written user-facing website docs for new features, or opened a (sub)issue to do so
- [ ] I have checked and updated existing website docs for changed features
- [ ] I have tested this change and know it succeeds and fails as expected
- [ ] I have written unit tests or purposefully omitted them
- [ ] I have written e2e tests or purposefully omitted them
- [ ] I have explained what this PR introduces and why, and linked to relevant context (e.g. linear issues, related PRs,
  documentation)
- [ ] I have introduced a short, clear and well-formatted changelog entry

<!-- need help with the changelog? see ../CONTRIBUTING.md#submitting-a-pull-request -->
<!-- Add more details of your changes below if needed -->