### PR TITLE
Reuse runtime.asmcgocall for the x86-64 Go 1.25+ syscall hook (experimental)

### DIFF
--- a/changelog.d/+go-asmcgocall.added.md
+++ b/changelog.d/+go-asmcgocall.added.md
@@ -1,0 +1,1 @@
+Added an experimental `go_asmcgocall` flag that makes the Go 1.25+ `syscall` hook on `x86-64` reuse the Go runtime's own `asmcgocall` stack-switching routine (as the `arm64` hook already does), fixing crashes seen in some Go programs that use `cgo`.

--- a/mirrord-schema.json
+++ b/mirrord-schema.json
@@ -1926,6 +1926,14 @@
             "null"
           ]
         },
+        "go_asmcgocall": {
+          "title": "_experimental_ go_asmcgocall {#go_asmcgocall}",
+          "description": "On x86-64, route the Go 1.25+ syscall hook through the Go runtime's own `runtime.asmcgocall`\nfor the switch to and from the `g0` system stack, instead of the hand-rolled assembly\nswitch. This mirrors what the arm64 hook already does and avoids corrupting the scheduler\nstate (`g.sched`) of goroutines blocked in a syscall, which can crash cgo-heavy Go programs.\nTakes precedence over `go_cgo_stack_switch` when both are set. No effect on arm64, which\nalways uses `runtime.asmcgocall`.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "go_cgo_stack_switch": {
           "title": "_experimental_ go_cgo_stack_switch {#go_cgo_stack_switch}",
           "description": "use cgo's depth-based stack restore when switching back from the g0 stack in the Go 1.25+\nsyscall hook.",

--- a/mirrord-schema.json
+++ b/mirrord-schema.json
@@ -1928,7 +1928,7 @@
         },
         "go_asmcgocall": {
           "title": "_experimental_ go_asmcgocall {#go_asmcgocall}",
-          "description": "On x86-64, route the Go 1.25+ syscall hook through the Go runtime's own `runtime.asmcgocall`\nfor the switch to and from the `g0` system stack, instead of the hand-rolled assembly\nswitch. This mirrors what the arm64 hook already does and avoids corrupting the scheduler\nstate (`g.sched`) of goroutines blocked in a syscall, which can crash cgo-heavy Go programs.\nTakes precedence over `go_cgo_stack_switch` when both are set. No effect on arm64, which\nalways uses `runtime.asmcgocall`.",
+          "description": "On x86-64, route the Go 1.25+ syscall hook through the Go runtime's own\n`runtime.asmcgocall` for the switch to and from the `g0` system stack, instead of the\nhand-rolled assembly switch. This mirrors what the arm64 hook already does and avoids\ncorrupting the scheduler state (`g.sched`) of goroutines blocked in a syscall, which\ncan crash cgo-heavy Go programs. Takes precedence over `go_cgo_stack_switch` when both\nare set. No effect on arm64, which always uses `runtime.asmcgocall`.",
           "type": [
             "boolean",
             "null"

--- a/mirrord/config/src/experimental.rs
+++ b/mirrord/config/src/experimental.rs
@@ -167,6 +167,17 @@ pub struct ExperimentalConfig {
     /// syscall hook.
     #[config(default = false)]
     pub go_cgo_stack_switch: bool,
+
+    /// ### _experimental_ go_asmcgocall {#go_asmcgocall}
+    ///
+    /// On x86-64, route the Go 1.25+ syscall hook through the Go runtime's own
+    /// `runtime.asmcgocall` for the switch to and from the `g0` system stack, instead of the
+    /// hand-rolled assembly switch. This mirrors what the arm64 hook already does and avoids
+    /// corrupting the scheduler state (`g.sched`) of goroutines blocked in a syscall, which
+    /// can crash cgo-heavy Go programs. Takes precedence over `go_cgo_stack_switch` when both
+    /// are set. No effect on arm64, which always uses `runtime.asmcgocall`.
+    #[config(default = false)]
+    pub go_asmcgocall: bool,
 }
 
 impl CollectAnalytics for &ExperimentalConfig {
@@ -190,6 +201,7 @@ impl CollectAnalytics for &ExperimentalConfig {
         analytics.add("applev", self.applev.is_some());
         analytics.add("sip_utils", self.sip_utils);
         analytics.add("go_cgo_stack_switch", self.go_cgo_stack_switch);
+        analytics.add("go_asmcgocall", self.go_asmcgocall);
     }
 }
 

--- a/mirrord/layer/src/go/linux_aarch64.rs
+++ b/mirrord/layer/src/go/linux_aarch64.rs
@@ -164,7 +164,11 @@ fn post_go1_23(hook_manager: &mut HookManager, go_version: f32, module_name: Opt
 /// Refer:
 ///   - File zsyscall_linux_amd64.go generated using mksyscall.pl.
 ///   - <https://cs.opensource.google/go/go/+/refs/tags/go1.18.5:src/syscall/syscall_unix.go>
-pub(crate) fn enable_hooks(hook_manager: &mut HookManager, _cgo_stack_switch: bool) {
+pub(crate) fn enable_hooks(
+    hook_manager: &mut HookManager,
+    _cgo_stack_switch: bool,
+    _use_asmcgocall: bool,
+) {
     let Some(version) = super::get_go_runtime_version(hook_manager) else {
         return;
     };
@@ -185,6 +189,7 @@ pub(crate) fn enable_hooks_in_loaded_module(
     hook_manager: &mut HookManager,
     module_name: String,
     _cgo_stack_switch: bool,
+    _use_asmcgocall: bool,
 ) {
     let Some(version) = super::get_go_runtime_version_in_module(hook_manager, &module_name) else {
         return;

--- a/mirrord/layer/src/go/linux_x64.rs
+++ b/mirrord/layer/src/go/linux_x64.rs
@@ -1316,7 +1316,7 @@ mod post_go_1_25 {
         );
     }
 
-    /// Calls [`c_abi_syscall6_handler`](crate::go::c_abi_syscall6_handler).
+    /// Calls [`c_abi_syscall6_handler`].
     ///
     /// Logic:
     /// 1. Make sure that stack conforms to C ABI.
@@ -1330,7 +1330,7 @@ mod post_go_1_25 {
     ///
     /// # Returns
     ///
-    /// * rax - value returned by [`c_abi_syscall6_handler`](crate::go::c_abi_syscall6_handler).
+    /// * rax - value returned by [`c_abi_syscall6_handler`].
     #[unsafe(naked)]
     unsafe extern "C" fn c_abi_wrapper() {
         naked_asm!(

--- a/mirrord/layer/src/go/linux_x64.rs
+++ b/mirrord/layer/src/go/linux_x64.rs
@@ -611,14 +611,18 @@ fn post_go1_23(hook_manager: &mut HookManager, module_name: Option<&str>) {
 /// Refer:
 ///   - File zsyscall_linux_amd64.go generated using mksyscall.pl.
 ///   - <https://cs.opensource.google/go/go/+/refs/tags/go1.18.5:src/syscall/syscall_unix.go>
-pub(crate) fn enable_hooks(hook_manager: &mut HookManager, cgo_stack_switch: bool) {
+pub(crate) fn enable_hooks(
+    hook_manager: &mut HookManager,
+    cgo_stack_switch: bool,
+    use_asmcgocall: bool,
+) {
     let Some(version) = super::get_go_runtime_version(hook_manager) else {
         return;
     };
 
     tracing::trace!(version, "Detected Go");
     if version >= 1.25 {
-        post_go_1_25::hook(hook_manager, version, cgo_stack_switch);
+        post_go_1_25::hook(hook_manager, version, cgo_stack_switch, use_asmcgocall);
     } else if version >= 1.23 {
         post_go1_23(hook_manager, None);
     } else if version >= 1.19 {
@@ -639,6 +643,7 @@ pub(crate) fn enable_hooks_in_loaded_module(
     hook_manager: &mut HookManager,
     module_name: String,
     cgo_stack_switch: bool,
+    use_asmcgocall: bool,
 ) {
     let Some(version) = super::get_go_runtime_version_in_module(hook_manager, &module_name) else {
         return;
@@ -650,6 +655,7 @@ pub(crate) fn enable_hooks_in_loaded_module(
             version,
             module_name.as_str(),
             cgo_stack_switch,
+            use_asmcgocall,
         );
     } else if version >= 1.23 {
         post_go1_23(hook_manager, Some(module_name.as_str()));
@@ -671,11 +677,20 @@ pub(crate) fn enable_hooks_in_loaded_module(
 mod post_go_1_25 {
     use std::{arch::naked_asm, ffi::c_void};
 
-    use crate::{hooks::HookManager, macros::hook_symbol};
+    use crate::{go::c_abi_syscall6_handler, hooks::HookManager, macros::hook_symbol};
 
     static mut FN_GOSAVE_SYSTEMSTACK_SWITCH: *const c_void = std::ptr::null();
 
-    pub fn hook(hook_manager: &mut HookManager, go_version: f32, cgo_stack_switch: bool) {
+    /// Address of the Go runtime's `runtime.asmcgocall`, resolved at hook time and used by
+    /// [`asmcgocall_syscall6_detour`].
+    static mut FN_ASMCGOCALL: *const c_void = std::ptr::null();
+
+    pub fn hook(
+        hook_manager: &mut HookManager,
+        go_version: f32,
+        cgo_stack_switch: bool,
+        use_asmcgocall: bool,
+    ) {
         let gosave_address = hook_manager
             .resolve_symbol_main_module("gosave_systemstack_switch")
             .expect(
@@ -693,7 +708,18 @@ mod post_go_1_25 {
             "internal/runtime/syscall.Syscall6"
         };
 
-        if cgo_stack_switch {
+        if use_asmcgocall {
+            let asmcgocall_address = hook_manager
+                .resolve_symbol_main_module("runtime.asmcgocall")
+                .expect(
+                    "couldn't find the address of symbol \
+                    `runtime.asmcgocall`, please file a bug",
+                );
+            unsafe {
+                FN_ASMCGOCALL = asmcgocall_address.0;
+            }
+            hook_symbol!(hook_manager, original_symbol, asmcgocall_syscall6_detour);
+        } else if cgo_stack_switch {
             hook_symbol!(
                 hook_manager,
                 original_symbol,
@@ -713,6 +739,7 @@ mod post_go_1_25 {
         go_version: f32,
         module_name: &str,
         cgo_stack_switch: bool,
+        use_asmcgocall: bool,
     ) {
         let gosave_address = hook_manager
             .resolve_symbol_in_module(module_name, "gosave_systemstack_switch")
@@ -731,7 +758,23 @@ mod post_go_1_25 {
             "internal/runtime/syscall.Syscall6"
         };
 
-        if cgo_stack_switch {
+        if use_asmcgocall {
+            let asmcgocall_address = hook_manager
+                .resolve_symbol_in_module(module_name, "runtime.asmcgocall")
+                .expect(
+                    "couldn't find the address of symbol \
+                    `runtime.asmcgocall`, please file a bug",
+                );
+            unsafe {
+                FN_ASMCGOCALL = asmcgocall_address.0;
+            }
+            hook_symbol!(
+                hook_manager,
+                module_name,
+                original_symbol,
+                asmcgocall_syscall6_detour
+            );
+        } else if cgo_stack_switch {
             hook_symbol!(
                 hook_manager,
                 module_name,
@@ -746,6 +789,130 @@ mod post_go_1_25 {
                 internal_runtime_syscall_syscall6_detour
             );
         }
+    }
+
+    /// Layout of the syscall number and its arguments as spilled onto the goroutine stack by
+    /// [`asmcgocall_syscall6_detour`] and read back by [`mirrord_syscall_handler`].
+    #[repr(C)]
+    struct SyscallArgs {
+        syscall: i64,
+        arg1: i64,
+        arg2: i64,
+        arg3: i64,
+        arg4: i64,
+        arg5: i64,
+        arg6: i64,
+    }
+
+    /// The C-ABI function handed to `runtime.asmcgocall` to run on the `g0` stack.
+    ///
+    /// `asmcgocall` can only pass a single pointer argument, so [`asmcgocall_syscall6_detour`]
+    /// spills the syscall number and arguments into a [`SyscallArgs`] on the goroutine stack and
+    /// passes its address here.
+    unsafe extern "C" fn mirrord_syscall_handler(args: *const SyscallArgs) -> i64 {
+        unsafe {
+            c_abi_syscall6_handler(
+                (*args).syscall,
+                (*args).arg1,
+                (*args).arg2,
+                (*args).arg3,
+                (*args).arg4,
+                (*args).arg5,
+                (*args).arg6,
+            )
+        }
+    }
+
+    /// Detour for `internal/runtime/syscall.Syscall6` that reuses the Go runtime's own
+    /// `runtime.asmcgocall` to switch to and from the `g0` system stack, instead of the hand-rolled
+    /// switch in [`internal_runtime_syscall_syscall6_detour`] /
+    /// [`experimental_c_abi_wrapper_on_systemstack`].
+    ///
+    /// This is what the arm64 hook has always done. `runtime.asmcgocall` is the runtime's
+    /// sanctioned way to run foreign C-ABI code on `g0`, and is exactly what `cgocall` uses while
+    /// the goroutine is `_Gsyscall`, so it preserves the `g.sched` that `entersyscall` owns for
+    /// goroutines that reached us through `syscall.Syscall6`. It never zeroes `g.sched.sp`/`bp` —
+    /// the corruption the hand-rolled [`internal_runtime_syscall_syscall6_detour`] path can cause.
+    ///
+    /// `asmcgocall` reads `g` from TLS and never writes `r14`, so the goroutine pointer the Go
+    /// caller expects in `r14` survives the call; we still reload it from TLS before returning, to
+    /// match the other detours. The full 64-bit handler result is left in `rax` by `asmcgocall`
+    /// (its `MOVL` to the Go return slot only truncates the copy written to the stack).
+    ///
+    /// # Params
+    ///
+    /// `internal/runtime/syscall.Syscall6` params in rax, rbx, rcx, rdi, rsi, r8, r9.
+    ///
+    /// # Returns
+    ///
+    /// Mocked `internal/runtime/syscall.Syscall6` return values in rax, rbx, and rcx.
+    #[unsafe(naked)]
+    unsafe extern "C" fn asmcgocall_syscall6_detour() {
+        naked_asm!(
+            // SYS_EXIT and SYS_EXIT_GROUP must pass through untouched, exactly like the other
+            // detours. See https://github.com/metalbear-co/mirrord/issues/2988.
+            "cmp    rax, 60",
+            "je     2f",
+            "cmp    rax, 231",
+            "je     2f",
+            // Establish a frame and reserve space for the `asmcgocall` call args plus the
+            // `SyscallArgs` struct (all relative to rsp after the `sub`):
+            //   [rsp+0x00] fn        (asmcgocall arg0)
+            //   [rsp+0x08] &args     (asmcgocall arg1)
+            //   [rsp+0x10] ret slot  (asmcgocall int32 return, unused - we read rax directly)
+            //   [rsp+0x18] args.syscall
+            //   [rsp+0x20] args.arg1
+            //   [rsp+0x28] args.arg2
+            //   [rsp+0x30] args.arg3
+            //   [rsp+0x38] args.arg4
+            //   [rsp+0x40] args.arg5
+            //   [rsp+0x48] args.arg6
+            "push   rbp",
+            "mov    rbp, rsp",
+            "sub    rsp, 0x50",
+            // Spill the syscall number and args from the Go ABIInternal registers to the struct.
+            "mov    [rsp+0x18], rax",
+            "mov    [rsp+0x20], rbx",
+            "mov    [rsp+0x28], rcx",
+            "mov    [rsp+0x30], rdi",
+            "mov    [rsp+0x38], rsi",
+            "mov    [rsp+0x40], r8",
+            "mov    [rsp+0x48], r9",
+            // asmcgocall(fn = mirrord_syscall_handler, arg = &args).
+            "lea    rax, [rsp+0x18]",
+            "mov    [rsp+0x08], rax",
+            "lea    rax, [rip + {syscall_handler}]",
+            "mov    [rsp], rax",
+            "mov    rax, [rip + {asmcgocall}]",
+            "call   rax",
+            // Full 64-bit result is in rax. Tear down our frame.
+            "add    rsp, 0x50",
+            "pop    rbp",
+            // Reload g into r14 for the Go caller's ABIInternal expectations.
+            "mov    r14, QWORD PTR fs:[0xfffffff8]",
+            // Format results as `internal/runtime/syscall.Syscall6` expects: r1=rax, r2=rbx,
+            // errno=rcx, using the same error boundary as Go's own Syscall6.
+            "cmp    rax, -0xfff",
+            "jbe    3f",
+            // Failure: errno in rcx, r1 = -1, r2 = 0.
+            "neg    rax",
+            "mov    rcx, rax",
+            "mov    rax, -0x1",
+            "mov    rbx, 0x0",
+            "ret",
+            // Success: r1 already in rax, clear r2 and errno.
+            "3:",
+            "mov    rbx, 0x0",
+            "mov    rcx, 0x0",
+            "ret",
+            // SYS_EXIT / SYS_EXIT_GROUP passthrough.
+            "2:",
+            "mov    rdx, rdi",
+            "syscall",
+
+            syscall_handler = sym mirrord_syscall_handler,
+            asmcgocall = sym FN_ASMCGOCALL,
+        )
     }
 
     /// Detour for `internal/runtime/syscall.Syscall6`.

--- a/mirrord/layer/src/lib.rs
+++ b/mirrord/layer/src/lib.rs
@@ -630,7 +630,11 @@ fn enable_hooks(state: &LayerSetup) {
         target_os = "linux"
     ))]
     {
-        go_hooks::enable_hooks(&mut hook_manager, state.experimental().go_cgo_stack_switch);
+        go_hooks::enable_hooks(
+            &mut hook_manager,
+            state.experimental().go_cgo_stack_switch,
+            state.experimental().go_asmcgocall,
+        );
     }
 
     #[cfg(all(
@@ -956,7 +960,13 @@ pub(crate) unsafe extern "C" fn dlopen_detour(
         .to_string_lossy()
         .into_owned();
     let go_cgo_stack_switch = setup().experimental().go_cgo_stack_switch;
-    go_hooks::enable_hooks_in_loaded_module(&mut hook_manager, filename, go_cgo_stack_switch);
+    let go_asmcgocall = setup().experimental().go_asmcgocall;
+    go_hooks::enable_hooks_in_loaded_module(
+        &mut hook_manager,
+        filename,
+        go_cgo_stack_switch,
+        go_asmcgocall,
+    );
 
     handle
 }


### PR DESCRIPTION
## Problem

The x86-64 Go 1.25+ syscall hook hand-rolls the switch to the `g0` system stack (`c_abi_wrapper_on_systemstack` in `linux_x64.rs`). Every blocking syscall — file reads included — reaches the hooked `internal/runtime/syscall.Syscall6` through `syscall.Syscall6`, which already ran `entersyscall`, so the goroutine is `_Gsyscall` and the runtime **owns its `g.sched`**.

The systemstack-style path restores `rsp`/`rbp` from `g.sched` and then **zeroes `g.sched.sp`/`bp`** (mimicking `runtime.systemstack`, which is only valid for `_Grunning`). That corrupts the scheduler context `entersyscall` saved. In cgo-heavy programs — where background pollers keep the GC and `sysmon` busy — the runtime observes/acts on the corrupted `g.sched`, and the corruption surfaces later as a general-protection fault on a non-canonical pointer in an unrelated goroutine:

```
[signal SIGSEGV: segmentation violation code=0x80 addr=0x0 ...]
internal/runtime/maps.(*Iter).Next(...)   table.go:818
```

`code=0x80` (`SI_KERNEL`) + `addr=0x0` is a `#GP` from dereferencing a non-canonical pointer — i.e. memory/stack corruption, not a plain nil deref. Because the corruption is timing-dependent, the crash site wanders between runs.

The **arm64** hook never had this class of bug: it resolves and calls the Go runtime's own `runtime.asmcgocall` for the switch ("_to avoid re-implementing it and doing it badly_").

## Fix

Add an experimental **`go_asmcgocall`** flag that makes the x86-64 hook do what arm64 does: spill the ABIInternal register args into a `SyscallArgs` struct on the goroutine stack and call the runtime's own `runtime.asmcgocall(mirrord_syscall_handler, &args)` for the `g0` switch. `asmcgocall` is the runtime's sanctioned way to run C-ABI code on `g0` and is exactly what `cgocall` uses from `_Gsyscall`, so it **never zeroes `g.sched`**.

## Behavior

- Default **off**. Precedence: `go_asmcgocall` > `go_cgo_stack_switch` > systemstack default. All three paths coexist for A/B testing.
- No effect on arm64 (already uses `runtime.asmcgocall`).
- If `runtime.asmcgocall` can't be resolved, the hook `expect`s with a clear "please file a bug" message (same failure mode arm64 already relies on).

Enable with:
```json
{ "experimental": { "go_asmcgocall": true } }
```

## Verification

- Config crate compiles + clippy-clean; `mirrord-schema.json` regenerated.
- The new detour's assembly was validated through LLVM (the same assembler `naked_asm!` uses) — encodings, forward labels, and RIP-relative operands all check out.
- **Not yet compiled for Linux** (authored on macOS, no cross-toolchain; the `go` module is `cfg`'d to linux). Relying on CI / `cargo check -p mirrord-layer --target x86_64-unknown-linux-gnu` for the final gate.

Follow-up idea: add a layer-test cgo app doing file reads so this path gets CI coverage.