### PR TITLE
INT-477: send operator connect params in a header

### DIFF
--- a/changelog.d/+connect-params-header.fixed.md
+++ b/changelog.d/+connect-params-header.fixed.md
@@ -1,0 +1,1 @@
+Queue splitting and other operator features now work through ingress proxies (e.g. GKE Connect Gateway) that reject the encoded JSON in the connect URL query string, by sending the connect parameters in a header when the operator supports it.

--- a/mirrord/operator/src/client.rs
+++ b/mirrord/operator/src/client.rs
@@ -59,8 +59,8 @@ use crate::{
         session::SessionCiInfo,
     },
     types::{
-        CLIENT_CERT_HEADER, CLIENT_HOSTNAME_HEADER, CLIENT_NAME_HEADER, MIRRORD_CLI_VERSION_HEADER,
-        SESSION_ID_HEADER,
+        CLIENT_CERT_HEADER, CLIENT_HOSTNAME_HEADER, CLIENT_NAME_HEADER, CONNECT_PARAMS_HEADER,
+        MIRRORD_CLI_VERSION_HEADER, SESSION_ID_HEADER,
     },
 };
 
@@ -134,6 +134,14 @@ pub struct OperatorSession {
     id: u64,
     /// URL where websocket connection request should be sent.
     connect_url: String,
+    /// Base64-encoded connect query string, sent in the [`CONNECT_PARAMS_HEADER`] header.
+    ///
+    /// Set only when the operator advertises [`NewOperatorFeature::ConnectParamsInHeader`]. When
+    /// present, [`Self::connect_url`] carries only `connect=true` and the rest of the parameters
+    /// travel in this header, so the request survives ingress proxies that reject the
+    /// percent-encoded JSON we put in query strings (e.g. GKE Connect Gateway).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    connect_params_header: Option<String>,
     /// Client certificate, should be included as header in the websocket connection request.
     client_cert: Certificate,
     /// Operator license fingerprint, right now only for setting [`Reporter`] properties.
@@ -165,6 +173,10 @@ impl fmt::Debug for OperatorSession {
         debug_struct
             .field("id", &format!("{:X}", self.id))
             .field("connect_url", &self.connect_url)
+            .field(
+                "connect_params_in_header",
+                &self.connect_params_header.is_some(),
+            )
             .field("cert_public_key_data", &self.client_cert.public_key_data())
             .field(
                 "operator_license_fingerprint",
@@ -1548,15 +1560,27 @@ impl OperatorApi<PreparedClientCert> {
             .as_ref()
             .and_then(|version| version.parse().ok());
         let operator_version = self.operator.spec.operator_version.clone();
-        let allow_reconnect = self
-            .operator
-            .spec
-            .supported_features()
-            .contains(&NewOperatorFeature::LayerReconnect);
+        let supported_features = self.operator.spec.supported_features();
+        let allow_reconnect = supported_features.contains(&NewOperatorFeature::LayerReconnect);
+
+        // Move the connect parameters out of the URL query string and into a header when the
+        // operator supports it, so the websocket upgrade survives ingress proxies that reject the
+        // percent-encoded JSON we put in query strings (e.g. GKE Connect Gateway). We keep only
+        // `connect=true` in the query so the operator still routes the request as a connect.
+        let (connect_url, connect_params_header) = match connect_url.split_once('?') {
+            Some((path, query))
+                if supported_features.contains(&NewOperatorFeature::ConnectParamsInHeader) =>
+            {
+                let header = general_purpose::STANDARD.encode(query);
+                (format!("{path}?connect=true"), Some(header))
+            }
+            _ => (connect_url, None),
+        };
 
         Ok(OperatorSession {
             id,
             connect_url,
+            connect_params_header,
             client_cert: self.client_cert.cert.clone(),
             operator_license_fingerprint: self.operator.spec.license.fingerprint.clone(),
             operator_protocol_version,
@@ -1976,6 +2000,11 @@ impl OperatorApi<PreparedClientCert> {
         };
         let request_builder = if let Some(baggage) = &session.baggage {
             request_builder.header("baggage", baggage.clone())
+        } else {
+            request_builder
+        };
+        let request_builder = if let Some(header) = &session.connect_params_header {
+            request_builder.header(CONNECT_PARAMS_HEADER, header.clone())
         } else {
             request_builder
         };

--- a/mirrord/operator/src/crd.rs
+++ b/mirrord/operator/src/crd.rs
@@ -551,6 +551,13 @@ pub enum NewOperatorFeature {
     /// This operator can perform queue splitting on Temporal task queues
     TemporalQueueSplitting,
 
+    /// This operator accepts the connect query string in the [`CONNECT_PARAMS_HEADER`] header
+    /// instead of (only) the URL query string, so sessions work through ingress proxies that reject
+    /// the percent-encoded JSON we put in the query string (e.g. GKE Connect Gateway).
+    ///
+    /// [`CONNECT_PARAMS_HEADER`]: crate::types::CONNECT_PARAMS_HEADER
+    ConnectParamsInHeader,
+
     /// This variant is what a client sees when the operator includes a feature the client is not
     /// yet aware of, because it was introduced in a version newer than the client's.
     #[schemars(skip)]
@@ -592,6 +599,7 @@ impl Display for NewOperatorFeature {
             NewOperatorFeature::GcpPubSubQueueSplitting => "GCP Pub/Sub queue splitting",
             NewOperatorFeature::RedisPubSubQueueSplitting => "Redis Pub/Sub queue splitting",
             NewOperatorFeature::TemporalQueueSplitting => "Temporal queue splitting",
+            NewOperatorFeature::ConnectParamsInHeader => "connect params in header",
             NewOperatorFeature::Unknown => "unknown feature",
         };
         f.write_str(name)

--- a/mirrord/operator/src/types.rs
+++ b/mirrord/operator/src/types.rs
@@ -37,6 +37,21 @@ pub const CLIENT_NAME_HEADER: &str = "x-client-name";
 /// Sent with target connection request.
 pub const SESSION_ID_HEADER: &str = "x-session-id";
 
+/// Name of HTTP header carrying the base64-encoded connect query string.
+///
+/// The target connection request is a websocket-upgrade `GET`, so its parameters (queue splits,
+/// branch databases, profile, etc.) are normally serialized into the URL query string. Some managed
+/// ingress proxies (notably GKE Connect Gateway's Envoy) reject query strings containing the
+/// percent-encoded JSON we use for complex parameters, failing the upgrade with `400 Bad Request`.
+///
+/// When the operator advertises [`NewOperatorFeature::ConnectParamsInHeader`], the CLI instead
+/// sends the whole connect query string base64-encoded in this header and leaves only
+/// `connect=true` in the URL. Header values aren't subject to the same proxy URL validation, so the
+/// upgrade succeeds.
+///
+/// [`NewOperatorFeature::ConnectParamsInHeader`]: crate::crd::NewOperatorFeature::ConnectParamsInHeader
+pub const CONNECT_PARAMS_HEADER: &str = "x-mirrord-connect-params";
+
 /// Code returned in error responses from the operator, when reconnecting to a session is no longer
 /// possible.
 ///


### PR DESCRIPTION
## Problem

The operator connect request is a websocket-upgrade `GET` that serializes all complex session params (queue splits, jq filters, branch DBs, `session_ci_info`, multi-cluster resources) as percent-encoded JSON in the URL query string (`connect_params.rs`). GKE Connect Gateway's managed Envoy rejects the encoded `{ " : }` in the query and fails the upgrade with `400 Bad Request` before the operator can complete it.

This affects **any** JSON-envelope param, not just Kafka — plain env/fs/mirror/steal sessions work because their params are flat scalars. So Connect Gateway is currently not a usable path for queue splitting / db branching / `mirrord ci start`.

## Change

Add `NewOperatorFeature::ConnectParamsInHeader`. When the operator advertises support, the CLI base64-encodes the connect query string into the `x-mirrord-connect-params` header (`CONNECT_PARAMS_HEADER`) and leaves only `connect=true` in the URL. Header values aren't subject to Envoy's query-string validation, so the upgrade succeeds.

- `types.rs` — `CONNECT_PARAMS_HEADER` const.
- `crd.rs` — `NewOperatorFeature::ConnectParamsInHeader`.
- `client.rs` — `OperatorSession` gains a header field; `make_operator_session` (the single choke point for all connect paths — target, copy-target, from-config, reconnect) relocates query→header when the feature is supported; `connect_target` attaches it.

Negotiated via the operator's advertised features — **no user-facing flag**. Against operators that don't advertise it, the CLI falls back to the query string (today's behavior), so it's fully backward compatible.

## Operator side

The operator-side consumer (parse the header, advertise the feature, plus multi-cluster envoy support) is a stacked PR in the `operator` repo that bumps the git rev to pick up these shared symbols.

Closes INT-477.