### PR TITLE
Change mirrord UI to run as background process

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3377,15 +3377,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
 
 [[package]]
-name = "home"
-version = "0.5.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "hostname"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4757,7 +4748,6 @@ dependencies = [
  "fs4",
  "futures",
  "hex",
- "home",
  "http 1.4.0",
  "http-body-util",
  "humantime",
@@ -4946,7 +4936,6 @@ dependencies = [
  "chrono",
  "flate2",
  "fs4",
- "home",
  "http 1.4.0",
  "k8s-openapi",
  "kube",
@@ -5383,7 +5372,6 @@ dependencies = [
  "bytes",
  "eventsource-stream",
  "futures",
- "home",
  "http 1.4.0",
  "http-body-util",
  "hyper",
@@ -5473,7 +5461,6 @@ dependencies = [
 name = "mirrord-tls-util"
 version = "3.226.0"
 dependencies = [
- "home",
  "http 1.4.0",
  "pem",
  "rcgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4734,7 +4734,6 @@ name = "mirrord"
 version = "3.226.0"
 dependencies = [
  "actix-codec",
- "anyhow",
  "axum 0.8.8",
  "axum-extra",
  "base64",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4734,6 +4734,7 @@ name = "mirrord"
 version = "3.226.0"
 dependencies = [
  "actix-codec",
+ "anyhow",
  "axum 0.8.8",
  "axum-extra",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,7 +123,6 @@ futures-util = "0.3"
 glob = "0.3"
 hex = "0.4"
 hickory-resolver = { version = "0.26.1", features = ["serde", "tokio", "system-config"] }
-home = "0.5"
 http = { version = "1" }
 http-body = "1"
 http-body-util = "0.1"

--- a/changelog.d/+ui-bg-process.changed.md
+++ b/changelog.d/+ui-bg-process.changed.md
@@ -1,2 +1,2 @@
-The `mirror ui` command now starts the local UI server as a separate process that runs in the background on your machine.
+The `mirrord ui` command now starts the local UI server as a separate process that runs in the background on your machine.
 To stop the server, run `mirrord ui stop`.

--- a/changelog.d/+ui-bg-process.changed.md
+++ b/changelog.d/+ui-bg-process.changed.md
@@ -1,0 +1,2 @@
+The `mirror ui` command now starts the local UI server as a separate process that runs in the background on your machine.
+To stop the server, run `mirrord ui stop`.

--- a/deny.toml
+++ b/deny.toml
@@ -18,6 +18,9 @@ ignore = [
   "RUSTSEC-2025-0141", # bincode is unmaintaned, but we cannot remove it yet.
   "RUSTSEC-2026-0097", # rand: unsound only with a custom logger using `rand::rng()`; we don't use that pattern.
   "RUSTSEC-2026-0173", # proc-macro-error2 is unmaintained; transitive dep, not actionable for us right now.
+  "RUSTSEC-2026-0194",
+  "RUSTSEC-2026-0195", # quick-xml, used by plist, has a vulnerability which doesn't affect plist
+  # update plist when possible, tracked by https://github.com/ebarnard/rust-plist/issues/190
 ]
 
 [licenses]

--- a/mirrord/auth/Cargo.toml
+++ b/mirrord/auth/Cargo.toml
@@ -21,7 +21,6 @@ workspace = true
 [features]
 default = ["client"]
 client = [
-	"dep:home",
 	"dep:flate2",
 	"dep:fs4",
 	"dep:k8s-openapi",
@@ -39,7 +38,6 @@ base64.workspace = true
 bincode.workspace = true
 chrono.workspace = true
 whoami = { workspace = true, optional = true }
-home = { workspace = true, optional = true }
 pem.workspace = true
 flate2 = { workspace = true, optional = true }
 fs4 = { workspace = true, optional = true }

--- a/mirrord/auth/src/credential_store.rs
+++ b/mirrord/auth/src/credential_store.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::{HashMap, hash_map::Entry},
+    env::home_dir,
     fmt::Debug,
     io::ErrorKind,
     path::PathBuf,
@@ -27,7 +28,7 @@ use crate::{
 
 /// "~/.mirrord"
 static CREDENTIALS_DIR: LazyLock<PathBuf> = LazyLock::new(|| {
-    home::home_dir()
+    home_dir()
         .unwrap_or_else(|| PathBuf::from("~"))
         .join(".mirrord")
 });

--- a/mirrord/cli/Cargo.toml
+++ b/mirrord/cli/Cargo.toml
@@ -68,7 +68,6 @@ tokio-rustls.workspace = true
 tokio-stream = { workspace = true, features = ["io-util", "net"] }
 regex.workspace = true
 mid.workspace = true
-home.workspace = true
 uuid.workspace = true
 fs4.workspace = true
 hex.workspace = true

--- a/mirrord/cli/Cargo.toml
+++ b/mirrord/cli/Cargo.toml
@@ -35,7 +35,6 @@ mirrord-protocol-io = { path = "../protocol-io" }
 mirrord-auth = { path = "../auth" }
 
 actix-codec.workspace = true
-anyhow.workspace = true
 clap.workspace = true
 dotenvy.workspace = true
 tracing.workspace = true

--- a/mirrord/cli/Cargo.toml
+++ b/mirrord/cli/Cargo.toml
@@ -35,6 +35,7 @@ mirrord-protocol-io = { path = "../protocol-io" }
 mirrord-auth = { path = "../auth" }
 
 actix-codec.workspace = true
+anyhow.workspace = true
 clap.workspace = true
 dotenvy.workspace = true
 tracing.workspace = true

--- a/mirrord/cli/src/config.rs
+++ b/mirrord/cli/src/config.rs
@@ -1616,6 +1616,22 @@ pub struct UiArgs {
     /// Run the command, including the UI, but do not automatically open the browser.
     #[arg(long)]
     pub no_browser: bool,
+
+    /// Subcommand to use with `mirrord ui`.
+    #[command(subcommand)]
+    pub command: Option<UiSubcommand>,
+}
+
+/// `mirrord ui` subcommands.
+#[derive(Subcommand, Debug)]
+pub enum UiSubcommand {
+    /// Start the `mirrord ui` server as a background task. If `mirrord ui` is already running,
+    /// prints its details and leaves it unchanged.
+    Start,
+
+    /// Stop the currently running `mirrord ui` server background task.
+    #[command(visible_alias = "kill")]
+    Stop,
 }
 
 /// Arguments for the `mirrord session` command.

--- a/mirrord/cli/src/db_branches.rs
+++ b/mirrord/cli/src/db_branches.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashSet, fmt::Debug, ops::Not, path::PathBuf};
+use std::{collections::HashSet, env::home_dir, fmt::Debug, ops::Not, path::PathBuf};
 
 use k8s_openapi::NamespaceResourceScope;
 use kube::{Api, Resource, api::DeleteParams};
@@ -36,7 +36,7 @@ pub struct PortforwardSession {
 
 /// Directory where portforward session files are stored (`~/.mirrord/db_branch_portforwards/`).
 pub fn portforward_session_dir() -> PathBuf {
-    home::home_dir()
+    home_dir()
         .unwrap_or_else(|| PathBuf::from("~"))
         .join(".mirrord")
         .join("db_branch_portforwards")

--- a/mirrord/cli/src/error.rs
+++ b/mirrord/cli/src/error.rs
@@ -29,6 +29,7 @@ use crate::{
     fix::FixKubeconfigError,
     port_forward::PortForwardError,
     profile::ProfileError,
+    ui::UiCliError,
     up::UpCliError,
 };
 
@@ -677,9 +678,13 @@ pub(crate) enum CliError {
     Up(#[from] UpCliError),
 
     /// Errors produced by the `mirrord ui` command.
-    #[error("Session monitor UI error: {0}")]
-    #[diagnostic(help("Check that no other process is using the port and try again."))]
-    UiError(String),
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    Ui(#[from] UiCliError),
+
+    /// Errors produced by the `mirrord session` command.
+    #[error("Session command failed with: {0}")]
+    Session(String),
 
     #[error("Failed to read credentials file: {0}")]
     #[diagnostic(help(

--- a/mirrord/cli/src/internal_proxy.rs
+++ b/mirrord/cli/src/internal_proxy.rs
@@ -15,7 +15,8 @@ mod db_portforwards;
 #[cfg(not(target_os = "windows"))]
 use std::os::unix::ffi::OsStrExt;
 use std::{
-    env, io,
+    env::{self, home_dir},
+    io,
     net::{Ipv4Addr, SocketAddr},
     ops::Not,
     time::Duration,
@@ -177,7 +178,7 @@ async fn start_session_monitor(
 
     let shutdown = CancellationToken::new();
 
-    let sessions_dir = home::home_dir().map(|home_dir| home_dir.join(".mirrord").join("sessions"));
+    let sessions_dir = home_dir().map(|home_dir| home_dir.join(".mirrord").join("sessions"));
 
     tokio::spawn(async move {
         let Some(sessions_dir) = sessions_dir else {

--- a/mirrord/cli/src/session.rs
+++ b/mirrord/cli/src/session.rs
@@ -141,7 +141,7 @@ async fn delete_command(
         .unzip();
 
     if deleted_ids.is_empty() {
-        return Err(CliError::UiError(format!(
+        return Err(CliError::Session(format!(
             "no local sessions found with key `{key}`"
         )));
     }
@@ -206,7 +206,7 @@ async fn merged_sessions(
 
 async fn load_sessions() -> Result<Vec<SessionConnection>, CliError> {
     let sessions_dir = sessions_dir()
-        .ok_or_else(|| CliError::UiError("could not determine home directory".to_owned()))?;
+        .ok_or_else(|| CliError::Session("could not determine home directory".to_owned()))?;
     let mut sessions = Vec::new();
 
     for (session_id, endpoint) in session_endpoints(&sessions_dir) {
@@ -292,7 +292,7 @@ async fn kill_local_then_remote(
 ) -> Result<(), CliError> {
     let local_killed = if let Some(session) = local_session {
         session.client.kill().await.map_err(|error| {
-            CliError::UiError(format!(
+            CliError::Session(format!(
                 "failed to kill local session `{}`: {error}",
                 session.info.session_id
             ))
@@ -305,7 +305,7 @@ async fn kill_local_then_remote(
     match try_kill_remote_session(common, session_id).await {
         Ok(RemoteKillResult::Killed) => Ok(()),
         Ok(RemoteKillResult::NotFound | RemoteKillResult::Unavailable) if local_killed => Ok(()),
-        Ok(RemoteKillResult::NotFound | RemoteKillResult::Unavailable) => Err(CliError::UiError(
+        Ok(RemoteKillResult::NotFound | RemoteKillResult::Unavailable) => Err(CliError::Session(
             format!("no local or remote session found with id `{session_id}`"),
         )),
         Err(error) if local_killed => {
@@ -412,12 +412,12 @@ async fn delete_remote_session_with_name(
     match session_api.delete(session_name, &Default::default()).await {
         Ok(_) => Ok(true),
         Err(kube::Error::Api(status)) if status.code == 404 && status.reason.contains("parse") => {
-            Err(CliError::UiError(
+            Err(CliError::Session(
                 "remote session management is not supported by this operator".to_owned(),
             ))
         }
         Err(kube::Error::Api(status)) if status.code == 404 => Ok(false),
-        Err(error) => Err(CliError::UiError(format!(
+        Err(error) => Err(CliError::Session(format!(
             "failed to kill remote session `{session_name}`: {error}"
         ))),
     }

--- a/mirrord/cli/src/ui.rs
+++ b/mirrord/cli/src/ui.rs
@@ -6,10 +6,11 @@
 //! transport (Unix domain socket or named pipe), and serves a React frontend plus
 //! REST/SSE/WebSocket endpoints on localhost.
 
+#[cfg(unix)]
+use std::num::ParseIntError;
 use std::{
     fs::File,
     net::{Ipv4Addr, SocketAddr},
-    num::ParseIntError,
     path::PathBuf,
     process::Stdio,
     str::FromStr,
@@ -19,6 +20,7 @@ use std::{
 use fs4::fs_std::FileExt;
 use miette::Diagnostic;
 use mirrord_session_monitor_client::sessions_dir;
+#[cfg(unix)]
 use nix::{
     errno::Errno,
     sys::signal::{Signal, kill},
@@ -66,8 +68,8 @@ const PID_FILE_NAME: &str = "server_pid";
 const TOKEN_FILE_NAME: &str = "token";
 
 /// The header key that can be used to set the auth token in requests to the ui server instead of
-/// using the `token` query parameter. It can also be set in a cookie. See the [`token_auth()`]
-/// middleware.
+/// using the `token` query parameter. It can also be set in a cookie. See the
+/// `ui::server::token_auth()` middleware.
 const TOKEN_HEADER_NAME: &str = "x-auth-token";
 
 /// The name of the env var containing the port that the ui server should run on. If present in env,
@@ -88,6 +90,7 @@ pub enum UiCliError {
     Io(#[from] std::io::Error),
 
     /// May occur while trying to kill the existing UI server.
+    #[cfg(unix)]
     #[error("failed to perform an operation on the UI server process: {0}")]
     #[diagnostic(help(
         "To forcefully stop the server process, try killing it manually. On \
@@ -106,6 +109,7 @@ pub enum UiCliError {
     #[error("the new server process ended unexpectedly")]
     ChildExitedUnexpectedly,
 
+    #[cfg(unix)]
     #[error("failed to parse a PID from file contents: {0}")]
     PidParse(ParseIntError),
 }

--- a/mirrord/cli/src/ui.rs
+++ b/mirrord/cli/src/ui.rs
@@ -65,11 +65,37 @@ mod chaos;
 
 const MAX_EVENTS_PER_SESSION: usize = 500;
 
+/// The name of the file that is locked by the currently running ui server. If a new server attempts
+/// to start running, it will fail to lock this fail and exit.
+///
+/// Only ever touched by the *child* process that runs the server, not the parent process running in
+/// the foreground.
 const UI_LOCK_FILE_NAME: &str = "ui.lock";
+
+/// The name of the file where we store the PID of the most recently started ui server. We use this
+/// to be able to kill the currently running server in a standalone command. If there is no lock on
+/// [`UI_LOCK_FILE_NAME`], no server is running: this file is stale.
+///
+/// Only ever written, read or deleted by the parent (foreground) process, not the child process
+/// that runs the ui server. Is not locked.
 const PID_FILE_NAME: &str = "server_pid";
+
+/// The name of the file containing the current auth token for the ui server.
+///
+/// Is written to by the child process (running the server) when it gets the file lock for
+/// [`UI_LOCK_FILE_NAME`]. Is read by the child process for authentication, and the parent
+/// (foreground) process when printing the ui server details to the user. Is not locked.
 const TOKEN_FILE_NAME: &str = "token";
+
+/// The header key that can be used to set the auth token in requests to the ui server instead of
+/// using the `token` query parameter. It can also be set in a cookie. See the [`token_auth()`]
+/// middleware.
 const TOKEN_HEADER_NAME: &str = "x-auth-token";
 
+/// The name of the env var containing the port that the ui server should run on. If present in env,
+/// indicated to the current invokation of `mirrord ui` that this process is a child process and
+/// needs to run the server instead of performing setup and running in the foreground. If not
+/// specified by the user, defaults to [`UI_DEFAULT_PORT`].
 const MIRRORD_SERVER_PORT_ENV_NAME: &str = "MIRRORD_SPAWNED_SERVER_PORT";
 
 #[cfg(not(debug_assertions))]
@@ -1085,11 +1111,6 @@ pub async fn ui_command(UiArgs { port, no_browser }: UiArgs) -> Result<(), CliEr
             }
         };
 
-        let child_pid = child
-            .id()
-            .map(|pid| pid.to_string())
-            .unwrap_or("unknown".to_string());
-
         let mut stdout = BufReader::new(child.stdout.take().expect("was piped")).lines();
 
         let first_line = tokio::time::timeout(Duration::from_secs(30), stdout.next_line()).await;
@@ -1122,22 +1143,37 @@ pub async fn ui_command(UiArgs { port, no_browser }: UiArgs) -> Result<(), CliEr
             }
         };
 
-        // store the server (child) process ID so we can use it to kill the process when `mirrord ui
-        // stop` is called.
         let pid_file = mirrord_dir::get_path_or_fallback().join(PID_FILE_NAME);
-        if let Err(err) = std::fs::write(&pid_file, &child_pid) {
-            // it's extremely unlikely to fail to write this file after we have the ui.lock file,
-            // but notify the user anyway because it means the ui stop command won't work as usual.
-            println!(
-                "Unable to save PID of the server process. This does not mean the server is not running, \
-                but you may have to kill the process manually to stop it. Error: `{err}`"
-            );
-        }
+        let child_pid = if server_already_running {
+            // read pid from file, and dont overwrite it
+            std::fs::read_to_string(&pid_file).unwrap_or("unknown".to_owned())
+        } else {
+            // store the server (child) process ID so we can use it to kill the process when
+            // `mirrord ui stop` is called.
+            let child_pid = match child.id().map(|pid| pid.to_string()) {
+                Some(pid) => pid,
+                None => {
+                    return Err(CliError::UiError(
+                        "new UI server process already ended".to_string(),
+                    ));
+                }
+            };
+
+            if let Err(err) = std::fs::write(&pid_file, &child_pid) {
+                // it's extremely unlikely to fail to write this file after we have the ui.lock
+                // file, but notify the user anyway because it means the ui stop
+                // command won't work as usual.
+                println!(
+                    "Unable to save PID of the server process. This does not mean the server is not running, \
+                    but you may have to kill the process manually to stop it. Error: `{err}`"
+                );
+            }
+            child_pid
+        };
 
         let token_path = mirrord_dir::get_path_or_fallback().join(TOKEN_FILE_NAME);
         let token = std::fs::read_to_string(&token_path)
-            .map_err(|e| warn!("failed to read token file: {e}"))
-            .unwrap_or("unknown".to_owned());
+            .map_err(|err| CliError::UiError(err.to_string()))?;
         let token = token.trim();
 
         let url = format!("http://{}:{port}?token={token}", Ipv4Addr::LOCALHOST);
@@ -1156,27 +1192,31 @@ pub async fn ui_command(UiArgs { port, no_browser }: UiArgs) -> Result<(), CliEr
 
 #[tracing::instrument(level = "trace", skip(token), ret)]
 fn ui_printout(already_running: bool, url: &str, token: &str, server_pid: &str) {
-    println!("");
-    if already_running {
-        println!("* Another session monitor is already running");
-    } else {
-        println!("* New mirrord session monitor started");
-    }
-    println!("* Server PID:");
-    println!(" -> {server_pid}");
+    let mut lines = String::new();
 
-    println!("");
-    println!("* Web UI:");
-    println!(" -> {url}");
-    println!("* API token:");
-    println!(" -> {TOKEN_HEADER_NAME}: {token}");
-
-    println!("");
+    lines.push('\n');
     if already_running {
-        println!("* mirrord session monitor unchanged");
+        lines.push_str("* Another session monitor is already running\n");
     } else {
-        println!("* mirrord session monitor ready!");
+        lines.push_str("* New mirrord session monitor started\n");
     }
+    lines.push_str("* Server PID:\n");
+    lines.push_str(format!(" -> {server_pid}\n").as_str());
+
+    lines.push('\n');
+    lines.push_str("* Web UI:\n");
+    lines.push_str(format!(" -> {url}\n").as_str());
+    lines.push_str("* API token:\n");
+    lines.push_str(format!(" -> {TOKEN_HEADER_NAME}: {token}\n").as_str());
+
+    lines.push('\n');
+    if already_running {
+        lines.push_str("* mirrord session monitor unchanged\n");
+    } else {
+        lines.push_str("* mirrord session monitor ready!\n");
+    }
+
+    println!("{lines}")
 }
 
 #[cfg(test)]

--- a/mirrord/cli/src/ui.rs
+++ b/mirrord/cli/src/ui.rs
@@ -12,6 +12,7 @@ use std::{
     fs::File,
     net::{Ipv4Addr, SocketAddr},
     path::PathBuf,
+    process::Stdio,
     str::FromStr,
     sync::Arc,
     time::{Duration, SystemTime, UNIX_EPOCH},
@@ -50,12 +51,19 @@ use tokio_stream::wrappers::ReceiverStream;
 use tower_http::{set_header::SetResponseHeaderLayer, trace::TraceLayer};
 use tracing::{debug, error, info, warn};
 
-use crate::{config::UiArgs, error::CliError, ui::chaos::chaos_router};
+use crate::{
+    config::{UI_DEFAULT_PORT, UiArgs},
+    error::CliError,
+    ui::chaos::chaos_router,
+    util::mirrord_dir::get_path_and_create_with_fallback,
+};
 
 mod chaos;
 
 const MAX_EVENTS_PER_SESSION: usize = 500;
 
+const UI_LOCK_FILE_NAME: &str = "ui.lock";
+const TOKEN_FILE_NAME: &str = "token";
 const TOKEN_HEADER_NAME: &str = "x-auth-token";
 
 #[cfg(not(debug_assertions))]
@@ -903,26 +911,12 @@ fn build_router(state: AppState) -> Router {
         .with_state(state)
 }
 
-/// Returns the path to the UI token file, `~/.mirrord/token`.
-///
-/// The running `mirrord ui` writes its auth token here so a second invocation can read it back and
-/// print a working URL. This file is never locked — on Windows an exclusive lock is mandatory and
-/// would stop the second process from reading it — so mutual exclusion lives in a separate lock
-/// file (see [`lock_file_path`]).
-fn token_file_path() -> Option<PathBuf> {
-    home::home_dir().map(|home| home.join(".mirrord").join("token"))
-}
-
-/// Returns the path to the UI lock file, `~/.mirrord/ui.lock`.
+/// Keeps the UI lock file, `~/.mirrord/ui.lock`, open and exclusively locked for as long as the UI
+/// server runs.
 ///
 /// A running `mirrord ui` holds an exclusive lock on this file. The lock — released by the OS even
 /// on a hard kill — is how a second invocation detects that one is already running. It is kept
 /// separate from the token file so the token stays freely readable on all platforms.
-fn lock_file_path() -> Option<PathBuf> {
-    home::home_dir().map(|home| home.join(".mirrord").join("ui.lock"))
-}
-
-/// Keeps the lock file open and exclusively locked for as long as the UI server runs.
 ///
 /// Dropping the guard removes the token file, signalling that the UI is no longer running. A hard
 /// kill skips this [`Drop`] and leaves the token file behind, but the OS releases the lock on
@@ -933,6 +927,11 @@ struct TokenFileGuard {
     /// while the handle is open is racy and a leftover empty file is harmless — the next run
     /// re-locks it). The lock releases when this handle closes, including on a hard kill.
     lock_file: File,
+
+    /// The running `mirrord ui` writes its auth token, `~/.mirrord/token`, here so a second
+    /// invocation can read it back and print a working URL. This file is never locked — on
+    /// Windows an exclusive lock is mandatory and would stop the second process from reading
+    /// it — so mutual exclusion lives in a separate lock file (`self.lock_file`).
     token_path: PathBuf,
 }
 
@@ -956,53 +955,56 @@ enum TokenClaim {
     AlreadyRunning { token: String },
 }
 
-/// Tries to become the single running `mirrord ui` instance by taking an exclusive lock on the
-/// lock file. If another instance already holds it, reads back the token it published.
-fn claim_token_file() -> Result<TokenClaim, CliError> {
-    let lock_path = lock_file_path()
-        .ok_or_else(|| CliError::UiError("could not determine home directory".to_owned()))?;
-    let token_path = token_file_path()
-        .ok_or_else(|| CliError::UiError("could not determine home directory".to_owned()))?;
-    claim_token_file_at(lock_path, token_path)
-}
+impl TokenClaim {
+    /// Tries to become the single running `mirrord ui` instance by taking an exclusive lock on the
+    /// lock file. If another instance already holds it, reads back the token it published.
+    pub fn claim_token_file() -> Result<TokenClaim, CliError> {
+        // ensure ~/.mirrord exists
+        let mirrord_dir =
+            get_path_and_create_with_fallback().map_err(|err| CliError::UiError(err))?;
 
-fn claim_token_file_at(lock_path: PathBuf, token_path: PathBuf) -> Result<TokenClaim, CliError> {
-    if let Some(parent) = lock_path.parent() {
-        std::fs::create_dir_all(parent)
-            .map_err(|e| CliError::UiError(format!("failed to create mirrord directory: {e}")))?;
+        Self::claim_token_file_at(
+            mirrord_dir.join(UI_LOCK_FILE_NAME),
+            mirrord_dir.join(TOKEN_FILE_NAME),
+        )
     }
 
-    let lock_file = std::fs::OpenOptions::new()
-        .create(true)
-        .read(true)
-        .write(true)
-        .truncate(false)
-        .open(&lock_path)
-        .map_err(|e| CliError::UiError(format!("failed to open lock file: {e}")))?;
+    fn claim_token_file_at(
+        lock_path: PathBuf,
+        token_path: PathBuf,
+    ) -> Result<TokenClaim, CliError> {
+        let lock_file = std::fs::OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .open(&lock_path)
+            .map_err(|e| CliError::UiError(format!("failed to open lock file: {e}")))?;
 
-    if !lock_file
-        .try_lock_exclusive()
-        .map_err(|e| CliError::UiError(format!("failed to lock lock file: {e}")))?
-    {
-        let token = std::fs::read_to_string(&token_path)
-            .map_err(|e| CliError::UiError(format!("failed to read token file: {e}")))?;
-        return Ok(TokenClaim::AlreadyRunning {
-            token: token.trim().to_owned(),
-        });
+        if !lock_file
+            .try_lock_exclusive()
+            .map_err(|e| CliError::UiError(format!("failed to lock lock file: {e}")))?
+        {
+            let token = std::fs::read_to_string(&token_path)
+                .map_err(|e| CliError::UiError(format!("failed to read token file: {e}")))?;
+            return Ok(TokenClaim::AlreadyRunning {
+                token: token.trim().to_owned(),
+            });
+        }
+
+        let token_bytes: [u8; 32] = rand::rng().random();
+        let token = hex::encode(token_bytes);
+        std::fs::write(&token_path, &token)
+            .map_err(|e| CliError::UiError(format!("failed to write token file: {e}")))?;
+
+        Ok(TokenClaim::Claimed {
+            guard: TokenFileGuard {
+                lock_file,
+                token_path,
+            },
+            token,
+        })
     }
-
-    let token_bytes: [u8; 32] = rand::rng().random();
-    let token = hex::encode(token_bytes);
-    std::fs::write(&token_path, &token)
-        .map_err(|e| CliError::UiError(format!("failed to write token file: {e}")))?;
-
-    Ok(TokenClaim::Claimed {
-        guard: TokenFileGuard {
-            lock_file,
-            token_path,
-        },
-        token,
-    })
 }
 
 /// Outcome of [`setup_ui`].
@@ -1022,27 +1024,92 @@ pub enum UiSetup {
     AlreadyRunning { url: String, token: String },
 }
 
-pub async fn ui_command(args: UiArgs) -> Result<(), CliError> {
-    match setup_ui(args.port).await? {
-        UiSetup::AlreadyRunning { url, token } => {
-            ui_printout(true, &url, &token);
-            Ok(())
+/// TODO: runs as bg task, prints info to std out to be read by parent task
+/// prints errors to stderr
+async fn ui_command_inner(port: u16) -> Result<(), CliError> {
+    // runs when "SECRET_THINGY" = true in env
+    // TODO: token claiming
+    let (guard, token) = match TokenClaim::claim_token_file().unwrap() {
+        TokenClaim::AlreadyRunning { token } => {
+            let url = format!("http://{}:{port}?token={token}", Ipv4Addr::LOCALHOST);
+            // return Ok(UiSetup::AlreadyRunning { url, token });
+            todo!("stop running child process")
         }
-        UiSetup::Started { server, url, token } => {
-            if !args.no_browser
-                && let Err(err) = opener::open_browser(&url)
-            {
-                warn!(?err, "Failed to open browser");
-            }
+        TokenClaim::Claimed { guard, token } => (guard, token),
+    };
 
-            ui_printout(false, &url, &token);
-            server.await
+    // TODO: setup
+    let sessions_dir = sessions_dir()
+        .ok_or_else(|| CliError::UiError("could not determine home directory".to_owned()))?;
+
+    std::fs::create_dir_all(&sessions_dir)
+        .map_err(|e| CliError::UiError(format!("failed to create sessions directory: {e}")))?;
+
+    let (notify_tx, _) = broadcast::channel::<SessionNotification>(256);
+
+    let state = AppState {
+        sessions: Default::default(),
+        operator_sessions: Default::default(),
+        operator_watch_status: Default::default(),
+        notify_tx,
+        token: token.clone(),
+    };
+
+    scan_existing_sessions(&sessions_dir, &state).await;
+    #[cfg(target_os = "macos")]
+    start_periodic_rescan(sessions_dir.clone(), state.clone());
+    start_filesystem_watcher(&sessions_dir, state.clone())?;
+    start_operator_watcher(state.clone());
+
+    let app = build_router(state);
+
+    let addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), port);
+    let listener = tokio::net::TcpListener::bind(&addr)
+        .await
+        .map_err(|e| CliError::UiError(format!("failed to bind to {addr}: {e}")))?;
+
+    let addr = listener
+        .local_addr()
+        .map_err(|e| CliError::UiError(format!("failed to get listener address: {e}")))?;
+    let url = format!("http://{addr}?token={token}");
+
+    // TODO: select or loop to allow kill command?
+
+    // Held until the server stops so the token file is removed on graceful shutdown.
+    let _guard = guard;
+    axum::serve(listener, app)
+        .await
+        .map_err(|e| CliError::UiError(format!("server error: {e}")))
+}
+
+pub async fn ui_command(UiArgs { port, no_browser }: UiArgs) -> Result<(), CliError> {
+    if let Ok(port) = std::env::var("SECRET_THINGY_PORT_NUMBER") {
+        return ui_command_inner(u16::from_str(&port).unwrap_or(UI_DEFAULT_PORT)).await;
+    } else {
+        // TODO: spawn child command
+
+        let child_pid = "0";
+
+        let server_already_running = false;
+
+        let token = "read-from-file";
+
+        let url = format!("http://{}:{port}?token={token}", Ipv4Addr::LOCALHOST);
+
+        // open browser and print details to user
+        if !server_already_running && no_browser {
+            let _ = opener::open_browser(&url).map_err(|err| {
+                warn!(?err, "Failed to open browser");
+            });
         }
+        ui_printout(server_already_running, &url, &token, &child_pid);
     }
+
+    Ok(())
 }
 
 #[tracing::instrument(level = "trace", skip(token), ret)]
-fn ui_printout(already_running: bool, url: &str, token: &str) {
+fn ui_printout(already_running: bool, url: &str, token: &str, server_pid: &str) {
     println!("");
     if already_running {
         println!("* Another session monitor is already running");
@@ -1065,7 +1132,7 @@ fn ui_printout(already_running: bool, url: &str, token: &str) {
 }
 
 pub async fn setup_ui(port: u16) -> Result<UiSetup, CliError> {
-    let (guard, token) = match claim_token_file()? {
+    let (guard, token) = match TokenClaim::claim_token_file()? {
         TokenClaim::AlreadyRunning { token } => {
             let url = format!("http://{}:{port}?token={token}", Ipv4Addr::LOCALHOST);
             return Ok(UiSetup::AlreadyRunning { url, token });
@@ -1377,7 +1444,7 @@ mod tests {
             let (lock, token_path) = paths(&dir);
 
             let TokenClaim::Claimed { guard, token } =
-                claim_token_file_at(lock, token_path.clone()).unwrap()
+                TokenClaim::claim_token_file_at(lock, token_path.clone()).unwrap()
             else {
                 panic!("first claim should succeed");
             };
@@ -1395,12 +1462,12 @@ mod tests {
             let (lock, token_path) = paths(&dir);
 
             let TokenClaim::Claimed { guard, token } =
-                claim_token_file_at(lock.clone(), token_path.clone()).unwrap()
+                TokenClaim::claim_token_file_at(lock.clone(), token_path.clone()).unwrap()
             else {
                 panic!("first claim should succeed");
             };
 
-            match claim_token_file_at(lock, token_path).unwrap() {
+            match TokenClaim::claim_token_file_at(lock, token_path).unwrap() {
                 TokenClaim::AlreadyRunning { token: seen } => assert_eq!(seen, token),
                 TokenClaim::Claimed { .. } => panic!("second claim should see the lock held"),
             }
@@ -1418,7 +1485,7 @@ mod tests {
             let TokenClaim::Claimed {
                 guard,
                 token: first,
-            } = claim_token_file_at(lock.clone(), token_path.clone()).unwrap()
+            } = TokenClaim::claim_token_file_at(lock.clone(), token_path.clone()).unwrap()
             else {
                 panic!("first claim should succeed");
             };
@@ -1429,7 +1496,7 @@ mod tests {
             );
 
             let TokenClaim::Claimed { token: second, .. } =
-                claim_token_file_at(lock, token_path).unwrap()
+                TokenClaim::claim_token_file_at(lock, token_path).unwrap()
             else {
                 panic!("reclaim after drop should succeed");
             };

--- a/mirrord/cli/src/ui.rs
+++ b/mirrord/cli/src/ui.rs
@@ -18,6 +18,7 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
+use anyhow::Context;
 use axum::{
     Router,
     extract::{
@@ -41,6 +42,11 @@ use mirrord_session_monitor_client::{
     session_endpoints, sessions_dir,
 };
 use mirrord_session_monitor_protocol::SessionInfo;
+use nix::{
+    errno::Errno,
+    sys::signal::{Signal, kill},
+    unistd::Pid,
+};
 use notify::{EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use rand::Rng;
 #[cfg(not(debug_assertions))]
@@ -55,7 +61,7 @@ use tower_http::{set_header::SetResponseHeaderLayer, trace::TraceLayer};
 use tracing::{debug, error, info, warn};
 
 use crate::{
-    config::{UI_DEFAULT_PORT, UiArgs},
+    config::{UI_DEFAULT_PORT, UiArgs, UiSubcommand},
     error::CliError,
     ui::chaos::chaos_router,
     util::mirrord_dir::{self, get_path_and_create_with_fallback},
@@ -1038,11 +1044,13 @@ impl TokenClaim {
     }
 }
 
-/// runs as bg task
-/// prints info to std out to be read by parent task
-/// errors go to stderr
-/// runs when "SECRET_THINGY" = true in env
-async fn ui_command_inner(port: u16) -> Result<(), CliError> {
+/// Performs setup and starts the UI server, serving [`build_router()`]. Prints a message to
+/// `stdout` when setup is completed successfully. Keeps ownership over [`UI_LOCK_FILE_NAME`] while
+/// alive after writing the latest token value to [`TOKEN_FILE_NAME`] . If this instance cannot
+/// claim the lock file, exits early with `Ok(())`.
+///
+/// Returns an error if setup fails, or when the server is running and exits due to an error.
+async fn ui_run_server(port: u16) -> Result<(), CliError> {
     let (guard, token) = match TokenClaim::claim_token_file()? {
         TokenClaim::AlreadyRunning => {
             println!("SERVER: ui server already running");
@@ -1090,9 +1098,17 @@ async fn ui_command_inner(port: u16) -> Result<(), CliError> {
         .map_err(|e| CliError::UiError(format!("server error: {e}")))
 }
 
-pub async fn ui_command(UiArgs { port, no_browser }: UiArgs) -> Result<(), CliError> {
+/// Starts the UI server. If [`MIRRORD_SERVER_PORT_ENV_NAME`] is present, runs [`ui_run_server()`]
+/// as the background process. Otherwise, spawns the [`UiSubcommand::Start`] with
+/// [`MIRRORD_SERVER_PORT_ENV_NAME`] set. The two processes perform setup tasks and the parent
+/// (foreground) process ensures the cild (background) process started as expected, before printing
+/// details to the user and exiting.
+///
+/// The server runs until it is killed by the user, either with [`UiSubcommand::Stop`] or `kill
+/// $PID`.
+pub async fn ui_start(port: u16, no_browser: bool) -> Result<(), CliError> {
     if let Ok(port) = std::env::var(MIRRORD_SERVER_PORT_ENV_NAME) {
-        return ui_command_inner(u16::from_str(&port).unwrap_or(UI_DEFAULT_PORT)).await;
+        return ui_run_server(u16::from_str(&port).unwrap_or(UI_DEFAULT_PORT)).await;
     } else {
         let mirrord_binary = std::env::current_exe().map_err(CliError::CliPathError)?;
 
@@ -1184,14 +1200,13 @@ pub async fn ui_command(UiArgs { port, no_browser }: UiArgs) -> Result<(), CliEr
                 warn!(?err, "Failed to open browser");
             });
         }
-        ui_printout(server_already_running, &url, token, &child_pid);
+        ui_start_printout(server_already_running, &url, token, &child_pid);
     }
 
     Ok(())
 }
 
-#[tracing::instrument(level = "trace", skip(token), ret)]
-fn ui_printout(already_running: bool, url: &str, token: &str, server_pid: &str) {
+fn ui_start_printout(already_running: bool, url: &str, token: &str, server_pid: &str) {
     let mut lines = String::new();
 
     lines.push('\n');
@@ -1217,6 +1232,105 @@ fn ui_printout(already_running: bool, url: &str, token: &str, server_pid: &str) 
     }
 
     println!("{lines}")
+}
+
+/// Kills the UI server that is currently running by reading the contents of the file
+/// [`PID_FILE_NAME`]. First checks a server is running by attempting to lock the file
+/// [`UI_LOCK_FILE_NAME`]. Releases the lock after deleting stale files.
+///
+/// @with_printouts: if `true`, prints info messages to stdout. Does not affect logs.
+pub async fn ui_stop(with_printouts: bool) -> Result<(), CliError> {
+    let mirrord_dir = mirrord_dir::get_path_or_fallback();
+    let pid_file = mirrord_dir.join(PID_FILE_NAME);
+    let pid: u32 = match std::fs::read_to_string(&pid_file)
+        .context("read failed")
+        .map(|s| s.parse().context("parse failed"))
+    {
+        Ok(Ok(pid)) => pid,
+        Ok(Err(err)) | Err(err) => {
+            return Err(CliError::UiError(format!(
+                "Couldn't read a process ID for `mirrord ui`. Try killing the process manually, \
+            for example by running `ps aux | grep mirrord` and then `kill $PID` in a terminal. \
+            Original error: `{err}`"
+            )));
+        }
+    };
+
+    debug!(
+        ?pid,
+        ?pid_file,
+        "UI server process ID read from file successfully"
+    );
+
+    let guard = match TokenClaim::claim_token_file()? {
+        TokenClaim::AlreadyRunning => {
+            kill(Pid::from_raw(pid as i32), Some(Signal::SIGKILL))
+                .or_else(|error| {
+                    if error == Errno::ESRCH {
+                        // ESRCH means that the process has already exited.
+                        Ok(())
+                    } else {
+                        Err(error)
+                    }
+                })
+                .map_err(|e| e.to_string())
+                .map_err(CliError::UiError)?;
+            if with_printouts {
+                println!("* Sent stop command to UI server (it may not exit immediately)");
+            }
+            None
+        }
+        TokenClaim::Claimed { guard, .. } => {
+            if with_printouts {
+                println!(
+                    "* No running instance of `mirrord ui` was found. If you think this is incorrect, \
+                try killing the process manually, for example by running `ps aux | grep mirrord` \
+                and then `kill $PID` in a terminal."
+                );
+            }
+            Some(guard)
+        }
+    };
+
+    // remove stale files regardless of if the server was running already, ignore errors since they
+    // won't cause problems being there
+    let _ = std::fs::remove_file(mirrord_dir::get_path_or_fallback().join(PID_FILE_NAME))
+        .inspect_err(|err| debug!(?err, "deleting PID file returned error"));
+    let _ = std::fs::remove_file(mirrord_dir::get_path_or_fallback().join(TOKEN_FILE_NAME))
+        .inspect_err(|err| debug!(?err, "deleting token file returned error"));
+
+    if with_printouts {
+        println!("* Cleaned up stale files");
+    }
+
+    drop(guard);
+    Ok(())
+}
+
+/// Runs the `mirrord ui` command to either start or stop the UI server.
+/// If starting a new server fails, runs `mirrord ui stop` silently to eliminate any leftover
+/// process or files, ignoring errors.
+pub async fn ui_command(
+    UiArgs {
+        port,
+        no_browser,
+        command,
+    }: UiArgs,
+) -> Result<(), CliError> {
+    match command.unwrap_or(UiSubcommand::Start) {
+        UiSubcommand::Start => {
+            let res = ui_start(port, no_browser).await;
+            if res.is_err() {
+                error!(
+                    ?res,
+                    "`mirrord ui` failed to start the server, running `mirrord ui stop`"
+                );
+                let _ = ui_stop(false).await;
+            }
+            res
+        }
+        UiSubcommand::Stop => ui_stop(true).await,
+    }
 }
 
 #[cfg(test)]

--- a/mirrord/cli/src/ui.rs
+++ b/mirrord/cli/src/ui.rs
@@ -961,7 +961,7 @@ enum TokenClaim {
         token: String,
     },
     /// Another `mirrord ui` is already running; `token` is the one it published.
-    AlreadyRunning { token: String },
+    AlreadyRunning,
 }
 
 impl TokenClaim {
@@ -994,11 +994,7 @@ impl TokenClaim {
             .try_lock_exclusive()
             .map_err(|e| CliError::UiError(format!("failed to lock lock file: {e}")))?
         {
-            let token = std::fs::read_to_string(&token_path)
-                .map_err(|e| CliError::UiError(format!("failed to read token file: {e}")))?;
-            return Ok(TokenClaim::AlreadyRunning {
-                token: token.trim().to_owned(),
-            });
+            return Ok(TokenClaim::AlreadyRunning);
         }
 
         let token_bytes: [u8; 32] = rand::rng().random();
@@ -1016,31 +1012,14 @@ impl TokenClaim {
     }
 }
 
-/// Outcome of [`setup_ui`].
-pub enum UiSetup {
-    /// This invocation owns the UI; `server` runs it.
-    Started {
-        server: futures::future::BoxFuture<'static, Result<(), CliError>>,
-
-        /// Clickable link to show the user to where the frontend web UI is served, including auth token query param eg. "http://127.0.0.1:59281?token=..."
-        url: String,
-
-        /// The auth token from `~/.mirrord/token`, to be passed as a query param in requests (also
-        /// gets saved as a cookie in the browser).
-        token: String,
-    },
-    /// Another `mirrord ui` is already running.
-    AlreadyRunning { url: String, token: String },
-}
-
 /// runs as bg task
 /// prints info to std out to be read by parent task
 /// errors go to stderr
 /// runs when "SECRET_THINGY" = true in env
 async fn ui_command_inner(port: u16) -> Result<(), CliError> {
     let (guard, token) = match TokenClaim::claim_token_file()? {
-        TokenClaim::AlreadyRunning { token } => {
-            println!("SERVER: ui server already running, token='{token}'");
+        TokenClaim::AlreadyRunning => {
+            println!("SERVER: ui server already running");
             return Ok(());
         }
         TokenClaim::Claimed { guard, token } => (guard, token),
@@ -1076,7 +1055,7 @@ async fn ui_command_inner(port: u16) -> Result<(), CliError> {
         .map_err(|e| CliError::UiError(format!("failed to bind to {addr}: {e}")))?;
 
     // print OK to parent process so it can detach
-    println!("OK: setup complete");
+    println!("SERVER: setup complete");
 
     // Held until the server stops so the token file is removed on graceful shutdown.
     let _guard = guard;
@@ -1114,7 +1093,7 @@ pub async fn ui_command(UiArgs { port, no_browser }: UiArgs) -> Result<(), CliEr
         let mut stdout = BufReader::new(child.stdout.take().expect("was piped")).lines();
 
         let first_line = tokio::time::timeout(Duration::from_secs(30), stdout.next_line()).await;
-        match first_line {
+        let server_already_running = match first_line {
             Err(..) => {
                 return Err(CliError::UiError(format!(
                     "timed out waiting for the server process to confirm setup complete",
@@ -1131,14 +1110,20 @@ pub async fn ui_command(UiArgs { port, no_browser }: UiArgs) -> Result<(), CliEr
                 )));
             }
             Ok(Ok(Some(line))) => {
-                if line != "OK: setup complete" {
+                if line == "SERVER: setup complete" {
+                    false
+                } else if line == "SERVER: ui server already running" {
+                    true
+                } else {
                     return Err(CliError::UiError(format!(
-                        "unexpected EOF when reading the server process' stdout",
+                        "unexpected message when reading the server process' stdout: {line}",
                     )));
                 }
             }
-        }
+        };
 
+        // store the server (child) process ID so we can use it to kill the process when `mirrord ui
+        // stop` is called.
         let pid_file = mirrord_dir::get_path_or_fallback().join(PID_FILE_NAME);
         if let Err(err) = std::fs::write(&pid_file, &child_pid) {
             // it's extremely unlikely to fail to write this file after we have the ui.lock file,
@@ -1149,11 +1134,10 @@ pub async fn ui_command(UiArgs { port, no_browser }: UiArgs) -> Result<(), CliEr
             );
         }
 
-        let server_already_running = false;
-
         let token_path = mirrord_dir::get_path_or_fallback().join(TOKEN_FILE_NAME);
         let token = std::fs::read_to_string(&token_path)
-            .map_err(|e| CliError::UiError(format!("failed to read token file: {e}")))?;
+            .map_err(|e| warn!("failed to read token file: {e}"))
+            .unwrap_or("unknown".to_owned());
         let token = token.trim();
 
         let url = format!("http://{}:{port}?token={token}", Ipv4Addr::LOCALHOST);
@@ -1178,6 +1162,8 @@ fn ui_printout(already_running: bool, url: &str, token: &str, server_pid: &str) 
     } else {
         println!("* New mirrord session monitor started");
     }
+    println!("* Server PID:");
+    println!(" -> {server_pid}");
 
     println!("");
     println!("* Web UI:");
@@ -1191,60 +1177,6 @@ fn ui_printout(already_running: bool, url: &str, token: &str, server_pid: &str) 
     } else {
         println!("* mirrord session monitor ready!");
     }
-}
-
-pub async fn setup_ui(port: u16) -> Result<UiSetup, CliError> {
-    let (guard, token) = match TokenClaim::claim_token_file()? {
-        TokenClaim::AlreadyRunning { token } => {
-            let url = format!("http://{}:{port}?token={token}", Ipv4Addr::LOCALHOST);
-            return Ok(UiSetup::AlreadyRunning { url, token });
-        }
-        TokenClaim::Claimed { guard, token } => (guard, token),
-    };
-
-    let sessions_dir = sessions_dir()
-        .ok_or_else(|| CliError::UiError("could not determine home directory".to_owned()))?;
-
-    std::fs::create_dir_all(&sessions_dir)
-        .map_err(|e| CliError::UiError(format!("failed to create sessions directory: {e}")))?;
-
-    let (notify_tx, _) = broadcast::channel::<SessionNotification>(256);
-
-    let state = AppState {
-        sessions: Default::default(),
-        operator_sessions: Default::default(),
-        operator_watch_status: Default::default(),
-        notify_tx,
-        token: token.clone(),
-    };
-
-    scan_existing_sessions(&sessions_dir, &state).await;
-    #[cfg(target_os = "macos")]
-    start_periodic_rescan(sessions_dir.clone(), state.clone());
-    start_filesystem_watcher(&sessions_dir, state.clone())?;
-    start_operator_watcher(state.clone());
-
-    let app = build_router(state);
-
-    let addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), port);
-    let listener = tokio::net::TcpListener::bind(&addr)
-        .await
-        .map_err(|e| CliError::UiError(format!("failed to bind to {addr}: {e}")))?;
-
-    let addr = listener
-        .local_addr()
-        .map_err(|e| CliError::UiError(format!("failed to get listener address: {e}")))?;
-    let url = format!("http://{addr}?token={token}");
-
-    let server = Box::pin(async move {
-        // Held until the server stops so the token file is removed on graceful shutdown.
-        let _guard = guard;
-        axum::serve(listener, app)
-            .await
-            .map_err(|e| CliError::UiError(format!("server error: {e}")))
-    });
-
-    Ok(UiSetup::Started { server, url, token })
 }
 
 #[cfg(test)]
@@ -1530,9 +1462,13 @@ mod tests {
             };
 
             match TokenClaim::claim_token_file_at(lock, token_path).unwrap() {
-                TokenClaim::AlreadyRunning { token: seen } => assert_eq!(seen, token),
+                TokenClaim::AlreadyRunning => (),
                 TokenClaim::Claimed { .. } => panic!("second claim should see the lock held"),
             }
+
+            let token_path = mirrord_dir::get_path_or_fallback().join(TOKEN_FILE_NAME);
+            let seen = std::fs::read_to_string(&token_path).expect("failed to read token file");
+            assert_eq!(token, seen.trim());
 
             drop(guard);
         }

--- a/mirrord/cli/src/ui.rs
+++ b/mirrord/cli/src/ui.rs
@@ -7,68 +7,39 @@
 //! REST/SSE/WebSocket endpoints on localhost.
 
 use std::{
-    collections::{BTreeMap, HashMap, hash_map::Entry},
-    convert::Infallible,
     fs::File,
     net::{Ipv4Addr, SocketAddr},
     num::ParseIntError,
     path::PathBuf,
     process::Stdio,
     str::FromStr,
-    sync::Arc,
-    time::{Duration, SystemTime, UNIX_EPOCH},
+    time::Duration,
 };
 
-use axum::{
-    Router,
-    extract::{
-        Path, Query, Request, State,
-        ws::{Message, WebSocket, WebSocketUpgrade},
-    },
-    http::{HeaderMap, HeaderValue, StatusCode, header},
-    middleware::{self, Next},
-    response::{IntoResponse, Response, sse},
-    routing::{get, post},
-};
-use axum_extra::extract::cookie::{Cookie, CookieJar, SameSite};
 use fs4::fs_std::FileExt;
-use futures::stream::StreamExt as _;
-use k8s_openapi::{api::authentication::v1::SelfSubjectReview, jiff::Timestamp};
-use kube::{Api, Client, api::PostParams};
 use miette::Diagnostic;
-use mirrord_config::target::{Target, TargetDisplay};
-use mirrord_operator::crd::{MirrordOperatorCrd, OPERATOR_STATUS_NAME, Session, SessionHttpFilter};
-use mirrord_session_monitor_client::{
-    SESSION_SENTINEL_EXTENSION, SessionClient, SessionEndpoint, connect_to_session,
-    session_endpoints, sessions_dir,
-};
-use mirrord_session_monitor_protocol::SessionInfo;
+use mirrord_session_monitor_client::sessions_dir;
 use nix::{
     errno::Errno,
     sys::signal::{Signal, kill},
     unistd::Pid,
 };
-use notify::{EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use rand::Rng;
-#[cfg(not(debug_assertions))]
-use rust_embed::Embed;
-use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tokio::{
     io::{AsyncBufReadExt, BufReader},
-    sync::{RwLock, broadcast, mpsc},
+    sync::broadcast,
 };
-use tokio_stream::wrappers::ReceiverStream;
-use tower_http::{set_header::SetResponseHeaderLayer, trace::TraceLayer};
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, warn};
 
 use crate::{
     config::{UI_DEFAULT_PORT, UiArgs, UiSubcommand},
-    ui::chaos::chaos_router,
+    ui::server::*,
     util::mirrord_dir::{self, get_path_and_create_with_fallback},
 };
 
 mod chaos;
+pub mod server;
 
 const MAX_EVENTS_PER_SESSION: usize = 500;
 
@@ -105,847 +76,7 @@ const TOKEN_HEADER_NAME: &str = "x-auth-token";
 /// specified by the user, defaults to [`UI_DEFAULT_PORT`].
 const MIRRORD_SERVER_PORT_ENV_NAME: &str = "MIRRORD_SPAWNED_SERVER_PORT";
 
-#[cfg(not(debug_assertions))]
-#[derive(Embed)]
-#[folder = "../../packages/monitor/dist/"]
-struct FrontendAssets;
-
-#[derive(Clone, Debug, Serialize)]
-#[serde(tag = "type", rename_all = "snake_case")]
-enum SessionNotification {
-    SessionAdded {
-        session: Box<TrackedSession>,
-    },
-    SessionRemoved {
-        session_id: String,
-    },
-    OperatorSessionAdded {
-        session: Box<OperatorSessionSummary>,
-    },
-    OperatorSessionRemoved {
-        id: String,
-    },
-    OperatorSessionUpdated {
-        session: Box<OperatorSessionSummary>,
-    },
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct OperatorSessionSummary {
-    pub id: String,
-    pub key: String,
-    pub namespace: String,
-    pub owner: OperatorSessionOwner,
-    pub target: Option<OperatorSessionTarget>,
-    pub created_at: String,
-    #[serde(default)]
-    pub duration_secs: u64,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub locked_ports: Vec<OperatorLockedPort>,
-    #[serde(default)]
-    pub queue_splits: OperatorQueueSplits,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub http_filter: Option<SessionHttpFilter>,
-}
-
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct OperatorLockedPort {
-    pub port: u16,
-    pub kind: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub filter: Option<String>,
-}
-
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct OperatorQueueSplits {
-    #[serde(default)]
-    pub sqs: usize,
-    #[serde(default)]
-    pub rabbitmq: usize,
-    #[serde(default)]
-    pub kafka: usize,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct OperatorSessionOwner {
-    pub username: String,
-    pub k8s_username: String,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct OperatorSessionTarget {
-    pub kind: String,
-    pub name: String,
-    pub container: String,
-}
-
-impl FromStr for OperatorSessionTarget {
-    type Err = ();
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match Target::from_str(s) {
-            Ok(Target::Targetless) | Err(_) => Err(()),
-            Ok(target) => Ok(OperatorSessionTarget {
-                kind: target.type_().to_owned(),
-                name: target.name().to_owned(),
-                container: String::new(),
-            }),
-        }
-    }
-}
-
-impl OperatorSessionSummary {
-    fn from_session(session: &Session) -> Option<Self> {
-        let id = session.id.clone()?;
-        let key = session.key.clone()?;
-        let namespace = session.namespace.clone().unwrap_or_default();
-        let owner = parse_session_owner(&session.user).unwrap_or_else(|| OperatorSessionOwner {
-            username: session.user.clone(),
-            k8s_username: session.user.clone(),
-        });
-
-        let target = OperatorSessionTarget::from_str(&session.target).ok();
-
-        let created_at = SystemTime::now()
-            .checked_sub(Duration::from_secs(session.duration_secs))
-            .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
-            .map(|d| d.as_secs())
-            .and_then(|secs| i64::try_from(secs).ok())
-            .and_then(|secs| Timestamp::from_second(secs).ok())
-            .map(|ts| ts.to_string())?;
-        let http_filter = session.http_filter.as_ref().map(|f| SessionHttpFilter {
-            header_filter: f.header_filter.clone(),
-        });
-        let locked_ports = session
-            .locked_ports
-            .as_ref()
-            .map(|ports| {
-                ports
-                    .iter()
-                    .map(|lp| {
-                        let lp = lp.to_locked_port();
-                        OperatorLockedPort {
-                            port: lp.port,
-                            kind: lp.kind,
-                            filter: lp.filter,
-                        }
-                    })
-                    .collect()
-            })
-            .unwrap_or_default();
-        let queue_splits = OperatorQueueSplits {
-            sqs: session.sqs.as_ref().map(|v| v.len()).unwrap_or(0),
-            rabbitmq: session.rmq.as_ref().map(|v| v.len()).unwrap_or(0),
-            kafka: session.kafka.as_ref().map(|v| v.len()).unwrap_or(0),
-        };
-        Some(Self {
-            id,
-            key,
-            namespace,
-            owner,
-            target,
-            created_at,
-            duration_secs: session.duration_secs,
-            locked_ports,
-            queue_splits,
-            http_filter,
-        })
-    }
-}
-
-fn parse_session_owner(user: &str) -> Option<OperatorSessionOwner> {
-    let (head, _hostname) = user.rsplit_once('@')?;
-    let (username, k8s_username) = head.split_once('/')?;
-    Some(OperatorSessionOwner {
-        username: username.to_owned(),
-        k8s_username: k8s_username.to_owned(),
-    })
-}
-
-#[derive(Clone, Debug, Serialize)]
-struct TrackedSession {
-    info: SessionInfo,
-    #[serde(skip)]
-    endpoint: SessionEndpoint,
-    #[serde(skip)]
-    events: Vec<serde_json::Value>,
-    #[serde(skip)]
-    client: SessionClient,
-}
-
-#[derive(Clone)]
-struct AppState {
-    sessions: Arc<RwLock<HashMap<String, TrackedSession>>>,
-    operator_sessions: Arc<RwLock<BTreeMap<String, OperatorSessionSummary>>>,
-    operator_watch_status: Arc<RwLock<OperatorWatchStatus>>,
-    notify_tx: broadcast::Sender<SessionNotification>,
-    token: String,
-}
-
-#[derive(Clone, Debug, Serialize, Default)]
-#[serde(tag = "status", rename_all = "snake_case")]
-pub enum OperatorWatchStatus {
-    #[default]
-    NotStarted,
-    Watching,
-    Error {
-        message: String,
-    },
-    Unavailable {
-        reason: String,
-    },
-}
-
-#[derive(Deserialize)]
-struct TokenQuery {
-    token: Option<String>,
-}
-
-/// Middleware that validates the request carries a valid auth token, either via the `mirrord_token`
-/// cookie, the `?token=` query parameter or the `x-auth-token` header.
-async fn token_auth(
-    State(state): State<AppState>,
-    jar: CookieJar,
-    Query(query): Query<TokenQuery>,
-    headers: HeaderMap,
-    request: Request,
-    next: Next,
-) -> Response {
-    if let Some(cookie) = jar.get("mirrord_token")
-        && cookie.value() == state.token
-    {
-        return next.run(request).await;
-    }
-
-    if query.token.as_ref() == Some(&state.token)
-        || headers
-            .get(TOKEN_HEADER_NAME)
-            .map(HeaderValue::to_str)
-            .transpose()
-            .unwrap_or_default()
-            == Some(&state.token)
-    {
-        let mut response = next.run(request).await;
-        let cookie = Cookie::build(("mirrord_token", state.token.clone()))
-            .http_only(true)
-            .same_site(SameSite::Strict)
-            .path("/")
-            .build();
-        if let Ok(value) = HeaderValue::from_str(&cookie.to_string()) {
-            response.headers_mut().append(header::SET_COOKIE, value);
-        }
-        return response;
-    }
-
-    StatusCode::UNAUTHORIZED.into_response()
-}
-
-/// Appends parsed SSE values to the session's event buffer, capping at
-/// [`MAX_EVENTS_PER_SESSION`].
-async fn buffer_session_events(session_id: &str, values: Vec<serde_json::Value>, state: &AppState) {
-    let mut sessions = state.sessions.write().await;
-    let Some(session) = sessions.get_mut(session_id) else {
-        return;
-    };
-    session.events.extend(values);
-    if session.events.len() > MAX_EVENTS_PER_SESSION {
-        session
-            .events
-            .drain(..session.events.len() - MAX_EVENTS_PER_SESSION);
-    }
-}
-
-/// Connects to a session's SSE /events endpoint and buffers events into the shared state.
-async fn stream_session_events(session_id: String, client: SessionClient, state: AppState) {
-    let mut sse_stream = match client.open_event_stream().await {
-        Ok(s) => s,
-        Err(err) => {
-            warn!(%session_id, ?err, "Failed to open SSE stream");
-            return;
-        }
-    };
-
-    while let Some(result) = sse_stream.next().await {
-        let event = match result {
-            Ok(e) => e,
-            Err(err) => {
-                debug!(%session_id, ?err, "SSE stream error");
-                break;
-            }
-        };
-        if let Ok(val) = serde_json::from_str::<serde_json::Value>(&event.data) {
-            buffer_session_events(&session_id, vec![val], &state).await;
-        }
-    }
-
-    info!(%session_id, "Session stream disconnected, removing");
-    if let Some(session) = state.sessions.read().await.get(&session_id)
-        && let Err(err) = std::fs::remove_file(&session.endpoint.sentinel_path)
-    {
-        warn!(%session_id, ?err, "Failed to remove session sentinel");
-    }
-    remove_session(&session_id, &state).await;
-}
-
-async fn scan_existing_sessions(sessions_dir: &std::path::Path, state: &AppState) {
-    for (session_id, endpoint) in session_endpoints(sessions_dir) {
-        add_session(session_id, endpoint, state.clone()).await;
-    }
-}
-
-async fn add_session(session_id: String, endpoint: SessionEndpoint, state: AppState) {
-    if state.sessions.read().await.contains_key(&session_id) {
-        return;
-    }
-
-    let connection = match connect_to_session(&endpoint.sentinel_path).await {
-        Ok(connection) => connection,
-        Err(err) => {
-            debug!(%session_id, ?err, "Could not fetch session info, removing stale sentinel");
-            if let Err(err) = std::fs::remove_file(&endpoint.sentinel_path) {
-                warn!(%session_id, ?err, "Failed to remove stale sentinel");
-            }
-            return;
-        }
-    };
-
-    let tracked = TrackedSession {
-        endpoint: connection.endpoint.clone(),
-        info: connection.info,
-        events: Vec::new(),
-        client: connection.client,
-    };
-
-    let session_client = tracked.client.clone();
-    let notification = SessionNotification::SessionAdded {
-        session: Box::new(tracked.clone()),
-    };
-
-    {
-        let mut sessions = state.sessions.write().await;
-        if let Entry::Vacant(entry) = sessions.entry(session_id.clone()) {
-            entry.insert(tracked);
-        } else {
-            return;
-        }
-    }
-
-    let _ = state.notify_tx.send(notification);
-    info!(%session_id, "Session added");
-
-    tokio::spawn(stream_session_events(session_id, session_client, state));
-}
-
-async fn remove_session(session_id: &str, state: &AppState) {
-    if state.sessions.write().await.remove(session_id).is_some() {
-        let _ = state.notify_tx.send(SessionNotification::SessionRemoved {
-            session_id: session_id.to_owned(),
-        });
-        info!(%session_id, "Session removed");
-    }
-}
-
-async fn list_sessions(State(state): State<AppState>) -> impl IntoResponse {
-    let sessions = state.sessions.read().await;
-    let list: Vec<SessionInfo> = sessions.values().map(|s| s.info.clone()).collect();
-    axum::Json(list)
-}
-
-async fn get_session(State(state): State<AppState>, Path(id): Path<String>) -> Response {
-    let sessions = state.sessions.read().await;
-    match sessions.get(&id) {
-        Some(session) => axum::Json(session.info.clone()).into_response(),
-        None => StatusCode::NOT_FOUND.into_response(),
-    }
-}
-
-async fn session_events_sse(State(state): State<AppState>, Path(id): Path<String>) -> Response {
-    let (buffered_events, client) = {
-        let sessions = state.sessions.read().await;
-        match sessions.get(&id) {
-            Some(session) => (session.events.clone(), session.client.clone()),
-            None => return StatusCode::NOT_FOUND.into_response(),
-        }
-    };
-
-    let (tx, rx) = mpsc::channel::<Result<sse::Event, Infallible>>(256);
-
-    tokio::spawn(async move {
-        for event in buffered_events {
-            let data =
-                serde_json::to_string(&event).expect("buffered event serialization cannot fail");
-            if tx.send(Ok(sse::Event::default().data(data))).await.is_err() {
-                return;
-            }
-        }
-
-        let mut sse_stream = match client.open_event_stream().await {
-            Ok(s) => s,
-            Err(err) => {
-                warn!(?err, "Failed to open SSE stream for proxy");
-                return;
-            }
-        };
-
-        use futures::stream::StreamExt as _;
-        while let Some(result) = sse_stream.next().await {
-            let event = match result {
-                Ok(e) => e,
-                Err(_) => break,
-            };
-            if let Ok(val) = serde_json::from_str::<serde_json::Value>(&event.data) {
-                let data_str =
-                    serde_json::to_string(&val).expect("SSE event serialization cannot fail");
-                if tx
-                    .send(Ok(sse::Event::default().data(data_str)))
-                    .await
-                    .is_err()
-                {
-                    return;
-                }
-            }
-        }
-    });
-
-    sse::Sse::new(ReceiverStream::new(rx))
-        .keep_alive(
-            sse::KeepAlive::new()
-                .interval(Duration::from_secs(15))
-                .text("ping"),
-        )
-        .into_response()
-}
-
-#[derive(Serialize)]
-struct OperatorSessionsResponse {
-    by_key: BTreeMap<String, Vec<OperatorSessionSummary>>,
-    sessions: Vec<OperatorSessionSummary>,
-    watch_status: OperatorWatchStatus,
-}
-
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
-struct CurrentUserResponse {
-    k8s_username: Option<String>,
-    error: Option<String>,
-}
-
-#[derive(Serialize)]
-struct TokenResponse {
-    token: String,
-}
-
-/// Returns the auth token to a request that already authenticated.
-///
-/// The browser extension's "Open mirrord ui" button (and any reload) navigates to the bare origin
-/// with no `?token=` query param. The page still authenticates via the `mirrord_token` cookie, but
-/// that cookie is `HttpOnly`, so the frontend JS can't read it to hand the token to the extension.
-/// This endpoint lets the already-authenticated page recover the token at runtime and forward it to
-/// the extension. Access is gated by [`token_auth`] (cookie / `?token=` / `x-auth-token`), so an
-/// unauthenticated caller never reaches it.
-async fn auth_token(State(state): State<AppState>) -> axum::Json<TokenResponse> {
-    axum::Json(TokenResponse {
-        token: state.token.clone(),
-    })
-}
-
-async fn current_user() -> axum::Json<CurrentUserResponse> {
-    let client = match Client::try_default().await {
-        Ok(c) => c,
-        Err(err) => {
-            return axum::Json(CurrentUserResponse {
-                k8s_username: None,
-                error: Some(format!("kube client init failed: {err}")),
-            });
-        }
-    };
-    let api: Api<SelfSubjectReview> = Api::all(client);
-    match api
-        .create(&PostParams::default(), &SelfSubjectReview::default())
-        .await
-    {
-        Ok(review) => {
-            let username = review
-                .status
-                .and_then(|s| s.user_info)
-                .and_then(|u| u.username);
-            axum::Json(CurrentUserResponse {
-                k8s_username: username,
-                error: None,
-            })
-        }
-        Err(err) => axum::Json(CurrentUserResponse {
-            k8s_username: None,
-            error: Some(format!("self-subject-review failed: {err}")),
-        }),
-    }
-}
-
-async fn list_operator_sessions(
-    State(state): State<AppState>,
-) -> axum::Json<OperatorSessionsResponse> {
-    let map = state.operator_sessions.read().await;
-    let watch_status = state.operator_watch_status.read().await.clone();
-
-    let mut by_key: BTreeMap<String, Vec<OperatorSessionSummary>> = BTreeMap::new();
-    let sessions: Vec<OperatorSessionSummary> = map.values().cloned().collect();
-    for s in &sessions {
-        by_key.entry(s.key.clone()).or_default().push(s.clone());
-    }
-
-    axum::Json(OperatorSessionsResponse {
-        by_key,
-        sessions,
-        watch_status,
-    })
-}
-
-async fn kill_session(State(state): State<AppState>, Path(id): Path<String>) -> Response {
-    let (client, sentinel_path) = {
-        let sessions = state.sessions.read().await;
-        match sessions.get(&id) {
-            Some(session) => (
-                session.client.clone(),
-                session.endpoint.sentinel_path.clone(),
-            ),
-            None => return StatusCode::NOT_FOUND.into_response(),
-        }
-    };
-
-    match client.kill().await {
-        Ok(()) => {
-            // Clean up the sentinel file (the socket on unix; the marker on windows) and
-            // remove the session from local tracking. The producer also removes the sentinel
-            // on shutdown via its own Drop guard, so this is best-effort.
-            if let Err(err) = std::fs::remove_file(&sentinel_path) {
-                warn!(%id, ?err, "Failed to remove session sentinel after kill");
-            }
-            remove_session(&id, &state).await;
-
-            axum::Json(serde_json::json!({"status": "ok"})).into_response()
-        }
-        Err(err) => {
-            error!(?err, "Failed to proxy kill request");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                axum::Json(serde_json::json!({"error": err.to_string()})),
-            )
-                .into_response()
-        }
-    }
-}
-
-/// Validates the WebSocket upgrade Origin header, rejecting non-localhost origins.
-fn validate_ws_origin(headers: &HeaderMap) -> bool {
-    match headers.get(header::ORIGIN) {
-        None => true, // No origin header is acceptable for non-browser clients
-        Some(origin) => {
-            if let Ok(origin_str) = origin.to_str() {
-                origin_str.starts_with("http://localhost")
-                    || origin_str.starts_with("http://127.0.0.1")
-                    || origin_str.starts_with("http://[::1]")
-            } else {
-                false
-            }
-        }
-    }
-}
-
-async fn ws_handler(
-    ws: WebSocketUpgrade,
-    headers: HeaderMap,
-    State(state): State<AppState>,
-) -> Response {
-    if !validate_ws_origin(&headers) {
-        return StatusCode::FORBIDDEN.into_response();
-    }
-    ws.on_upgrade(|socket| ws_connection(socket, state))
-}
-
-async fn ws_connection(mut socket: WebSocket, state: AppState) {
-    {
-        let sessions = state.sessions.read().await;
-        for session in sessions.values() {
-            let notification = SessionNotification::SessionAdded {
-                session: Box::new(session.clone()),
-            };
-            let msg = serde_json::to_string(&notification)
-                .expect("notification serialization cannot fail");
-            if socket.send(Message::Text(msg.into())).await.is_err() {
-                return;
-            }
-        }
-    }
-
-    let mut rx = state.notify_tx.subscribe();
-    loop {
-        match rx.recv().await {
-            Ok(notification) => {
-                let msg = serde_json::to_string(&notification)
-                    .expect("notification serialization cannot fail");
-                if socket.send(Message::Text(msg.into())).await.is_err() {
-                    break;
-                }
-            }
-            Err(broadcast::error::RecvError::Lagged(n)) => {
-                warn!(n, "WebSocket client lagged, dropped messages");
-            }
-            Err(broadcast::error::RecvError::Closed) => break,
-        }
-    }
-}
-
-fn guess_mime(path: &str) -> &'static str {
-    mime_guess::from_path(path)
-        .first_raw()
-        .unwrap_or("application/octet-stream")
-}
-
-fn get_asset(path: &str) -> Option<Vec<u8>> {
-    #[cfg(debug_assertions)]
-    {
-        let base = concat!(env!("CARGO_MANIFEST_DIR"), "/../../packages/monitor/dist/");
-        std::fs::read(format!("{base}{path}")).ok()
-    }
-    #[cfg(not(debug_assertions))]
-    {
-        FrontendAssets::get(path).map(|f| f.data.to_vec())
-    }
-}
-
-async fn static_handler(uri: axum::http::Uri) -> impl IntoResponse {
-    let path = uri.path().trim_start_matches('/');
-
-    if let Some(data) = get_asset(path) {
-        let mime = guess_mime(path);
-        return ([(header::CONTENT_TYPE, mime)], data).into_response();
-    }
-
-    // SPA fallback
-    match get_asset("index.html") {
-        Some(data) => ([(header::CONTENT_TYPE, "text/html")], data).into_response(),
-        None => StatusCode::NOT_FOUND.into_response(),
-    }
-}
-
-/// Spawns a background task that rescans the sessions directory every 2 seconds.
-/// Filesystem watchers can miss events on macOS, so this serves as a fallback.
-#[cfg(target_os = "macos")]
-fn start_periodic_rescan(sessions_dir: PathBuf, state: AppState) {
-    tokio::spawn(async move {
-        loop {
-            tokio::time::sleep(Duration::from_secs(2)).await;
-            scan_existing_sessions(&sessions_dir, &state).await;
-        }
-    });
-}
-
-/// Sets up a filesystem watcher on the sessions directory and spawns a background task
-/// to handle socket file creation and removal events.
-fn start_filesystem_watcher(
-    sessions_dir: &std::path::Path,
-    state: AppState,
-) -> Result<(), notify::Error> {
-    let (watcher_tx, mut watcher_rx) = mpsc::channel::<notify::Event>(100);
-
-    let mut watcher: RecommendedWatcher =
-        notify::recommended_watcher(move |res: Result<notify::Event, notify::Error>| match res {
-            Ok(event) => {
-                if let Err(err) = watcher_tx.blocking_send(event) {
-                    tracing::warn!(%err, "Failed to send filesystem watcher event");
-                }
-            }
-            Err(err) => {
-                tracing::warn!(?err, "Filesystem watcher error");
-            }
-        })?;
-
-    watcher.watch(sessions_dir, RecursiveMode::NonRecursive)?;
-
-    tokio::spawn(async move {
-        let _watcher = watcher;
-        while let Some(event) = watcher_rx.recv().await {
-            for path in &event.paths {
-                if path.extension().and_then(|e| e.to_str()) != Some(SESSION_SENTINEL_EXTENSION) {
-                    continue;
-                }
-
-                let Some(endpoint) = SessionEndpoint::from_sentinel(path) else {
-                    continue;
-                };
-                let session_id = endpoint.session_id.clone();
-
-                match event.kind {
-                    EventKind::Create(_) => {
-                        tokio::time::sleep(Duration::from_millis(100)).await;
-                        add_session(session_id, endpoint, state.clone()).await;
-                    }
-                    EventKind::Remove(_) => {
-                        remove_session(&session_id, &state).await;
-                    }
-                    _ => {}
-                }
-            }
-        }
-    });
-
-    Ok(())
-}
-
-fn start_operator_watcher(state: AppState) {
-    tokio::spawn(async move {
-        let client = match Client::try_default().await {
-            Ok(client) => client,
-            Err(err) => {
-                let reason = format!("kube client init failed: {err}");
-                warn!("{reason}");
-                *state.operator_watch_status.write().await =
-                    OperatorWatchStatus::Unavailable { reason };
-                return;
-            }
-        };
-
-        let api: Api<MirrordOperatorCrd> = Api::all(client);
-
-        if let Err(err) = api.get(OPERATOR_STATUS_NAME).await {
-            let reason = format!("operator not available: {err}");
-            warn!("{reason}");
-            *state.operator_watch_status.write().await =
-                OperatorWatchStatus::Unavailable { reason };
-            return;
-        }
-
-        *state.operator_watch_status.write().await = OperatorWatchStatus::Watching;
-
-        let mut interval = tokio::time::interval(Duration::from_secs(5));
-        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
-        loop {
-            interval.tick().await;
-            match api.get(OPERATOR_STATUS_NAME).await {
-                Ok(operator) => reconcile_operator_sessions(&state, &operator).await,
-                Err(err) => {
-                    let reason = format!("operator status fetch error: {err}");
-                    warn!("{reason}");
-                    *state.operator_watch_status.write().await =
-                        OperatorWatchStatus::Error { message: reason };
-                }
-            }
-        }
-    });
-}
-
-async fn reconcile_operator_sessions(state: &AppState, operator: &MirrordOperatorCrd) {
-    let observed: HashMap<String, OperatorSessionSummary> = operator
-        .status
-        .as_ref()
-        .map(|s| s.sessions.as_slice())
-        .unwrap_or_default()
-        .iter()
-        .filter_map(OperatorSessionSummary::from_session)
-        .map(|s| (s.id.clone(), s))
-        .collect();
-
-    let mut map = state.operator_sessions.write().await;
-    apply_observed_sessions(&mut map, &observed, &state.notify_tx);
-    drop_stale_sessions(&mut map, &observed, &state.notify_tx);
-}
-
-fn apply_observed_sessions(
-    map: &mut BTreeMap<String, OperatorSessionSummary>,
-    observed: &HashMap<String, OperatorSessionSummary>,
-    notify_tx: &broadcast::Sender<SessionNotification>,
-) {
-    for (id, summary) in observed {
-        let prior = map.insert(id.clone(), summary.clone());
-        let event = if prior.is_none() {
-            SessionNotification::OperatorSessionAdded {
-                session: Box::new(summary.clone()),
-            }
-        } else {
-            SessionNotification::OperatorSessionUpdated {
-                session: Box::new(summary.clone()),
-            }
-        };
-        let _ = notify_tx.send(event);
-    }
-}
-
-fn drop_stale_sessions(
-    map: &mut BTreeMap<String, OperatorSessionSummary>,
-    observed: &HashMap<String, OperatorSessionSummary>,
-    notify_tx: &broadcast::Sender<SessionNotification>,
-) {
-    let stale: Vec<String> = map
-        .keys()
-        .filter(|id| !observed.contains_key(*id))
-        .cloned()
-        .collect();
-    for id in stale {
-        map.remove(&id);
-        let _ = notify_tx.send(SessionNotification::OperatorSessionRemoved { id });
-    }
-}
-
-async fn health() -> impl IntoResponse {
-    axum::Json(serde_json::json!({"status": "ok"}))
-}
-
-fn build_router(state: AppState) -> Router {
-    let api_routes = Router::new()
-        .route("/sessions", get(list_sessions))
-        .route("/sessions/{id}", get(get_session))
-        .route("/sessions/{id}/events", get(session_events_sse))
-        .route("/sessions/{id}/kill", post(kill_session))
-        .route("/operator-sessions", get(list_operator_sessions))
-        .route("/me", get(current_user))
-        .route("/token", get(auth_token));
-
-    let authenticated_routes = Router::new()
-        .nest("/chaos/rules", chaos_router(state.clone()))
-        .nest("/api", api_routes)
-        .route("/ws", get(ws_handler))
-        .fallback(static_handler)
-        .layer(middleware::from_fn_with_state(state.clone(), token_auth));
-
-    // posthog-js lazy-loads its session recorder bundle from the api host at runtime, so the
-    // PostHog origin must be listed in both `script-src` (for the recorder bundle) and
-    // `connect-src` (for `/e/` event capture and `/s/` session replay ingest). Without these,
-    // telemetry is silently dropped by the browser's CSP enforcement.
-    let csp_value = HeaderValue::from_static(
-        "default-src 'self'; script-src 'self' https://hog.metalbear.com; \
-         style-src 'self' 'unsafe-inline'; \
-         connect-src 'self' https://hog.metalbear.com \
-         ws://localhost:* ws://127.0.0.1:* ws://[::1]:*; \
-         img-src 'self' data:; object-src 'none'; frame-ancestors 'none'",
-    );
-
-    Router::new()
-        .route("/health", get(health))
-        .merge(authenticated_routes)
-        .layer(SetResponseHeaderLayer::overriding(
-            header::X_FRAME_OPTIONS,
-            HeaderValue::from_static("DENY"),
-        ))
-        .layer(SetResponseHeaderLayer::overriding(
-            header::X_CONTENT_TYPE_OPTIONS,
-            HeaderValue::from_static("nosniff"),
-        ))
-        .layer(SetResponseHeaderLayer::overriding(
-            header::REFERRER_POLICY,
-            HeaderValue::from_static("no-referrer"),
-        ))
-        .layer(SetResponseHeaderLayer::overriding(
-            header::CONTENT_SECURITY_POLICY,
-            csp_value,
-        ))
-        .layer(TraceLayer::new_for_http())
-        .with_state(state)
-}
+// ===================================== cli code starts roughly here =============================
 
 #[derive(Debug, Error, Diagnostic)]
 pub enum UiCliError {
@@ -1261,9 +392,7 @@ fn ui_start_printout(already_running: bool, url: &str, token: &str, server_pid: 
 pub async fn ui_stop(with_printouts: bool) -> Result<(), UiCliError> {
     let mirrord_dir = mirrord_dir::get_path_or_fallback();
     let pid_file = mirrord_dir.join(PID_FILE_NAME);
-    let pid: u32 = std::fs::read_to_string(&pid_file)?
-        .parse()
-        .map_err(UiCliError::PidParse)?;
+    let pid = std::fs::read_to_string(&pid_file)?;
 
     debug!(
         ?pid,
@@ -1273,14 +402,24 @@ pub async fn ui_stop(with_printouts: bool) -> Result<(), UiCliError> {
 
     let guard = match TokenClaim::claim_token_file()? {
         TokenClaim::AlreadyRunning => {
-            kill(Pid::from_raw(pid as i32), Some(Signal::SIGKILL)).or_else(|error| {
-                if error == Errno::ESRCH {
-                    // ESRCH means that the process has already exited.
-                    Ok(())
-                } else {
-                    Err(error)
-                }
-            })?;
+            #[cfg(unix)]
+            {
+                let pid = pid.parse().map_err(UiCliError::PidParse)?;
+                kill(Pid::from_raw(pid), Some(Signal::SIGKILL)).or_else(|error| {
+                    if error == Errno::ESRCH {
+                        // ESRCH means that the process has already exited.
+                        Ok(())
+                    } else {
+                        Err(error)
+                    }
+                })?;
+            }
+
+            #[cfg(windows)]
+            std::process::Command::new("taskkill")
+                .args(["/pid", &pid, "/t"])
+                .output()?;
+
             if with_printouts {
                 println!("* Sent stop command to UI server (it may not exit immediately)");
             }
@@ -1343,396 +482,78 @@ pub async fn ui_command(
 
 #[cfg(test)]
 mod tests {
-    use axum::{
-        body::Body,
-        http::{Request, StatusCode, header},
-    };
-    use tower::ServiceExt;
-
     use super::*;
 
-    const TEST_TOKEN: &str = "test-token-1234567890abcdef";
-
-    fn test_state() -> AppState {
-        let (notify_tx, _) = broadcast::channel(16);
-        AppState {
-            sessions: Default::default(),
-            operator_sessions: Default::default(),
-            operator_watch_status: Default::default(),
-            notify_tx,
-            token: TEST_TOKEN.to_owned(),
-        }
+    fn paths(dir: &tempfile::TempDir) -> (PathBuf, PathBuf) {
+        (dir.path().join("ui.lock"), dir.path().join("token"))
     }
 
-    fn req(uri: &str) -> Request<Body> {
-        Request::builder().uri(uri).body(Body::empty()).unwrap()
-    }
-
-    async fn status_of(req: Request<Body>) -> StatusCode {
-        build_router(test_state())
-            .oneshot(req)
-            .await
-            .unwrap()
-            .status()
-    }
-
-    /// `/health` is intentionally outside the auth middleware so k8s probes can hit it.
-    #[tokio::test]
-    async fn health_endpoint_does_not_require_token() {
-        assert_eq!(status_of(req("/health")).await, StatusCode::OK);
-    }
-
-    /// Without a token, every API request should be rejected. This is the core protection
-    /// against malicious local processes and CSRF from other browser tabs.
-    #[tokio::test]
-    async fn api_without_token_returns_unauthorized() {
-        assert_eq!(
-            status_of(req("/api/sessions")).await,
-            StatusCode::UNAUTHORIZED
-        );
-    }
-
-    /// A request with the wrong token must also be rejected (no timing oracle, just a
-    /// constant-time string compare via `==` is fine because the token is high-entropy).
-    #[tokio::test]
-    async fn api_with_wrong_token_returns_unauthorized() {
-        assert_eq!(
-            status_of(req("/api/sessions?token=wrong")).await,
-            StatusCode::UNAUTHORIZED
-        );
-    }
-
-    /// First request with a valid `?token=` query param should both succeed AND set the
-    /// `mirrord_token` cookie so subsequent requests can authenticate via cookie alone.
-    #[tokio::test]
-    async fn api_with_valid_token_query_param_sets_cookie() {
-        let response = build_router(test_state())
-            .oneshot(req(&format!("/api/sessions?token={TEST_TOKEN}")))
-            .await
-            .unwrap();
-        assert_eq!(response.status(), StatusCode::OK);
-
-        let cookie = response
-            .headers()
-            .get(header::SET_COOKIE)
-            .expect("auth middleware should set the mirrord_token cookie");
-        let cookie_str = cookie.to_str().unwrap();
-        assert!(cookie_str.contains(&format!("mirrord_token={TEST_TOKEN}")));
-        assert!(
-            cookie_str.contains("HttpOnly"),
-            "cookie must be HttpOnly to prevent XSS exfiltration"
-        );
-        assert!(
-            cookie_str.contains("SameSite=Strict"),
-            "cookie must be SameSite=Strict to prevent CSRF"
-        );
-    }
-
-    /// Once the cookie is set, requests should authenticate via cookie without needing
-    /// the query param. This is what the React frontend does after the initial page load.
-    #[tokio::test]
-    async fn api_with_valid_cookie_succeeds() {
-        let request = Request::builder()
-            .uri("/api/sessions")
-            .header(header::COOKIE, format!("mirrord_token={TEST_TOKEN}"))
-            .body(Body::empty())
-            .unwrap();
-        assert_eq!(status_of(request).await, StatusCode::OK);
-    }
-
-    /// A wrong cookie must be rejected. Without this, an attacker who guesses or steals
-    /// a stale token could impersonate the user.
-    #[tokio::test]
-    async fn api_with_wrong_cookie_returns_unauthorized() {
-        let request = Request::builder()
-            .uri("/api/sessions")
-            .header(header::COOKIE, "mirrord_token=wrong")
-            .body(Body::empty())
-            .unwrap();
-        assert_eq!(status_of(request).await, StatusCode::UNAUTHORIZED);
-    }
-
-    /// `/api/token` is gated by the auth middleware like every other API route, so an
-    /// unauthenticated caller can't use it to lift the token.
-    #[tokio::test]
-    async fn token_endpoint_without_token_returns_unauthorized() {
-        assert_eq!(status_of(req("/api/token")).await, StatusCode::UNAUTHORIZED);
-    }
-
-    /// A page that authenticated via the `HttpOnly` cookie (which JS can't read) recovers the
-    /// token from `/api/token` so it can forward it to the browser extension.
-    #[tokio::test]
-    async fn token_endpoint_with_cookie_returns_token() {
-        let request = Request::builder()
-            .uri("/api/token")
-            .header(header::COOKIE, format!("mirrord_token={TEST_TOKEN}"))
-            .body(Body::empty())
-            .unwrap();
-        let response = build_router(test_state()).oneshot(request).await.unwrap();
-        assert_eq!(response.status(), StatusCode::OK);
-
-        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
-            .await
-            .unwrap();
-        let parsed: serde_json::Value = serde_json::from_slice(&body).unwrap();
-        assert_eq!(
-            parsed.get("token").and_then(|v| v.as_str()),
-            Some(TEST_TOKEN)
-        );
-    }
-
-    /// All authenticated responses should carry the security headers from the RFC.
-    /// These protect against clickjacking, MIME sniffing, referrer leaks, and XSS.
-    #[tokio::test]
-    async fn responses_include_security_headers() {
-        let response = build_router(test_state())
-            .oneshot(req(&format!("/api/sessions?token={TEST_TOKEN}")))
-            .await
-            .unwrap();
-
-        let headers = response.headers();
-        assert_eq!(headers.get(header::X_FRAME_OPTIONS).unwrap(), "DENY");
-        assert_eq!(
-            headers.get(header::X_CONTENT_TYPE_OPTIONS).unwrap(),
-            "nosniff"
-        );
-        assert_eq!(headers.get(header::REFERRER_POLICY).unwrap(), "no-referrer");
-
-        // Per the RFC, CSP must restrict scripts to 'self' (no inline scripts).
-        let csp = headers.get(header::CONTENT_SECURITY_POLICY).unwrap();
-        let csp_str = csp.to_str().unwrap();
-        assert!(csp_str.contains("script-src 'self'"));
-        assert!(!csp_str.contains("script-src 'self' 'unsafe-inline'"));
-        assert!(csp_str.contains("frame-ancestors 'none'"));
-        assert!(csp_str.contains("object-src 'none'"));
-    }
-
-    /// WebSocket upgrades from a non-localhost Origin must be rejected. WebSocket
-    /// connections do NOT enforce same-origin policy by default, so without this check
-    /// any malicious website the user visits could open `ws://localhost:59281/ws` and
-    /// stream every session event in real time.
+    /// The first claim takes the lock and writes a fresh token to the token file.
     #[test]
-    fn validate_ws_origin_rejects_non_localhost() {
-        let mut headers = HeaderMap::new();
-        headers.insert(header::ORIGIN, "http://evil.com".parse().unwrap());
-        assert!(!validate_ws_origin(&headers));
+    fn first_claim_succeeds_and_writes_token() {
+        let dir = tempfile::tempdir().unwrap();
+        let (lock, token_path) = paths(&dir);
 
-        headers.insert(header::ORIGIN, "https://localhost:59281".parse().unwrap());
-        assert!(
-            !validate_ws_origin(&headers),
-            "https origin must be rejected, mirrord ui only serves http"
-        );
+        let TokenClaim::Claimed { guard, token } =
+            TokenClaim::claim_token_file_at(lock, token_path.clone()).unwrap()
+        else {
+            panic!("first claim should succeed");
+        };
+
+        assert!(!token.is_empty());
+        assert_eq!(std::fs::read_to_string(&token_path).unwrap(), token);
+        drop(guard);
     }
 
-    /// Localhost origins (in any common form) should be accepted.
+    /// While one claim holds the lock, a second claim reports the UI is already running and
+    /// hands back the same token, so the caller can build a working URL.
     #[test]
-    fn validate_ws_origin_accepts_localhost() {
-        for origin in [
-            "http://localhost",
-            "http://localhost:59281",
-            "http://127.0.0.1:59281",
-            "http://[::1]:59281",
-        ] {
-            let mut headers = HeaderMap::new();
-            headers.insert(header::ORIGIN, origin.parse().unwrap());
-            assert!(
-                validate_ws_origin(&headers),
-                "should accept origin: {origin}"
-            );
+    fn second_claim_while_held_returns_already_running_with_same_token() {
+        let dir = tempfile::tempdir().unwrap();
+        let (lock, token_path) = paths(&dir);
+
+        let TokenClaim::Claimed { guard, token } =
+            TokenClaim::claim_token_file_at(lock.clone(), token_path.clone()).unwrap()
+        else {
+            panic!("first claim should succeed");
+        };
+
+        match TokenClaim::claim_token_file_at(lock, token_path.clone()).unwrap() {
+            TokenClaim::AlreadyRunning => (),
+            TokenClaim::Claimed { .. } => panic!("second claim should see the lock held"),
         }
+
+        let seen = std::fs::read_to_string(&token_path).expect("failed to read token file");
+        assert_eq!(token, seen.trim());
+
+        drop(guard);
     }
 
-    /// Non-browser clients (curl, native code) typically omit the Origin header. We accept
-    /// these because the Unix socket and TCP localhost binding are the access control there.
+    /// Dropping the guard removes the token file and releases the lock, so a later invocation
+    /// claims it fresh — this is how a clean shutdown signals the UI is gone.
     #[test]
-    fn validate_ws_origin_accepts_missing_origin() {
-        let headers = HeaderMap::new();
-        assert!(validate_ws_origin(&headers));
-    }
+    fn dropping_guard_removes_file_and_allows_reclaim() {
+        let dir = tempfile::tempdir().unwrap();
+        let (lock, token_path) = paths(&dir);
 
-    /// CSRF check: a malicious form-POST from another origin would not include the cookie
-    /// (because of SameSite=Strict), so any state-changing endpoint must reject it.
-    #[tokio::test]
-    async fn kill_endpoint_without_token_returns_unauthorized() {
-        let request = Request::builder()
-            .method("POST")
-            .uri("/api/sessions/some-id/kill")
-            .body(Body::empty())
-            .unwrap();
-        assert_eq!(status_of(request).await, StatusCode::UNAUTHORIZED);
-    }
-
-    /// Static assets are served behind the auth middleware so the token cookie is set on
-    /// the very first page load (the user clicks `?token=...` in their browser, the static
-    /// HTML response sets the cookie, and subsequent API/WS calls authenticate via cookie).
-    #[tokio::test]
-    async fn static_handler_without_token_returns_unauthorized() {
-        assert_eq!(status_of(req("/")).await, StatusCode::UNAUTHORIZED);
-    }
-
-    /// The `?token=` query param works for any path, including the root, so the initial
-    /// page load establishes the cookie.
-    #[tokio::test]
-    async fn static_handler_with_token_sets_cookie() {
-        let response = build_router(test_state())
-            .oneshot(req(&format!("/?token={TEST_TOKEN}")))
-            .await
-            .unwrap();
-        // Status may be 200 (if asset embedded) or 404 (if no embedded assets in test build)
-        // either way, the cookie should be set.
+        let TokenClaim::Claimed {
+            guard,
+            token: first,
+        } = TokenClaim::claim_token_file_at(lock.clone(), token_path.clone()).unwrap()
+        else {
+            panic!("first claim should succeed");
+        };
+        drop(guard);
         assert!(
-            response.headers().get(header::SET_COOKIE).is_some(),
-            "cookie must be set on the first authenticated request, even if the body is 404"
+            !token_path.exists(),
+            "guard drop should remove the token file"
         );
-    }
 
-    mod token_file {
-        use super::*;
-
-        fn paths(dir: &tempfile::TempDir) -> (PathBuf, PathBuf) {
-            (dir.path().join("ui.lock"), dir.path().join("token"))
-        }
-
-        /// The first claim takes the lock and writes a fresh token to the token file.
-        #[test]
-        fn first_claim_succeeds_and_writes_token() {
-            let dir = tempfile::tempdir().unwrap();
-            let (lock, token_path) = paths(&dir);
-
-            let TokenClaim::Claimed { guard, token } =
-                TokenClaim::claim_token_file_at(lock, token_path.clone()).unwrap()
-            else {
-                panic!("first claim should succeed");
-            };
-
-            assert!(!token.is_empty());
-            assert_eq!(std::fs::read_to_string(&token_path).unwrap(), token);
-            drop(guard);
-        }
-
-        /// While one claim holds the lock, a second claim reports the UI is already running and
-        /// hands back the same token, so the caller can build a working URL.
-        #[test]
-        fn second_claim_while_held_returns_already_running_with_same_token() {
-            let dir = tempfile::tempdir().unwrap();
-            let (lock, token_path) = paths(&dir);
-
-            let TokenClaim::Claimed { guard, token } =
-                TokenClaim::claim_token_file_at(lock.clone(), token_path.clone()).unwrap()
-            else {
-                panic!("first claim should succeed");
-            };
-
-            match TokenClaim::claim_token_file_at(lock, token_path).unwrap() {
-                TokenClaim::AlreadyRunning => (),
-                TokenClaim::Claimed { .. } => panic!("second claim should see the lock held"),
-            }
-
-            let token_path = mirrord_dir::get_path_or_fallback().join(TOKEN_FILE_NAME);
-            let seen = std::fs::read_to_string(&token_path).expect("failed to read token file");
-            assert_eq!(token, seen.trim());
-
-            drop(guard);
-        }
-
-        /// Dropping the guard removes the token file and releases the lock, so a later invocation
-        /// claims it fresh — this is how a clean shutdown signals the UI is gone.
-        #[test]
-        fn dropping_guard_removes_file_and_allows_reclaim() {
-            let dir = tempfile::tempdir().unwrap();
-            let (lock, token_path) = paths(&dir);
-
-            let TokenClaim::Claimed {
-                guard,
-                token: first,
-            } = TokenClaim::claim_token_file_at(lock.clone(), token_path.clone()).unwrap()
-            else {
-                panic!("first claim should succeed");
-            };
-            drop(guard);
-            assert!(
-                !token_path.exists(),
-                "guard drop should remove the token file"
-            );
-
-            let TokenClaim::Claimed { token: second, .. } =
-                TokenClaim::claim_token_file_at(lock, token_path).unwrap()
-            else {
-                panic!("reclaim after drop should succeed");
-            };
-            assert_ne!(first, second, "a reclaim should publish a fresh token");
-        }
-    }
-
-    mod operator_sessions {
-        use mirrord_operator::crd::Session;
-
-        use super::*;
-
-        fn sample_session(id: &str, key: &str) -> Session {
-            Session {
-                id: Some(id.to_owned()),
-                duration_secs: 60,
-                user: "alice/alice@ex@host".to_owned(),
-                target: "deployment/web".to_owned(),
-                namespace: Some("default".to_owned()),
-                locked_ports: None,
-                user_id: Some("u".to_owned()),
-                sqs: None,
-                rmq: None,
-                kafka: None,
-                key: Some(key.to_owned()),
-                http_filter: None,
-            }
-        }
-
-        #[test]
-        fn summary_from_session_extracts_key_and_parses_target_owner() {
-            let session = sample_session("cr-1", "alice-session");
-            let summary = OperatorSessionSummary::from_session(&session).unwrap();
-            assert_eq!(summary.id, "cr-1");
-            assert_eq!(summary.key, "alice-session");
-            assert_eq!(summary.namespace, "default");
-            assert_eq!(
-                summary.target.as_ref().map(|t| t.name.as_str()),
-                Some("web")
-            );
-            assert_eq!(
-                summary.target.as_ref().map(|t| t.kind.as_str()),
-                Some("deployment")
-            );
-            assert_eq!(summary.owner.username, "alice");
-            assert_eq!(summary.owner.k8s_username, "alice@ex");
-        }
-
-        #[tokio::test]
-        async fn operator_sessions_groups_by_key_with_none_bucket() {
-            let (tx, _rx) = broadcast::channel::<SessionNotification>(16);
-            let state = AppState {
-                sessions: Default::default(),
-                operator_sessions: Arc::new(RwLock::new({
-                    let mut m = BTreeMap::new();
-                    let s1 =
-                        OperatorSessionSummary::from_session(&sample_session("a", "k")).unwrap();
-                    let s2 =
-                        OperatorSessionSummary::from_session(&sample_session("b", "k")).unwrap();
-                    let s3 =
-                        OperatorSessionSummary::from_session(&sample_session("c", "k2")).unwrap();
-                    m.insert("a".into(), s1);
-                    m.insert("b".into(), s2);
-                    m.insert("c".into(), s3);
-                    m
-                })),
-                operator_watch_status: Arc::new(RwLock::new(OperatorWatchStatus::Watching)),
-                notify_tx: tx,
-                token: "t".into(),
-            };
-
-            let resp = list_operator_sessions(axum::extract::State(state)).await.0;
-            assert_eq!(resp.sessions.len(), 3);
-            assert_eq!(resp.by_key.get("k").map(|v| v.len()), Some(2));
-            assert_eq!(resp.by_key.get("k2").map(|v| v.len()), Some(1));
-            assert!(matches!(resp.watch_status, OperatorWatchStatus::Watching));
-        }
+        let TokenClaim::Claimed { token: second, .. } =
+            TokenClaim::claim_token_file_at(lock, token_path).unwrap()
+        else {
+            panic!("reclaim after drop should succeed");
+        };
+        assert_ne!(first, second, "a reclaim should publish a fresh token");
     }
 }

--- a/mirrord/cli/src/ui.rs
+++ b/mirrord/cli/src/ui.rs
@@ -9,16 +9,19 @@
 #[cfg(unix)]
 use std::num::ParseIntError;
 use std::{
+    collections::HashMap,
+    env::{temp_dir, vars},
     fs::File,
     net::{Ipv4Addr, SocketAddr},
     path::PathBuf,
     process::Stdio,
     str::FromStr,
-    time::Duration,
+    time::{Duration, SystemTime},
 };
 
 use fs4::fs_std::FileExt;
 use miette::Diagnostic;
+use mirrord_progress::MIRRORD_PROGRESS_ENV;
 use mirrord_session_monitor_client::sessions_dir;
 #[cfg(unix)]
 use nix::{
@@ -29,6 +32,7 @@ use nix::{
 use rand::Rng;
 use thiserror::Error;
 use tokio::{
+    fs::create_dir_all,
     io::{AsyncBufReadExt, BufReader},
     sync::broadcast,
 };
@@ -46,7 +50,7 @@ pub mod server;
 const MAX_EVENTS_PER_SESSION: usize = 500;
 
 /// The name of the file that is locked by the currently running ui server. If a new server attempts
-/// to start running, it will fail to lock this fail and exit.
+/// to start running, it will fail to lock this file and exit.
 ///
 /// Only ever touched by the *child* process that runs the server, not the parent process running in
 /// the foreground.
@@ -260,6 +264,7 @@ async fn ui_run_server(port: u16) -> Result<(), UiServerError> {
 
     // print OK to parent process so it can detach
     println!("SERVER: setup complete");
+    debug!(?addr, ?token, "serving router for mirrord ui");
 
     // Held until the server stops so the token file is removed on graceful shutdown.
     let _guard = guard;
@@ -279,12 +284,34 @@ async fn ui_run_server(port: u16) -> Result<(), UiServerError> {
 pub async fn ui_start(port: u16, no_browser: bool) -> Result<(), UiCliError> {
     let mirrord_binary = std::env::current_exe()?;
 
+    let std_err_dir = temp_dir()
+        .join("mirrord")
+        .join(format!("ui-{}", env!("CARGO_PKG_VERSION")));
+    create_dir_all(&std_err_dir).await?;
+    let timestamp = SystemTime::UNIX_EPOCH
+        .elapsed()
+        .expect("system time should not be earlier than UNIX EPOCH")
+        .as_secs();
+
+    // stderr is piped into the file `/tmp/mirrord/ui-{MIRRORD_VERSION}/stderr-{timestamp}`
+    // if a server is already running, logs will still get piped to this file
+    let std_err_file = std_err_dir.join(format!("stderr-{timestamp}"));
+
+    let mut env_vars: HashMap<String, String> = vars().collect();
+    env_vars.insert(MIRRORD_SERVER_PORT_ENV_NAME.to_owned(), port.to_string());
+    env_vars.insert(MIRRORD_PROGRESS_ENV.to_owned(), "off".to_owned());
+
+    // default to debug level for logs sent to `std_err_file`
+    if !env_vars.contains_key("RUST_LOG") {
+        env_vars.insert("RUST_LOG".to_owned(), "mirrord=debug".to_string());
+    }
+
     let mut child = tokio::process::Command::new(mirrord_binary)
         .args(vec!["ui"])
-        .envs(vec![(MIRRORD_SERVER_PORT_ENV_NAME, port.to_string())])
+        .envs(env_vars)
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
-        .stderr(Stdio::inherit())
+        .stderr(File::create(&std_err_file)?)
         .kill_on_drop(false)
         .spawn()?;
 
@@ -355,12 +382,24 @@ pub async fn ui_start(port: u16, no_browser: bool) -> Result<(), UiCliError> {
             warn!(?err, "Failed to open browser");
         });
     }
-    ui_start_printout(server_already_running, &url, token, &child_pid);
+    ui_start_printout(
+        server_already_running,
+        &url,
+        token,
+        &child_pid,
+        &std_err_file.to_string_lossy(),
+    );
 
     Ok(())
 }
 
-fn ui_start_printout(already_running: bool, url: &str, token: &str, server_pid: &str) {
+fn ui_start_printout(
+    already_running: bool,
+    url: &str,
+    token: &str,
+    server_pid: &str,
+    std_err_file: &str,
+) {
     let mut lines = String::new();
 
     lines.push('\n');
@@ -383,6 +422,7 @@ fn ui_start_printout(already_running: bool, url: &str, token: &str, server_pid: 
         lines.push_str("* mirrord session monitor unchanged\n");
     } else {
         lines.push_str("* mirrord session monitor ready!\n");
+        lines.push_str(format!(" -> server log file: {std_err_file}\n").as_str());
     }
 
     println!("{lines}")

--- a/mirrord/cli/src/ui.rs
+++ b/mirrord/cli/src/ui.rs
@@ -11,6 +11,7 @@ use std::{
     convert::Infallible,
     fs::File,
     net::{Ipv4Addr, SocketAddr},
+    num::ParseIntError,
     path::PathBuf,
     process::Stdio,
     str::FromStr,
@@ -18,7 +19,6 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
-use anyhow::Context;
 use axum::{
     Router,
     extract::{
@@ -35,6 +35,7 @@ use fs4::fs_std::FileExt;
 use futures::stream::StreamExt as _;
 use k8s_openapi::{api::authentication::v1::SelfSubjectReview, jiff::Timestamp};
 use kube::{Api, Client, api::PostParams};
+use miette::Diagnostic;
 use mirrord_config::target::{Target, TargetDisplay};
 use mirrord_operator::crd::{MirrordOperatorCrd, OPERATOR_STATUS_NAME, Session, SessionHttpFilter};
 use mirrord_session_monitor_client::{
@@ -52,6 +53,7 @@ use rand::Rng;
 #[cfg(not(debug_assertions))]
 use rust_embed::Embed;
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 use tokio::{
     io::{AsyncBufReadExt, BufReader},
     sync::{RwLock, broadcast, mpsc},
@@ -62,7 +64,6 @@ use tracing::{debug, error, info, warn};
 
 use crate::{
     config::{UI_DEFAULT_PORT, UiArgs, UiSubcommand},
-    error::CliError,
     ui::chaos::chaos_router,
     util::mirrord_dir::{self, get_path_and_create_with_fallback},
 };
@@ -749,7 +750,7 @@ fn start_periodic_rescan(sessions_dir: PathBuf, state: AppState) {
 fn start_filesystem_watcher(
     sessions_dir: &std::path::Path,
     state: AppState,
-) -> Result<(), CliError> {
+) -> Result<(), notify::Error> {
     let (watcher_tx, mut watcher_rx) = mpsc::channel::<notify::Event>(100);
 
     let mut watcher: RecommendedWatcher =
@@ -762,12 +763,9 @@ fn start_filesystem_watcher(
             Err(err) => {
                 tracing::warn!(?err, "Filesystem watcher error");
             }
-        })
-        .map_err(|e| CliError::UiError(format!("failed to create file watcher: {e}")))?;
+        })?;
 
-    watcher
-        .watch(sessions_dir, RecursiveMode::NonRecursive)
-        .map_err(|e| CliError::UiError(format!("failed to watch sessions directory: {e}")))?;
+    watcher.watch(sessions_dir, RecursiveMode::NonRecursive)?;
 
     tokio::spawn(async move {
         let _watcher = watcher;
@@ -949,6 +947,48 @@ fn build_router(state: AppState) -> Router {
         .with_state(state)
 }
 
+#[derive(Debug, Error, Diagnostic)]
+pub enum UiCliError {
+    #[error("the mirrord UI server process failed: {0}")]
+    UiServer(#[from] UiServerError),
+
+    /// IO error for the foreground process - for the server, use [`UiServerError::Io`].
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+
+    /// May occur while trying to kill the existing UI server.
+    #[error("failed to perform an operation on the UI server process: {0}")]
+    #[diagnostic(help(
+        "To forcefully stop the server process, try killing it manually. On \
+        unix for example, find the process with `ps aux | grep mirrord ui` and \
+        then `kill $PID` to stop it running."
+    ))]
+    Process(#[from] Errno),
+
+    /// Occurs when the foreground task is waiting to read an "OK" message from the stdout of the
+    /// child, and it times out or gets a different response or error.
+    #[error("failed to communicate with the server background process: {0}")]
+    SpawnBackgroundTask(String),
+
+    /// May occur when the foreground task cannot get the child task's PID, indicating that the
+    /// process has exited.
+    #[error("the new server process ended unexpectedly")]
+    ChildExitedUnexpectedly,
+
+    #[error("failed to parse a PID from file contents: {0}")]
+    PidParse(ParseIntError),
+}
+
+#[derive(Debug, Error, Diagnostic)]
+pub enum UiServerError {
+    /// IO error for the background process.
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+
+    #[error("failed to create watcher: {0}")]
+    Watcher(#[from] notify::Error),
+}
+
 /// Keeps the UI lock file, `~/.mirrord/ui.lock`, open and exclusively locked for as long as the UI
 /// server runs.
 ///
@@ -999,10 +1039,9 @@ enum TokenClaim {
 impl TokenClaim {
     /// Tries to become the single running `mirrord ui` instance by taking an exclusive lock on the
     /// lock file. If another instance already holds it, reads back the token it published.
-    pub fn claim_token_file() -> Result<TokenClaim, CliError> {
+    pub fn claim_token_file() -> Result<TokenClaim, std::io::Error> {
         // ensure ~/.mirrord exists
-        let mirrord_dir =
-            get_path_and_create_with_fallback().map_err(|err| CliError::UiError(err))?;
+        let mirrord_dir = get_path_and_create_with_fallback()?;
 
         Self::claim_token_file_at(
             mirrord_dir.join(UI_LOCK_FILE_NAME),
@@ -1013,26 +1052,21 @@ impl TokenClaim {
     fn claim_token_file_at(
         lock_path: PathBuf,
         token_path: PathBuf,
-    ) -> Result<TokenClaim, CliError> {
+    ) -> Result<TokenClaim, std::io::Error> {
         let lock_file = std::fs::OpenOptions::new()
             .create(true)
             .read(true)
             .write(true)
             .truncate(false)
-            .open(&lock_path)
-            .map_err(|e| CliError::UiError(format!("failed to open lock file: {e}")))?;
+            .open(&lock_path)?;
 
-        if !lock_file
-            .try_lock_exclusive()
-            .map_err(|e| CliError::UiError(format!("failed to lock lock file: {e}")))?
-        {
+        if !lock_file.try_lock_exclusive()? {
             return Ok(TokenClaim::AlreadyRunning);
         }
 
         let token_bytes: [u8; 32] = rand::rng().random();
         let token = hex::encode(token_bytes);
-        std::fs::write(&token_path, &token)
-            .map_err(|e| CliError::UiError(format!("failed to write token file: {e}")))?;
+        std::fs::write(&token_path, &token)?;
 
         Ok(TokenClaim::Claimed {
             guard: TokenFileGuard {
@@ -1050,7 +1084,7 @@ impl TokenClaim {
 /// claim the lock file, exits early with `Ok(())`.
 ///
 /// Returns an error if setup fails, or when the server is running and exits due to an error.
-async fn ui_run_server(port: u16) -> Result<(), CliError> {
+async fn ui_run_server(port: u16) -> Result<(), UiServerError> {
     let (guard, token) = match TokenClaim::claim_token_file()? {
         TokenClaim::AlreadyRunning => {
             println!("SERVER: ui server already running");
@@ -1059,11 +1093,14 @@ async fn ui_run_server(port: u16) -> Result<(), CliError> {
         TokenClaim::Claimed { guard, token } => (guard, token),
     };
 
-    let sessions_dir = sessions_dir()
-        .ok_or_else(|| CliError::UiError("could not determine home directory".to_owned()))?;
+    let sessions_dir = sessions_dir().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "failed to find home directory",
+        )
+    })?;
 
-    std::fs::create_dir_all(&sessions_dir)
-        .map_err(|e| CliError::UiError(format!("failed to create sessions directory: {e}")))?;
+    std::fs::create_dir_all(&sessions_dir)?;
 
     let (notify_tx, _) = broadcast::channel::<SessionNotification>(256);
 
@@ -1084,9 +1121,7 @@ async fn ui_run_server(port: u16) -> Result<(), CliError> {
     let app = build_router(state);
 
     let addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), port);
-    let listener = tokio::net::TcpListener::bind(&addr)
-        .await
-        .map_err(|e| CliError::UiError(format!("failed to bind to {addr}: {e}")))?;
+    let listener = tokio::net::TcpListener::bind(&addr).await?;
 
     // print OK to parent process so it can detach
     println!("SERVER: setup complete");
@@ -1095,7 +1130,7 @@ async fn ui_run_server(port: u16) -> Result<(), CliError> {
     let _guard = guard;
     axum::serve(listener, app)
         .await
-        .map_err(|e| CliError::UiError(format!("server error: {e}")))
+        .map_err(UiServerError::from)
 }
 
 /// Starts the UI server. If [`MIRRORD_SERVER_PORT_ENV_NAME`] is present, runs [`ui_run_server()`]
@@ -1106,102 +1141,86 @@ async fn ui_run_server(port: u16) -> Result<(), CliError> {
 ///
 /// The server runs until it is killed by the user, either with [`UiSubcommand::Stop`] or `kill
 /// $PID`.
-pub async fn ui_start(port: u16, no_browser: bool) -> Result<(), CliError> {
-    if let Ok(port) = std::env::var(MIRRORD_SERVER_PORT_ENV_NAME) {
-        return ui_run_server(u16::from_str(&port).unwrap_or(UI_DEFAULT_PORT)).await;
-    } else {
-        let mirrord_binary = std::env::current_exe().map_err(CliError::CliPathError)?;
+pub async fn ui_start(port: u16, no_browser: bool) -> Result<(), UiCliError> {
+    let mirrord_binary = std::env::current_exe()?;
 
-        let mut child = match tokio::process::Command::new(mirrord_binary)
-            .args(vec!["ui"])
-            .envs(vec![(MIRRORD_SERVER_PORT_ENV_NAME, port.to_string())])
-            .stdin(Stdio::null())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::inherit())
-            .kill_on_drop(false)
-            .spawn()
-        {
-            Ok(child) => child,
-            Err(fail) => {
-                return Err(CliError::UiError(fail.to_string()));
-            }
-        };
+    let mut child = tokio::process::Command::new(mirrord_binary)
+        .args(vec!["ui"])
+        .envs(vec![(MIRRORD_SERVER_PORT_ENV_NAME, port.to_string())])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .kill_on_drop(false)
+        .spawn()?;
 
-        let mut stdout = BufReader::new(child.stdout.take().expect("was piped")).lines();
+    let mut stdout = BufReader::new(child.stdout.take().expect("was piped")).lines();
 
-        let first_line = tokio::time::timeout(Duration::from_secs(30), stdout.next_line()).await;
-        let server_already_running = match first_line {
-            Err(..) => {
-                return Err(CliError::UiError(format!(
-                    "timed out waiting for the server process to confirm setup complete",
-                )));
-            }
-            Ok(Err(error)) => {
-                return Err(CliError::UiError(format!(
-                    "failed to read the server process' stdout with {error}",
-                )));
-            }
-            Ok(Ok(None)) => {
-                return Err(CliError::UiError(format!(
-                    "unexpected EOF when reading the server process' stdout",
-                )));
-            }
-            Ok(Ok(Some(line))) => {
-                if line == "SERVER: setup complete" {
-                    false
-                } else if line == "SERVER: ui server already running" {
-                    true
-                } else {
-                    return Err(CliError::UiError(format!(
-                        "unexpected message when reading the server process' stdout: {line}",
-                    )));
-                }
-            }
-        };
-
-        let pid_file = mirrord_dir::get_path_or_fallback().join(PID_FILE_NAME);
-        let child_pid = if server_already_running {
-            // read pid from file, and dont overwrite it
-            std::fs::read_to_string(&pid_file).unwrap_or("unknown".to_owned())
-        } else {
-            // store the server (child) process ID so we can use it to kill the process when
-            // `mirrord ui stop` is called.
-            let child_pid = match child.id().map(|pid| pid.to_string()) {
-                Some(pid) => pid,
-                None => {
-                    return Err(CliError::UiError(
-                        "new UI server process already ended".to_string(),
-                    ));
-                }
-            };
-
-            if let Err(err) = std::fs::write(&pid_file, &child_pid) {
-                // it's extremely unlikely to fail to write this file after we have the ui.lock
-                // file, but notify the user anyway because it means the ui stop
-                // command won't work as usual.
-                println!(
-                    "Unable to save PID of the server process. This does not mean the server is not running, \
-                    but you may have to kill the process manually to stop it. Error: `{err}`"
-                );
-            }
-            child_pid
-        };
-
-        let token_path = mirrord_dir::get_path_or_fallback().join(TOKEN_FILE_NAME);
-        let token = std::fs::read_to_string(&token_path)
-            .map_err(|err| CliError::UiError(err.to_string()))?;
-        let token = token.trim();
-
-        let url = format!("http://{}:{port}?token={token}", Ipv4Addr::LOCALHOST);
-
-        // open browser and print details to user
-        if !(server_already_running || no_browser) {
-            let _ = opener::open_browser(&url).map_err(|err| {
-                warn!(?err, "Failed to open browser");
-            });
+    let first_line = tokio::time::timeout(Duration::from_secs(30), stdout.next_line()).await;
+    let server_already_running = match first_line {
+        Err(..) => {
+            return Err(UiCliError::SpawnBackgroundTask(
+                "timed out waiting for the server process to confirm setup complete".to_owned(),
+            ));
         }
-        ui_start_printout(server_already_running, &url, token, &child_pid);
+        Ok(Err(error)) => {
+            return Err(UiCliError::SpawnBackgroundTask(format!(
+                "failed to read the server process' stdout with {error}",
+            )));
+        }
+        Ok(Ok(None)) => {
+            return Err(UiCliError::SpawnBackgroundTask(
+                "unexpected EOF when reading the server process' stdout".to_owned(),
+            ));
+        }
+        Ok(Ok(Some(line))) => {
+            if line == "SERVER: setup complete" {
+                false
+            } else if line == "SERVER: ui server already running" {
+                true
+            } else {
+                return Err(UiCliError::SpawnBackgroundTask(format!(
+                    "unexpected message when reading the server process' stdout: {line}",
+                )));
+            }
+        }
+    };
+
+    let pid_file = mirrord_dir::get_path_or_fallback().join(PID_FILE_NAME);
+    let child_pid = if server_already_running {
+        // read pid from file, and dont overwrite it
+        std::fs::read_to_string(&pid_file).unwrap_or("unknown".to_owned())
+    } else {
+        // store the server (child) process ID so we can use it to kill the process when
+        // `mirrord ui stop` is called.
+        let Some(child_pid) = child.id().map(|pid| pid.to_string()) else {
+            return Err(UiCliError::ChildExitedUnexpectedly);
+        };
+
+        if let Err(err) = std::fs::write(&pid_file, &child_pid) {
+            // it's extremely unlikely to fail to write this file after we have the ui.lock
+            // file, but notify the user anyway because it means the ui stop
+            // command won't work as usual.
+            println!(
+                "Unable to save PID of the server process. This does not mean the server is not running, \
+                but you may have to kill the process manually to stop it. Error: `{err}`"
+            );
+        }
+        child_pid
+    };
+
+    let token_path = mirrord_dir::get_path_or_fallback().join(TOKEN_FILE_NAME);
+    let token = std::fs::read_to_string(&token_path)?;
+    let token = token.trim();
+
+    let url = format!("http://{}:{port}?token={token}", Ipv4Addr::LOCALHOST);
+
+    // open browser and print details to user
+    if !(server_already_running || no_browser) {
+        let _ = opener::open_browser(&url).map_err(|err| {
+            warn!(?err, "Failed to open browser");
+        });
     }
+    ui_start_printout(server_already_running, &url, token, &child_pid);
 
     Ok(())
 }
@@ -1239,22 +1258,12 @@ fn ui_start_printout(already_running: bool, url: &str, token: &str, server_pid: 
 /// [`UI_LOCK_FILE_NAME`]. Releases the lock after deleting stale files.
 ///
 /// @with_printouts: if `true`, prints info messages to stdout. Does not affect logs.
-pub async fn ui_stop(with_printouts: bool) -> Result<(), CliError> {
+pub async fn ui_stop(with_printouts: bool) -> Result<(), UiCliError> {
     let mirrord_dir = mirrord_dir::get_path_or_fallback();
     let pid_file = mirrord_dir.join(PID_FILE_NAME);
-    let pid: u32 = match std::fs::read_to_string(&pid_file)
-        .context("read failed")
-        .map(|s| s.parse().context("parse failed"))
-    {
-        Ok(Ok(pid)) => pid,
-        Ok(Err(err)) | Err(err) => {
-            return Err(CliError::UiError(format!(
-                "Couldn't read a process ID for `mirrord ui`. Try killing the process manually, \
-            for example by running `ps aux | grep mirrord` and then `kill $PID` in a terminal. \
-            Original error: `{err}`"
-            )));
-        }
-    };
+    let pid: u32 = std::fs::read_to_string(&pid_file)?
+        .parse()
+        .map_err(UiCliError::PidParse)?;
 
     debug!(
         ?pid,
@@ -1264,17 +1273,14 @@ pub async fn ui_stop(with_printouts: bool) -> Result<(), CliError> {
 
     let guard = match TokenClaim::claim_token_file()? {
         TokenClaim::AlreadyRunning => {
-            kill(Pid::from_raw(pid as i32), Some(Signal::SIGKILL))
-                .or_else(|error| {
-                    if error == Errno::ESRCH {
-                        // ESRCH means that the process has already exited.
-                        Ok(())
-                    } else {
-                        Err(error)
-                    }
-                })
-                .map_err(|e| e.to_string())
-                .map_err(CliError::UiError)?;
+            kill(Pid::from_raw(pid as i32), Some(Signal::SIGKILL)).or_else(|error| {
+                if error == Errno::ESRCH {
+                    // ESRCH means that the process has already exited.
+                    Ok(())
+                } else {
+                    Err(error)
+                }
+            })?;
             if with_printouts {
                 println!("* Sent stop command to UI server (it may not exit immediately)");
             }
@@ -1316,18 +1322,20 @@ pub async fn ui_command(
         no_browser,
         command,
     }: UiArgs,
-) -> Result<(), CliError> {
+) -> Result<(), UiCliError> {
     match command.unwrap_or(UiSubcommand::Start) {
         UiSubcommand::Start => {
-            let res = ui_start(port, no_browser).await;
-            if res.is_err() {
-                error!(
-                    ?res,
-                    "`mirrord ui` failed to start the server, running `mirrord ui stop`"
-                );
-                let _ = ui_stop(false).await;
+            if let Ok(port) = std::env::var(MIRRORD_SERVER_PORT_ENV_NAME) {
+                ui_run_server(u16::from_str(&port).unwrap_or(UI_DEFAULT_PORT)).await?;
+                Ok(())
+            } else {
+                let res = ui_start(port, no_browser).await;
+                if res.is_err() {
+                    error!("`mirrord ui` failed to start the server, running `mirrord ui stop`");
+                    let _ = ui_stop(false).await;
+                }
+                res
             }
-            res
         }
         UiSubcommand::Stop => ui_stop(true).await,
     }

--- a/mirrord/cli/src/ui.rs
+++ b/mirrord/cli/src/ui.rs
@@ -46,7 +46,10 @@ use rand::Rng;
 #[cfg(not(debug_assertions))]
 use rust_embed::Embed;
 use serde::{Deserialize, Serialize};
-use tokio::sync::{RwLock, broadcast, mpsc};
+use tokio::{
+    io::{AsyncBufReadExt, BufReader},
+    sync::{RwLock, broadcast, mpsc},
+};
 use tokio_stream::wrappers::ReceiverStream;
 use tower_http::{set_header::SetResponseHeaderLayer, trace::TraceLayer};
 use tracing::{debug, error, info, warn};
@@ -55,7 +58,7 @@ use crate::{
     config::{UI_DEFAULT_PORT, UiArgs},
     error::CliError,
     ui::chaos::chaos_router,
-    util::mirrord_dir::get_path_and_create_with_fallback,
+    util::mirrord_dir::{self, get_path_and_create_with_fallback},
 };
 
 mod chaos;
@@ -63,8 +66,11 @@ mod chaos;
 const MAX_EVENTS_PER_SESSION: usize = 500;
 
 const UI_LOCK_FILE_NAME: &str = "ui.lock";
+const PID_FILE_NAME: &str = "server_pid";
 const TOKEN_FILE_NAME: &str = "token";
 const TOKEN_HEADER_NAME: &str = "x-auth-token";
+
+const MIRRORD_SERVER_PORT_ENV_NAME: &str = "MIRRORD_SPAWNED_SERVER_PORT";
 
 #[cfg(not(debug_assertions))]
 #[derive(Embed)]
@@ -938,7 +944,10 @@ struct TokenFileGuard {
 impl Drop for TokenFileGuard {
     fn drop(&mut self) {
         if let Err(err) = std::fs::remove_file(&self.token_path) {
-            warn!(?err, path = %self.token_path.display(), "Failed to remove UI token file");
+            println!(
+                "Failed to remove UI token file at {}: {err}",
+                self.token_path.display()
+            );
         }
         let _ = FileExt::unlock(&self.lock_file);
     }
@@ -1024,21 +1033,19 @@ pub enum UiSetup {
     AlreadyRunning { url: String, token: String },
 }
 
-/// TODO: runs as bg task, prints info to std out to be read by parent task
-/// prints errors to stderr
+/// runs as bg task
+/// prints info to std out to be read by parent task
+/// errors go to stderr
+/// runs when "SECRET_THINGY" = true in env
 async fn ui_command_inner(port: u16) -> Result<(), CliError> {
-    // runs when "SECRET_THINGY" = true in env
-    // TODO: token claiming
-    let (guard, token) = match TokenClaim::claim_token_file().unwrap() {
+    let (guard, token) = match TokenClaim::claim_token_file()? {
         TokenClaim::AlreadyRunning { token } => {
-            let url = format!("http://{}:{port}?token={token}", Ipv4Addr::LOCALHOST);
-            // return Ok(UiSetup::AlreadyRunning { url, token });
-            todo!("stop running child process")
+            println!("SERVER: ui server already running, token='{token}'");
+            return Ok(());
         }
         TokenClaim::Claimed { guard, token } => (guard, token),
     };
 
-    // TODO: setup
     let sessions_dir = sessions_dir()
         .ok_or_else(|| CliError::UiError("could not determine home directory".to_owned()))?;
 
@@ -1068,12 +1075,8 @@ async fn ui_command_inner(port: u16) -> Result<(), CliError> {
         .await
         .map_err(|e| CliError::UiError(format!("failed to bind to {addr}: {e}")))?;
 
-    let addr = listener
-        .local_addr()
-        .map_err(|e| CliError::UiError(format!("failed to get listener address: {e}")))?;
-    let url = format!("http://{addr}?token={token}");
-
-    // TODO: select or loop to allow kill command?
+    // print OK to parent process so it can detach
+    println!("OK: setup complete");
 
     // Held until the server stops so the token file is removed on graceful shutdown.
     let _guard = guard;
@@ -1083,26 +1086,85 @@ async fn ui_command_inner(port: u16) -> Result<(), CliError> {
 }
 
 pub async fn ui_command(UiArgs { port, no_browser }: UiArgs) -> Result<(), CliError> {
-    if let Ok(port) = std::env::var("SECRET_THINGY_PORT_NUMBER") {
+    if let Ok(port) = std::env::var(MIRRORD_SERVER_PORT_ENV_NAME) {
         return ui_command_inner(u16::from_str(&port).unwrap_or(UI_DEFAULT_PORT)).await;
     } else {
-        // TODO: spawn child command
+        let mirrord_binary = std::env::current_exe().map_err(CliError::CliPathError)?;
 
-        let child_pid = "0";
+        let mut child = match tokio::process::Command::new(mirrord_binary)
+            .args(vec!["ui"])
+            .envs(vec![(MIRRORD_SERVER_PORT_ENV_NAME, port.to_string())])
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit())
+            .kill_on_drop(false)
+            .spawn()
+        {
+            Ok(child) => child,
+            Err(fail) => {
+                return Err(CliError::UiError(fail.to_string()));
+            }
+        };
+
+        let child_pid = child
+            .id()
+            .map(|pid| pid.to_string())
+            .unwrap_or("unknown".to_string());
+
+        let mut stdout = BufReader::new(child.stdout.take().expect("was piped")).lines();
+
+        let first_line = tokio::time::timeout(Duration::from_secs(30), stdout.next_line()).await;
+        match first_line {
+            Err(..) => {
+                return Err(CliError::UiError(format!(
+                    "timed out waiting for the server process to confirm setup complete",
+                )));
+            }
+            Ok(Err(error)) => {
+                return Err(CliError::UiError(format!(
+                    "failed to read the server process' stdout with {error}",
+                )));
+            }
+            Ok(Ok(None)) => {
+                return Err(CliError::UiError(format!(
+                    "unexpected EOF when reading the server process' stdout",
+                )));
+            }
+            Ok(Ok(Some(line))) => {
+                if line != "OK: setup complete" {
+                    return Err(CliError::UiError(format!(
+                        "unexpected EOF when reading the server process' stdout",
+                    )));
+                }
+            }
+        }
+
+        let pid_file = mirrord_dir::get_path_or_fallback().join(PID_FILE_NAME);
+        if let Err(err) = std::fs::write(&pid_file, &child_pid) {
+            // it's extremely unlikely to fail to write this file after we have the ui.lock file,
+            // but notify the user anyway because it means the ui stop command won't work as usual.
+            println!(
+                "Unable to save PID of the server process. This does not mean the server is not running, \
+                but you may have to kill the process manually to stop it. Error: `{err}`"
+            );
+        }
 
         let server_already_running = false;
 
-        let token = "read-from-file";
+        let token_path = mirrord_dir::get_path_or_fallback().join(TOKEN_FILE_NAME);
+        let token = std::fs::read_to_string(&token_path)
+            .map_err(|e| CliError::UiError(format!("failed to read token file: {e}")))?;
+        let token = token.trim();
 
         let url = format!("http://{}:{port}?token={token}", Ipv4Addr::LOCALHOST);
 
         // open browser and print details to user
-        if !server_already_running && no_browser {
+        if !(server_already_running || no_browser) {
             let _ = opener::open_browser(&url).map_err(|err| {
                 warn!(?err, "Failed to open browser");
             });
         }
-        ui_printout(server_already_running, &url, &token, &child_pid);
+        ui_printout(server_already_running, &url, token, &child_pid);
     }
 
     Ok(())

--- a/mirrord/cli/src/ui/chaos.rs
+++ b/mirrord/cli/src/ui/chaos.rs
@@ -7,7 +7,7 @@ use axum::{
     routing::{post, put},
 };
 
-use crate::ui::{AppState, chaos::error::ChaosApiError};
+use crate::ui::{chaos::error::ChaosApiError, server::AppState};
 
 mod api;
 mod error;

--- a/mirrord/cli/src/ui/chaos/api.rs
+++ b/mirrord/cli/src/ui/chaos/api.rs
@@ -14,7 +14,7 @@ use tracing::Level;
 use uuid::Uuid;
 
 use super::ChaosResult;
-use crate::ui::{AppState, chaos::error::ChaosApiError};
+use crate::ui::{chaos::error::ChaosApiError, server::AppState};
 
 /// The route for the internal proxy session monitor server chaos rules.
 const BASE_INTPROXY_CHAOS_ROUTE: &str = "/chaos/rules";

--- a/mirrord/cli/src/ui/server.rs
+++ b/mirrord/cli/src/ui/server.rs
@@ -1,0 +1,1201 @@
+use std::{
+    collections::{BTreeMap, HashMap, hash_map::Entry},
+    convert::Infallible,
+    path::PathBuf,
+    str::FromStr,
+    sync::Arc,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+use axum::{
+    Router,
+    extract::{
+        Path, Query, Request, State,
+        ws::{Message, WebSocket, WebSocketUpgrade},
+    },
+    http::{HeaderMap, HeaderValue, StatusCode, header},
+    middleware::{self, Next},
+    response::{IntoResponse, Response, sse},
+    routing::{get, post},
+};
+use axum_extra::extract::cookie::{Cookie, CookieJar, SameSite};
+use futures::stream::StreamExt as _;
+use k8s_openapi::{api::authentication::v1::SelfSubjectReview, jiff::Timestamp};
+use kube::{Api, Client, api::PostParams};
+use mirrord_config::target::{Target, TargetDisplay};
+use mirrord_operator::crd::{MirrordOperatorCrd, OPERATOR_STATUS_NAME, Session, SessionHttpFilter};
+use mirrord_session_monitor_client::{
+    SESSION_SENTINEL_EXTENSION, SessionClient, SessionEndpoint, connect_to_session,
+    session_endpoints,
+};
+use mirrord_session_monitor_protocol::SessionInfo;
+use notify::{EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+#[cfg(not(debug_assertions))]
+use rust_embed::Embed;
+use serde::{Deserialize, Serialize};
+use tokio::sync::{RwLock, broadcast, mpsc};
+use tokio_stream::wrappers::ReceiverStream;
+use tower_http::{set_header::SetResponseHeaderLayer, trace::TraceLayer};
+use tracing::{debug, error, info, warn};
+
+use crate::ui::{MAX_EVENTS_PER_SESSION, TOKEN_HEADER_NAME, chaos::chaos_router};
+
+#[cfg(not(debug_assertions))]
+#[derive(Embed)]
+#[folder = "../../packages/monitor/dist/"]
+struct FrontendAssets;
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub(crate) enum SessionNotification {
+    SessionAdded {
+        session: Box<TrackedSession>,
+    },
+    SessionRemoved {
+        session_id: String,
+    },
+    OperatorSessionAdded {
+        session: Box<OperatorSessionSummary>,
+    },
+    OperatorSessionRemoved {
+        id: String,
+    },
+    OperatorSessionUpdated {
+        session: Box<OperatorSessionSummary>,
+    },
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OperatorSessionSummary {
+    pub id: String,
+    pub key: String,
+    pub namespace: String,
+    pub owner: OperatorSessionOwner,
+    pub target: Option<OperatorSessionTarget>,
+    pub created_at: String,
+    #[serde(default)]
+    pub duration_secs: u64,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub locked_ports: Vec<OperatorLockedPort>,
+    #[serde(default)]
+    pub queue_splits: OperatorQueueSplits,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub http_filter: Option<SessionHttpFilter>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OperatorLockedPort {
+    pub port: u16,
+    pub kind: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub filter: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OperatorQueueSplits {
+    #[serde(default)]
+    pub sqs: usize,
+    #[serde(default)]
+    pub rabbitmq: usize,
+    #[serde(default)]
+    pub kafka: usize,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OperatorSessionOwner {
+    pub username: String,
+    pub k8s_username: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OperatorSessionTarget {
+    pub kind: String,
+    pub name: String,
+    pub container: String,
+}
+
+impl FromStr for OperatorSessionTarget {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match Target::from_str(s) {
+            Ok(Target::Targetless) | Err(_) => Err(()),
+            Ok(target) => Ok(OperatorSessionTarget {
+                kind: target.type_().to_owned(),
+                name: target.name().to_owned(),
+                container: String::new(),
+            }),
+        }
+    }
+}
+
+impl OperatorSessionSummary {
+    pub(crate) fn from_session(session: &Session) -> Option<Self> {
+        let id = session.id.clone()?;
+        let key = session.key.clone()?;
+        let namespace = session.namespace.clone().unwrap_or_default();
+        let owner = parse_session_owner(&session.user).unwrap_or_else(|| OperatorSessionOwner {
+            username: session.user.clone(),
+            k8s_username: session.user.clone(),
+        });
+
+        let target = OperatorSessionTarget::from_str(&session.target).ok();
+
+        let created_at = SystemTime::now()
+            .checked_sub(Duration::from_secs(session.duration_secs))
+            .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+            .map(|d| d.as_secs())
+            .and_then(|secs| i64::try_from(secs).ok())
+            .and_then(|secs| Timestamp::from_second(secs).ok())
+            .map(|ts| ts.to_string())?;
+        let http_filter = session.http_filter.as_ref().map(|f| SessionHttpFilter {
+            header_filter: f.header_filter.clone(),
+        });
+        let locked_ports = session
+            .locked_ports
+            .as_ref()
+            .map(|ports| {
+                ports
+                    .iter()
+                    .map(|lp| {
+                        let lp = lp.to_locked_port();
+                        OperatorLockedPort {
+                            port: lp.port,
+                            kind: lp.kind,
+                            filter: lp.filter,
+                        }
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        let queue_splits = OperatorQueueSplits {
+            sqs: session.sqs.as_ref().map(|v| v.len()).unwrap_or(0),
+            rabbitmq: session.rmq.as_ref().map(|v| v.len()).unwrap_or(0),
+            kafka: session.kafka.as_ref().map(|v| v.len()).unwrap_or(0),
+        };
+        Some(Self {
+            id,
+            key,
+            namespace,
+            owner,
+            target,
+            created_at,
+            duration_secs: session.duration_secs,
+            locked_ports,
+            queue_splits,
+            http_filter,
+        })
+    }
+}
+
+fn parse_session_owner(user: &str) -> Option<OperatorSessionOwner> {
+    let (head, _hostname) = user.rsplit_once('@')?;
+    let (username, k8s_username) = head.split_once('/')?;
+    Some(OperatorSessionOwner {
+        username: username.to_owned(),
+        k8s_username: k8s_username.to_owned(),
+    })
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub(crate) struct TrackedSession {
+    pub(crate) info: SessionInfo,
+    #[serde(skip)]
+    pub(crate) endpoint: SessionEndpoint,
+    #[serde(skip)]
+    pub(crate) events: Vec<serde_json::Value>,
+    #[serde(skip)]
+    pub(crate) client: SessionClient,
+}
+
+#[derive(Clone)]
+pub struct AppState {
+    pub(crate) sessions: Arc<RwLock<HashMap<String, TrackedSession>>>,
+    pub(crate) operator_sessions: Arc<RwLock<BTreeMap<String, OperatorSessionSummary>>>,
+    pub(crate) operator_watch_status: Arc<RwLock<OperatorWatchStatus>>,
+    pub(crate) notify_tx: broadcast::Sender<SessionNotification>,
+    pub(crate) token: String,
+}
+
+#[derive(Clone, Debug, Serialize, Default)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum OperatorWatchStatus {
+    #[default]
+    NotStarted,
+    Watching,
+    Error {
+        message: String,
+    },
+    Unavailable {
+        reason: String,
+    },
+}
+
+#[derive(Deserialize)]
+struct TokenQuery {
+    token: Option<String>,
+}
+
+/// Middleware that validates the request carries a valid auth token, either via the `mirrord_token`
+/// cookie, the `?token=` query parameter or the `x-auth-token` header.
+async fn token_auth(
+    State(state): State<AppState>,
+    jar: CookieJar,
+    Query(query): Query<TokenQuery>,
+    headers: HeaderMap,
+    request: Request,
+    next: Next,
+) -> Response {
+    if let Some(cookie) = jar.get("mirrord_token")
+        && cookie.value() == state.token
+    {
+        return next.run(request).await;
+    }
+
+    if query.token.as_ref() == Some(&state.token)
+        || headers
+            .get(TOKEN_HEADER_NAME)
+            .map(HeaderValue::to_str)
+            .transpose()
+            .unwrap_or_default()
+            == Some(&state.token)
+    {
+        let mut response = next.run(request).await;
+        let cookie = Cookie::build(("mirrord_token", state.token.clone()))
+            .http_only(true)
+            .same_site(SameSite::Strict)
+            .path("/")
+            .build();
+        if let Ok(value) = HeaderValue::from_str(&cookie.to_string()) {
+            response.headers_mut().append(header::SET_COOKIE, value);
+        }
+        return response;
+    }
+
+    StatusCode::UNAUTHORIZED.into_response()
+}
+
+/// Appends parsed SSE values to the session's event buffer, capping at
+/// [`MAX_EVENTS_PER_SESSION`].
+async fn buffer_session_events(session_id: &str, values: Vec<serde_json::Value>, state: &AppState) {
+    let mut sessions = state.sessions.write().await;
+    let Some(session) = sessions.get_mut(session_id) else {
+        return;
+    };
+    session.events.extend(values);
+    if session.events.len() > MAX_EVENTS_PER_SESSION {
+        session
+            .events
+            .drain(..session.events.len() - MAX_EVENTS_PER_SESSION);
+    }
+}
+
+/// Connects to a session's SSE /events endpoint and buffers events into the shared state.
+async fn stream_session_events(session_id: String, client: SessionClient, state: AppState) {
+    let mut sse_stream = match client.open_event_stream().await {
+        Ok(s) => s,
+        Err(err) => {
+            warn!(%session_id, ?err, "Failed to open SSE stream");
+            return;
+        }
+    };
+
+    while let Some(result) = sse_stream.next().await {
+        let event = match result {
+            Ok(e) => e,
+            Err(err) => {
+                debug!(%session_id, ?err, "SSE stream error");
+                break;
+            }
+        };
+        if let Ok(val) = serde_json::from_str::<serde_json::Value>(&event.data) {
+            buffer_session_events(&session_id, vec![val], &state).await;
+        }
+    }
+
+    info!(%session_id, "Session stream disconnected, removing");
+    if let Some(session) = state.sessions.read().await.get(&session_id)
+        && let Err(err) = std::fs::remove_file(&session.endpoint.sentinel_path)
+    {
+        warn!(%session_id, ?err, "Failed to remove session sentinel");
+    }
+    remove_session(&session_id, &state).await;
+}
+
+pub(crate) async fn scan_existing_sessions(sessions_dir: &std::path::Path, state: &AppState) {
+    for (session_id, endpoint) in session_endpoints(sessions_dir) {
+        add_session(session_id, endpoint, state.clone()).await;
+    }
+}
+
+async fn add_session(session_id: String, endpoint: SessionEndpoint, state: AppState) {
+    if state.sessions.read().await.contains_key(&session_id) {
+        return;
+    }
+
+    let connection = match connect_to_session(&endpoint.sentinel_path).await {
+        Ok(connection) => connection,
+        Err(err) => {
+            debug!(%session_id, ?err, "Could not fetch session info, removing stale sentinel");
+            if let Err(err) = std::fs::remove_file(&endpoint.sentinel_path) {
+                warn!(%session_id, ?err, "Failed to remove stale sentinel");
+            }
+            return;
+        }
+    };
+
+    let tracked = TrackedSession {
+        endpoint: connection.endpoint.clone(),
+        info: connection.info,
+        events: Vec::new(),
+        client: connection.client,
+    };
+
+    let session_client = tracked.client.clone();
+    let notification = SessionNotification::SessionAdded {
+        session: Box::new(tracked.clone()),
+    };
+
+    {
+        let mut sessions = state.sessions.write().await;
+        if let Entry::Vacant(entry) = sessions.entry(session_id.clone()) {
+            entry.insert(tracked);
+        } else {
+            return;
+        }
+    }
+
+    let _ = state.notify_tx.send(notification);
+    info!(%session_id, "Session added");
+
+    tokio::spawn(stream_session_events(session_id, session_client, state));
+}
+
+async fn remove_session(session_id: &str, state: &AppState) {
+    if state.sessions.write().await.remove(session_id).is_some() {
+        let _ = state.notify_tx.send(SessionNotification::SessionRemoved {
+            session_id: session_id.to_owned(),
+        });
+        info!(%session_id, "Session removed");
+    }
+}
+
+async fn list_sessions(State(state): State<AppState>) -> impl IntoResponse {
+    let sessions = state.sessions.read().await;
+    let list: Vec<SessionInfo> = sessions.values().map(|s| s.info.clone()).collect();
+    axum::Json(list)
+}
+
+async fn get_session(State(state): State<AppState>, Path(id): Path<String>) -> Response {
+    let sessions = state.sessions.read().await;
+    match sessions.get(&id) {
+        Some(session) => axum::Json(session.info.clone()).into_response(),
+        None => StatusCode::NOT_FOUND.into_response(),
+    }
+}
+
+async fn session_events_sse(State(state): State<AppState>, Path(id): Path<String>) -> Response {
+    let (buffered_events, client) = {
+        let sessions = state.sessions.read().await;
+        match sessions.get(&id) {
+            Some(session) => (session.events.clone(), session.client.clone()),
+            None => return StatusCode::NOT_FOUND.into_response(),
+        }
+    };
+
+    let (tx, rx) = mpsc::channel::<Result<sse::Event, Infallible>>(256);
+
+    tokio::spawn(async move {
+        for event in buffered_events {
+            let data =
+                serde_json::to_string(&event).expect("buffered event serialization cannot fail");
+            if tx.send(Ok(sse::Event::default().data(data))).await.is_err() {
+                return;
+            }
+        }
+
+        let mut sse_stream = match client.open_event_stream().await {
+            Ok(s) => s,
+            Err(err) => {
+                warn!(?err, "Failed to open SSE stream for proxy");
+                return;
+            }
+        };
+
+        use futures::stream::StreamExt as _;
+        while let Some(result) = sse_stream.next().await {
+            let event = match result {
+                Ok(e) => e,
+                Err(_) => break,
+            };
+            if let Ok(val) = serde_json::from_str::<serde_json::Value>(&event.data) {
+                let data_str =
+                    serde_json::to_string(&val).expect("SSE event serialization cannot fail");
+                if tx
+                    .send(Ok(sse::Event::default().data(data_str)))
+                    .await
+                    .is_err()
+                {
+                    return;
+                }
+            }
+        }
+    });
+
+    sse::Sse::new(ReceiverStream::new(rx))
+        .keep_alive(
+            sse::KeepAlive::new()
+                .interval(Duration::from_secs(15))
+                .text("ping"),
+        )
+        .into_response()
+}
+
+#[derive(Serialize)]
+pub(crate) struct OperatorSessionsResponse {
+    pub(crate) by_key: BTreeMap<String, Vec<OperatorSessionSummary>>,
+    pub(crate) sessions: Vec<OperatorSessionSummary>,
+    pub(crate) watch_status: OperatorWatchStatus,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CurrentUserResponse {
+    k8s_username: Option<String>,
+    error: Option<String>,
+}
+
+#[derive(Serialize)]
+struct TokenResponse {
+    token: String,
+}
+
+/// Returns the auth token to a request that already authenticated.
+///
+/// The browser extension's "Open mirrord ui" button (and any reload) navigates to the bare origin
+/// with no `?token=` query param. The page still authenticates via the `mirrord_token` cookie, but
+/// that cookie is `HttpOnly`, so the frontend JS can't read it to hand the token to the extension.
+/// This endpoint lets the already-authenticated page recover the token at runtime and forward it to
+/// the extension. Access is gated by [`token_auth`] (cookie / `?token=` / `x-auth-token`), so an
+/// unauthenticated caller never reaches it.
+async fn auth_token(State(state): State<AppState>) -> axum::Json<TokenResponse> {
+    axum::Json(TokenResponse {
+        token: state.token.clone(),
+    })
+}
+
+async fn current_user() -> axum::Json<CurrentUserResponse> {
+    let client = match Client::try_default().await {
+        Ok(c) => c,
+        Err(err) => {
+            return axum::Json(CurrentUserResponse {
+                k8s_username: None,
+                error: Some(format!("kube client init failed: {err}")),
+            });
+        }
+    };
+    let api: Api<SelfSubjectReview> = Api::all(client);
+    match api
+        .create(&PostParams::default(), &SelfSubjectReview::default())
+        .await
+    {
+        Ok(review) => {
+            let username = review
+                .status
+                .and_then(|s| s.user_info)
+                .and_then(|u| u.username);
+            axum::Json(CurrentUserResponse {
+                k8s_username: username,
+                error: None,
+            })
+        }
+        Err(err) => axum::Json(CurrentUserResponse {
+            k8s_username: None,
+            error: Some(format!("self-subject-review failed: {err}")),
+        }),
+    }
+}
+
+pub(crate) async fn list_operator_sessions(
+    State(state): State<AppState>,
+) -> axum::Json<OperatorSessionsResponse> {
+    let map = state.operator_sessions.read().await;
+    let watch_status = state.operator_watch_status.read().await.clone();
+
+    let mut by_key: BTreeMap<String, Vec<OperatorSessionSummary>> = BTreeMap::new();
+    let sessions: Vec<OperatorSessionSummary> = map.values().cloned().collect();
+    for s in &sessions {
+        by_key.entry(s.key.clone()).or_default().push(s.clone());
+    }
+
+    axum::Json(OperatorSessionsResponse {
+        by_key,
+        sessions,
+        watch_status,
+    })
+}
+
+async fn kill_session(State(state): State<AppState>, Path(id): Path<String>) -> Response {
+    let (client, sentinel_path) = {
+        let sessions = state.sessions.read().await;
+        match sessions.get(&id) {
+            Some(session) => (
+                session.client.clone(),
+                session.endpoint.sentinel_path.clone(),
+            ),
+            None => return StatusCode::NOT_FOUND.into_response(),
+        }
+    };
+
+    match client.kill().await {
+        Ok(()) => {
+            // Clean up the sentinel file (the socket on unix; the marker on windows) and
+            // remove the session from local tracking. The producer also removes the sentinel
+            // on shutdown via its own Drop guard, so this is best-effort.
+            if let Err(err) = std::fs::remove_file(&sentinel_path) {
+                warn!(%id, ?err, "Failed to remove session sentinel after kill");
+            }
+            remove_session(&id, &state).await;
+
+            axum::Json(serde_json::json!({"status": "ok"})).into_response()
+        }
+        Err(err) => {
+            error!(?err, "Failed to proxy kill request");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                axum::Json(serde_json::json!({"error": err.to_string()})),
+            )
+                .into_response()
+        }
+    }
+}
+
+/// Validates the WebSocket upgrade Origin header, rejecting non-localhost origins.
+pub(crate) fn validate_ws_origin(headers: &HeaderMap) -> bool {
+    match headers.get(header::ORIGIN) {
+        None => true, // No origin header is acceptable for non-browser clients
+        Some(origin) => {
+            if let Ok(origin_str) = origin.to_str() {
+                origin_str.starts_with("http://localhost")
+                    || origin_str.starts_with("http://127.0.0.1")
+                    || origin_str.starts_with("http://[::1]")
+            } else {
+                false
+            }
+        }
+    }
+}
+
+async fn ws_handler(
+    ws: WebSocketUpgrade,
+    headers: HeaderMap,
+    State(state): State<AppState>,
+) -> Response {
+    if !validate_ws_origin(&headers) {
+        return StatusCode::FORBIDDEN.into_response();
+    }
+    ws.on_upgrade(|socket| ws_connection(socket, state))
+}
+
+async fn ws_connection(mut socket: WebSocket, state: AppState) {
+    {
+        let sessions = state.sessions.read().await;
+        for session in sessions.values() {
+            let notification = SessionNotification::SessionAdded {
+                session: Box::new(session.clone()),
+            };
+            let msg = serde_json::to_string(&notification)
+                .expect("notification serialization cannot fail");
+            if socket.send(Message::Text(msg.into())).await.is_err() {
+                return;
+            }
+        }
+    }
+
+    let mut rx = state.notify_tx.subscribe();
+    loop {
+        match rx.recv().await {
+            Ok(notification) => {
+                let msg = serde_json::to_string(&notification)
+                    .expect("notification serialization cannot fail");
+                if socket.send(Message::Text(msg.into())).await.is_err() {
+                    break;
+                }
+            }
+            Err(broadcast::error::RecvError::Lagged(n)) => {
+                warn!(n, "WebSocket client lagged, dropped messages");
+            }
+            Err(broadcast::error::RecvError::Closed) => break,
+        }
+    }
+}
+
+fn guess_mime(path: &str) -> &'static str {
+    mime_guess::from_path(path)
+        .first_raw()
+        .unwrap_or("application/octet-stream")
+}
+
+fn get_asset(path: &str) -> Option<Vec<u8>> {
+    #[cfg(debug_assertions)]
+    {
+        let base = concat!(env!("CARGO_MANIFEST_DIR"), "/../../packages/monitor/dist/");
+        std::fs::read(format!("{base}{path}")).ok()
+    }
+    #[cfg(not(debug_assertions))]
+    {
+        FrontendAssets::get(path).map(|f| f.data.to_vec())
+    }
+}
+
+async fn static_handler(uri: axum::http::Uri) -> impl IntoResponse {
+    let path = uri.path().trim_start_matches('/');
+
+    if let Some(data) = get_asset(path) {
+        let mime = guess_mime(path);
+        return ([(header::CONTENT_TYPE, mime)], data).into_response();
+    }
+
+    // SPA fallback
+    match get_asset("index.html") {
+        Some(data) => ([(header::CONTENT_TYPE, "text/html")], data).into_response(),
+        None => StatusCode::NOT_FOUND.into_response(),
+    }
+}
+
+/// Spawns a background task that rescans the sessions directory every 2 seconds.
+/// Filesystem watchers can miss events on macOS, so this serves as a fallback.
+#[cfg(target_os = "macos")]
+pub(crate) fn start_periodic_rescan(sessions_dir: PathBuf, state: AppState) {
+    tokio::spawn(async move {
+        loop {
+            tokio::time::sleep(Duration::from_secs(2)).await;
+            scan_existing_sessions(&sessions_dir, &state).await;
+        }
+    });
+}
+
+/// Sets up a filesystem watcher on the sessions directory and spawns a background task
+/// to handle socket file creation and removal events.
+pub(crate) fn start_filesystem_watcher(
+    sessions_dir: &std::path::Path,
+    state: AppState,
+) -> Result<(), notify::Error> {
+    let (watcher_tx, mut watcher_rx) = mpsc::channel::<notify::Event>(100);
+
+    let mut watcher: RecommendedWatcher =
+        notify::recommended_watcher(move |res: Result<notify::Event, notify::Error>| match res {
+            Ok(event) => {
+                if let Err(err) = watcher_tx.blocking_send(event) {
+                    tracing::warn!(%err, "Failed to send filesystem watcher event");
+                }
+            }
+            Err(err) => {
+                tracing::warn!(?err, "Filesystem watcher error");
+            }
+        })?;
+
+    watcher.watch(sessions_dir, RecursiveMode::NonRecursive)?;
+
+    tokio::spawn(async move {
+        let _watcher = watcher;
+        while let Some(event) = watcher_rx.recv().await {
+            for path in &event.paths {
+                if path.extension().and_then(|e| e.to_str()) != Some(SESSION_SENTINEL_EXTENSION) {
+                    continue;
+                }
+
+                let Some(endpoint) = SessionEndpoint::from_sentinel(path) else {
+                    continue;
+                };
+                let session_id = endpoint.session_id.clone();
+
+                match event.kind {
+                    EventKind::Create(_) => {
+                        tokio::time::sleep(Duration::from_millis(100)).await;
+                        add_session(session_id, endpoint, state.clone()).await;
+                    }
+                    EventKind::Remove(_) => {
+                        remove_session(&session_id, &state).await;
+                    }
+                    _ => {}
+                }
+            }
+        }
+    });
+
+    Ok(())
+}
+
+pub(crate) fn start_operator_watcher(state: AppState) {
+    tokio::spawn(async move {
+        let client = match Client::try_default().await {
+            Ok(client) => client,
+            Err(err) => {
+                let reason = format!("kube client init failed: {err}");
+                warn!("{reason}");
+                *state.operator_watch_status.write().await =
+                    OperatorWatchStatus::Unavailable { reason };
+                return;
+            }
+        };
+
+        let api: Api<MirrordOperatorCrd> = Api::all(client);
+
+        if let Err(err) = api.get(OPERATOR_STATUS_NAME).await {
+            let reason = format!("operator not available: {err}");
+            warn!("{reason}");
+            *state.operator_watch_status.write().await =
+                OperatorWatchStatus::Unavailable { reason };
+            return;
+        }
+
+        *state.operator_watch_status.write().await = OperatorWatchStatus::Watching;
+
+        let mut interval = tokio::time::interval(Duration::from_secs(5));
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        loop {
+            interval.tick().await;
+            match api.get(OPERATOR_STATUS_NAME).await {
+                Ok(operator) => reconcile_operator_sessions(&state, &operator).await,
+                Err(err) => {
+                    let reason = format!("operator status fetch error: {err}");
+                    warn!("{reason}");
+                    *state.operator_watch_status.write().await =
+                        OperatorWatchStatus::Error { message: reason };
+                }
+            }
+        }
+    });
+}
+
+async fn reconcile_operator_sessions(state: &AppState, operator: &MirrordOperatorCrd) {
+    let observed: HashMap<String, OperatorSessionSummary> = operator
+        .status
+        .as_ref()
+        .map(|s| s.sessions.as_slice())
+        .unwrap_or_default()
+        .iter()
+        .filter_map(OperatorSessionSummary::from_session)
+        .map(|s| (s.id.clone(), s))
+        .collect();
+
+    let mut map = state.operator_sessions.write().await;
+    apply_observed_sessions(&mut map, &observed, &state.notify_tx);
+    drop_stale_sessions(&mut map, &observed, &state.notify_tx);
+}
+
+fn apply_observed_sessions(
+    map: &mut BTreeMap<String, OperatorSessionSummary>,
+    observed: &HashMap<String, OperatorSessionSummary>,
+    notify_tx: &broadcast::Sender<SessionNotification>,
+) {
+    for (id, summary) in observed {
+        let prior = map.insert(id.clone(), summary.clone());
+        let event = if prior.is_none() {
+            SessionNotification::OperatorSessionAdded {
+                session: Box::new(summary.clone()),
+            }
+        } else {
+            SessionNotification::OperatorSessionUpdated {
+                session: Box::new(summary.clone()),
+            }
+        };
+        let _ = notify_tx.send(event);
+    }
+}
+
+fn drop_stale_sessions(
+    map: &mut BTreeMap<String, OperatorSessionSummary>,
+    observed: &HashMap<String, OperatorSessionSummary>,
+    notify_tx: &broadcast::Sender<SessionNotification>,
+) {
+    let stale: Vec<String> = map
+        .keys()
+        .filter(|id| !observed.contains_key(*id))
+        .cloned()
+        .collect();
+    for id in stale {
+        map.remove(&id);
+        let _ = notify_tx.send(SessionNotification::OperatorSessionRemoved { id });
+    }
+}
+
+async fn health() -> impl IntoResponse {
+    axum::Json(serde_json::json!({"status": "ok"}))
+}
+
+pub(crate) fn build_router(state: AppState) -> Router {
+    let api_routes = Router::new()
+        .route("/sessions", get(list_sessions))
+        .route("/sessions/{id}", get(get_session))
+        .route("/sessions/{id}/events", get(session_events_sse))
+        .route("/sessions/{id}/kill", post(kill_session))
+        .route("/operator-sessions", get(list_operator_sessions))
+        .route("/me", get(current_user))
+        .route("/token", get(auth_token));
+
+    let authenticated_routes = Router::new()
+        .nest("/chaos/rules", chaos_router(state.clone()))
+        .nest("/api", api_routes)
+        .route("/ws", get(ws_handler))
+        .fallback(static_handler)
+        .layer(middleware::from_fn_with_state(state.clone(), token_auth));
+
+    // posthog-js lazy-loads its session recorder bundle from the api host at runtime, so the
+    // PostHog origin must be listed in both `script-src` (for the recorder bundle) and
+    // `connect-src` (for `/e/` event capture and `/s/` session replay ingest). Without these,
+    // telemetry is silently dropped by the browser's CSP enforcement.
+    let csp_value = HeaderValue::from_static(
+        "default-src 'self'; script-src 'self' https://hog.metalbear.com; \
+         style-src 'self' 'unsafe-inline'; \
+         connect-src 'self' https://hog.metalbear.com \
+         ws://localhost:* ws://127.0.0.1:* ws://[::1]:*; \
+         img-src 'self' data:; object-src 'none'; frame-ancestors 'none'",
+    );
+
+    Router::new()
+        .route("/health", get(health))
+        .merge(authenticated_routes)
+        .layer(SetResponseHeaderLayer::overriding(
+            header::X_FRAME_OPTIONS,
+            HeaderValue::from_static("DENY"),
+        ))
+        .layer(SetResponseHeaderLayer::overriding(
+            header::X_CONTENT_TYPE_OPTIONS,
+            HeaderValue::from_static("nosniff"),
+        ))
+        .layer(SetResponseHeaderLayer::overriding(
+            header::REFERRER_POLICY,
+            HeaderValue::from_static("no-referrer"),
+        ))
+        .layer(SetResponseHeaderLayer::overriding(
+            header::CONTENT_SECURITY_POLICY,
+            csp_value,
+        ))
+        .layer(TraceLayer::new_for_http())
+        .with_state(state)
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode, header},
+    };
+    use tower::ServiceExt;
+
+    use super::*;
+
+    const TEST_TOKEN: &str = "test-token-1234567890abcdef";
+
+    fn test_state() -> AppState {
+        let (notify_tx, _) = broadcast::channel(16);
+        AppState {
+            sessions: Default::default(),
+            operator_sessions: Default::default(),
+            operator_watch_status: Default::default(),
+            notify_tx,
+            token: TEST_TOKEN.to_owned(),
+        }
+    }
+
+    fn req(uri: &str) -> Request<Body> {
+        Request::builder().uri(uri).body(Body::empty()).unwrap()
+    }
+
+    async fn status_of(req: Request<Body>) -> StatusCode {
+        build_router(test_state())
+            .oneshot(req)
+            .await
+            .unwrap()
+            .status()
+    }
+
+    /// `/health` is intentionally outside the auth middleware so k8s probes can hit it.
+    #[tokio::test]
+    async fn health_endpoint_does_not_require_token() {
+        assert_eq!(status_of(req("/health")).await, StatusCode::OK);
+    }
+
+    /// Without a token, every API request should be rejected. This is the core protection
+    /// against malicious local processes and CSRF from other browser tabs.
+    #[tokio::test]
+    async fn api_without_token_returns_unauthorized() {
+        assert_eq!(
+            status_of(req("/api/sessions")).await,
+            StatusCode::UNAUTHORIZED
+        );
+    }
+
+    /// A request with the wrong token must also be rejected (no timing oracle, just a
+    /// constant-time string compare via `==` is fine because the token is high-entropy).
+    #[tokio::test]
+    async fn api_with_wrong_token_returns_unauthorized() {
+        assert_eq!(
+            status_of(req("/api/sessions?token=wrong")).await,
+            StatusCode::UNAUTHORIZED
+        );
+    }
+
+    /// First request with a valid `?token=` query param should both succeed AND set the
+    /// `mirrord_token` cookie so subsequent requests can authenticate via cookie alone.
+    #[tokio::test]
+    async fn api_with_valid_token_query_param_sets_cookie() {
+        let response = build_router(test_state())
+            .oneshot(req(&format!("/api/sessions?token={TEST_TOKEN}")))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let cookie = response
+            .headers()
+            .get(header::SET_COOKIE)
+            .expect("auth middleware should set the mirrord_token cookie");
+        let cookie_str = cookie.to_str().unwrap();
+        assert!(cookie_str.contains(&format!("mirrord_token={TEST_TOKEN}")));
+        assert!(
+            cookie_str.contains("HttpOnly"),
+            "cookie must be HttpOnly to prevent XSS exfiltration"
+        );
+        assert!(
+            cookie_str.contains("SameSite=Strict"),
+            "cookie must be SameSite=Strict to prevent CSRF"
+        );
+    }
+
+    /// Once the cookie is set, requests should authenticate via cookie without needing
+    /// the query param. This is what the React frontend does after the initial page load.
+    #[tokio::test]
+    async fn api_with_valid_cookie_succeeds() {
+        let request = Request::builder()
+            .uri("/api/sessions")
+            .header(header::COOKIE, format!("mirrord_token={TEST_TOKEN}"))
+            .body(Body::empty())
+            .unwrap();
+        assert_eq!(status_of(request).await, StatusCode::OK);
+    }
+
+    /// A wrong cookie must be rejected. Without this, an attacker who guesses or steals
+    /// a stale token could impersonate the user.
+    #[tokio::test]
+    async fn api_with_wrong_cookie_returns_unauthorized() {
+        let request = Request::builder()
+            .uri("/api/sessions")
+            .header(header::COOKIE, "mirrord_token=wrong")
+            .body(Body::empty())
+            .unwrap();
+        assert_eq!(status_of(request).await, StatusCode::UNAUTHORIZED);
+    }
+
+    /// `/api/token` is gated by the auth middleware like every other API route, so an
+    /// unauthenticated caller can't use it to lift the token.
+    #[tokio::test]
+    async fn token_endpoint_without_token_returns_unauthorized() {
+        assert_eq!(status_of(req("/api/token")).await, StatusCode::UNAUTHORIZED);
+    }
+
+    /// A page that authenticated via the `HttpOnly` cookie (which JS can't read) recovers the
+    /// token from `/api/token` so it can forward it to the browser extension.
+    #[tokio::test]
+    async fn token_endpoint_with_cookie_returns_token() {
+        let request = Request::builder()
+            .uri("/api/token")
+            .header(header::COOKIE, format!("mirrord_token={TEST_TOKEN}"))
+            .body(Body::empty())
+            .unwrap();
+        let response = build_router(test_state()).oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let parsed: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(
+            parsed.get("token").and_then(|v| v.as_str()),
+            Some(TEST_TOKEN)
+        );
+    }
+
+    /// All authenticated responses should carry the security headers from the RFC.
+    /// These protect against clickjacking, MIME sniffing, referrer leaks, and XSS.
+    #[tokio::test]
+    async fn responses_include_security_headers() {
+        let response = build_router(test_state())
+            .oneshot(req(&format!("/api/sessions?token={TEST_TOKEN}")))
+            .await
+            .unwrap();
+
+        let headers = response.headers();
+        assert_eq!(headers.get(header::X_FRAME_OPTIONS).unwrap(), "DENY");
+        assert_eq!(
+            headers.get(header::X_CONTENT_TYPE_OPTIONS).unwrap(),
+            "nosniff"
+        );
+        assert_eq!(headers.get(header::REFERRER_POLICY).unwrap(), "no-referrer");
+
+        // Per the RFC, CSP must restrict scripts to 'self' (no inline scripts).
+        let csp = headers.get(header::CONTENT_SECURITY_POLICY).unwrap();
+        let csp_str = csp.to_str().unwrap();
+        assert!(csp_str.contains("script-src 'self'"));
+        assert!(!csp_str.contains("script-src 'self' 'unsafe-inline'"));
+        assert!(csp_str.contains("frame-ancestors 'none'"));
+        assert!(csp_str.contains("object-src 'none'"));
+    }
+
+    /// WebSocket upgrades from a non-localhost Origin must be rejected. WebSocket
+    /// connections do NOT enforce same-origin policy by default, so without this check
+    /// any malicious website the user visits could open `ws://localhost:59281/ws` and
+    /// stream every session event in real time.
+    #[test]
+    fn validate_ws_origin_rejects_non_localhost() {
+        let mut headers = HeaderMap::new();
+        headers.insert(header::ORIGIN, "http://evil.com".parse().unwrap());
+        assert!(!validate_ws_origin(&headers));
+
+        headers.insert(header::ORIGIN, "https://localhost:59281".parse().unwrap());
+        assert!(
+            !validate_ws_origin(&headers),
+            "https origin must be rejected, mirrord ui only serves http"
+        );
+    }
+
+    /// Localhost origins (in any common form) should be accepted.
+    #[test]
+    fn validate_ws_origin_accepts_localhost() {
+        for origin in [
+            "http://localhost",
+            "http://localhost:59281",
+            "http://127.0.0.1:59281",
+            "http://[::1]:59281",
+        ] {
+            let mut headers = HeaderMap::new();
+            headers.insert(header::ORIGIN, origin.parse().unwrap());
+            assert!(
+                validate_ws_origin(&headers),
+                "should accept origin: {origin}"
+            );
+        }
+    }
+
+    /// Non-browser clients (curl, native code) typically omit the Origin header. We accept
+    /// these because the Unix socket and TCP localhost binding are the access control there.
+    #[test]
+    fn validate_ws_origin_accepts_missing_origin() {
+        let headers = HeaderMap::new();
+        assert!(validate_ws_origin(&headers));
+    }
+
+    /// CSRF check: a malicious form-POST from another origin would not include the cookie
+    /// (because of SameSite=Strict), so any state-changing endpoint must reject it.
+    #[tokio::test]
+    async fn kill_endpoint_without_token_returns_unauthorized() {
+        let request = Request::builder()
+            .method("POST")
+            .uri("/api/sessions/some-id/kill")
+            .body(Body::empty())
+            .unwrap();
+        assert_eq!(status_of(request).await, StatusCode::UNAUTHORIZED);
+    }
+
+    /// Static assets are served behind the auth middleware so the token cookie is set on
+    /// the very first page load (the user clicks `?token=...` in their browser, the static
+    /// HTML response sets the cookie, and subsequent API/WS calls authenticate via cookie).
+    #[tokio::test]
+    async fn static_handler_without_token_returns_unauthorized() {
+        assert_eq!(status_of(req("/")).await, StatusCode::UNAUTHORIZED);
+    }
+
+    /// The `?token=` query param works for any path, including the root, so the initial
+    /// page load establishes the cookie.
+    #[tokio::test]
+    async fn static_handler_with_token_sets_cookie() {
+        let response = build_router(test_state())
+            .oneshot(req(&format!("/?token={TEST_TOKEN}")))
+            .await
+            .unwrap();
+        // Status may be 200 (if asset embedded) or 404 (if no embedded assets in test build)
+        // either way, the cookie should be set.
+        assert!(
+            response.headers().get(header::SET_COOKIE).is_some(),
+            "cookie must be set on the first authenticated request, even if the body is 404"
+        );
+    }
+
+    mod operator_sessions {
+        use mirrord_operator::crd::Session;
+
+        use super::*;
+
+        fn sample_session(id: &str, key: &str) -> Session {
+            Session {
+                id: Some(id.to_owned()),
+                duration_secs: 60,
+                user: "alice/alice@ex@host".to_owned(),
+                target: "deployment/web".to_owned(),
+                namespace: Some("default".to_owned()),
+                locked_ports: None,
+                user_id: Some("u".to_owned()),
+                sqs: None,
+                rmq: None,
+                kafka: None,
+                key: Some(key.to_owned()),
+                http_filter: None,
+            }
+        }
+
+        #[test]
+        fn summary_from_session_extracts_key_and_parses_target_owner() {
+            let session = sample_session("cr-1", "alice-session");
+            let summary = OperatorSessionSummary::from_session(&session).unwrap();
+            assert_eq!(summary.id, "cr-1");
+            assert_eq!(summary.key, "alice-session");
+            assert_eq!(summary.namespace, "default");
+            assert_eq!(
+                summary.target.as_ref().map(|t| t.name.as_str()),
+                Some("web")
+            );
+            assert_eq!(
+                summary.target.as_ref().map(|t| t.kind.as_str()),
+                Some("deployment")
+            );
+            assert_eq!(summary.owner.username, "alice");
+            assert_eq!(summary.owner.k8s_username, "alice@ex");
+        }
+
+        #[tokio::test]
+        async fn operator_sessions_groups_by_key_with_none_bucket() {
+            let (tx, _rx) = broadcast::channel::<SessionNotification>(16);
+            let state = AppState {
+                sessions: Default::default(),
+                operator_sessions: Arc::new(RwLock::new({
+                    let mut m = BTreeMap::new();
+                    let s1 =
+                        OperatorSessionSummary::from_session(&sample_session("a", "k")).unwrap();
+                    let s2 =
+                        OperatorSessionSummary::from_session(&sample_session("b", "k")).unwrap();
+                    let s3 =
+                        OperatorSessionSummary::from_session(&sample_session("c", "k2")).unwrap();
+                    m.insert("a".into(), s1);
+                    m.insert("b".into(), s2);
+                    m.insert("c".into(), s3);
+                    m
+                })),
+                operator_watch_status: Arc::new(RwLock::new(OperatorWatchStatus::Watching)),
+                notify_tx: tx,
+                token: "t".into(),
+            };
+
+            let resp = list_operator_sessions(axum::extract::State(state)).await.0;
+            assert_eq!(resp.sessions.len(), 3);
+            assert_eq!(resp.by_key.get("k").map(|v| v.len()), Some(2));
+            assert_eq!(resp.by_key.get("k2").map(|v| v.len()), Some(1));
+            assert!(matches!(resp.watch_status, OperatorWatchStatus::Watching));
+        }
+    }
+}

--- a/mirrord/cli/src/ui/server.rs
+++ b/mirrord/cli/src/ui/server.rs
@@ -1,7 +1,8 @@
+#[cfg(target_os = "macos")]
+use std::path::PathBuf;
 use std::{
     collections::{BTreeMap, HashMap, hash_map::Entry},
     convert::Infallible,
-    path::PathBuf,
     str::FromStr,
     sync::Arc,
     time::{Duration, SystemTime, UNIX_EPOCH},

--- a/mirrord/cli/src/up.rs
+++ b/mirrord/cli/src/up.rs
@@ -1,6 +1,6 @@
 //! The `mirrord up` command - runs multiple mirrord sessions from a `mirrord-up.yaml` file.
 
-use std::io::ErrorKind;
+use std::{io::ErrorKind, process::Stdio};
 
 use miette::Diagnostic;
 use mirrord_analytics::{Analytics, AnalyticsReporter, CollectAnalytics, Reporter};
@@ -10,7 +10,7 @@ use thiserror::Error;
 use uuid::Uuid;
 
 use crate::{
-    config::{UI_DEFAULT_PORT, UpArgs, UpSubcommand},
+    config::{UpArgs, UpSubcommand},
     user_data::UserData,
 };
 
@@ -86,28 +86,27 @@ async fn run_up(args: UpArgs, analytics: &mut AnalyticsReporter) -> Result<(), U
     // Run UI
     analytics.get_mut().add("ui_enabled", args.ui);
 
-    if args.ui {
-        tokio::spawn(async move {
-            let (server, url) = match crate::ui::setup_ui(UI_DEFAULT_PORT).await {
-                Ok(crate::ui::UiSetup::Started { server, url, .. }) => (server, url),
-                Ok(crate::ui::UiSetup::AlreadyRunning { url, .. }) => {
-                    tracing::info!(%url, "local UI already running, not starting another");
-                    return;
-                }
-                Err(err) => {
-                    tracing::warn!(?err, "failed to start local UI");
-                    return;
-                }
-            };
-
-            if let Err(err) = opener::open(&url) {
-                tracing::warn!(?err, "Failed to open browser");
+    if let Ok(mirrord_binary) = std::env::current_exe()
+        && args.ui
+    {
+        match tokio::process::Command::new(mirrord_binary)
+            .args(vec!["ui", "--no-browser"])
+            .stdin(Stdio::null())
+            .stdout(Stdio::inherit())
+            .stderr(Stdio::inherit())
+            .kill_on_drop(false)
+            .spawn()
+        {
+            Ok(child) => {
+                tracing::info!(
+                    child_pid = ?child.id(),
+                    "spawned `mirrord ui` command",
+                );
             }
-
-            let _ = server
-                .await
-                .inspect_err(|err| tracing::warn!(?err, "error serving local ui"));
-        });
+            Err(err) => {
+                tracing::warn!(?err, "failed to start local UI");
+            }
+        }
     }
 
     let result = mirrord_up::run(up_config, key, correlation_id, ready.clone()).await;

--- a/mirrord/cli/src/user_data.rs
+++ b/mirrord/cli/src/user_data.rs
@@ -1,4 +1,4 @@
-use std::{ops::Not, path::PathBuf, sync::LazyLock};
+use std::{env::home_dir, ops::Not, path::PathBuf, sync::LazyLock};
 
 use fs4::tokio::AsyncFileExt;
 use serde::{Deserialize, Serialize};
@@ -11,7 +11,7 @@ use uuid::Uuid;
 
 /// "~/.mirrord"
 static DATA_STORE_DIR: LazyLock<PathBuf> = LazyLock::new(|| {
-    home::home_dir()
+    home_dir()
         .unwrap_or_else(|| PathBuf::from("~"))
         .join(".mirrord")
 });

--- a/mirrord/cli/src/util.rs
+++ b/mirrord/cli/src/util.rs
@@ -270,10 +270,10 @@ pub(crate) mod mirrord_dir {
     /// Returns a [`PathBuf`] for `$HOME/.mirrord` if $HOME could be determined, and creates
     /// `$HOME/.mirrord` if it doesn't exist. Tries to create `~/.mirrord` if $HOME could not be
     /// determined.
-    pub(crate) fn get_path_and_create_with_fallback() -> Result<PathBuf, String> {
+    pub(crate) fn get_path_and_create_with_fallback() -> Result<PathBuf, std::io::Error> {
         let dir = get_path_or_fallback();
         if !dir.exists() {
-            let _ = create_dir_all(&dir).map_err(|err| err.to_string())?;
+            create_dir_all(&dir)?;
         }
         Ok(dir)
     }

--- a/mirrord/cli/src/util.rs
+++ b/mirrord/cli/src/util.rs
@@ -263,3 +263,30 @@ pub async fn get_user_git_branch() -> Option<String> {
         }
     }
 }
+
+pub(crate) mod mirrord_dir {
+    use std::{env::home_dir, fs::create_dir_all, path::PathBuf};
+
+    /// Returns a [`PathBuf`] for `$HOME/.mirrord` if $HOME could be determined, and creates
+    /// `$HOME/.mirrord` if it doesn't exist. Tries to create `~/.mirrord` if $HOME could not be
+    /// determined.
+    pub(crate) fn get_path_and_create_with_fallback() -> Result<PathBuf, String> {
+        let dir = get_path_or_fallback();
+        if !dir.exists() {
+            let _ = create_dir_all(&dir).map_err(|err| err.to_string())?;
+        }
+        Ok(dir)
+    }
+
+    /// Returns a [`PathBuf`] for `$HOME/.mirrord` if $HOME could be determined or `~/.mirrord`. The
+    /// directory is not guaranteed to exist.
+    pub(crate) fn get_path_or_fallback() -> PathBuf {
+        get_path().unwrap_or(PathBuf::from("~"))
+    }
+
+    /// Returns a [`PathBuf`] for `$HOME/.mirrord` if $HOME could be determined. The directory is
+    /// not guaranteed to exist.
+    pub(crate) fn get_path() -> Option<PathBuf> {
+        home_dir().map(|home| home.join(".mirrord"))
+    }
+}

--- a/mirrord/session-monitor-client/Cargo.toml
+++ b/mirrord/session-monitor-client/Cargo.toml
@@ -18,7 +18,6 @@ workspace = true
 
 [dependencies]
 mirrord-session-monitor-protocol.workspace = true
-home.workspace = true
 thiserror.workspace = true
 hyper = { workspace = true, features = ["client", "http1"] }
 hyper-util = { workspace = true, features = ["tokio"] }

--- a/mirrord/session-monitor-client/src/lib.rs
+++ b/mirrord/session-monitor-client/src/lib.rs
@@ -14,6 +14,7 @@
 //! implementation small and the lifecycle of the SSE event stream simple.
 
 use std::{
+    env::home_dir,
     path::{Path, PathBuf},
     pin::Pin,
 };
@@ -41,7 +42,7 @@ pub use request_builder::{RequestBuilder, Response};
 /// Returns `~/.mirrord/sessions`, the directory where session sentinel files (and on unix the
 /// sockets themselves) live.
 pub fn sessions_dir() -> Option<PathBuf> {
-    home::home_dir().map(|home_dir| home_dir.join(".mirrord").join("sessions"))
+    home_dir().map(|home_dir| home_dir.join(".mirrord").join("sessions"))
 }
 
 /// Address of a single session's HTTP API.

--- a/mirrord/tls-util/Cargo.toml
+++ b/mirrord/tls-util/Cargo.toml
@@ -16,7 +16,6 @@ edition.workspace = true
 [features]
 
 [dependencies]
-home.workspace = true
 http.workspace = true
 pem.workspace = true
 rcgen.workspace = true

--- a/mirrord/tls-util/src/secure_channel.rs
+++ b/mirrord/tls-util/src/secure_channel.rs
@@ -1,4 +1,4 @@
-use std::{io::Write, path::Path, sync::Arc};
+use std::{env::home_dir, io::Write, path::Path, sync::Arc};
 
 use pem::{EncodeConfig, LineEnding, Pem};
 use rcgen::CertifiedKey;
@@ -56,7 +56,7 @@ impl SecureChannelSetup {
             EncodeConfig::new().set_line_ending(LineEnding::LF),
         );
 
-        let pem_dir = home::home_dir()
+        let pem_dir = home_dir()
             .unwrap_or_else(std::env::temp_dir)
             .join(".mirrord")
             .join("temp");


### PR DESCRIPTION
This PR changes the UI server spawned by running `mirrord ui` to run in the background, detached from the terminal where the command was invoked. This is a UX improvement that will let users leave the server running on their machines for long periods of time.

NB: I use the term "UI server" to refer to the `axum` server that serves the local mirrord UI frontend (also called the dashboard in some places), and not the session monitor server that is started by the intproxy process during a single mirrord session, which is internal and not accessible by the user, but which communicates with the UI server.

### Overview

Old behaviour: The user runs `mirrord ui` to start the server, and can then view the frontend to see session details or use the chaos endpoints to manage chaos rules. The server blocks the terminal where it was started, and runs until the command is cancelled.

New behaviour: The user runs `mirrord ui` to start the server. The terminal is only blocked while the server is being set up, and then the command returns. The server runs for as long as the background task/ process lives. It can be stopped by running `mirrord ui stop` or by killing the process manually by PID (which is printed to the user during startup).

### How does it do that though

1. `ui_start()` decides if the current process is foreground or background by looking for a special env var. The first time it runs, it's the foreground task that the user is seeing in their terminal, and the env var is not present
2. `tokio`'s `Command::spawn()` is used to spawn a child process running `mirrord ui` with the special env var present. `stderr` is inherited, so errors from the server setup will be visible in the terminal
3. The child process finds the env var present, and runs `ui_run_server()` - the first thing it attempts to do is lock the ui.lock file, thus making sure it is the only UI server running on the machine. If it fails, it exits with `Ok` and informs the parent process that a server is already running via `stdout`
4. The child process sets up the server and prints an OK message before starting the server itself
5. The parent process sees that the server started successfully and prints details to the user: the token, the server url and the PID of the server
6. If the server _did not start properly_ and `ui_start()` returns an error, `ui_stop()` is run to clean up
7. After the user is done with the server and runs `mirrord ui stop`, `ui_stop()` attempts to kill the process by its PID (stored in a file next to the token and lockfile) and remove the stale PID & token files

### This PR

I recommend you review this PR either commit by commit (I know there are a few, and I overwrite previous changes a lot) **or** you exclude the final few commits (so you view everything before `meta: move server code to ui::server`) to review the UI server changes first. This is because the commit marked `meta` moves a lot of code into a new file, which makes the git diff very difficult to read.