### PR TITLE
Improve upstreaming errors from the session monitor to the mirrord ui.

### DIFF
--- a/.vale/styles/config/vocabularies/Metalbear/accept.txt
+++ b/.vale/styles/config/vocabularies/Metalbear/accept.txt
@@ -71,7 +71,6 @@ const
 consts
 fd
 fds
-ui
 syscalls
 subcommand
 ASCII

--- a/.vale/styles/config/vocabularies/Metalbear/accept.txt
+++ b/.vale/styles/config/vocabularies/Metalbear/accept.txt
@@ -71,7 +71,6 @@ const
 consts
 fd
 fds
-UI
 ui
 syscalls
 subcommand

--- a/.vale/styles/config/vocabularies/Metalbear/accept.txt
+++ b/.vale/styles/config/vocabularies/Metalbear/accept.txt
@@ -71,6 +71,8 @@ const
 consts
 fd
 fds
+UI
+ui
 syscalls
 subcommand
 ASCII

--- a/.vale/styles/write-good/TooWordy.yml
+++ b/.vale/styles/write-good/TooWordy.yml
@@ -142,7 +142,6 @@ tokens:
   - minimize
   - minimum
   - modify
-  - monitor
   - multiple
   - necessitate
   - nevertheless

--- a/changelog.d/+cor-1624.changed.md
+++ b/changelog.d/+cor-1624.changed.md
@@ -1,1 +1,1 @@
-Properly upstream errors from the session monitor to the ui server.
+Properly upstream errors from the session monitor to the UI server.

--- a/changelog.d/+cor-1624.changed.md
+++ b/changelog.d/+cor-1624.changed.md
@@ -1,0 +1,1 @@
+Properly upstream errors from the session monitor to the ui server.

--- a/mirrord/cli/src/ui/chaos/error.rs
+++ b/mirrord/cli/src/ui/chaos/error.rs
@@ -11,9 +11,13 @@ pub(super) enum ChaosApiError {
     #[error("session `{0}` not found")]
     SessionNotFound(String),
 
-    #[error("chaos rule not found")]
-    ChaosRuleNotFound,
+    /// We got a response error from the session monitor chaos api (intproxy), e.g. we made a
+    /// request with `rule_id={some-uid}`, and it returned `404`, so we use this to upstream the
+    /// error.
+    #[error("session monitor returned status {status}: {body}")]
+    Upstream { status: StatusCode, body: String },
 
+    /// Something went wrong communicating with the session monitor.
     #[error(transparent)]
     SessionMonitor(SessionError),
 }
@@ -21,7 +25,7 @@ pub(super) enum ChaosApiError {
 impl From<SessionError> for ChaosApiError {
     fn from(error: SessionError) -> Self {
         match error {
-            SessionError::BadStatus(StatusCode::NOT_FOUND) => Self::ChaosRuleNotFound,
+            SessionError::Upstream { status, body } => Self::Upstream { status, body },
             other => Self::SessionMonitor(other),
         }
     }
@@ -35,11 +39,7 @@ impl IntoResponse for ChaosApiError {
                 format!("Could not find session: {self}"),
             )
                 .into_response(),
-            Self::ChaosRuleNotFound => (
-                StatusCode::NOT_FOUND,
-                format!("Could not find chaos rule: {self}"),
-            )
-                .into_response(),
+            Self::Upstream { status, body } => (status, body).into_response(),
             Self::SessionMonitor(_) => (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 format!("Something went wrong: {self}"),

--- a/mirrord/session-monitor-client/src/lib.rs
+++ b/mirrord/session-monitor-client/src/lib.rs
@@ -14,6 +14,7 @@
 //! implementation small and the lifecycle of the SSE event stream simple.
 
 use std::{
+    ops::Not,
     path::{Path, PathBuf},
     pin::Pin,
 };
@@ -148,19 +149,39 @@ pub enum SessionError {
     Request(hyper::Error),
     #[error("HTTP request build failed: {0}")]
     Build(http::Error),
-    #[error("unexpected status {0} from session API")]
-    BadStatus(StatusCode),
+
+    /// We got a response error from the session monitor api (intproxy), e.g. we made a request for
+    /// a resource, and it returned `404`, so we use this to upstream the error.
+    #[error("internal proxy session monitor error ({status}) {body}")]
+    Upstream { status: StatusCode, body: String },
     #[error("body read failed: {0}")]
     Body(String),
     #[error("JSON deserialization failed: {0}")]
     Json(#[from] serde_json::Error),
     #[error(transparent)]
     Io(#[from] std::io::Error),
+
+    /// `response.into_body.collect()` failed for whatever reason.
+    #[error("Could not read response body ({0})")]
+    InvalidBody(StatusCode),
 }
 
 /// HTTP body emitted by the session API for streaming endpoints (currently `/events`). Maps
 /// hyper body errors into `std::io::Error` so the public type doesn't leak hyper internals.
 type SseByteResult = Result<Bytes, std::io::Error>;
+
+pub(crate) async fn upstream_session_monitor_error(
+    response: http::Response<hyper::body::Incoming>,
+) -> SessionError {
+    let status = response.status();
+    let Ok(body) = response.into_body().collect().await else {
+        return SessionError::InvalidBody(status);
+    };
+
+    let body = String::from_utf8_lossy(&body.to_bytes()).to_string();
+
+    SessionError::Upstream { status, body }
+}
 
 /// Opaque pinned-boxed [`Stream`] of parsed Server-Sent Events. The error type is
 /// [`std::io::Error`] for the same reason as [`SseByteResult`].
@@ -245,24 +266,11 @@ impl SessionClient {
     }
 
     pub async fn fetch_info(&self) -> Result<SessionInfo, SessionError> {
-        let resp = self.send_request(Method::GET, "/info", None).await?;
-        if !resp.status().is_success() {
-            return Err(SessionError::BadStatus(resp.status()));
-        }
-        let body_bytes = resp
-            .into_body()
-            .collect()
-            .await
-            .map_err(|e| SessionError::Body(e.to_string()))?
-            .to_bytes();
-        Ok(serde_json::from_slice(&body_bytes)?)
+        self.get("/info").send().await?.json().await
     }
 
     pub async fn kill(&self) -> Result<(), SessionError> {
-        let resp = self.send_request(Method::POST, "/kill", None).await?;
-        if !resp.status().is_success() {
-            return Err(SessionError::BadStatus(resp.status()));
-        }
+        self.post("/kill").send().await?.bytes().await?;
         Ok(())
     }
 
@@ -270,8 +278,8 @@ impl SessionClient {
         let resp = self
             .send_request(Method::GET, "/events", Some("text/event-stream"))
             .await?;
-        if !resp.status().is_success() {
-            return Err(SessionError::BadStatus(resp.status()));
+        if resp.status().is_success().not() {
+            return Err(upstream_session_monitor_error(resp).await);
         }
         let byte_stream = BodyDataStream::new(resp.into_body())
             .map(|frame_result| -> SseByteResult { frame_result.map_err(std::io::Error::other) });

--- a/mirrord/session-monitor-client/src/request_builder.rs
+++ b/mirrord/session-monitor-client/src/request_builder.rs
@@ -5,7 +5,7 @@ use http::{Method, Request, StatusCode, Uri, header};
 use http_body_util::{BodyExt, Full};
 use serde::{Serialize, de::DeserializeOwned};
 
-use crate::{SessionClient, SessionError};
+use crate::{SessionClient, SessionError, upstream_session_monitor_error};
 
 /// Minimal request builder for the session monitor transport.
 ///
@@ -82,9 +82,8 @@ impl Response {
     }
 
     pub async fn bytes(self) -> Result<Bytes, SessionError> {
-        let status = self.0.status();
-        if status.is_success().not() {
-            return Err(SessionError::BadStatus(status));
+        if self.0.status().is_success().not() {
+            return Err(upstream_session_monitor_error(self.0).await);
         }
 
         Ok(self


### PR DESCRIPTION
<!-- Thank you for contributing to mirrord! -->
<!-- Please use the checklist below as a guide for docs, tests and admin tasks for your PR -->
<!-- Feel free to ~strikethrough~ any items that you don't think apply -->

- Issue: https://linear.app/metalbear/issue/COR-1624/review-and-fix-chaos-api-errors

Some errors (especially for the chaos api) were being turned into `500`s by the ui server, now we just upstream them from the session monitor, by having an error variant that has the `StatusCode` of the error we got in the response, and also the body of the response.

### Quality Checklist:

- [x] I have documented new code sufficiently
- [x] I have checked and updated the relevant existing docs in code, including removing outdated material
- [ ] I have written user-facing website docs for new features, or opened a (sub)issue to do so
- [ ] I have checked and updated existing website docs for changed features
- [x] I have tested this change and know it succeeds and fails as expected
- [ ] I have written unit tests or purposefully omitted them
- [ ] I have written e2e tests or purposefully omitted them
- [x] I have explained what this PR introduces and why, and linked to relevant context (e.g. linear issues, related PRs,
  documentation)
- [x] I have introduced a short, clear and well-formatted changelog entry

<!-- need help with the changelog? see ../CONTRIBUTING.md#submitting-a-pull-request -->
<!-- Add more details of your changes below if needed -->