### PR TITLE
fix: override AWS_DEFAULT_OUTPUT to json for credential resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5110,6 +5110,7 @@ dependencies = [
  "serde",
  "serde_json",
  "shellexpand",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-retry",
@@ -5216,6 +5217,7 @@ dependencies = [
  "rand 0.9.2",
  "rstest",
  "serde_json",
+ "serial_test",
  "tempfile",
  "tokio",
  "tracing",
@@ -7879,6 +7881,31 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/mirrord/cli/src/main.rs
+++ b/mirrord/cli/src/main.rs
@@ -456,6 +456,16 @@ where
         env_vars.remove(key);
     }
 
+    if std::env::var("MIRRORD_AWS_DEFAULT_OUTPUT_SET_CHECK").is_ok() {
+        if let Ok(original_val) = std::env::var("MIRRORD_ORIGINAL_AWS_DEFAULT_OUTPUT") {
+            env_vars.insert("AWS_DEFAULT_OUTPUT".to_string(), original_val);
+        } else {
+            env_vars.remove("AWS_DEFAULT_OUTPUT");
+        }
+        env_vars.remove("MIRRORD_ORIGINAL_AWS_DEFAULT_OUTPUT");
+        env_vars.remove("MIRRORD_AWS_DEFAULT_OUTPUT_SET_CHECK");
+    }
+
     // Put original executable in argv[0] even if actually running patched version.
     let binary_args = std::iter::once(&args.binary)
         .chain(args.binary_args.iter())

--- a/mirrord/cli/src/pitm.rs
+++ b/mirrord/cli/src/pitm.rs
@@ -176,6 +176,17 @@ fn build_child_environment(child_env: ChildEnv) -> HashMap<String, String> {
     for k in child_env.unset {
         env.remove(&k);
     }
+
+    if std::env::var("MIRRORD_AWS_DEFAULT_OUTPUT_SET_CHECK").is_ok() {
+        if let Ok(original_val) = std::env::var("MIRRORD_ORIGINAL_AWS_DEFAULT_OUTPUT") {
+            env.insert("AWS_DEFAULT_OUTPUT".to_string(), original_val);
+        } else {
+            env.remove("AWS_DEFAULT_OUTPUT");
+        }
+        env.remove("MIRRORD_ORIGINAL_AWS_DEFAULT_OUTPUT");
+        env.remove("MIRRORD_AWS_DEFAULT_OUTPUT_SET_CHECK");
+    }
+
     env
 }
 

--- a/mirrord/kube/Cargo.toml
+++ b/mirrord/kube/Cargo.toml
@@ -48,6 +48,7 @@ itertools.workspace = true
 
 [dev-dependencies]
 rstest.workspace = true
+tempfile.workspace = true
 
 [lib]
 doctest = false

--- a/mirrord/kube/src/api/kubernetes.rs
+++ b/mirrord/kube/src/api/kubernetes.rs
@@ -365,6 +365,20 @@ pub async fn create_kube_config<P>(
 where
     P: AsRef<OsStr>,
 {
+    // We override AWS_DEFAULT_OUTPUT to json to prevent kubeconfig auth exec commands
+    // (like aws eks get-token) from outputting yaml or other formats that kube-rs cannot parse.
+    if std::env::var("MIRRORD_AWS_DEFAULT_OUTPUT_SET_CHECK").is_err() {
+        if let Ok(val) = std::env::var("AWS_DEFAULT_OUTPUT") {
+            unsafe {
+                std::env::set_var("MIRRORD_ORIGINAL_AWS_DEFAULT_OUTPUT", val);
+            }
+        }
+        unsafe {
+            std::env::set_var("MIRRORD_AWS_DEFAULT_OUTPUT_SET_CHECK", "true");
+            std::env::set_var("AWS_DEFAULT_OUTPUT", "json");
+        }
+    }
+
     let kube_config_opts = KubeConfigOptions {
         context: kube_context,
         ..Default::default()
@@ -420,5 +434,92 @@ where
         Api::namespaced(client.clone(), namespace)
     } else {
         Api::default_namespaced(client.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{fs::File, io::Write};
+
+    use tempfile::tempdir;
+
+    use super::*;
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_create_kube_config_aws_default_output_yaml() {
+        let dir = tempdir().unwrap();
+        let script_path = dir.path().join("mock_aws_helper.sh");
+
+        let script_content = r#"#!/bin/sh
+if [ "$AWS_DEFAULT_OUTPUT" = "json" ]; then
+  echo '{"kind":"ExecCredential","apiVersion":"client.authentication.k8s.io/v1","spec":{},"status":{"token":"my-dummy-token"}}'
+else
+  echo 'invalid format (or yaml)'
+fi
+"#;
+        {
+            let mut f = File::create(&script_path).unwrap();
+            f.write_all(script_content.as_bytes()).unwrap();
+        }
+
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(&script_path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&script_path, perms).unwrap();
+
+        let kubeconfig_path = dir.path().join("kubeconfig.yaml");
+        let kubeconfig_content = format!(
+            r#"apiVersion: v1
+clusters:
+- cluster:
+    server: https://127.0.0.1:6443
+  name: test-cluster
+contexts:
+- context:
+    cluster: test-cluster
+    user: test-user
+  name: test-context
+current-context: test-context
+kind: Config
+users:
+- name: test-user
+  user:
+    exec:
+      apiVersion: client.authentication.k8s.io/v1
+      command: {}
+      args: []
+"#,
+            script_path.display()
+        );
+        {
+            let mut f = File::create(&kubeconfig_path).unwrap();
+            f.write_all(kubeconfig_content.as_bytes()).unwrap();
+        }
+
+        unsafe {
+            std::env::set_var("AWS_DEFAULT_OUTPUT", "yaml");
+        }
+
+        let config = create_kube_config::<&std::ffi::OsStr>(
+            Some(false),
+            Some(kubeconfig_path.as_os_str()),
+            None,
+        )
+        .await;
+
+        assert!(
+            config.is_ok(),
+            "Failed to create kube config: {:?}",
+            config.err()
+        );
+        let config = config.unwrap();
+
+        let client_result = kube::Client::try_from(config);
+        assert!(
+            client_result.is_ok(),
+            "Failed to build client: {:?}",
+            client_result.err()
+        );
     }
 }


### PR DESCRIPTION
### Quality Checklist:

- [x] I have documented new code sufficiently
- [x] I have checked and updated the relevant existing docs in code, including removing outdated material
- [ ] ~I have written user-facing website docs for new features, or opened a (sub)issue to do so~
- [x] I have checked and updated existing website docs for changed features
- [x] I have tested this change and know it succeeds and fails as expected
- [x] I have written unit tests or purposefully omitted them
- [ ] ~I have written e2e tests or purposefully omitted them~
- [x] I have explained what this PR introduces and why, and linked to relevant context (e.g. linear issues, related PRs, documentation)
- [ ] ~I have introduced a short, clear and well-formatted changelog entry~

## Related issue

Closes #4354

## Summary

When a user has `AWS_DEFAULT_OUTPUT=yaml` set in their shell environment, exec-credential helper binaries (e.g. `aws eks get-token`) invoked by `kube-rs` during kubeconfig auth resolution emit YAML output. Because `kube-rs` strictly requires JSON for exec-credential stdout, this causes mirrord to fail immediately with:

```
auth error: failed to parse auth exec output: expected value at line 1 column 1
```

The fix overrides `AWS_DEFAULT_OUTPUT` to `json` inside `create_kube_config` before the exec-credential helper runs, and restores the original value (or removes the variable entirely if it was not previously set) when launching the target application's child processes in `main.rs` and `pitm.rs`.

The override uses two sentinel env vars (`MIRRORD_AWS_DEFAULT_OUTPUT_SET_CHECK` / `MIRRORD_ORIGINAL_AWS_DEFAULT_OUTPUT`) so that nested or re-entrant calls to `create_kube_config` are idempotent and the restoration logic in the child launchers can distinguish between "was not set originally" and "was set to something else".

## Test Plan

Added a `#[tokio::test]` in `mirrord/kube/src/api/kubernetes.rs` (`test_create_kube_config_aws_default_output_yaml`) that:

1. Writes a mock exec-credential shell script that returns a valid JSON `ExecCredential` when `AWS_DEFAULT_OUTPUT=json` and returns garbage otherwise.
2. Writes a minimal kubeconfig pointing at that script.
3. Sets `AWS_DEFAULT_OUTPUT=yaml` in the test process environment.
4. Calls `create_kube_config` and asserts the returned config builds a valid `kube::Client` — verifying the override takes effect.

```
cargo test -p mirrord-kube test_create_kube_config_aws_default_output_yaml -- --nocapture
```

Pass.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The unit test validates the override/restore logic in isolation without requiring a live AWS account or a running cluster. The test is Unix-only (`#[cfg(unix)]`) because the mock credential helper is a shell script; the underlying env-var logic is platform-agnostic and the real fix applies on all platforms.
