### PR TITLE
CI: overlap e2e with the agent image build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -269,8 +269,12 @@ jobs:
       rust_toolchain: ${{ needs.plan.outputs.rust_toolchain }}
     secrets: inherit
 
+  # NOTE: e2e intentionally does not `need` test_agent_image so the two run concurrently.
+  # e2e spends its first ~9 min on cluster setup + building the CLI before it actually
+  # needs the agent image, so overlapping that with the ~10 min image build keeps the
+  # build off the critical path. The `download image` step polls for the artifact.
   e2e:
-    needs: [plan, test_agent_image]
+    needs: [plan]
     if: ${{ needs.plan.outputs.rs_changed == 'true' || needs.plan.outputs.ci_changed == 'true' }}
     uses: ./.github/workflows/test-e2e.yaml
     secrets: inherit

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -276,6 +276,12 @@ jobs:
   e2e:
     needs: [plan]
     if: ${{ needs.plan.outputs.rs_changed == 'true' || needs.plan.outputs.ci_changed == 'true' }}
+    # The workflow-level default is `contents: read` (everything else `none`). A
+    # `workflow_call` job can only pass down scopes the caller holds, and test-e2e.yaml's
+    # `download image` step needs `actions: read` to poll the run's artifacts, so grant it here.
+    permissions:
+      contents: read
+      actions: read
     uses: ./.github/workflows/test-e2e.yaml
     secrets: inherit
 

--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -54,12 +54,20 @@ jobs:
       # The agent image is built by a sibling job that runs concurrently with this one
       # (e2e no longer `needs` it), so the `test` artifact may not exist yet when we get
       # here. Poll for it until it's ready, giving the build up to 8 minutes to finish.
+      # If the build job finishes without producing the artifact it has failed (a success
+      # would have uploaded it), so bail out immediately instead of waiting out the timeout.
       - name: download image
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           deadline=$((SECONDS + 480))
           until gh run download "$GITHUB_RUN_ID" --name test --dir /tmp; do
+            build_state=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/jobs" --paginate \
+              --jq '.jobs[] | select(.name | endswith("build-agent-image")) | .status' | head -n1)
+            if [ "$build_state" = "completed" ]; then
+              echo "::error::Agent image build finished without producing the image artifact; failing fast"
+              exit 1
+            fi
             if [ "$SECONDS" -ge "$deadline" ]; then
               echo "::error::Timed out after 8 minutes waiting for the agent image artifact"
               exit 1

--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -5,6 +5,9 @@ on:
 
 permissions:
   contents: read
+  # `download image` polls the run's artifacts via `gh run download` while the
+  # agent image build may still be in flight, which needs the actions read scope.
+  actions: read
 
 env:
   MIRRORD_TELEMETRY: false
@@ -48,11 +51,22 @@ jobs:
           container-runtime: ${{ matrix.container-runtime }}
           cluster-runtime: ${{ matrix.cluster-runtime }}
           kind-cluster-name: ${{ env.KIND_CLUSTER_NAME }}
+      # The agent image is built by a sibling job that runs concurrently with this one
+      # (e2e no longer `needs` it), so the `test` artifact may not exist yet when we get
+      # here. Poll for it until it's ready, giving the build up to 8 minutes to finish.
       - name: download image
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
-        with:
-          name: test
-          path: /tmp
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          deadline=$((SECONDS + 480))
+          until gh run download "$GITHUB_RUN_ID" --name test --dir /tmp; do
+            if [ "$SECONDS" -ge "$deadline" ]; then
+              echo "::error::Timed out after 8 minutes waiting for the agent image artifact"
+              exit 1
+            fi
+            echo "Agent image artifact not ready yet, retrying in 15s..."
+            sleep 15
+          done
       - name: Load test image into minikube
         if: ${{ matrix.cluster-runtime == 'minikube' }}
         run: minikube image load /tmp/test.tar && rm /tmp/test.tar

--- a/changelog.d/+ci-e2e-overlap-agent-image.internal.md
+++ b/changelog.d/+ci-e2e-overlap-agent-image.internal.md
@@ -1,0 +1,1 @@
+Run the CI e2e jobs concurrently with the agent image build instead of waiting for it, polling for the image artifact when it's actually needed, to keep the image build off the critical path.


### PR DESCRIPTION
## What

The CI critical path is `plan → test_agent_image (~10 min) → e2e (~17 min)`. But e2e doesn't actually use the agent image until ~9 min into its own run:

From run `28391365861`, the e2e (kind) job timeline:
- cluster setup (`e2e-setup`): ~4.5 min
- `cargo xtask build-cli`: ~4.5 min
- **load agent image: <10 s** ← the only step that needs the artifact
- e2e tests: ~7 min

So waiting for the entire `test_agent_image` job before e2e even *starts* makes the image build pure additive latency.

## Change

- Drop `test_agent_image` from `e2e`'s `needs` so the two jobs run **concurrently**. e2e's cluster bring-up + CLI build now overlap the image build.
- Replace the `download image` step (`actions/download-artifact`, which fails immediately if the artifact isn't up yet) with a poll using `gh run download` that retries for up to **8 minutes** until the image artifact is ready, then loads it.
- Grant the reusable workflow `actions: read` so `gh run download` can read the run's artifacts.

By the time e2e reaches the image-load step (~9 min in), the ~10-min image build is essentially done, so the poll waits ~0–1 min instead of ~10. Expected to take roughly **8–9 min off** the critical path.

### Notes
- Whenever e2e runs (`rs_changed || ci_changed`), `test_agent_image` also runs (`rs_changed || ci_changed || dockerfile_changed`) — its condition is a superset — so the artifact is always produced. If the image build *fails*, the poll times out after 8 min and e2e fails (vs. failing fast before); acceptable trade-off, and the 8-min cap matches the build's worst case.
- `ci-success` still lists both jobs as required, so branch protection is unchanged.

Pairs with the agent/CLI image cache PR; together they target the same critical path.