### PR TITLE
Fix getifaddrs hook

### DIFF
--- a/changelog.d/+getifaddrs.fixed.md
+++ b/changelog.d/+getifaddrs.fixed.md
@@ -1,0 +1,1 @@
+Fixed use-after-free in `getifaddrs` hook, which is used when `hide_ipv6_interfaces` is enabled.

--- a/mirrord/layer-lib/src/error.rs
+++ b/mirrord/layer-lib/src/error.rs
@@ -507,6 +507,7 @@ pub(crate) fn get_platform_errno(fail: HookError) -> u32 {
         HookError::ConnectError(_) => WSAEFAULT,
         HookError::SendToError(_) => WSAEFAULT,
         HookError::HostnameResolveError(_) => WSAEFAULT,
+        HookError::MallocFail => ERROR_NOT_ENOUGH_MEMORY,
     }
 }
 

--- a/mirrord/layer-lib/src/error.rs
+++ b/mirrord/layer-lib/src/error.rs
@@ -225,6 +225,9 @@ pub enum HookError {
 
     #[error("mirrord-layer: Hostname resolution failed with `{0}`!")]
     HostnameResolveError(#[from] HostnameResolveError),
+
+    #[error("mirrord-layer: malloc returned null!")]
+    MallocFail,
 }
 
 /// Errors internal to mirrord-layer.
@@ -429,6 +432,7 @@ fn get_platform_errno(fail: HookError) -> i32 {
         HookError::ConnectError(_) => libc::EFAULT,
         HookError::SendToError(_) => libc::EFAULT,
         HookError::HostnameResolveError(_) => libc::EFAULT,
+        HookError::MallocFail => libc::ENOMEM,
     }
 }
 

--- a/mirrord/layer-tests/tests/apps/getifaddrs/getifaddrs.c
+++ b/mirrord/layer-tests/tests/apps/getifaddrs/getifaddrs.c
@@ -52,10 +52,13 @@ static const char *family_token(const struct sockaddr *sa) {
 int main(void) {
     struct ifaddrs *head = NULL;
 
+	fprintf(stderr, "hello, boutta call\n");
     if (getifaddrs(&head) != 0) {
         perror("getifaddrs");
         return 1;
     }
+
+	fprintf(stderr, "called getifaddrs, got 0x%lx\n", head);
 
     int n = 0;
     for (struct ifaddrs *ifa = head; ifa != NULL; ifa = ifa->ifa_next) {

--- a/mirrord/layer-tests/tests/apps/getifaddrs/getifaddrs.c
+++ b/mirrord/layer-tests/tests/apps/getifaddrs/getifaddrs.c
@@ -1,0 +1,87 @@
+#include <arpa/inet.h>
+#include <ifaddrs.h>
+#include <net/if.h>
+#include <netinet/in.h>
+#include <stdio.h>
+#include <sys/socket.h>
+
+/* Read one byte through a volatile lvalue: the access is a mandated side effect. */
+static inline unsigned char vread(const void *p) {
+    return *(const volatile unsigned char *)p;
+}
+
+/* Touch every byte of a sockaddr through volatile reads (freed-memory probe). */
+static void touch_sockaddr(const struct sockaddr *sa) {
+    if (sa == NULL) {
+        return;
+    }
+
+    sa_family_t fam = ((const volatile struct sockaddr *)sa)->sa_family;
+    size_t len;
+    switch (fam) {
+    case AF_INET:
+        len = sizeof(struct sockaddr_in);
+        break;
+    case AF_INET6:
+        len = sizeof(struct sockaddr_in6);
+        break;
+    default:
+        len = sizeof(struct sockaddr);
+        break;
+    }
+
+    for (size_t i = 0; i < len; i++) {
+        vread((const unsigned char *)sa + i);
+    }
+}
+
+static const char *family_token(const struct sockaddr *sa) {
+    if (sa == NULL) {
+        return "none";
+    }
+    switch (sa->sa_family) {
+    case AF_INET:
+        return "IPv4";
+    case AF_INET6:
+        return "IPv6";
+    default:
+        return "other";
+    }
+}
+
+int main(void) {
+    struct ifaddrs *head = NULL;
+
+    if (getifaddrs(&head) != 0) {
+        perror("getifaddrs");
+        return 1;
+    }
+
+    int n = 0;
+    for (struct ifaddrs *ifa = head; ifa != NULL; ifa = ifa->ifa_next) {
+        n++;
+
+        /* Probe every inner pointer via volatile reads. */
+        if (ifa->ifa_name != NULL) {
+            for (size_t i = 0; vread((const unsigned char *)ifa->ifa_name + i) != 0; i++) {
+            }
+        }
+        touch_sockaddr(ifa->ifa_addr);
+        touch_sockaddr(ifa->ifa_netmask);
+        touch_sockaddr(ifa->ifa_broadaddr); /* ifa_ifu union */
+        if (ifa->ifa_data != NULL) {
+            for (size_t i = 0; i < 16; i++) {
+                vread((const unsigned char *)ifa->ifa_data + i);
+            }
+        }
+
+        printf("interface name=%s family=%s\n",
+               ifa->ifa_name ? ifa->ifa_name : "(null)",
+               family_token(ifa->ifa_addr));
+    }
+
+    printf("walked %d interfaces\n", n);
+
+    freeifaddrs(head);
+    return 0;
+}

--- a/mirrord/layer-tests/tests/common/mod.rs
+++ b/mirrord/layer-tests/tests/common/mod.rs
@@ -191,6 +191,10 @@ pub enum Application {
     /// C app that calls `connect(2)` on a unix socket with a too-large `addrlen`
     /// so that `sun_path` carries trailing null bytes.
     UnixConnectAddrlen,
+    /// C app that walks `getifaddrs()` reading every pointer reachable from each
+    /// node, then calls `freeifaddrs()`. Exercises the hooks enabled by the
+    /// `hide_ipv6_interfaces` feature (for ASan and IPv6-hiding checks).
+    Getifaddrs,
 }
 
 impl Application {
@@ -390,6 +394,11 @@ impl Application {
                 env!("CARGO_MANIFEST_DIR"),
                 "tests/apps/unix_connect_addrlen/out.c_test_app",
             ),
+            Application::Getifaddrs => format!(
+                "{}/{}",
+                env!("CARGO_MANIFEST_DIR"),
+                "tests/apps/getifaddrs/out.c_test_app",
+            ),
         }
     }
 
@@ -521,7 +530,8 @@ impl Application {
             | Application::Connectx
             | Application::DoubleListen
             | Application::DupListen
-            | Application::UnixConnectAddrlen => vec![],
+            | Application::UnixConnectAddrlen
+            | Application::Getifaddrs => vec![],
             Application::RustOutgoingUdp => ["--udp", RUST_OUTGOING_LOCAL, RUST_OUTGOING_PEERS]
                 .into_iter()
                 .map(Into::into)
@@ -619,6 +629,7 @@ impl Application {
             | Application::PythonSocketPair
             | Application::PythonCor1401Seqpacket
             | Application::UnixConnectAddrlen
+            | Application::Getifaddrs
             | Application::Connectx => unimplemented!("shouldn't get here"),
             Application::PythonSelfConnect => 1337,
             Application::RustIssue2058 => 1234,

--- a/mirrord/layer-tests/tests/getifaddrs.rs
+++ b/mirrord/layer-tests/tests/getifaddrs.rs
@@ -1,0 +1,54 @@
+#![cfg(target_family = "unix")]
+#![warn(clippy::indexing_slicing)]
+
+use std::time::Duration;
+
+use rstest::rstest;
+
+mod common;
+
+pub use common::*;
+
+/// Exercises the `getifaddrs`/`freeifaddrs` hooks that the `hide_ipv6_interfaces`
+/// experimental feature installs. The C app ([`Application::Getifaddrs`]) walks
+/// the whole interface list and reads every pointer reachable from each node, so
+/// once ASan is wired into the test suite this catches a use-after-free in the
+/// hook's copy of the list.
+#[rstest]
+#[tokio::test]
+#[timeout(Duration::from_secs(60))]
+async fn getifaddrs(#[values(false, true)] hide_ipv6_interfaces: bool) {
+    let application = Application::Getifaddrs;
+
+    let dir = tempfile::tempdir().unwrap();
+    let file_id = rand::random::<u64>();
+    let config_path = dir.path().join(format!("{file_id:X}.json"));
+
+    let config = serde_json::json!({
+        "experimental": {
+            "hide_ipv6_interfaces": hide_ipv6_interfaces,
+        },
+        "feature": {
+            "network": {
+                "dns": false
+            },
+            "fs": "local",
+        }
+    });
+
+    tokio::fs::write(&config_path, serde_json::to_string_pretty(&config).unwrap())
+        .await
+        .expect("failed to save layer config to tmp file");
+
+    let (mut test_process, _intproxy) = application
+        .start_process(Default::default(), Some(&config_path))
+        .await;
+
+    test_process.wait_assert_success().await;
+
+    if hide_ipv6_interfaces {
+        test_process
+            .assert_stdout_doesnt_contain("family=IPv6")
+            .await;
+    }
+}

--- a/mirrord/layer-tests/tests/issue2807.rs
+++ b/mirrord/layer-tests/tests/issue2807.rs
@@ -20,7 +20,6 @@ pub use common::*;
 #[rstest]
 #[tokio::test]
 #[timeout(Duration::from_secs(60))]
-#[ignore = "flaky, disabled until we fix the underlying flakiness"]
 async fn test_issue2807_with_ipv6_ignore(
     #[values(Application::NodeIssue2807)] application: Application,
 ) {

--- a/mirrord/layer/src/hooks.rs
+++ b/mirrord/layer/src/hooks.rs
@@ -33,13 +33,25 @@ impl<'a> HookManager<'a> {
 
             if let Some(function) = module.find_export_by_name(symbol) {
                 trace!("found {symbol:?} in {module_name:?}, hooking");
+                let dbg = symbol == "getifaddrs" || symbol == "freeifaddrs";
+                if dbg {
+                    eprintln!("HOOKDBG {symbol}: fallback trying {module_name:?} export {:?}", function.0);
+                }
                 match self.interceptor.replace(
                     function,
                     NativePointer(detour),
                     NativePointer(null_mut()),
                 ) {
-                    Ok(original) => return Ok(original),
+                    Ok(original) => {
+                        if dbg {
+                            eprintln!("HOOKDBG {symbol}: fallback hooked in {module_name:?}");
+                        }
+                        return Ok(original);
+                    }
                     Err(err) => {
+                        if dbg {
+                            eprintln!("HOOKDBG {symbol}: fallback replace in {module_name:?} failed: {err:?}");
+                        }
                         trace!("hook {symbol:?} in {module_name:?} failed with err {err:?}")
                     }
                 }
@@ -58,12 +70,24 @@ impl<'a> HookManager<'a> {
     ) -> Result<NativePointer> {
         // First try to hook the default exported one, if it fails, fallback to first lib that
         // provides it.
+        let dbg = symbol == "getifaddrs" || symbol == "freeifaddrs";
         let function = Module::find_global_export_by_name(symbol);
+        if dbg {
+            eprintln!(
+                "HOOKDBG {symbol}: detour={detour:?} global export={:?}",
+                function.as_ref().map(|f| f.0)
+            );
+        }
         match function {
-            Some(func) => self
-                .interceptor
-                .replace(func, NativePointer(detour), NativePointer(null_mut()))
-                .or_else(|_| self.hook_any_lib_export(symbol, detour, None)),
+            Some(func) => {
+                let res =
+                    self.interceptor
+                        .replace(func, NativePointer(detour), NativePointer(null_mut()));
+                if dbg {
+                    eprintln!("HOOKDBG {symbol}: global replace ok={}", res.is_ok());
+                }
+                res.or_else(|_| self.hook_any_lib_export(symbol, detour, None))
+            }
             None => self.hook_any_lib_export(symbol, detour, None),
         }
     }

--- a/mirrord/layer/src/hooks.rs
+++ b/mirrord/layer/src/hooks.rs
@@ -77,6 +77,18 @@ impl<'a> HookManager<'a> {
                 "HOOKDBG {symbol}: detour={detour:?} global export={:?}",
                 function.as_ref().map(|f| f.0)
             );
+            // Dump the prologue: frida can't inline-hook an arm64 function whose first
+            // instruction is an unconditional branch (`b`, opcode 0x14000000/0xFC000000)
+            // or that burns both x16/x17 scratch registers -- replace() then errors and
+            // we silently fall back to hooking a decoy copy.
+            if let Some(f) = function.as_ref() {
+                let words = unsafe { std::slice::from_raw_parts(f.0 as *const u32, 4) };
+                let is_b = words[0] & 0xFC00_0000 == 0x1400_0000;
+                eprintln!(
+                    "HOOKDBG {symbol}: prologue={:#010x} {:#010x} {:#010x} {:#010x} first_is_uncond_branch={is_b}",
+                    words[0], words[1], words[2], words[3]
+                );
+            }
         }
         match function {
             Some(func) => {

--- a/mirrord/layer/src/hooks.rs
+++ b/mirrord/layer/src/hooks.rs
@@ -33,25 +33,13 @@ impl<'a> HookManager<'a> {
 
             if let Some(function) = module.find_export_by_name(symbol) {
                 trace!("found {symbol:?} in {module_name:?}, hooking");
-                let dbg = symbol == "getifaddrs" || symbol == "freeifaddrs";
-                if dbg {
-                    eprintln!("HOOKDBG {symbol}: fallback trying {module_name:?} export {:?}", function.0);
-                }
                 match self.interceptor.replace(
                     function,
                     NativePointer(detour),
                     NativePointer(null_mut()),
                 ) {
-                    Ok(original) => {
-                        if dbg {
-                            eprintln!("HOOKDBG {symbol}: fallback hooked in {module_name:?}");
-                        }
-                        return Ok(original);
-                    }
+                    Ok(original) => return Ok(original),
                     Err(err) => {
-                        if dbg {
-                            eprintln!("HOOKDBG {symbol}: fallback replace in {module_name:?} failed: {err:?}");
-                        }
                         trace!("hook {symbol:?} in {module_name:?} failed with err {err:?}")
                     }
                 }
@@ -70,36 +58,12 @@ impl<'a> HookManager<'a> {
     ) -> Result<NativePointer> {
         // First try to hook the default exported one, if it fails, fallback to first lib that
         // provides it.
-        let dbg = symbol == "getifaddrs" || symbol == "freeifaddrs";
         let function = Module::find_global_export_by_name(symbol);
-        if dbg {
-            eprintln!(
-                "HOOKDBG {symbol}: detour={detour:?} global export={:?}",
-                function.as_ref().map(|f| f.0)
-            );
-            // Dump the prologue: frida can't inline-hook an arm64 function whose first
-            // instruction is an unconditional branch (`b`, opcode 0x14000000/0xFC000000)
-            // or that burns both x16/x17 scratch registers -- replace() then errors and
-            // we silently fall back to hooking a decoy copy.
-            if let Some(f) = function.as_ref() {
-                let words = unsafe { std::slice::from_raw_parts(f.0 as *const u32, 4) };
-                let is_b = words[0] & 0xFC00_0000 == 0x1400_0000;
-                eprintln!(
-                    "HOOKDBG {symbol}: prologue={:#010x} {:#010x} {:#010x} {:#010x} first_is_uncond_branch={is_b}",
-                    words[0], words[1], words[2], words[3]
-                );
-            }
-        }
         match function {
-            Some(func) => {
-                let res =
-                    self.interceptor
-                        .replace(func, NativePointer(detour), NativePointer(null_mut()));
-                if dbg {
-                    eprintln!("HOOKDBG {symbol}: global replace ok={}", res.is_ok());
-                }
-                res.or_else(|_| self.hook_any_lib_export(symbol, detour, None))
-            }
+            Some(func) => self
+                .interceptor
+                .replace(func, NativePointer(detour), NativePointer(null_mut()))
+                .or_else(|_| self.hook_any_lib_export(symbol, detour, None)),
             None => self.hook_any_lib_export(symbol, detour, None),
         }
     }

--- a/mirrord/layer/src/socket/hooks.rs
+++ b/mirrord/layer/src/socket/hooks.rs
@@ -636,9 +636,9 @@ unsafe extern "C" fn dns_configuration_free_detour(config: *mut dns_config_t) {
     }
 }
 
-#[hook_fn]
+#[hook_guard_fn]
 pub(crate) unsafe extern "C" fn getifaddrs_detour(ifaddrs: *mut *mut libc::ifaddrs) -> c_int {
-    eprintln!("getifaddrs_detour ENTER");
+    eprintln!("GETIFADDRS HOOK CALLED");
     unsafe {
         match getifaddrs() {
             Ok(got_ifaddrs) => {
@@ -647,25 +647,6 @@ pub(crate) unsafe extern "C" fn getifaddrs_detour(ifaddrs: *mut *mut libc::ifadd
             }
             Err(error) => error.into(),
         }
-    }
-}
-
-#[hook_guard_fn]
-pub(crate) unsafe extern "C" fn freeifaddrs_detour(ifaddrs: *mut libc::ifaddrs) {
-    if ifaddrs.is_null() {
-        return;
-    }
-    unsafe {
-        eprintln!("got ifaddrs ptr: {ifaddrs:?}");
-        let allocation_base = (ifaddrs as *mut u8).sub(std::mem::size_of_val(&ifaddrs));
-        eprintln!("alloc base: {allocation_base:?}");
-        // See `getifaddrs` implementation for clarification
-        let original_allocation = *(allocation_base as *mut *mut libc::ifaddrs);
-        eprintln!("original allocation: {original_allocation:?}");
-        FN_FREEIFADDRS(original_allocation);
-        eprintln!("freed original allocation");
-        libc::free(allocation_base as *mut c_void);
-        eprintln!("freed real");
     }
 }
 
@@ -893,29 +874,13 @@ pub(crate) unsafe fn enable_socket_hooks(
         }
 
         if experimental.hide_ipv6_interfaces {
-            match hook_manager
-                .hook_export_or_any("getifaddrs", getifaddrs_detour as FnGetifaddrs as *mut _)
-            {
-                Ok(replaced) => {
-                    eprintln!("PROBE getifaddrs: hook installed");
-                    FN_GETIFADDRS
-                        .set(std::mem::transmute::<_, FnGetifaddrs>(replaced))
-                        .unwrap();
-                }
-                Err(err) => eprintln!("PROBE getifaddrs: hook FAILED: {err:?}"),
-            }
-
-            match hook_manager
-                .hook_export_or_any("freeifaddrs", freeifaddrs_detour as FnFreeifaddrs as *mut _)
-            {
-                Ok(replaced) => {
-                    eprintln!("PROBE freeifaddrs: hook installed");
-                    FN_FREEIFADDRS
-                        .set(std::mem::transmute::<_, FnFreeifaddrs>(replaced))
-                        .unwrap();
-                }
-                Err(err) => eprintln!("PROBE freeifaddrs: hook FAILED: {err:?}"),
-            }
+            replace!(
+                hook_manager,
+                "getifaddrs",
+                getifaddrs_detour,
+                FnGetifaddrs,
+                FN_GETIFADDRS
+            );
         }
 
         #[cfg(target_os = "macos")]

--- a/mirrord/layer/src/socket/hooks.rs
+++ b/mirrord/layer/src/socket/hooks.rs
@@ -1,6 +1,6 @@
 use alloc::ffi::CString;
 use core::{cmp, ffi::CStr};
-use std::{collections::HashSet, os::unix::io::RawFd, sync::LazyLock};
+use std::{backtrace::Backtrace, collections::HashSet, os::unix::io::RawFd, sync::LazyLock};
 
 use libc::{c_char, c_int, c_void, hostent, size_t, sockaddr, socklen_t, ssize_t};
 #[cfg(target_os = "macos")]
@@ -653,7 +653,14 @@ pub(crate) unsafe extern "C" fn getifaddrs_detour(ifaddrs: *mut *mut libc::ifadd
 
 #[hook_guard_fn]
 pub(crate) unsafe extern "C" fn freeifaddrs_detour(ifaddrs: *mut libc::ifaddrs) {
-    eprintln!("FREEIFADDRS CALLED WITH {ifaddrs:?}");
+    static CALLS: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+    let n = CALLS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    if n < 5 {
+        eprintln!(
+            "FREEIFADDRS CALLED WITH {ifaddrs:?} (#{n})\n{}",
+            Backtrace::force_capture()
+        );
+    }
     return;
     // if ifaddrs.is_null() {
     //     return;

--- a/mirrord/layer/src/socket/hooks.rs
+++ b/mirrord/layer/src/socket/hooks.rs
@@ -642,6 +642,7 @@ pub(crate) unsafe extern "C" fn getifaddrs_detour(ifaddrs: *mut *mut libc::ifadd
     unsafe {
         match getifaddrs() {
             Ok(got_ifaddrs) => {
+                eprintln!("returning {got_ifaddrs:?} from hook");
                 *ifaddrs = got_ifaddrs;
                 0
             }
@@ -652,6 +653,7 @@ pub(crate) unsafe extern "C" fn getifaddrs_detour(ifaddrs: *mut *mut libc::ifadd
 
 #[hook_guard_fn]
 pub(crate) unsafe extern "C" fn freeifaddrs_detour(ifaddrs: *mut libc::ifaddrs) {
+    eprintln!("FREEIFADDRS CALLED WITH {ifaddrs:?}");
     return;
     // if ifaddrs.is_null() {
     //     return;

--- a/mirrord/layer/src/socket/hooks.rs
+++ b/mirrord/layer/src/socket/hooks.rs
@@ -655,10 +655,16 @@ pub(crate) unsafe extern "C" fn freeifaddrs_detour(ifaddrs: *mut libc::ifaddrs) 
         return;
     }
     unsafe {
+        eprintln!("got ifaddrs ptr: {ifaddrs:?}");
         let allocation_base = (ifaddrs as *mut u8).sub(std::mem::size_of_val(&ifaddrs));
+        eprintln!("alloc base: {allocation_base:?}");
         // See `getifaddrs` implementation for clarification
-        FN_FREEIFADDRS(*(allocation_base as *mut *mut libc::ifaddrs));
+        let original_allocation = *(allocation_base as *mut *mut libc::ifaddrs);
+        eprintln!("original allocation: {original_allocation:?}");
+        FN_FREEIFADDRS(original_allocation);
+        eprintln!("freed original allocation");
         libc::free(allocation_base as *mut c_void);
+        eprintln!("freed real");
     }
 }
 

--- a/mirrord/layer/src/socket/hooks.rs
+++ b/mirrord/layer/src/socket/hooks.rs
@@ -636,7 +636,7 @@ unsafe extern "C" fn dns_configuration_free_detour(config: *mut dns_config_t) {
     }
 }
 
-#[hook_guard_fn]
+#[hook_fn]
 pub(crate) unsafe extern "C" fn getifaddrs_detour(ifaddrs: *mut *mut libc::ifaddrs) -> c_int {
     eprintln!("getifaddrs_detour ENTER");
     unsafe {

--- a/mirrord/layer/src/socket/hooks.rs
+++ b/mirrord/layer/src/socket/hooks.rs
@@ -652,21 +652,22 @@ pub(crate) unsafe extern "C" fn getifaddrs_detour(ifaddrs: *mut *mut libc::ifadd
 
 #[hook_guard_fn]
 pub(crate) unsafe extern "C" fn freeifaddrs_detour(ifaddrs: *mut libc::ifaddrs) {
-    if ifaddrs.is_null() {
-        return;
-    }
-    unsafe {
-        eprintln!("got ifaddrs ptr: {ifaddrs:?}");
-        let allocation_base = (ifaddrs as *mut u8).sub(std::mem::size_of_val(&ifaddrs));
-        eprintln!("alloc base: {allocation_base:?}");
-        // See `getifaddrs` implementation for clarification
-        let original_allocation = *(allocation_base as *mut *mut libc::ifaddrs);
-        eprintln!("original allocation: {original_allocation:?}");
-        FN_FREEIFADDRS(original_allocation);
-        eprintln!("freed original allocation");
-        libc::free(allocation_base as *mut c_void);
-        eprintln!("freed real");
-    }
+    return;
+    // if ifaddrs.is_null() {
+    //     return;
+    // }
+    // unsafe {
+    //     eprintln!("got ifaddrs ptr: {ifaddrs:?}");
+    //     let allocation_base = (ifaddrs as *mut u8).sub(std::mem::size_of_val(&ifaddrs));
+    //     eprintln!("alloc base: {allocation_base:?}");
+    //     // See `getifaddrs` implementation for clarification
+    //     let original_allocation = *(allocation_base as *mut *mut libc::ifaddrs);
+    //     eprintln!("original allocation: {original_allocation:?}");
+    //     FN_FREEIFADDRS(original_allocation);
+    //     eprintln!("freed original allocation");
+    //     libc::free(allocation_base as *mut c_void);
+    //     eprintln!("freed real");
+    // }
 }
 
 #[cfg(target_os = "macos")]

--- a/mirrord/layer/src/socket/hooks.rs
+++ b/mirrord/layer/src/socket/hooks.rs
@@ -893,21 +893,29 @@ pub(crate) unsafe fn enable_socket_hooks(
         }
 
         if experimental.hide_ipv6_interfaces {
-            replace!(
-                hook_manager,
-                "getifaddrs",
-                getifaddrs_detour,
-                FnGetifaddrs,
-                FN_GETIFADDRS
-            );
+            match hook_manager
+                .hook_export_or_any("getifaddrs", getifaddrs_detour as FnGetifaddrs as *mut _)
+            {
+                Ok(replaced) => {
+                    eprintln!("PROBE getifaddrs: hook installed");
+                    FN_GETIFADDRS
+                        .set(std::mem::transmute::<_, FnGetifaddrs>(replaced))
+                        .unwrap();
+                }
+                Err(err) => eprintln!("PROBE getifaddrs: hook FAILED: {err:?}"),
+            }
 
-            replace!(
-                hook_manager,
-                "freeifaddrs",
-                freeifaddrs_detour,
-                FnFreeifaddrs,
-                FN_FREEIFADDRS
-            );
+            match hook_manager
+                .hook_export_or_any("freeifaddrs", freeifaddrs_detour as FnFreeifaddrs as *mut _)
+            {
+                Ok(replaced) => {
+                    eprintln!("PROBE freeifaddrs: hook installed");
+                    FN_FREEIFADDRS
+                        .set(std::mem::transmute::<_, FnFreeifaddrs>(replaced))
+                        .unwrap();
+                }
+                Err(err) => eprintln!("PROBE freeifaddrs: hook FAILED: {err:?}"),
+            }
         }
 
         #[cfg(target_os = "macos")]

--- a/mirrord/layer/src/socket/hooks.rs
+++ b/mirrord/layer/src/socket/hooks.rs
@@ -649,6 +649,19 @@ pub(crate) unsafe extern "C" fn getifaddrs_detour(ifaddrs: *mut *mut libc::ifadd
     }
 }
 
+#[hook_guard_fn]
+pub(crate) unsafe extern "C" fn freeifaddrs_detour(ifaddrs: *mut libc::ifaddrs) {
+    if ifaddrs.is_null() {
+        return;
+    }
+    unsafe {
+        let allocation_base = (ifaddrs as *mut u8).sub(std::mem::size_of_val(&ifaddrs));
+        // See `getifaddrs` implementation for clarification
+        FN_FREEIFADDRS(*(allocation_base as *mut *mut libc::ifaddrs));
+        libc::free(allocation_base as *mut c_void);
+    }
+}
+
 #[cfg(target_os = "macos")]
 #[hook_guard_fn]
 pub(crate) unsafe extern "C" fn connectx_detour(
@@ -879,6 +892,14 @@ pub(crate) unsafe fn enable_socket_hooks(
                 getifaddrs_detour,
                 FnGetifaddrs,
                 FN_GETIFADDRS
+            );
+
+            replace!(
+                hook_manager,
+                "freeifaddrs",
+                freeifaddrs_detour,
+                FnFreeifaddrs,
+                FN_FREEIFADDRS
             );
         }
 

--- a/mirrord/layer/src/socket/hooks.rs
+++ b/mirrord/layer/src/socket/hooks.rs
@@ -650,6 +650,25 @@ pub(crate) unsafe extern "C" fn getifaddrs_detour(ifaddrs: *mut *mut libc::ifadd
     }
 }
 
+#[hook_guard_fn]
+pub(crate) unsafe extern "C" fn freeifaddrs_detour(ifaddrs: *mut libc::ifaddrs) {
+    if ifaddrs.is_null() {
+        return;
+    }
+    unsafe {
+        eprintln!("got ifaddrs ptr: {ifaddrs:?}");
+        let allocation_base = (ifaddrs as *mut u8).sub(std::mem::size_of_val(&ifaddrs));
+        eprintln!("alloc base: {allocation_base:?}");
+        // See `getifaddrs` implementation for clarification
+        let original_allocation = *(allocation_base as *mut *mut libc::ifaddrs);
+        eprintln!("original allocation: {original_allocation:?}");
+        FN_FREEIFADDRS(original_allocation);
+        eprintln!("freed original allocation");
+        libc::free(allocation_base as *mut c_void);
+        eprintln!("freed real");
+    }
+}
+
 #[cfg(target_os = "macos")]
 #[hook_guard_fn]
 pub(crate) unsafe extern "C" fn connectx_detour(
@@ -880,6 +899,14 @@ pub(crate) unsafe fn enable_socket_hooks(
                 getifaddrs_detour,
                 FnGetifaddrs,
                 FN_GETIFADDRS
+            );
+
+            replace!(
+                hook_manager,
+                "freeifaddrs",
+                freeifaddrs_detour,
+                FnFreeifaddrs,
+                FN_FREEIFADDRS
             );
         }
 

--- a/mirrord/layer/src/socket/hooks.rs
+++ b/mirrord/layer/src/socket/hooks.rs
@@ -638,6 +638,7 @@ unsafe extern "C" fn dns_configuration_free_detour(config: *mut dns_config_t) {
 
 #[hook_guard_fn]
 pub(crate) unsafe extern "C" fn getifaddrs_detour(ifaddrs: *mut *mut libc::ifaddrs) -> c_int {
+    eprintln!("getifaddrs_detour ENTER");
     unsafe {
         match getifaddrs() {
             Ok(got_ifaddrs) => {

--- a/mirrord/layer/src/socket/ops.rs
+++ b/mirrord/layer/src/socket/ops.rs
@@ -1360,10 +1360,9 @@ pub(super) fn remote_dns_configuration_copy() -> Detour<*mut dns_config_t> {
 /// Calls [`libc::getifaddrs`] and removes IPv6 addresses from the list.
 #[mirrord_layer_macro::instrument(level = Level::TRACE, ret, err)]
 pub(super) fn getifaddrs() -> HookResult<*mut libc::ifaddrs> {
+    eprintln!("GETIFADDRS OPS CALLED");
     let mut original_head = std::ptr::null_mut();
-    eprintln!("hook: calling original");
     let result: i32 = unsafe { FN_GETIFADDRS(&mut original_head) };
-    eprintln!("hook: called original: {result}");
     if result != 0 {
         Err(io::Error::from_raw_os_error(result))?;
     }
@@ -1377,35 +1376,13 @@ pub(super) fn getifaddrs() -> HookResult<*mut libc::ifaddrs> {
             count_head = ifaddr.ifa_next;
         }
     }
-    eprintln!("hook: counted {entry_count} nodes");
-
-    // Allocate space for 1 extra pointer, store the original list head there.
-    // Free it in the `freeifaddrs` hook.
-    let allocation_base = unsafe {
-        libc::malloc(
-            mem::size_of::<libc::ifaddrs>() * entry_count + mem::size_of_val(&original_head),
-        )
-    };
-
-    eprintln!("hook: allocation_base={allocation_base:?}");
-
-    if allocation_base.is_null() {
-        return Err(HookError::MallocFail);
-    }
-
-    unsafe {
-        *(allocation_base as *mut *mut ifaddrs) = original_head;
-    }
-
-    eprintln!(
-        "hook: allocation_base={allocation_base:?} new_list_start={:?} stored original_head={original_head:?}",
-        unsafe { allocation_base.add(mem::size_of_val(&original_head)) }
-    );
 
     // Allocate new list so we can safely free the original list later
     // Safety: We assume `libc::malloc` is the same allocator as the user's system.
-    let new_list_start =
-        unsafe { allocation_base.add(mem::size_of_val(&original_head)) } as *mut libc::ifaddrs;
+    let new_list_start: *mut libc::ifaddrs = unsafe {
+        libc::malloc((mem::size_of::<libc::ifaddrs>() as libc::size_t) * entry_count)
+            as *mut libc::ifaddrs
+    };
     // Address to place next new address
     let mut next_new: *mut libc::ifaddrs = new_list_start;
     // Currently inspected element of the original interface addresses list.
@@ -1448,6 +1425,7 @@ pub(super) fn getifaddrs() -> HookResult<*mut libc::ifaddrs> {
                 }
             }
             inspected = ifaddr.ifa_next;
+            ifaddr.ifa_next = std::ptr::null_mut();
         }
 
         // Ensure that final element in new list doesn't point to another entry
@@ -1456,13 +1434,8 @@ pub(super) fn getifaddrs() -> HookResult<*mut libc::ifaddrs> {
         }
     }
 
-    if previous_new_entry.is_null() {
-        unsafe {
-            libc::free(allocation_base);
-            FN_FREEIFADDRS(original_head);
-        };
-        return Ok(std::ptr::null_mut());
-    } else {
-        Ok(new_list_start)
-    }
+    // Free the original list
+    // unsafe { libc::freeifaddrs(original_head) };
+
+    Ok(new_list_start)
 }

--- a/mirrord/layer/src/socket/ops.rs
+++ b/mirrord/layer/src/socket/ops.rs
@@ -15,7 +15,7 @@ use std::{
     sync::{Arc, OnceLock},
 };
 
-use libc::{AF_UNIX, c_int, c_void, hostent, sockaddr, socklen_t};
+use libc::{AF_UNIX, c_int, c_void, hostent, ifaddrs, sockaddr, socklen_t};
 #[cfg(target_os = "macos")]
 use libc::{SAE_ASSOCID_ANY, c_uint, iovec, sa_endpoints_t, sae_associd_t, sae_connid_t, size_t};
 use mirrord_config::feature::network::incoming::{IncomingConfig, IncomingMode};
@@ -1376,12 +1376,26 @@ pub(super) fn getifaddrs() -> HookResult<*mut libc::ifaddrs> {
         }
     }
 
+    // Allocate space for 1 extra pointer, store the original list head there.
+    // Free it in the `freeifaddrs` hook.
+    let allocation_base = unsafe {
+        libc::malloc(
+            mem::size_of::<libc::ifaddrs>() * entry_count + mem::size_of_val(&original_head),
+        )
+    };
+
+    if allocation_base.is_null() {
+        return Err(HookError::MallocFail);
+    }
+
+    unsafe {
+        *(allocation_base as *mut *mut ifaddrs) = original_head;
+    }
+
     // Allocate new list so we can safely free the original list later
     // Safety: We assume `libc::malloc` is the same allocator as the user's system.
-    let new_list_start: *mut libc::ifaddrs = unsafe {
-        libc::malloc((mem::size_of::<libc::ifaddrs>() as libc::size_t) * entry_count)
-            as *mut libc::ifaddrs
-    };
+    let new_list_start =
+        unsafe { allocation_base.add(mem::size_of_val(&original_head)) } as *mut libc::ifaddrs;
     // Address to place next new address
     let mut next_new: *mut libc::ifaddrs = new_list_start;
     // Currently inspected element of the original interface addresses list.
@@ -1424,7 +1438,6 @@ pub(super) fn getifaddrs() -> HookResult<*mut libc::ifaddrs> {
                 }
             }
             inspected = ifaddr.ifa_next;
-            ifaddr.ifa_next = std::ptr::null_mut();
         }
 
         // Ensure that final element in new list doesn't point to another entry
@@ -1433,8 +1446,13 @@ pub(super) fn getifaddrs() -> HookResult<*mut libc::ifaddrs> {
         }
     }
 
-    // Free the original list
-    unsafe { libc::freeifaddrs(original_head) };
-
-    Ok(new_list_start)
+    if previous_new_entry.is_null() {
+        unsafe {
+            libc::free(allocation_base);
+            FN_FREEIFADDRS(original_head);
+        };
+        return Ok(std::ptr::null_mut());
+    } else {
+        Ok(new_list_start)
+    }
 }

--- a/mirrord/layer/src/socket/ops.rs
+++ b/mirrord/layer/src/socket/ops.rs
@@ -15,7 +15,7 @@ use std::{
     sync::{Arc, OnceLock},
 };
 
-use libc::{AF_UNIX, c_int, c_void, hostent, ifaddrs, sockaddr, socklen_t};
+use libc::{AF_UNIX, c_int, c_void, hostent, sockaddr, socklen_t};
 #[cfg(target_os = "macos")]
 use libc::{SAE_ASSOCID_ANY, c_uint, iovec, sa_endpoints_t, sae_associd_t, sae_connid_t, size_t};
 use mirrord_config::feature::network::incoming::{IncomingConfig, IncomingMode};

--- a/mirrord/layer/src/socket/ops.rs
+++ b/mirrord/layer/src/socket/ops.rs
@@ -15,7 +15,7 @@ use std::{
     sync::{Arc, OnceLock},
 };
 
-use libc::{AF_UNIX, c_int, c_void, hostent, sockaddr, socklen_t};
+use libc::{AF_UNIX, c_int, c_void, hostent, ifaddrs, sockaddr, socklen_t};
 #[cfg(target_os = "macos")]
 use libc::{SAE_ASSOCID_ANY, c_uint, iovec, sa_endpoints_t, sae_associd_t, sae_connid_t, size_t};
 use mirrord_config::feature::network::incoming::{IncomingConfig, IncomingMode};
@@ -1357,10 +1357,10 @@ pub(super) fn remote_dns_configuration_copy() -> Detour<*mut dns_config_t> {
     Detour::Success(config)
 }
 
+
 /// Calls [`libc::getifaddrs`] and removes IPv6 addresses from the list.
 #[mirrord_layer_macro::instrument(level = Level::TRACE, ret, err)]
 pub(super) fn getifaddrs() -> HookResult<*mut libc::ifaddrs> {
-    eprintln!("GETIFADDRS OPS CALLED");
     let mut original_head = std::ptr::null_mut();
     let result: i32 = unsafe { FN_GETIFADDRS(&mut original_head) };
     if result != 0 {
@@ -1377,12 +1377,26 @@ pub(super) fn getifaddrs() -> HookResult<*mut libc::ifaddrs> {
         }
     }
 
+    // Allocate space for 1 extra pointer, store the original list head there.
+    // Free it in the `freeifaddrs` hook.
+    let allocation_base = unsafe {
+        libc::malloc(
+            mem::size_of::<libc::ifaddrs>() * entry_count + mem::size_of_val(&original_head),
+        )
+    };
+
+    if allocation_base.is_null() {
+        return Err(HookError::MallocFail);
+    }
+
+    unsafe {
+        *(allocation_base as *mut *mut ifaddrs) = original_head;
+    }
+
     // Allocate new list so we can safely free the original list later
     // Safety: We assume `libc::malloc` is the same allocator as the user's system.
-    let new_list_start: *mut libc::ifaddrs = unsafe {
-        libc::malloc((mem::size_of::<libc::ifaddrs>() as libc::size_t) * entry_count)
-            as *mut libc::ifaddrs
-    };
+    let new_list_start =
+        unsafe { allocation_base.add(mem::size_of_val(&original_head)) } as *mut libc::ifaddrs;
     // Address to place next new address
     let mut next_new: *mut libc::ifaddrs = new_list_start;
     // Currently inspected element of the original interface addresses list.
@@ -1425,7 +1439,6 @@ pub(super) fn getifaddrs() -> HookResult<*mut libc::ifaddrs> {
                 }
             }
             inspected = ifaddr.ifa_next;
-            ifaddr.ifa_next = std::ptr::null_mut();
         }
 
         // Ensure that final element in new list doesn't point to another entry
@@ -1434,8 +1447,13 @@ pub(super) fn getifaddrs() -> HookResult<*mut libc::ifaddrs> {
         }
     }
 
-    // Free the original list
-    // unsafe { libc::freeifaddrs(original_head) };
-
-    Ok(new_list_start)
+    if previous_new_entry.is_null() {
+        unsafe {
+            libc::free(allocation_base);
+            FN_FREEIFADDRS(original_head);
+        };
+        return Ok(std::ptr::null_mut());
+    } else {
+        Ok(new_list_start)
+    }
 }

--- a/mirrord/layer/src/socket/ops.rs
+++ b/mirrord/layer/src/socket/ops.rs
@@ -1392,6 +1392,11 @@ pub(super) fn getifaddrs() -> HookResult<*mut libc::ifaddrs> {
         *(allocation_base as *mut *mut ifaddrs) = original_head;
     }
 
+    eprintln!(
+        "getifaddrs: allocation_base={allocation_base:?} new_list_start={:?} stored original_head={original_head:?}",
+        unsafe { allocation_base.add(mem::size_of_val(&original_head)) }
+    );
+
     // Allocate new list so we can safely free the original list later
     // Safety: We assume `libc::malloc` is the same allocator as the user's system.
     let new_list_start =

--- a/mirrord/layer/src/socket/ops.rs
+++ b/mirrord/layer/src/socket/ops.rs
@@ -1361,7 +1361,9 @@ pub(super) fn remote_dns_configuration_copy() -> Detour<*mut dns_config_t> {
 #[mirrord_layer_macro::instrument(level = Level::TRACE, ret, err)]
 pub(super) fn getifaddrs() -> HookResult<*mut libc::ifaddrs> {
     let mut original_head = std::ptr::null_mut();
+    eprintln!("hook: calling original");
     let result: i32 = unsafe { FN_GETIFADDRS(&mut original_head) };
+    eprintln!("hook: called original: {result}");
     if result != 0 {
         Err(io::Error::from_raw_os_error(result))?;
     }
@@ -1375,6 +1377,7 @@ pub(super) fn getifaddrs() -> HookResult<*mut libc::ifaddrs> {
             count_head = ifaddr.ifa_next;
         }
     }
+    eprintln!("hook: counted {entry_count} nodes");
 
     // Allocate space for 1 extra pointer, store the original list head there.
     // Free it in the `freeifaddrs` hook.
@@ -1383,6 +1386,8 @@ pub(super) fn getifaddrs() -> HookResult<*mut libc::ifaddrs> {
             mem::size_of::<libc::ifaddrs>() * entry_count + mem::size_of_val(&original_head),
         )
     };
+
+    eprintln!("hook: allocation_base={allocation_base:?}");
 
     if allocation_base.is_null() {
         return Err(HookError::MallocFail);
@@ -1393,7 +1398,7 @@ pub(super) fn getifaddrs() -> HookResult<*mut libc::ifaddrs> {
     }
 
     eprintln!(
-        "getifaddrs: allocation_base={allocation_base:?} new_list_start={:?} stored original_head={original_head:?}",
+        "hook: allocation_base={allocation_base:?} new_list_start={:?} stored original_head={original_head:?}",
         unsafe { allocation_base.add(mem::size_of_val(&original_head)) }
     );
 

--- a/xtask/src/tasks/cli.rs
+++ b/xtask/src/tasks/cli.rs
@@ -110,10 +110,12 @@ pub fn build_cli(
         "mirrord"
     };
 
-    let cli_path = Path::new("target")
-        .join(target.triple())
-        .join(mode)
-        .join(binary_name);
+    let cli_path = crate::relative_to_root(
+        &Path::new("target")
+            .join(target.triple())
+            .join(mode)
+            .join(binary_name),
+    );
 
     println!("✓ CLI built: {}", cli_path.display());
     Ok(cli_path)


### PR DESCRIPTION
<!-- Thank you for contributing to mirrord! -->
<!-- Please use the checklist below as a guide for docs, tests and admin tasks for your PR -->
<!-- Feel free to ~strikethrough~ any items that you don't think apply -->

### Quality Checklist:

- [X] I have documented new code sufficiently
- [X] I have checked and updated the relevant existing docs in code, including removing outdated material
- [X] I have written user-facing website docs for new features, or opened a (sub)issue to do so
- [X] I have checked and updated existing website docs for changed features
- [X] I have tested this change and know it succeeds and fails as expected
- [X] I have written unit tests or purposefully omitted them
- [X] I have written e2e tests or purposefully omitted them
- [X] I have explained what this PR introduces and why, and linked to relevant context (e.g. linear issues, related PRs,
  documentation)
- [X] I have introduced a short, clear and well-formatted changelog entry

<!-- need help with the changelog? see ../CONTRIBUTING.md#submitting-a-pull-request -->
<!-- Add more details of your changes below if needed -->

Our `getifaddrs` had a use-after-free bug, because it did a shallow copy of the nodes returned by libc and freed the original backing buffer.