### PR TITLE
Update kube-rs to metalbear-co/kube fork (4.0) for rustls platform verifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,6 +253,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "annotate-snippets"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f211a51805bc641f3ad5b7664c77d2547af685cc33b4cd8d31964027a46f13f1"
+dependencies = [
+ "anstyle",
+ "memchr",
+ "unicode-width 0.2.2",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -452,6 +463,12 @@ checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 dependencies = [
  "derive_arbitrary",
 ]
+
+[[package]]
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
 name = "arrayvec"
@@ -2558,6 +2575,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding_rs_io"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83"
+dependencies = [
+ "encoding_rs",
+]
+
+[[package]]
 name = "enum-ordinalize"
 version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3170,6 +3196,16 @@ dependencies = [
  "log",
  "plain",
  "scroll 0.13.0",
+]
+
+[[package]]
+name = "granit-parser"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50ba32164f9e098d5da618776a32afbb32270adcbe3d3d006107dae11e37c91"
+dependencies = [
+ "arraydeque",
+ "smallvec",
 ]
 
 [[package]]
@@ -4232,9 +4268,9 @@ dependencies = [
 
 [[package]]
 name = "k8s-openapi"
-version = "0.27.1"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b326f5219dd55872a72c1b6ddd1b830b8334996c667449c29391d657d78d5e"
+checksum = "d9c6922f6afe80418dd6019818af5d0d34584c371780ff09b9752370c25b4abb"
 dependencies = [
  "base64",
  "jiff",
@@ -4285,9 +4321,8 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acc5a6a69da2975ed9925d56b5dcfc9cc739b66f37add06785b7c9f6d1e88741"
+version = "4.0.0"
+source = "git+https://github.com/metalbear-co/kube.git?rev=ae49cce192b85db3d734d290a6031aa2d9ac60e0#ae49cce192b85db3d734d290a6031aa2d9ac60e0"
 dependencies = [
  "k8s-openapi",
  "kube-client",
@@ -4298,9 +4333,8 @@ dependencies = [
 
 [[package]]
 name = "kube-client"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fcaf2d1f1a91e1805d4cd82e8333c022767ae8ffd65909bbef6802733a7dd40"
+version = "4.0.0"
+source = "git+https://github.com/metalbear-co/kube.git?rev=ae49cce192b85db3d734d290a6031aa2d9ac60e0#ae49cce192b85db3d734d290a6031aa2d9ac60e0"
 dependencies = [
  "base64",
  "bytes",
@@ -4320,13 +4354,14 @@ dependencies = [
  "kube-core",
  "pem",
  "rustls",
+ "rustls-platform-verifier 0.7.0",
  "secrecy",
  "serde",
+ "serde-saphyr",
  "serde_json",
- "serde_yaml",
  "thiserror 2.0.18",
  "tokio",
- "tokio-tungstenite 0.28.0",
+ "tokio-tungstenite 0.29.0",
  "tokio-util",
  "tower 0.5.3",
  "tower-http",
@@ -4335,9 +4370,8 @@ dependencies = [
 
 [[package]]
 name = "kube-core"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f126d2db7a8b532ec1d839ece2a71e2485dc3bbca6cc3c3f929becaa810e719e"
+version = "4.0.0"
+source = "git+https://github.com/metalbear-co/kube.git?rev=ae49cce192b85db3d734d290a6031aa2d9ac60e0#ae49cce192b85db3d734d290a6031aa2d9ac60e0"
 dependencies = [
  "derive_more",
  "form_urlencoded",
@@ -4354,9 +4388,8 @@ dependencies = [
 
 [[package]]
 name = "kube-derive"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6b9b97e121fce957f9cafc6da534abc4276983ab03190b76c09361e2df849fa"
+version = "4.0.0"
+source = "git+https://github.com/metalbear-co/kube.git?rev=ae49cce192b85db3d734d290a6031aa2d9ac60e0#ae49cce192b85db3d734d290a6031aa2d9ac60e0"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -4368,9 +4401,8 @@ dependencies = [
 
 [[package]]
 name = "kube-runtime"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c072737075826ee74d3e615e80334e41e617ca3d14fb46ef7cdfda822d6f15f2"
+version = "4.0.0"
+source = "git+https://github.com/metalbear-co/kube.git?rev=ae49cce192b85db3d734d290a6031aa2d9ac60e0#ae49cce192b85db3d734d290a6031aa2d9ac60e0"
 dependencies = [
  "ahash",
  "async-broadcast",
@@ -7123,7 +7155,7 @@ dependencies = [
  "quinn",
  "rustls",
  "rustls-pki-types",
- "rustls-platform-verifier",
+ "rustls-platform-verifier 0.6.2",
  "serde",
  "serde_json",
  "sync_wrapper",
@@ -7421,6 +7453,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni 0.22.4",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs 0.8.3",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework 3.7.0",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustls-platform-verifier-android"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7668,6 +7721,25 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-saphyr"
+version = "0.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5897b4c3faadadd35fdb6689f015641f3bc481d5adaaac56231ea15aeb243db3"
+dependencies = [
+ "ahash",
+ "annotate-snippets",
+ "base64",
+ "encoding_rs_io",
+ "getrandom 0.3.4",
+ "granit-parser",
+ "nohash-hasher",
+ "num-traits",
+ "serde",
+ "smallvec",
+ "zmij",
 ]
 
 [[package]]
@@ -8660,6 +8732,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.29.0",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9086,6 +9170,22 @@ dependencies = [
  "sha1",
  "thiserror 2.0.18",
  "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http 1.4.0",
+ "httparse",
+ "log",
+ "rand 0.9.2",
+ "sha1",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,8 +141,8 @@ jaq-core = "2.2.1"
 jaq-json = "1.1.3"
 jaq-std = "2.1.2"
 k8s-cri = "0.9"
-k8s-openapi = { version = "0.27", features = ["v1_31"] }
-kube = { version = "3.1", default-features = false, features = [
+k8s-openapi = { version = "0.28", features = ["v1_32"] }
+kube = { git = "https://github.com/metalbear-co/kube.git", rev = "ae49cce192b85db3d734d290a6031aa2d9ac60e0", default-features = false, features = [
     "runtime",
     "derive",
     "client",

--- a/changelog.d/4468.changed.md
+++ b/changelog.d/4468.changed.md
@@ -1,1 +1,1 @@
-Updated `kube-rs` to 4.0. The Kubernetes client now falls back to the OS-native trust store via the rustls platform verifier when no CA is configured, instead of bundled webpki roots.
+Updated `kube-rs` to 4.0. The Kubernetes client now falls back to the operating system's native trust store through the rustls platform verifier when a kubeconfig sets no CA, rather than to a bundled set of root certificates.

--- a/changelog.d/4468.changed.md
+++ b/changelog.d/4468.changed.md
@@ -1,0 +1,1 @@
+Updated `kube-rs` to 4.0. The Kubernetes client now falls back to the OS-native trust store via the rustls platform verifier when no CA is configured, instead of bundled webpki roots.

--- a/mirrord/config/Cargo.toml
+++ b/mirrord/config/Cargo.toml
@@ -36,7 +36,7 @@ bimap.workspace = true
 nom.workspace = true
 ipnet.workspace = true
 bitflags.workspace = true
-k8s-openapi = { workspace = true, features = ["schemars", "v1_31"] }
+k8s-openapi = { workspace = true, features = ["schemars", "v1_32"] }
 tera.workspace = true
 fancy-regex.workspace = true
 regex.workspace = true

--- a/mirrord/kube/src/retry.rs
+++ b/mirrord/kube/src/retry.rs
@@ -22,5 +22,6 @@ pub fn retry_policy_from_config(
         Duration::from_millis(*min_ms),
         Duration::from_millis(*max_ms),
         *max_retries,
+        false,
     )
 }

--- a/mirrord/kube/src/retry.rs
+++ b/mirrord/kube/src/retry.rs
@@ -22,6 +22,6 @@ pub fn retry_policy_from_config(
         Duration::from_millis(*min_ms),
         Duration::from_millis(*max_ms),
         *max_retries,
-        false,
+        true,
     )
 }


### PR DESCRIPTION
## What

Points `kube` at the [metalbear-co/kube](https://github.com/metalbear-co/kube) fork at commit `ae49cce` (v4.0.0). The fork's client falls back to the OS-native trust store via `rustls-platform-verifier` when no CA is configured, instead of bundled webpki roots.

## Details

- `kube`: crates.io `3.1` → git fork `ae49cce`
- `k8s-openapi`: `0.27` → `0.28` with feature `v1_32` (0.28 dropped `v1_31`)
- Adapts to the new `RetryPolicy::new` `server_retry` argument (passes `true` so the startup retry policy respects the server's `Retry-After` header)

## TLS / platform verifier

The `webpki-roots` feature is intentionally left disabled. kube-client 4.0 gates in `tls.rs` with `#[cfg(not(feature = "webpki-roots"))]` → `rustls_platform_verifier::with_platform_verifier()`, so leaving the feature off keeps the platform-verifier path active. Verified via `cargo tree`: kube-client is built with `rustls-tls` but not `webpki-roots`.

## Testing

`cargo check --workspace` is clean (aside from the pre-existing `MIRRORD_LAYER_FILE` compile-time env requirement for the `mirrord` binary, unrelated to this change). `cargo clippy -- --deny warnings` clean on the touched crates.