### PR TITLE
fix(ui): send flat SessionInfo in ws session_added notifications

### DIFF
--- a/changelog.d/+ui-ws-session-shape.fixed.md
+++ b/changelog.d/+ui-ws-session-shape.fixed.md
@@ -1,0 +1,1 @@
+Fixed a phantom session in `mirrord ui` showing an empty target and "NaNs" uptime that could not be removed and crashed the page when clicked. The WebSocket `session_added` payload now carries the same flat session shape as `GET /api/sessions`.

--- a/mirrord/cli/src/ui.rs
+++ b/mirrord/cli/src/ui.rs
@@ -67,7 +67,7 @@ struct FrontendAssets;
 #[serde(tag = "type", rename_all = "snake_case")]
 enum SessionNotification {
     SessionAdded {
-        session: Box<TrackedSession>,
+        session: Box<SessionInfo>,
     },
     SessionRemoved {
         session_id: String,
@@ -220,14 +220,11 @@ fn parse_session_owner(user: &str) -> Option<OperatorSessionOwner> {
     })
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug)]
 struct TrackedSession {
     info: SessionInfo,
-    #[serde(skip)]
     endpoint: SessionEndpoint,
-    #[serde(skip)]
     events: Vec<serde_json::Value>,
-    #[serde(skip)]
     client: SessionClient,
 }
 
@@ -376,7 +373,7 @@ async fn add_session(session_id: String, endpoint: SessionEndpoint, state: AppSt
 
     let session_client = tracked.client.clone();
     let notification = SessionNotification::SessionAdded {
-        session: Box::new(tracked.clone()),
+        session: Box::new(tracked.info.clone()),
     };
 
     {
@@ -625,7 +622,7 @@ async fn ws_connection(mut socket: WebSocket, state: AppState) {
         let sessions = state.sessions.read().await;
         for session in sessions.values() {
             let notification = SessionNotification::SessionAdded {
-                session: Box::new(session.clone()),
+                session: Box::new(session.info.clone()),
             };
             let msg = serde_json::to_string(&notification)
                 .expect("notification serialization cannot fail");
@@ -1325,6 +1322,34 @@ mod tests {
     fn validate_ws_origin_accepts_missing_origin() {
         let headers = HeaderMap::new();
         assert!(validate_ws_origin(&headers));
+    }
+
+    /// The frontend reads the ws `session_added` payload as a flat [`SessionInfo`], the same
+    /// shape `GET /api/sessions` returns. A wrapped payload (e.g. `{"info": {...}}`) shows up
+    /// as a phantom session with no target, "NaNs" uptime, and a crash on click.
+    #[test]
+    fn session_added_notification_serializes_flat_session_info() {
+        let notification = SessionNotification::SessionAdded {
+            session: Box::new(SessionInfo {
+                session_id: "test-session".to_owned(),
+                key: None,
+                target: "deployment/test".to_owned(),
+                namespace: None,
+                started_at: "2026-07-02T12:00:00Z".to_owned(),
+                mirrord_version: "0.0.0".to_owned(),
+                is_operator: false,
+                processes: Vec::new(),
+                port_subscriptions: Vec::new(),
+                config: serde_json::Value::Null,
+            }),
+        };
+        let json = serde_json::to_value(&notification).unwrap();
+
+        assert_eq!(json["type"], "session_added");
+        assert_eq!(json["session"]["session_id"], "test-session");
+        assert_eq!(json["session"]["target"], "deployment/test");
+        assert_eq!(json["session"]["started_at"], "2026-07-02T12:00:00Z");
+        assert_eq!(json["session"]["config"], serde_json::Value::Null);
     }
 
     /// CSRF check: a malicious form-POST from another origin would not include the cookie

--- a/mirrord/cli/src/ui.rs
+++ b/mirrord/cli/src/ui.rs
@@ -1328,6 +1328,7 @@ mod tests {
     /// shape `GET /api/sessions` returns. A wrapped payload (e.g. `{"info": {...}}`) shows up
     /// as a phantom session with no target, "NaNs" uptime, and a crash on click.
     #[test]
+    #[allow(clippy::indexing_slicing)]
     fn session_added_notification_serializes_flat_session_info() {
         let notification = SessionNotification::SessionAdded {
             session: Box::new(SessionInfo {

--- a/packages/monitor/src/App.tsx
+++ b/packages/monitor/src/App.tsx
@@ -202,6 +202,10 @@ export default function App() {
         }
         if (msg.type === 'session_added') {
           const session = msg.session
+          if (!session?.session_id) {
+            console.warn('Ignoring session_added without session_id', msg)
+            return
+          }
           setSessions((prev) =>
             prev.find((s) => s.session_id === session.session_id) ? prev : [...prev, session]
           )

--- a/packages/monitor/src/api.ts
+++ b/packages/monitor/src/api.ts
@@ -82,11 +82,20 @@ export const api = {
     return r.json()
   },
 
-  killSession: async (sessionId: string): Promise<Response> => {
-    const r = await fetch(withToken(`/api/sessions/${encodeURIComponent(sessionId)}/kill`), {
-      method: 'POST',
-      credentials: 'include',
-    })
+  killSession: async (sessionId: string): Promise<void> => {
+    let r: Response
+    try {
+      r = await fetch(withToken(`/api/sessions/${encodeURIComponent(sessionId)}/kill`), {
+        method: 'POST',
+        credentials: 'include',
+      })
+    } catch (err) {
+      emitUserBlocked('session_kill_failed', 'user_action', {
+        session_id: sessionId,
+        error: err instanceof Error ? err.message : String(err),
+      })
+      return
+    }
     if (!r.ok) {
       emitUserBlocked('session_kill_failed', 'user_action', {
         session_id: sessionId,
@@ -96,7 +105,6 @@ export const api = {
     } else {
       emitUserSucceeded('session_killed', 'user_action', { session_id: sessionId })
     }
-    return r
   },
 
   eventStreamUrl: (sessionId: string): string =>

--- a/packages/monitor/src/components/JsonHighlight.tsx
+++ b/packages/monitor/src/components/JsonHighlight.tsx
@@ -2,7 +2,7 @@ const JSON_TOKEN_RE =
   /("(?:\\.|[^"\\])*"\s*:)|("(?:\\.|[^"\\])*")|\b(true|false|null)\b|(-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)/g
 
 export default function JsonHighlight({ value }: { value: unknown }) {
-  const text = JSON.stringify(value, null, 2)
+  const text = JSON.stringify(value ?? null, null, 2)
   const parts: Array<{ kind: string; text: string }> = []
   let last = 0
   for (const match of text.matchAll(JSON_TOKEN_RE)) {

--- a/packages/monitor/src/utils.ts
+++ b/packages/monitor/src/utils.ts
@@ -1,5 +1,6 @@
 export function formatUptime(startedAt: string): string {
   const parsed = /^\d+$/.test(startedAt) ? Number(startedAt) * 1000 : new Date(startedAt).getTime()
+  if (!Number.isFinite(parsed)) return '—'
   const diff = Date.now() - parsed
   return formatDurationSecs(Math.floor(diff / 1000))
 }


### PR DESCRIPTION
## Summary

The `mirrord ui` WebSocket `session_added` payload wrapped `SessionInfo` inside `TrackedSession`, serializing as `{"session": {"info": {...}}}`, while the frontend reads `msg.session` as a flat `SessionInfo` (the same shape `GET /api/sessions` returns).

As a result, every session delivered over the WebSocket (live adds and the per-connect snapshot) rendered as a phantom card: blank target, "NaNs" uptime, grouped under "No session key". It could not be killed or removed (its `session_id` was `undefined`, so `session_removed` never matched), and clicking it crashed the page. The crash comes from `JsonHighlight`: `JSON.stringify(undefined)` returns `undefined`, then `.matchAll` throws. This matches the `ui_crashed` telemetry in PostHog (`Cannot read properties of undefined (reading 'matchAll')`).

Changes:
- `SessionNotification::SessionAdded` now carries `Box<SessionInfo>` (both send sites), matching the REST shape and the frontend `WsMessage` type.
- `TrackedSession` no longer derives `Serialize` (nothing serializes it anymore).
- Frontend hardening so a stale CLI can never crash the page again: `session_added` messages without a `session_id` are ignored, `JsonHighlight` tolerates `undefined`, and `formatUptime` renders an em dash for unparseable timestamps.

## Test plan

- New unit test `session_added_notification_serializes_flat_session_info` asserts the wire shape (written first against the old code, failed with `session_id` nested under `info`, passes after the fix).
- `cargo test -p mirrord`, `cargo fmt`, `cargo clippy` clean; `tsc && vite build` clean for `packages/monitor`.
- Manual end-to-end: built the CLI, started `mirrord ui`, opened the page, then created a fake session socket serving `/info` so the session arrives via the WebSocket path. The card renders with real target, key group, and uptime; the detail view opens with Events and Config; no crash. Kill and `session_removed` now match by real `session_id`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)