### PR TITLE
Ignore flaky test_issue2807_with_ipv6_ignore layer test

### DIFF
--- a/changelog.d/+ignore-flaky-issue2807-ipv6.internal.md
+++ b/changelog.d/+ignore-flaky-issue2807-ipv6.internal.md
@@ -1,0 +1,1 @@
+Ignore the flaky `test_issue2807_with_ipv6_ignore` layer test until the underlying flakiness is fixed.

--- a/mirrord/layer-tests/tests/issue2807.rs
+++ b/mirrord/layer-tests/tests/issue2807.rs
@@ -20,6 +20,7 @@ pub use common::*;
 #[rstest]
 #[tokio::test]
 #[timeout(Duration::from_secs(60))]
+#[ignore = "flaky, disabled until we fix the underlying flakiness"]
 async fn test_issue2807_with_ipv6_ignore(
     #[values(Application::NodeIssue2807)] application: Application,
 ) {


### PR DESCRIPTION
## What

Marks the `test_issue2807_with_ipv6_ignore` layer test (`application_1_Application__NodeIssue2807`) as `#[ignore]` so it stops running in CI.

## Why

The test is flaky — it intermittently panics at `test-utils/src/lib.rs:96`. Disabling it until we fix the underlying flakiness so it stops blocking CI.

The test remains in the tree and can still be run explicitly with `cargo test -- --ignored`.
