### PR TITLE
Fix flaky NodeHTTP http_mirroring layer test

### DIFF
--- a/changelog.d/+flaky-node-http-mirror-test.internal.md
+++ b/changelog.d/+flaky-node-http-mirror-test.internal.md
@@ -1,0 +1,1 @@
+Fixed flaky `mirroring_with_http` layer test (NodeHTTP case) that could hang until timeout on loaded CI by marking request completion before sending the (discarded) response.

--- a/mirrord/layer-tests/tests/apps/app_node.js
+++ b/mirrord/layer-tests/tests/apps/app_node.js
@@ -19,10 +19,16 @@ function exit() {
 function get_handler(method) {
   return function (req, res) {
     console.log(method + ": Request completed");
-    res.send(method);
     done[method] = true;
     if (Object.values(done).every(Boolean))
       exit();
+    // The intproxy only lingers briefly on a mirror connection, so by the time
+    // we respond the local connection may already be torn down. The response is
+    // discarded anyway (nothing reads it back), so swallow any write error and
+    // rely on `done` having been set above to drive the exit.
+    try {
+      res.send(method);
+    } catch (_err) {}
   }
 }
 


### PR DESCRIPTION
## What

The `mirroring_with_http` layer test (the `NodeHTTP` case, `application_3`) intermittently hangs until the 60s `rstest` timeout on loaded Linux CI runners.

## Why

The test fires four fire-and-forget mirrored HTTP requests, and the Node/Express app self-exits only once it has handled all four. The old handler recorded completion *after* responding:

```js
res.send(method);      // respond first
done[method] = true;   // record completion second
```

For a **mirror** connection the intproxy lingers only briefly (`MIRROR_MODE_LINGER_TIMEOUT = 1s`, `mirrord/intproxy/src/proxies/incoming/tcp_proxy.rs`) before tearing down the local connection to the app. On a slow/loaded runner Express can reach the handler after that window, so by the time it calls `res.send()` the local socket is already gone. `res.send()` throws synchronously, Express's handler wrapper catches it, and `done[method] = true` is never reached — so the app never satisfies its exit condition and `test_process.wait()` blocks until the outer timeout. (The request itself is always delivered via a clean TCP FIN, which is why "Request completed" still prints — completion is just never marked.)

The Python apps (Flask/FastAPI) don't flake because they set `done` *before* returning the body; the Go app survives because a failed write doesn't unwind the handler.

## Fix

Record completion and check the exit condition *before* responding (matching the Flask/FastAPI test apps), and wrap `res.send()` in `try/catch` so a write to an already-torn-down mirror connection can't abort the handler or leak an error to stderr (which would otherwise trip `assert_no_error_in_stderr`).

Test-fixture change only — no production code touched.