### PR TITLE
Show SQS jq filters in operator status

### DIFF
--- a/changelog.d/+int-380-sqs-jq-filter.fixed.md
+++ b/changelog.d/+int-380-sqs-jq-filter.fixed.md
@@ -1,0 +1,1 @@
+operator status for SQS now shows jq-filter-only sessions

--- a/mirrord/cli/src/operator/status.rs
+++ b/mirrord/cli/src/operator/status.rs
@@ -124,6 +124,7 @@ impl StatusCommandHandler {
             names: &'a BTreeMap<String, QueueNameUpdate>,
             consumer: &'a QueueConsumer,
             filters: &'a HashMap<String, BTreeMap<String, String>>,
+            jq_filters: &'a HashMap<String, String>,
         }
 
         let mut rows: HashMap<QueueConsumer, Vec<Row>> = HashMap::new();
@@ -133,6 +134,7 @@ impl StatusCommandHandler {
             names,
             consumer,
             filters,
+            jq_filters,
         } in queues.filter_map(|queue| {
             // Dig into the `MirrordSqsSession` crd and get the meaningful parts.
             Some(QueueDisplayInfo {
@@ -144,6 +146,7 @@ impl StatusCommandHandler {
                     .queue_names,
                 consumer: &queue.spec.queue_consumer,
                 filters: &queue.spec.queue_filters,
+                jq_filters: &queue.spec.queue_jq_filters,
             })
         }) {
             // From the list of queue names, loop over them so we can match the `QueueId`
@@ -168,30 +171,26 @@ impl StatusCommandHandler {
                 if let Some(filters_by_id) = filters_by_id {
                     // Loop over the filters and start building the rows.
                     for (filter_key, filter) in filters_by_id.iter() {
-                        // Group rows by the queue `consumer`.
-                        match rows.entry(consumer.clone()) {
-                            Entry::Occupied(mut consumer_rows) => {
-                                consumer_rows.get_mut().push(row![
-                                    session_id,
-                                    queue_id,
-                                    user,
-                                    original_name,
-                                    output_name,
-                                    format!("{filter_key}:{filter}")
-                                ]);
-                            }
-                            Entry::Vacant(consumer_rows) => {
-                                consumer_rows.insert(vec![row![
-                                    session_id,
-                                    queue_id,
-                                    user,
-                                    original_name,
-                                    output_name,
-                                    format!("{filter_key}:{filter}")
-                                ]]);
-                            }
-                        }
+                        rows.entry(consumer.clone()).or_default().push(row![
+                            session_id,
+                            queue_id,
+                            user,
+                            original_name,
+                            output_name,
+                            format!("{filter_key}:{filter}")
+                        ]);
                     }
+                }
+
+                if let Some(jq_filter) = jq_filters.get(queue_id).or_else(|| jq_filters.get("*")) {
+                    rows.entry(consumer.clone()).or_default().push(row![
+                        session_id,
+                        queue_id,
+                        user,
+                        original_name,
+                        output_name,
+                        format!("jq:{jq_filter}")
+                    ]);
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Fixes INT-380 by including `queue_jq_filters` when rendering SQS rows for `mirrord operator status`.
- Preserves existing attribute/body filter rendering and adds jq-only filters as `jq:<filter>` rows.
- This matches the Slack/customer scenario where SQS/EventBridge routing used a jq body filter, the session and queue splitting worked, but the SQS status table was missing.

## Root cause
`mirrord operator status` only inspected `queue_filters` when building SQS table rows. Sessions configured only with `queue_jq_filters` had queue status data, but produced no SQS rows, so the `SQS Queue for ...` table did not appear.
