### PR TITLE
CI: enable GHA layer cache for agent and CLI image builds

### DIFF
--- a/.github/workflows/build-agent-image.yaml
+++ b/.github/workflows/build-agent-image.yaml
@@ -12,11 +12,19 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
+      # Exposes ACTIONS_RUNTIME_TOKEN / ACTIONS_CACHE_URL to the bake `run` step so the
+      # `type=gha` cache declared in ci/docker-bake.hcl actually imports/exports. Without it
+      # the cache is silently a no-op and every run rebuilds the agent image from scratch.
+      - uses: crazy-max/ghaction-github-runtime@3cb05d89e1f492524af3d41a1c98c83bc3025124 # v3.0.0
       - name: build and export
         env:
           PLATFORMS: "linux/amd64"
           AGENT_TAGS: "test"
-        run: docker buildx bake -f ci/docker-bake.hcl agent --set "agent.output=type=docker,dest=${{ github.workspace }}/test.tar"
+        run: |
+          docker buildx bake -f ci/docker-bake.hcl agent \
+            --set "agent.output=type=docker,dest=${{ github.workspace }}/test.tar" \
+            --set "agent.cache-from=type=gha,scope=agent" \
+            --set "agent.cache-to=type=gha,mode=max,scope=agent"
       - name: upload image
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:

--- a/.github/workflows/build-agent-image.yaml
+++ b/.github/workflows/build-agent-image.yaml
@@ -12,19 +12,22 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
-      # Exposes ACTIONS_RUNTIME_TOKEN / ACTIONS_CACHE_URL to the bake `run` step so the
-      # `type=gha` cache declared in ci/docker-bake.hcl actually imports/exports. Without it
-      # the cache is silently a no-op and every run rebuilds the agent image from scratch.
-      - uses: crazy-max/ghaction-github-runtime@3cb05d89e1f492524af3d41a1c98c83bc3025124 # v3.0.0
+      # bake-action exposes the Actions cache runtime to BuildKit, so the `type=gha` cache
+      # declared in ci/docker-bake.hcl actually imports/exports. A plain `run: docker buildx
+      # bake` can't (ACTIONS_RUNTIME_TOKEN / ACTIONS_CACHE_URL aren't in run-step env), so the
+      # cache was silently a no-op and every run rebuilt the agent image from scratch.
       - name: build and export
+        uses: docker/bake-action@6614cfa25eff9a0b2b2697efb0b6159e7680d584 # v7.2.0
         env:
           PLATFORMS: "linux/amd64"
           AGENT_TAGS: "test"
-        run: |
-          docker buildx bake -f ci/docker-bake.hcl agent \
-            --set "agent.output=type=docker,dest=${{ github.workspace }}/test.tar" \
-            --set "agent.cache-from=type=gha,scope=agent" \
-            --set "agent.cache-to=type=gha,mode=max,scope=agent"
+        with:
+          files: ci/docker-bake.hcl
+          targets: agent
+          set: |
+            agent.output=type=docker,dest=${{ github.workspace }}/test.tar
+            agent.cache-from=type=gha,scope=agent
+            agent.cache-to=type=gha,mode=max,scope=agent
       - name: upload image
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:

--- a/.github/workflows/build-cli-image.yaml
+++ b/.github/workflows/build-cli-image.yaml
@@ -19,17 +19,20 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
-      # Exposes ACTIONS_RUNTIME_TOKEN / ACTIONS_CACHE_URL to the bake `run` step so the
-      # `type=gha` cache declared in ci/docker-bake.hcl actually imports/exports. Without it
-      # the cache is silently a no-op and every run rebuilds the CLI image from scratch.
-      - uses: crazy-max/ghaction-github-runtime@3cb05d89e1f492524af3d41a1c98c83bc3025124 # v3.0.0
+      # bake-action exposes the Actions cache runtime to BuildKit, so the `type=gha` cache
+      # declared in ci/docker-bake.hcl actually imports/exports. A plain `run: docker buildx
+      # bake` can't (ACTIONS_RUNTIME_TOKEN / ACTIONS_CACHE_URL aren't in run-step env), so the
+      # cache was silently a no-op and every run rebuilt the CLI image from scratch.
       - name: build and export
+        uses: docker/bake-action@6614cfa25eff9a0b2b2697efb0b6159e7680d584 # v7.2.0
         env:
           PLATFORMS: ${{ matrix.platform }}
           CLI_TAGS: "cli_image"
         # Per-arch cache scope so the amd64 and arm64 legs don't overwrite each other's cache index.
-        run: |
-          docker buildx bake -f ci/docker-bake.hcl cli \
-            --set "cli.output=type=docker,dest=${{ github.workspace }}/cli_image.tar" \
-            --set "cli.cache-from=type=gha,scope=cli-${{ matrix.arch }}" \
-            --set "cli.cache-to=type=gha,mode=max,scope=cli-${{ matrix.arch }}"
+        with:
+          files: ci/docker-bake.hcl
+          targets: cli
+          set: |
+            cli.output=type=docker,dest=${{ github.workspace }}/cli_image.tar
+            cli.cache-from=type=gha,scope=cli-${{ matrix.arch }}
+            cli.cache-to=type=gha,mode=max,scope=cli-${{ matrix.arch }}

--- a/.github/workflows/build-cli-image.yaml
+++ b/.github/workflows/build-cli-image.yaml
@@ -11,12 +11,25 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        platform: [linux/amd64, linux/arm64]
+        include:
+          - platform: linux/amd64
+            arch: amd64
+          - platform: linux/arm64
+            arch: arm64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
+      # Exposes ACTIONS_RUNTIME_TOKEN / ACTIONS_CACHE_URL to the bake `run` step so the
+      # `type=gha` cache declared in ci/docker-bake.hcl actually imports/exports. Without it
+      # the cache is silently a no-op and every run rebuilds the CLI image from scratch.
+      - uses: crazy-max/ghaction-github-runtime@3cb05d89e1f492524af3d41a1c98c83bc3025124 # v3.0.0
       - name: build and export
         env:
           PLATFORMS: ${{ matrix.platform }}
           CLI_TAGS: "cli_image"
-        run: docker buildx bake -f ci/docker-bake.hcl cli --set "cli.output=type=docker,dest=${{ github.workspace }}/cli_image.tar"
+        # Per-arch cache scope so the amd64 and arm64 legs don't overwrite each other's cache index.
+        run: |
+          docker buildx bake -f ci/docker-bake.hcl cli \
+            --set "cli.output=type=docker,dest=${{ github.workspace }}/cli_image.tar" \
+            --set "cli.cache-from=type=gha,scope=cli-${{ matrix.arch }}" \
+            --set "cli.cache-to=type=gha,mode=max,scope=cli-${{ matrix.arch }}"

--- a/changelog.d/+ci-image-build-gha-cache.internal.md
+++ b/changelog.d/+ci-image-build-gha-cache.internal.md
@@ -1,0 +1,1 @@
+Enable the GitHub Actions layer cache for the agent and CLI image builds in CI, so unchanged images are restored from cache instead of rebuilt from scratch.


### PR DESCRIPTION
## What

`ci/docker-bake.hcl` already declares `cache-from`/`cache-to = type=gha` for the `agent` and `cli` targets, but the cache has been **silently inert**: `docker buildx bake` ran from a plain `run:` step, which does **not** have `ACTIONS_RUNTIME_TOKEN` / `ACTIONS_CACHE_URL` in its environment, so the `type=gha` backend no-ops. Every PR rebuilt the agent and CLI images from scratch.

Verified on a recent green run (`28391365861`): the agent "build and export" step took **9.5 min**, and the build log shows **no** `importing cache manifest` at the start and **no** gha cache export at the end (only `exporting layers` to the docker tarball).

This matters because the agent image build sits on the CI **critical path** — `plan → test_agent_image (~10 min) → e2e (~17 min)`.

## Change

- Switch the agent + CLI image builds from a raw `run: docker buildx bake` to the official **`docker/bake-action`** (pinned by SHA), which exposes the Actions cache runtime to BuildKit so the already-declared `type=gha` cache actually imports/exports. No extra third-party action.
- Pin **distinct cache scopes** per image and per arch (`agent`, `cli-amd64`, `cli-arm64`) so the builds don't overwrite each other's cache index.

## Effect

On PRs that don't change the agent/CLI sources or their builder images, the image builds become layer-cache hits instead of ~10-min cold rebuilds. The stable builder/runtime image layers (the ~6 min apt/toolchain setup) are cached across runs regardless.

### Caveats / things to watch
- **10GB GHA cache cap** (the one documented at the top of `ci.yaml`): `mode=max` caches the builder stage layers, which is what makes the rebuild fast — but those are large, and could compete with the cargo caches `setup-rust-toolchain` keeps. GitHub evicts LRU, and the cargo caches are hit far more often so should survive, but worth watching cache sizes after this lands. `mode=min` was considered but wouldn't cache the expensive builder stage (it's discarded from the final scratch-based image), so it wouldn't help.
- BuildKit `--mount=type=cache` mounts (cargo registry/target) are not persisted by `type=gha`; a source change still recompiles. This targets layer caching, the bulk of the win for the common no-image-change PR.

One of two PRs aimed at the agent-image → e2e critical path; the other (#4445) lets e2e start concurrently with the image build.