### PR TITLE
Use nextest in CI to retry test flakes

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,2 @@
+[profile.ci]
+retries = 2

--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -46,6 +46,11 @@ jobs:
       - uses: metalbear-co/setup-rust-toolchain@a8d42d5aa259519dac1faeee20e37c1fb43453a3
         with:
           cache-shared-key: mirrord-${{ runner.os }}-${{ runner.arch }}
+        # nextest is used to rerun flakes, config is in `.config/nextest.toml`
+      - uses: metalbear-co/install-action@c127aaa0fa8c555cbfb72bfa29b29a692d25d267
+        with:
+          tool: nextest@0.9.98
+          fallback: none
       - uses: ./.github/actions/e2e-setup
         with:
           container-runtime: ${{ matrix.container-runtime }}
@@ -93,19 +98,19 @@ jobs:
       - name: Run cli E2E tests
         if: ${{ matrix.container-runtime == 'docker' }}
         run: |
-          cargo xtask test-e2e --binary target/x86_64-unknown-linux-gnu/debug/mirrord --layer target/x86_64-unknown-linux-gnu/debug/libmirrord_layer.so -- --target=x86_64-unknown-linux-gnu --no-default-features --features cli -- --test-threads=6
+          cargo xtask test-e2e --binary target/x86_64-unknown-linux-gnu/debug/mirrord --layer target/x86_64-unknown-linux-gnu/debug/libmirrord_layer.so -- --profile ci --target=x86_64-unknown-linux-gnu --no-default-features --features cli --test-threads=6
       - run: |
           ./target/x86_64-unknown-linux-gnu/debug/mirrord wizard &
           sleep 2 && curl localhost:3000
       - name: Run targetless E2E test
         run: |
-          cargo xtask test-e2e --binary target/x86_64-unknown-linux-gnu/debug/mirrord --layer target/x86_64-unknown-linux-gnu/debug/libmirrord_layer.so -- --target=x86_64-unknown-linux-gnu --no-default-features --features targetless -- --test-threads=6 targetless
+          cargo xtask test-e2e --binary target/x86_64-unknown-linux-gnu/debug/mirrord --layer target/x86_64-unknown-linux-gnu/debug/libmirrord_layer.so -- --profile ci --target=x86_64-unknown-linux-gnu --no-default-features --features targetless --test-threads=6 -- targetless
       - run: kubectl create namespace argo-rollouts
       - run: kubectl apply -n argo-rollouts -f https://github.com/argoproj/argo-rollouts/releases/latest/download/install.yaml
       - name: Run all E2E tests
         run: |
-          cargo xtask test-e2e --binary target/x86_64-unknown-linux-gnu/debug/mirrord --layer target/x86_64-unknown-linux-gnu/debug/libmirrord_layer.so -- --target=x86_64-unknown-linux-gnu --no-default-features --features job -- --test-threads=6
-          cargo xtask test-e2e --binary target/x86_64-unknown-linux-gnu/debug/mirrord --layer target/x86_64-unknown-linux-gnu/debug/libmirrord_layer.so -- --target=x86_64-unknown-linux-gnu --no-default-features --features ephemeral -- --test-threads=6
+          cargo xtask test-e2e --binary target/x86_64-unknown-linux-gnu/debug/mirrord --layer target/x86_64-unknown-linux-gnu/debug/libmirrord_layer.so -- --profile ci --target=x86_64-unknown-linux-gnu --no-default-features --features job --test-threads=6
+          cargo xtask test-e2e --binary target/x86_64-unknown-linux-gnu/debug/mirrord --layer target/x86_64-unknown-linux-gnu/debug/libmirrord_layer.so -- --profile ci --target=x86_64-unknown-linux-gnu --no-default-features --features ephemeral --test-threads=6
       - name: Collect logs
         if: ${{ failure() }}
         run: |

--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -21,6 +21,11 @@ jobs:
         with:
           cache-shared-key: mirrord-${{ runner.os }}-${{ runner.arch }}
           target: x86_64-unknown-linux-gnu
+        # nextest is used to rerun flakes, config is in `.config/nextest.toml`
+      - uses: metalbear-co/install-action@c127aaa0fa8c555cbfb72bfa29b29a692d25d267
+        with:
+          tool: nextest@0.9.98
+          fallback: none
       - run: |
           cd mirrord/layer-tests/tests/apps/issue1123
           rustc issue1123.rs --out-dir target
@@ -121,27 +126,27 @@ jobs:
       - run: ./scripts/build_c_apps.sh
       - run: cargo build --target x86_64-unknown-linux-gnu -p mirrord-layer
       - run: cargo build --target x86_64-unknown-linux-gnu -p mirrord
-      - run: cargo test --target x86_64-unknown-linux-gnu -p mirrord-layer-lib
-      - run: cargo test --target x86_64-unknown-linux-gnu -p mirrord-layer-tests --no-default-features
-      - run: cargo test --target x86_64-unknown-linux-gnu -p mirrord-layer
+      - run: cargo nextest run --target x86_64-unknown-linux-gnu -p mirrord-layer-lib --profile ci
+      - run: cargo nextest run --target x86_64-unknown-linux-gnu -p mirrord-layer-tests --no-default-features --profile ci
+      - run: cargo nextest run --target x86_64-unknown-linux-gnu -p mirrord-layer --profile ci
       - name: mirrord protocol UT
-        run: cargo test --target x86_64-unknown-linux-gnu -p mirrord-protocol
+        run: cargo nextest run --target x86_64-unknown-linux-gnu -p mirrord-protocol --profile ci
       - name: mirrord config UT
-        run: cargo test --target x86_64-unknown-linux-gnu -p mirrord-config
+        run: cargo nextest run --target x86_64-unknown-linux-gnu -p mirrord-config --profile ci
       - name: mirrord kube UT
-        run: cargo test --target x86_64-unknown-linux-gnu -p mirrord-kube --all-features
+        run: cargo nextest run --target x86_64-unknown-linux-gnu -p mirrord-kube --all-features --profile ci
       - name: mirrord intproxy UT
-        run: cargo test --target x86_64-unknown-linux-gnu -p mirrord-intproxy
+        run: cargo nextest run --target x86_64-unknown-linux-gnu -p mirrord-intproxy --profile ci
       - name: mirrord auth UT
-        run: cargo test --target x86_64-unknown-linux-gnu -p mirrord-auth
+        run: cargo nextest run --target x86_64-unknown-linux-gnu -p mirrord-auth --profile ci
       - name: mirrord operator UT
-        run: cargo test --target x86_64-unknown-linux-gnu -p mirrord-operator --features "crd, client"
+        run: cargo nextest run --target x86_64-unknown-linux-gnu -p mirrord-operator --features "crd, client" --profile ci
       - name: mirrord cli UT
         run: cargo xtask test-ut -- --target x86_64-unknown-linux-gnu
       - name: mirrord protocol-io UT
-        run: cargo test --target x86_64-unknown-linux-gnu -p mirrord-protocol-io
+        run: cargo nextest run --target x86_64-unknown-linux-gnu -p mirrord-protocol-io --profile ci
       - name: mirrord jaq UT
-        run: cargo test --target x86_64-unknown-linux-gnu -p mirrord-jaq
+        run: cargo nextest run --target x86_64-unknown-linux-gnu -p mirrord-jaq --profile ci
       - name: save intproxy logs
         continue-on-error: true
         if: ${{ always() }}

--- a/.vale/styles/config/vocabularies/Metalbear/accept.txt
+++ b/.vale/styles/config/vocabularies/Metalbear/accept.txt
@@ -52,6 +52,7 @@ xtask
 Tera
 tera
 pnpm
+nextest
 
 # Async / concurrency
 async

--- a/changelog.d/+nextest-retry.internal.md
+++ b/changelog.d/+nextest-retry.internal.md
@@ -1,2 +1,2 @@
 Added step to e2e workflow to install nextest with configuration at `.config/nextest.toml`. Failed
-e2e tests will now retry twice after failing before failing the whole CI.
+e2e and integration tests will now retry twice after failing before failing the whole CI.

--- a/changelog.d/+nextest-retry.internal.md
+++ b/changelog.d/+nextest-retry.internal.md
@@ -1,0 +1,2 @@
+Added step to e2e workflow to install nextest with configuration at `.config/nextest.toml`. Failed
+e2e tests will now retry twice after failing before failing the whole CI.


### PR DESCRIPTION
- E2E and integration tests in CI now retry twice after failure.
- This is not a fix for flaky tests! But it might make merging less painful for tests that flake often.