### PR TITLE
INT-377 Fix DB branching docs issues

### DIFF
--- a/changelog.d/+db-branches-docs-dedup.fixed.md
+++ b/changelog.d/+db-branches-docs-dedup.fixed.md
@@ -1,0 +1,1 @@
+Fixed the database branching config docs repeating the shared branch fields (`connection`, `id`, `name`, `ttl_secs`, `ttl_mins`, `creation_timeout_secs`, `version`, `migrations`) once per engine, which produced duplicate `-1`/`-2` anchors on the config options page. They are now documented once.

--- a/mirrord-schema.json
+++ b/mirrord-schema.json
@@ -1156,15 +1156,14 @@
       ]
     },
     "DatabaseBranchConfig": {
-      "description": "Configuration for a database branch.\n\nExample:\n\n```json\n{\n  \"id\": \"my-branch-db\",\n  \"name\": \"my-database-name\",\n  \"ttl_secs\": 120,\n  \"type\": \"mysql\",\n  \"version\": \"8.0\",\n  \"connection\": {\n    \"url\": {\n      \"type\": \"env\",\n      \"variable\": \"DB_CONNECTION_URL\"\n    }\n  }\n}\n```",
+      "description": "Configuration for a database branch.\n\nExample:\n\n```json\n{\n  \"id\": \"my-branch-db\",\n  \"name\": \"my-database-name\",\n  \"ttl_secs\": 120,\n  \"type\": \"mysql\",\n  \"version\": \"8.0\",\n  \"connection\": {\n    \"url\": {\n      \"type\": \"env\",\n      \"variable\": \"DB_CONNECTION_URL\"\n    }\n  }\n}\n```\n\nThe fields below are shared by every engine. Engine-specific fields (copy modes,\n`iam_auth`, `connection_settings`, `emulator_host`) are documented under each `type`.\n\n#### feature.db_branches[].id (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-id}\n\nUsers can choose to specify a unique `id`. This is useful for reusing or sharing\nthe same database branch among Kubernetes users.\n\n#### feature.db_branches[].name (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-name}\n\nWhen source database connection detail is not accessible to mirrord operator, users\ncan specify the database `name` so it is included in the connection options mirrord\nuses as the override.\n\n#### feature.db_branches[].ttl_secs (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-ttl_secs}\n\nMirrord operator starts counting the TTL when a branch is no longer used by any session.\nThe time-to-live (TTL) for the branch database is set to 300 seconds by default.\nUsers can set `ttl_secs` to customize this value according to their need. Please note\nthat longer TTL paired with frequent mirrord session turnover can result in increased\nresource usage. For this reason, branch database TTL caps out at 15 min.\n\nMutually exclusive with [`ttl_mins`](#feature-db_branches-sql-ttl_mins).\n\n#### feature.db_branches[].ttl_mins (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-ttl_mins}\n\nSame as [`ttl_secs`](#feature-db_branches-sql-ttl_secs) but expressed in minutes.\n\nMutually exclusive with [`ttl_secs`](#feature-db_branches-sql-ttl_secs).\n\n#### feature.db_branches[].creation_timeout_secs (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-creation_timeout_secs}\n\nThe timeout in seconds to wait for a database branch to become ready after creation.\nDefaults to 60 seconds. Adjust this value based on your database size and cluster\nperformance.\n\n#### feature.db_branches[].version (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-version}\n\nMirrord operator uses a default version of the database image unless `version` is given.\n\n#### feature.db_branches[].connection (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-connection}\n\n`connection` describes how to get the connection information to the source database.\nWhen the branch database is ready for use, Mirrord operator will replace the connection\ninformation with the branch database's. It accepts a connection URL or individual params:\n\n```json\n{ \"url\": { \"type\": \"env\", \"variable\": \"DB_CONNECTION_URL\" } }\n```\n```json\n{ \"type\": \"env\", \"url\": \"DB_CONNECTION_URL\" }\n```\n```json\n{ \"type\": \"env\", \"params\": { \"host\": \"DB_HOST\", \"port\": \"DB_PORT\", \"user\": \"DB_USER\", \"password\": \"DB_PASSWORD\", \"database\": \"DB_NAME\" } }\n```\n\nAny param can also be read from a Kubernetes Secret instead of a target-pod env var:\n\n```json\n{ \"type\": \"env\", \"params\": { \"host\": \"DB_HOST\", \"password\": { \"secret\": \"my-secret\", \"key\": \"password\" }, \"database\": \"DB_NAME\" } }\n```\n\n#### feature.db_branches[].migrations (type: mysql, pg, mssql, clickhouse) {#feature-db_branches-sql-migrations}\n\nSchema migrations to run on the branch after it is created. Currently supports\n[Flyway](https://documentation.red-gate.com/flyway):\n\n```json\n{ \"migrations\": { \"flavor\": \"flyway\", \"path\": \"./migrations\" } }\n```\n\n- `path`: local directory holding the migration files, resolved relative to the working\n  directory.\n- `image`: optional container image override for the migration runner.\n\nRequires [`name`](#feature-db_branches-sql-name) to be set.",
       "oneOf": [
         {
           "description": "When configuring a branch for ClickHouse, set `type` to `clickhouse`.",
           "type": "object",
           "properties": {
             "connection": {
-              "title": "feature.db_branches[].connection (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-connection}",
-              "description": "`connection` describes how to get the connection information to the source database.\nWhen the branch database is ready for use, Mirrord operator will replace the connection\ninformation with the branch database's.",
+              "description": "How to source the connection info for the source database. The operator swaps it for\nthe branch's connection once the branch is ready.",
               "$ref": "#/$defs/DbBranchingConnectionSource"
             },
             "copy": {
@@ -1175,24 +1174,21 @@
               }
             },
             "creation_timeout_secs": {
-              "title": "feature.db_branches[].creation_timeout_secs (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-creation_timeout_secs}",
-              "description": "The timeout in seconds to wait for a database branch to become ready after creation.\nDefaults to 60 seconds. Adjust this value based on your database size and cluster\nperformance.",
+              "description": "Seconds to wait for a branch to become ready after creation. Defaults to 60.",
               "type": "integer",
               "format": "uint64",
               "default": 60,
               "minimum": 0
             },
             "id": {
-              "title": "feature.db_branches[].id (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-id}",
-              "description": "Users can choose to specify a unique `id`. This is useful for reusing or sharing\nthe same database branch among Kubernetes users.",
+              "description": "Optional stable id for reusing or sharing a branch across users.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "migrations": {
-              "title": "feature.db_branches[].migrations (type: mysql, pg, mssql, clickhouse) {#feature-db_branches-sql-migrations}",
-              "description": "Schema migrations to run on the branch.",
+              "description": "<!--${internal}-->\nDocumented on `DatabaseBranchConfig` (shared across SQL engines).",
               "anyOf": [
                 {
                   "$ref": "#/$defs/SqlBranchMigrationsConfig"
@@ -1203,16 +1199,14 @@
               ]
             },
             "name": {
-              "title": "feature.db_branches[].name (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-name}",
-              "description": "When source database connection detail is not accessible to mirrord operator, users\ncan specify the database `name` so it is included in the connection options mirrord\nuses as the override.",
+              "description": "Source database name, used when the operator cannot read it from the connection.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "ttl_mins": {
-              "title": "feature.db_branches[].ttl_mins (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-ttl_mins}",
-              "description": "Same as [`ttl_secs`](#feature-db_branches-sql-ttl_secs) but expressed in minutes.\n\nMutually exclusive with [`ttl_secs`](#feature-db_branches-sql-ttl_secs).",
+              "description": "Branch TTL in minutes, counted from when the branch is last used. Mutually exclusive\nwith `ttl_secs`.",
               "type": [
                 "integer",
                 "null"
@@ -1221,8 +1215,7 @@
               "minimum": 0
             },
             "ttl_secs": {
-              "title": "feature.db_branches[].ttl_secs (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-ttl_secs}",
-              "description": "Mirrord operator starts counting the TTL when a branch is no longer used by any session.\nThe time-to-live (TTL) for the branch database is set to 300 seconds by default.\nUsers can set `ttl_secs` to customize this value according to their need. Please note\nthat longer TTL paired with frequent mirrord session turnover can result in increased\nresource usage. For this reason, branch database TTL caps out at 15 min.\n\nMutually exclusive with [`ttl_mins`](#feature-db_branches-sql-ttl_mins).",
+              "description": "Branch TTL in seconds, counted from when the branch is last used. Mutually exclusive\nwith `ttl_mins`. Defaults to 300, capped at 15 minutes.",
               "type": [
                 "integer",
                 "null"
@@ -1235,8 +1228,7 @@
               "const": "clickhouse"
             },
             "version": {
-              "title": "feature.db_branches[].version (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-version}",
-              "description": "Mirrord operator uses a default version of the database image unless `version` is given.",
+              "description": "Source database image version. Defaults to the operator's built-in version.",
               "type": [
                 "string",
                 "null"
@@ -1254,8 +1246,7 @@
           "type": "object",
           "properties": {
             "connection": {
-              "title": "feature.db_branches[].connection (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-connection}",
-              "description": "`connection` describes how to get the connection information to the source database.\nWhen the branch database is ready for use, Mirrord operator will replace the connection\ninformation with the branch database's.",
+              "description": "How to source the connection info for the source database. The operator swaps it for\nthe branch's connection once the branch is ready.",
               "$ref": "#/$defs/DbBranchingConnectionSource"
             },
             "copy": {
@@ -1266,8 +1257,7 @@
               }
             },
             "creation_timeout_secs": {
-              "title": "feature.db_branches[].creation_timeout_secs (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-creation_timeout_secs}",
-              "description": "The timeout in seconds to wait for a database branch to become ready after creation.\nDefaults to 60 seconds. Adjust this value based on your database size and cluster\nperformance.",
+              "description": "Seconds to wait for a branch to become ready after creation. Defaults to 60.",
               "type": "integer",
               "format": "uint64",
               "default": 60,
@@ -1286,24 +1276,21 @@
               ]
             },
             "id": {
-              "title": "feature.db_branches[].id (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-id}",
-              "description": "Users can choose to specify a unique `id`. This is useful for reusing or sharing\nthe same database branch among Kubernetes users.",
+              "description": "Optional stable id for reusing or sharing a branch across users.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "name": {
-              "title": "feature.db_branches[].name (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-name}",
-              "description": "When source database connection detail is not accessible to mirrord operator, users\ncan specify the database `name` so it is included in the connection options mirrord\nuses as the override.",
+              "description": "Source database name, used when the operator cannot read it from the connection.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "ttl_mins": {
-              "title": "feature.db_branches[].ttl_mins (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-ttl_mins}",
-              "description": "Same as [`ttl_secs`](#feature-db_branches-sql-ttl_secs) but expressed in minutes.\n\nMutually exclusive with [`ttl_secs`](#feature-db_branches-sql-ttl_secs).",
+              "description": "Branch TTL in minutes, counted from when the branch is last used. Mutually exclusive\nwith `ttl_secs`.",
               "type": [
                 "integer",
                 "null"
@@ -1312,8 +1299,7 @@
               "minimum": 0
             },
             "ttl_secs": {
-              "title": "feature.db_branches[].ttl_secs (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-ttl_secs}",
-              "description": "Mirrord operator starts counting the TTL when a branch is no longer used by any session.\nThe time-to-live (TTL) for the branch database is set to 300 seconds by default.\nUsers can set `ttl_secs` to customize this value according to their need. Please note\nthat longer TTL paired with frequent mirrord session turnover can result in increased\nresource usage. For this reason, branch database TTL caps out at 15 min.\n\nMutually exclusive with [`ttl_mins`](#feature-db_branches-sql-ttl_mins).",
+              "description": "Branch TTL in seconds, counted from when the branch is last used. Mutually exclusive\nwith `ttl_mins`. Defaults to 300, capped at 15 minutes.",
               "type": [
                 "integer",
                 "null"
@@ -1326,8 +1312,7 @@
               "const": "dynamodb"
             },
             "version": {
-              "title": "feature.db_branches[].version (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-version}",
-              "description": "Mirrord operator uses a default version of the database image unless `version` is given.",
+              "description": "Source database image version. Defaults to the operator's built-in version.",
               "type": [
                 "string",
                 "null"
@@ -1345,8 +1330,7 @@
           "type": "object",
           "properties": {
             "connection": {
-              "title": "feature.db_branches[].connection (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-connection}",
-              "description": "`connection` describes how to get the connection information to the source database.\nWhen the branch database is ready for use, Mirrord operator will replace the connection\ninformation with the branch database's.",
+              "description": "How to source the connection info for the source database. The operator swaps it for\nthe branch's connection once the branch is ready.",
               "$ref": "#/$defs/DbBranchingConnectionSource"
             },
             "copy": {
@@ -1357,32 +1341,28 @@
               }
             },
             "creation_timeout_secs": {
-              "title": "feature.db_branches[].creation_timeout_secs (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-creation_timeout_secs}",
-              "description": "The timeout in seconds to wait for a database branch to become ready after creation.\nDefaults to 60 seconds. Adjust this value based on your database size and cluster\nperformance.",
+              "description": "Seconds to wait for a branch to become ready after creation. Defaults to 60.",
               "type": "integer",
               "format": "uint64",
               "default": 60,
               "minimum": 0
             },
             "id": {
-              "title": "feature.db_branches[].id (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-id}",
-              "description": "Users can choose to specify a unique `id`. This is useful for reusing or sharing\nthe same database branch among Kubernetes users.",
+              "description": "Optional stable id for reusing or sharing a branch across users.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "name": {
-              "title": "feature.db_branches[].name (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-name}",
-              "description": "When source database connection detail is not accessible to mirrord operator, users\ncan specify the database `name` so it is included in the connection options mirrord\nuses as the override.",
+              "description": "Source database name, used when the operator cannot read it from the connection.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "ttl_mins": {
-              "title": "feature.db_branches[].ttl_mins (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-ttl_mins}",
-              "description": "Same as [`ttl_secs`](#feature-db_branches-sql-ttl_secs) but expressed in minutes.\n\nMutually exclusive with [`ttl_secs`](#feature-db_branches-sql-ttl_secs).",
+              "description": "Branch TTL in minutes, counted from when the branch is last used. Mutually exclusive\nwith `ttl_secs`.",
               "type": [
                 "integer",
                 "null"
@@ -1391,8 +1371,7 @@
               "minimum": 0
             },
             "ttl_secs": {
-              "title": "feature.db_branches[].ttl_secs (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-ttl_secs}",
-              "description": "Mirrord operator starts counting the TTL when a branch is no longer used by any session.\nThe time-to-live (TTL) for the branch database is set to 300 seconds by default.\nUsers can set `ttl_secs` to customize this value according to their need. Please note\nthat longer TTL paired with frequent mirrord session turnover can result in increased\nresource usage. For this reason, branch database TTL caps out at 15 min.\n\nMutually exclusive with [`ttl_mins`](#feature-db_branches-sql-ttl_mins).",
+              "description": "Branch TTL in seconds, counted from when the branch is last used. Mutually exclusive\nwith `ttl_mins`. Defaults to 300, capped at 15 minutes.",
               "type": [
                 "integer",
                 "null"
@@ -1405,8 +1384,7 @@
               "const": "mongodb"
             },
             "version": {
-              "title": "feature.db_branches[].version (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-version}",
-              "description": "Mirrord operator uses a default version of the database image unless `version` is given.",
+              "description": "Source database image version. Defaults to the operator's built-in version.",
               "type": [
                 "string",
                 "null"
@@ -1424,8 +1402,7 @@
           "type": "object",
           "properties": {
             "connection": {
-              "title": "feature.db_branches[].connection (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-connection}",
-              "description": "`connection` describes how to get the connection information to the source database.\nWhen the branch database is ready for use, Mirrord operator will replace the connection\ninformation with the branch database's.",
+              "description": "How to source the connection info for the source database. The operator swaps it for\nthe branch's connection once the branch is ready.",
               "$ref": "#/$defs/DbBranchingConnectionSource"
             },
             "copy": {
@@ -1436,24 +1413,21 @@
               }
             },
             "creation_timeout_secs": {
-              "title": "feature.db_branches[].creation_timeout_secs (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-creation_timeout_secs}",
-              "description": "The timeout in seconds to wait for a database branch to become ready after creation.\nDefaults to 60 seconds. Adjust this value based on your database size and cluster\nperformance.",
+              "description": "Seconds to wait for a branch to become ready after creation. Defaults to 60.",
               "type": "integer",
               "format": "uint64",
               "default": 60,
               "minimum": 0
             },
             "id": {
-              "title": "feature.db_branches[].id (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-id}",
-              "description": "Users can choose to specify a unique `id`. This is useful for reusing or sharing\nthe same database branch among Kubernetes users.",
+              "description": "Optional stable id for reusing or sharing a branch across users.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "migrations": {
-              "title": "feature.db_branches[].migrations (type: mysql, pg, mssql, clickhouse) {#feature-db_branches-sql-migrations}",
-              "description": "Schema migrations to run on the branch.",
+              "description": "<!--${internal}-->\nDocumented on `DatabaseBranchConfig` (shared across SQL engines).",
               "anyOf": [
                 {
                   "$ref": "#/$defs/SqlBranchMigrationsConfig"
@@ -1464,16 +1438,14 @@
               ]
             },
             "name": {
-              "title": "feature.db_branches[].name (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-name}",
-              "description": "When source database connection detail is not accessible to mirrord operator, users\ncan specify the database `name` so it is included in the connection options mirrord\nuses as the override.",
+              "description": "Source database name, used when the operator cannot read it from the connection.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "ttl_mins": {
-              "title": "feature.db_branches[].ttl_mins (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-ttl_mins}",
-              "description": "Same as [`ttl_secs`](#feature-db_branches-sql-ttl_secs) but expressed in minutes.\n\nMutually exclusive with [`ttl_secs`](#feature-db_branches-sql-ttl_secs).",
+              "description": "Branch TTL in minutes, counted from when the branch is last used. Mutually exclusive\nwith `ttl_secs`.",
               "type": [
                 "integer",
                 "null"
@@ -1482,8 +1454,7 @@
               "minimum": 0
             },
             "ttl_secs": {
-              "title": "feature.db_branches[].ttl_secs (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-ttl_secs}",
-              "description": "Mirrord operator starts counting the TTL when a branch is no longer used by any session.\nThe time-to-live (TTL) for the branch database is set to 300 seconds by default.\nUsers can set `ttl_secs` to customize this value according to their need. Please note\nthat longer TTL paired with frequent mirrord session turnover can result in increased\nresource usage. For this reason, branch database TTL caps out at 15 min.\n\nMutually exclusive with [`ttl_mins`](#feature-db_branches-sql-ttl_mins).",
+              "description": "Branch TTL in seconds, counted from when the branch is last used. Mutually exclusive\nwith `ttl_mins`. Defaults to 300, capped at 15 minutes.",
               "type": [
                 "integer",
                 "null"
@@ -1496,8 +1467,7 @@
               "const": "mssql"
             },
             "version": {
-              "title": "feature.db_branches[].version (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-version}",
-              "description": "Mirrord operator uses a default version of the database image unless `version` is given.",
+              "description": "Source database image version. Defaults to the operator's built-in version.",
               "type": [
                 "string",
                 "null"
@@ -1515,8 +1485,7 @@
           "type": "object",
           "properties": {
             "connection": {
-              "title": "feature.db_branches[].connection (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-connection}",
-              "description": "`connection` describes how to get the connection information to the source database.\nWhen the branch database is ready for use, Mirrord operator will replace the connection\ninformation with the branch database's.",
+              "description": "How to source the connection info for the source database. The operator swaps it for\nthe branch's connection once the branch is ready.",
               "$ref": "#/$defs/DbBranchingConnectionSource"
             },
             "copy": {
@@ -1527,8 +1496,7 @@
               }
             },
             "creation_timeout_secs": {
-              "title": "feature.db_branches[].creation_timeout_secs (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-creation_timeout_secs}",
-              "description": "The timeout in seconds to wait for a database branch to become ready after creation.\nDefaults to 60 seconds. Adjust this value based on your database size and cluster\nperformance.",
+              "description": "Seconds to wait for a branch to become ready after creation. Defaults to 60.",
               "type": "integer",
               "format": "uint64",
               "default": 60,
@@ -1547,16 +1515,14 @@
               ]
             },
             "id": {
-              "title": "feature.db_branches[].id (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-id}",
-              "description": "Users can choose to specify a unique `id`. This is useful for reusing or sharing\nthe same database branch among Kubernetes users.",
+              "description": "Optional stable id for reusing or sharing a branch across users.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "migrations": {
-              "title": "feature.db_branches[].migrations (type: mysql, pg, mssql, clickhouse) {#feature-db_branches-sql-migrations}",
-              "description": "Schema migrations to run on the branch.",
+              "description": "<!--${internal}-->\nDocumented on `DatabaseBranchConfig` (shared across SQL engines).",
               "anyOf": [
                 {
                   "$ref": "#/$defs/SqlBranchMigrationsConfig"
@@ -1567,16 +1533,14 @@
               ]
             },
             "name": {
-              "title": "feature.db_branches[].name (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-name}",
-              "description": "When source database connection detail is not accessible to mirrord operator, users\ncan specify the database `name` so it is included in the connection options mirrord\nuses as the override.",
+              "description": "Source database name, used when the operator cannot read it from the connection.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "ttl_mins": {
-              "title": "feature.db_branches[].ttl_mins (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-ttl_mins}",
-              "description": "Same as [`ttl_secs`](#feature-db_branches-sql-ttl_secs) but expressed in minutes.\n\nMutually exclusive with [`ttl_secs`](#feature-db_branches-sql-ttl_secs).",
+              "description": "Branch TTL in minutes, counted from when the branch is last used. Mutually exclusive\nwith `ttl_secs`.",
               "type": [
                 "integer",
                 "null"
@@ -1585,8 +1549,7 @@
               "minimum": 0
             },
             "ttl_secs": {
-              "title": "feature.db_branches[].ttl_secs (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-ttl_secs}",
-              "description": "Mirrord operator starts counting the TTL when a branch is no longer used by any session.\nThe time-to-live (TTL) for the branch database is set to 300 seconds by default.\nUsers can set `ttl_secs` to customize this value according to their need. Please note\nthat longer TTL paired with frequent mirrord session turnover can result in increased\nresource usage. For this reason, branch database TTL caps out at 15 min.\n\nMutually exclusive with [`ttl_mins`](#feature-db_branches-sql-ttl_mins).",
+              "description": "Branch TTL in seconds, counted from when the branch is last used. Mutually exclusive\nwith `ttl_mins`. Defaults to 300, capped at 15 minutes.",
               "type": [
                 "integer",
                 "null"
@@ -1599,8 +1562,7 @@
               "const": "mysql"
             },
             "version": {
-              "title": "feature.db_branches[].version (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-version}",
-              "description": "Mirrord operator uses a default version of the database image unless `version` is given.",
+              "description": "Source database image version. Defaults to the operator's built-in version.",
               "type": [
                 "string",
                 "null"
@@ -1618,8 +1580,7 @@
           "type": "object",
           "properties": {
             "connection": {
-              "title": "feature.db_branches[].connection (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-connection}",
-              "description": "`connection` describes how to get the connection information to the source database.\nWhen the branch database is ready for use, Mirrord operator will replace the connection\ninformation with the branch database's.",
+              "description": "How to source the connection info for the source database. The operator swaps it for\nthe branch's connection once the branch is ready.",
               "$ref": "#/$defs/DbBranchingConnectionSource"
             },
             "connection_settings": {
@@ -1638,8 +1599,7 @@
               }
             },
             "creation_timeout_secs": {
-              "title": "feature.db_branches[].creation_timeout_secs (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-creation_timeout_secs}",
-              "description": "The timeout in seconds to wait for a database branch to become ready after creation.\nDefaults to 60 seconds. Adjust this value based on your database size and cluster\nperformance.",
+              "description": "Seconds to wait for a branch to become ready after creation. Defaults to 60.",
               "type": "integer",
               "format": "uint64",
               "default": 60,
@@ -1658,16 +1618,14 @@
               ]
             },
             "id": {
-              "title": "feature.db_branches[].id (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-id}",
-              "description": "Users can choose to specify a unique `id`. This is useful for reusing or sharing\nthe same database branch among Kubernetes users.",
+              "description": "Optional stable id for reusing or sharing a branch across users.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "migrations": {
-              "title": "feature.db_branches[].migrations (type: mysql, pg, mssql, clickhouse) {#feature-db_branches-sql-migrations}",
-              "description": "Schema migrations to run on the branch.",
+              "description": "<!--${internal}-->\nDocumented on `DatabaseBranchConfig` (shared across SQL engines).",
               "anyOf": [
                 {
                   "$ref": "#/$defs/SqlBranchMigrationsConfig"
@@ -1678,16 +1636,14 @@
               ]
             },
             "name": {
-              "title": "feature.db_branches[].name (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-name}",
-              "description": "When source database connection detail is not accessible to mirrord operator, users\ncan specify the database `name` so it is included in the connection options mirrord\nuses as the override.",
+              "description": "Source database name, used when the operator cannot read it from the connection.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "ttl_mins": {
-              "title": "feature.db_branches[].ttl_mins (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-ttl_mins}",
-              "description": "Same as [`ttl_secs`](#feature-db_branches-sql-ttl_secs) but expressed in minutes.\n\nMutually exclusive with [`ttl_secs`](#feature-db_branches-sql-ttl_secs).",
+              "description": "Branch TTL in minutes, counted from when the branch is last used. Mutually exclusive\nwith `ttl_secs`.",
               "type": [
                 "integer",
                 "null"
@@ -1696,8 +1652,7 @@
               "minimum": 0
             },
             "ttl_secs": {
-              "title": "feature.db_branches[].ttl_secs (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-ttl_secs}",
-              "description": "Mirrord operator starts counting the TTL when a branch is no longer used by any session.\nThe time-to-live (TTL) for the branch database is set to 300 seconds by default.\nUsers can set `ttl_secs` to customize this value according to their need. Please note\nthat longer TTL paired with frequent mirrord session turnover can result in increased\nresource usage. For this reason, branch database TTL caps out at 15 min.\n\nMutually exclusive with [`ttl_mins`](#feature-db_branches-sql-ttl_mins).",
+              "description": "Branch TTL in seconds, counted from when the branch is last used. Mutually exclusive\nwith `ttl_mins`. Defaults to 300, capped at 15 minutes.",
               "type": [
                 "integer",
                 "null"
@@ -1710,8 +1665,7 @@
               "const": "pg"
             },
             "version": {
-              "title": "feature.db_branches[].version (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-version}",
-              "description": "Mirrord operator uses a default version of the database image unless `version` is given.",
+              "description": "Source database image version. Defaults to the operator's built-in version.",
               "type": [
                 "string",
                 "null"
@@ -1789,8 +1743,7 @@
               "type": "object",
               "properties": {
                 "connection": {
-                  "title": "feature.db_branches[].connection (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-connection}",
-                  "description": "`connection` describes how to get the connection information to the source database.\nWhen the branch database is ready for use, Mirrord operator will replace the connection\ninformation with the branch database's.",
+                  "description": "How to source the connection info for the source database. The operator swaps it for\nthe branch's connection once the branch is ready.",
                   "$ref": "#/$defs/DbBranchingConnectionSource"
                 },
                 "copy": {
@@ -1802,16 +1755,14 @@
                   }
                 },
                 "creation_timeout_secs": {
-                  "title": "feature.db_branches[].creation_timeout_secs (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-creation_timeout_secs}",
-                  "description": "The timeout in seconds to wait for a database branch to become ready after creation.\nDefaults to 60 seconds. Adjust this value based on your database size and cluster\nperformance.",
+                  "description": "Seconds to wait for a branch to become ready after creation. Defaults to 60.",
                   "type": "integer",
                   "format": "uint64",
                   "default": 60,
                   "minimum": 0
                 },
                 "id": {
-                  "title": "feature.db_branches[].id (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-id}",
-                  "description": "Users can choose to specify a unique `id`. This is useful for reusing or sharing\nthe same database branch among Kubernetes users.",
+                  "description": "Optional stable id for reusing or sharing a branch across users.",
                   "type": [
                     "string",
                     "null"
@@ -1823,16 +1774,14 @@
                   "const": "remote"
                 },
                 "name": {
-                  "title": "feature.db_branches[].name (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-name}",
-                  "description": "When source database connection detail is not accessible to mirrord operator, users\ncan specify the database `name` so it is included in the connection options mirrord\nuses as the override.",
+                  "description": "Source database name, used when the operator cannot read it from the connection.",
                   "type": [
                     "string",
                     "null"
                   ]
                 },
                 "ttl_mins": {
-                  "title": "feature.db_branches[].ttl_mins (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-ttl_mins}",
-                  "description": "Same as [`ttl_secs`](#feature-db_branches-sql-ttl_secs) but expressed in minutes.\n\nMutually exclusive with [`ttl_secs`](#feature-db_branches-sql-ttl_secs).",
+                  "description": "Branch TTL in minutes, counted from when the branch is last used. Mutually exclusive\nwith `ttl_secs`.",
                   "type": [
                     "integer",
                     "null"
@@ -1841,8 +1790,7 @@
                   "minimum": 0
                 },
                 "ttl_secs": {
-                  "title": "feature.db_branches[].ttl_secs (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-ttl_secs}",
-                  "description": "Mirrord operator starts counting the TTL when a branch is no longer used by any session.\nThe time-to-live (TTL) for the branch database is set to 300 seconds by default.\nUsers can set `ttl_secs` to customize this value according to their need. Please note\nthat longer TTL paired with frequent mirrord session turnover can result in increased\nresource usage. For this reason, branch database TTL caps out at 15 min.\n\nMutually exclusive with [`ttl_mins`](#feature-db_branches-sql-ttl_mins).",
+                  "description": "Branch TTL in seconds, counted from when the branch is last used. Mutually exclusive\nwith `ttl_mins`. Defaults to 300, capped at 15 minutes.",
                   "type": [
                     "integer",
                     "null"
@@ -1851,8 +1799,7 @@
                   "minimum": 0
                 },
                 "version": {
-                  "title": "feature.db_branches[].version (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-version}",
-                  "description": "Mirrord operator uses a default version of the database image unless `version` is given.",
+                  "description": "Source database image version. Defaults to the operator's built-in version.",
                   "type": [
                     "string",
                     "null"
@@ -1873,8 +1820,7 @@
           "type": "object",
           "properties": {
             "connection": {
-              "title": "feature.db_branches[].connection (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-connection}",
-              "description": "`connection` describes how to get the connection information to the source database.\nWhen the branch database is ready for use, Mirrord operator will replace the connection\ninformation with the branch database's.",
+              "description": "How to source the connection info for the source database. The operator swaps it for\nthe branch's connection once the branch is ready.",
               "$ref": "#/$defs/DbBranchingConnectionSource"
             },
             "copy": {
@@ -1885,8 +1831,7 @@
               }
             },
             "creation_timeout_secs": {
-              "title": "feature.db_branches[].creation_timeout_secs (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-creation_timeout_secs}",
-              "description": "The timeout in seconds to wait for a database branch to become ready after creation.\nDefaults to 60 seconds. Adjust this value based on your database size and cluster\nperformance.",
+              "description": "Seconds to wait for a branch to become ready after creation. Defaults to 60.",
               "type": "integer",
               "format": "uint64",
               "default": 60,
@@ -1899,24 +1844,21 @@
               "default": "SPANNER_EMULATOR_HOST"
             },
             "id": {
-              "title": "feature.db_branches[].id (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-id}",
-              "description": "Users can choose to specify a unique `id`. This is useful for reusing or sharing\nthe same database branch among Kubernetes users.",
+              "description": "Optional stable id for reusing or sharing a branch across users.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "name": {
-              "title": "feature.db_branches[].name (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-name}",
-              "description": "When source database connection detail is not accessible to mirrord operator, users\ncan specify the database `name` so it is included in the connection options mirrord\nuses as the override.",
+              "description": "Source database name, used when the operator cannot read it from the connection.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "ttl_mins": {
-              "title": "feature.db_branches[].ttl_mins (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-ttl_mins}",
-              "description": "Same as [`ttl_secs`](#feature-db_branches-sql-ttl_secs) but expressed in minutes.\n\nMutually exclusive with [`ttl_secs`](#feature-db_branches-sql-ttl_secs).",
+              "description": "Branch TTL in minutes, counted from when the branch is last used. Mutually exclusive\nwith `ttl_secs`.",
               "type": [
                 "integer",
                 "null"
@@ -1925,8 +1867,7 @@
               "minimum": 0
             },
             "ttl_secs": {
-              "title": "feature.db_branches[].ttl_secs (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-ttl_secs}",
-              "description": "Mirrord operator starts counting the TTL when a branch is no longer used by any session.\nThe time-to-live (TTL) for the branch database is set to 300 seconds by default.\nUsers can set `ttl_secs` to customize this value according to their need. Please note\nthat longer TTL paired with frequent mirrord session turnover can result in increased\nresource usage. For this reason, branch database TTL caps out at 15 min.\n\nMutually exclusive with [`ttl_mins`](#feature-db_branches-sql-ttl_mins).",
+              "description": "Branch TTL in seconds, counted from when the branch is last used. Mutually exclusive\nwith `ttl_mins`. Defaults to 300, capped at 15 minutes.",
               "type": [
                 "integer",
                 "null"
@@ -1939,8 +1880,7 @@
               "const": "spanner"
             },
             "version": {
-              "title": "feature.db_branches[].version (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-version}",
-              "description": "Mirrord operator uses a default version of the database image unless `version` is given.",
+              "description": "Source database image version. Defaults to the operator's built-in version.",
               "type": [
                 "string",
                 "null"
@@ -4811,7 +4751,7 @@
       ]
     },
     "SqlBranchMigrationsConfig": {
-      "description": "Runs schema migrations on a SQL branch.",
+      "description": "<!--${internal}-->\nRuns schema migrations on a SQL branch. Documented on [`DatabaseBranchConfig`].",
       "oneOf": [
         {
           "description": "Apply migrations with [Flyway](https://documentation.red-gate.com/flyway).",

--- a/mirrord/config/src/feature/database_branches.rs
+++ b/mirrord/config/src/feature/database_branches.rs
@@ -147,7 +147,8 @@ pub struct BranchItemCopyConfig {
     pub filter: Option<String>,
 }
 
-/// Runs schema migrations on a SQL branch.
+/// <!--${internal}-->
+/// Runs schema migrations on a SQL branch. Documented on [`DatabaseBranchConfig`].
 #[derive(Clone, Debug, Eq, PartialEq, JsonSchema, Serialize, Deserialize)]
 #[serde(tag = "flavor", rename_all = "lowercase", deny_unknown_fields)]
 pub enum SqlBranchMigrationsConfig {
@@ -508,6 +509,83 @@ impl ConnectionParamsVars {
 ///   }
 /// }
 /// ```
+///
+/// The fields below are shared by every engine. Engine-specific fields (copy modes,
+/// `iam_auth`, `connection_settings`, `emulator_host`) are documented under each `type`.
+///
+/// #### feature.db_branches[].id (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-id}
+///
+/// Users can choose to specify a unique `id`. This is useful for reusing or sharing
+/// the same database branch among Kubernetes users.
+///
+/// #### feature.db_branches[].name (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-name}
+///
+/// When source database connection detail is not accessible to mirrord operator, users
+/// can specify the database `name` so it is included in the connection options mirrord
+/// uses as the override.
+///
+/// #### feature.db_branches[].ttl_secs (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-ttl_secs}
+///
+/// Mirrord operator starts counting the TTL when a branch is no longer used by any session.
+/// The time-to-live (TTL) for the branch database is set to 300 seconds by default.
+/// Users can set `ttl_secs` to customize this value according to their need. Please note
+/// that longer TTL paired with frequent mirrord session turnover can result in increased
+/// resource usage. For this reason, branch database TTL caps out at 15 min.
+///
+/// Mutually exclusive with [`ttl_mins`](#feature-db_branches-sql-ttl_mins).
+///
+/// #### feature.db_branches[].ttl_mins (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-ttl_mins}
+///
+/// Same as [`ttl_secs`](#feature-db_branches-sql-ttl_secs) but expressed in minutes.
+///
+/// Mutually exclusive with [`ttl_secs`](#feature-db_branches-sql-ttl_secs).
+///
+/// #### feature.db_branches[].creation_timeout_secs (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-creation_timeout_secs}
+///
+/// The timeout in seconds to wait for a database branch to become ready after creation.
+/// Defaults to 60 seconds. Adjust this value based on your database size and cluster
+/// performance.
+///
+/// #### feature.db_branches[].version (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-version}
+///
+/// Mirrord operator uses a default version of the database image unless `version` is given.
+///
+/// #### feature.db_branches[].connection (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-connection}
+///
+/// `connection` describes how to get the connection information to the source database.
+/// When the branch database is ready for use, Mirrord operator will replace the connection
+/// information with the branch database's. It accepts a connection URL or individual params:
+///
+/// ```json
+/// { "url": { "type": "env", "variable": "DB_CONNECTION_URL" } }
+/// ```
+/// ```json
+/// { "type": "env", "url": "DB_CONNECTION_URL" }
+/// ```
+/// ```json
+/// { "type": "env", "params": { "host": "DB_HOST", "port": "DB_PORT", "user": "DB_USER", "password": "DB_PASSWORD", "database": "DB_NAME" } }
+/// ```
+///
+/// Any param can also be read from a Kubernetes Secret instead of a target-pod env var:
+///
+/// ```json
+/// { "type": "env", "params": { "host": "DB_HOST", "password": { "secret": "my-secret", "key": "password" }, "database": "DB_NAME" } }
+/// ```
+///
+/// #### feature.db_branches[].migrations (type: mysql, pg, mssql, clickhouse) {#feature-db_branches-sql-migrations}
+///
+/// Schema migrations to run on the branch after it is created. Currently supports
+/// [Flyway](https://documentation.red-gate.com/flyway):
+///
+/// ```json
+/// { "migrations": { "flavor": "flyway", "path": "./migrations" } }
+/// ```
+///
+/// - `path`: local directory holding the migration files, resolved relative to the working
+///   directory.
+/// - `image`: optional container image override for the migration runner.
+///
+/// Requires [`name`](#feature-db_branches-sql-name) to be set.
 #[derive(Clone, Debug, Eq, PartialEq, JsonSchema, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "lowercase", deny_unknown_fields)]
 pub enum DatabaseBranchConfig {
@@ -521,61 +599,38 @@ pub enum DatabaseBranchConfig {
     Spanner(Box<SpannerBranchConfig>),
 }
 
-/// All database branch config objects share the following fields.
+/// <!--${internal}-->
+/// Fields shared by every database branch config. They are documented once on
+/// [`DatabaseBranchConfig`] so the generated config docs do not repeat them for each engine;
+/// keep only short schema descriptions here.
 #[derive(MirrordConfig, Clone, Debug, Eq, PartialEq, JsonSchema, Serialize, Deserialize)]
 #[config(map_to = "DatabaseBranchBaseFileConfig")]
 pub struct DatabaseBranchBaseConfig {
-    /// #### feature.db_branches[].id (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-id}
-    ///
-    /// Users can choose to specify a unique `id`. This is useful for reusing or sharing
-    /// the same database branch among Kubernetes users.
+    /// Optional stable id for reusing or sharing a branch across users.
     pub id: Option<String>,
 
-    /// #### feature.db_branches[].name (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-name}
-    ///
-    /// When source database connection detail is not accessible to mirrord operator, users
-    /// can specify the database `name` so it is included in the connection options mirrord
-    /// uses as the override.
+    /// Source database name, used when the operator cannot read it from the connection.
     pub name: Option<String>,
 
-    /// #### feature.db_branches[].ttl_secs (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-ttl_secs}
-    ///
-    /// Mirrord operator starts counting the TTL when a branch is no longer used by any session.
-    /// The time-to-live (TTL) for the branch database is set to 300 seconds by default.
-    /// Users can set `ttl_secs` to customize this value according to their need. Please note
-    /// that longer TTL paired with frequent mirrord session turnover can result in increased
-    /// resource usage. For this reason, branch database TTL caps out at 15 min.
-    ///
-    /// Mutually exclusive with [`ttl_mins`](#feature-db_branches-sql-ttl_mins).
+    /// Branch TTL in seconds, counted from when the branch is last used. Mutually exclusive
+    /// with `ttl_mins`. Defaults to 300, capped at 15 minutes.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ttl_secs: Option<u64>,
 
-    /// #### feature.db_branches[].ttl_mins (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-ttl_mins}
-    ///
-    /// Same as [`ttl_secs`](#feature-db_branches-sql-ttl_secs) but expressed in minutes.
-    ///
-    /// Mutually exclusive with [`ttl_secs`](#feature-db_branches-sql-ttl_secs).
+    /// Branch TTL in minutes, counted from when the branch is last used. Mutually exclusive
+    /// with `ttl_secs`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ttl_mins: Option<u64>,
 
-    /// #### feature.db_branches[].creation_timeout_secs (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-creation_timeout_secs}
-    ///
-    /// The timeout in seconds to wait for a database branch to become ready after creation.
-    /// Defaults to 60 seconds. Adjust this value based on your database size and cluster
-    /// performance.
+    /// Seconds to wait for a branch to become ready after creation. Defaults to 60.
     #[serde(default = "default_creation_timeout_secs")]
     pub creation_timeout_secs: u64,
 
-    /// #### feature.db_branches[].version (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-version}
-    ///
-    /// Mirrord operator uses a default version of the database image unless `version` is given.
+    /// Source database image version. Defaults to the operator's built-in version.
     pub version: Option<String>,
 
-    /// #### feature.db_branches[].connection (type: mysql, pg, mongodb, mssql, redis) {#feature-db_branches-sql-connection}
-    ///
-    /// `connection` describes how to get the connection information to the source database.
-    /// When the branch database is ready for use, Mirrord operator will replace the connection
-    /// information with the branch database's.
+    /// How to source the connection info for the source database. The operator swaps it for
+    /// the branch's connection once the branch is ready.
     pub connection: ConnectionSource,
 }
 

--- a/mirrord/config/src/feature/database_branches/clickhouse.rs
+++ b/mirrord/config/src/feature/database_branches/clickhouse.rs
@@ -15,9 +15,8 @@ pub struct ClickhouseBranchConfig {
     #[serde(default)]
     pub copy: ClickhouseBranchCopyConfig,
 
-    /// #### feature.db_branches[].migrations (type: mysql, pg, mssql, clickhouse) {#feature-db_branches-sql-migrations}
-    ///
-    /// Schema migrations to run on the branch.
+    /// <!--${internal}-->
+    /// Documented on `DatabaseBranchConfig` (shared across SQL engines).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub migrations: Option<SqlBranchMigrationsConfig>,
 }

--- a/mirrord/config/src/feature/database_branches/mssql.rs
+++ b/mirrord/config/src/feature/database_branches/mssql.rs
@@ -15,9 +15,8 @@ pub struct MssqlBranchConfig {
     #[serde(default)]
     pub copy: MssqlBranchCopyConfig,
 
-    /// #### feature.db_branches[].migrations (type: mysql, pg, mssql, clickhouse) {#feature-db_branches-sql-migrations}
-    ///
-    /// Schema migrations to run on the branch.
+    /// <!--${internal}-->
+    /// Documented on `DatabaseBranchConfig` (shared across SQL engines).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub migrations: Option<SqlBranchMigrationsConfig>,
 }

--- a/mirrord/config/src/feature/database_branches/mysql.rs
+++ b/mirrord/config/src/feature/database_branches/mysql.rs
@@ -23,9 +23,8 @@ pub struct MysqlBranchConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub iam_auth: Option<IamAuthConfig>,
 
-    /// #### feature.db_branches[].migrations (type: mysql, pg, mssql, clickhouse) {#feature-db_branches-sql-migrations}
-    ///
-    /// Schema migrations to run on the branch.
+    /// <!--${internal}-->
+    /// Documented on `DatabaseBranchConfig` (shared across SQL engines).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub migrations: Option<SqlBranchMigrationsConfig>,
 }

--- a/mirrord/config/src/feature/database_branches/pg.rs
+++ b/mirrord/config/src/feature/database_branches/pg.rs
@@ -39,9 +39,8 @@ pub struct PgBranchConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub iam_auth: Option<IamAuthConfig>,
 
-    /// #### feature.db_branches[].migrations (type: mysql, pg, mssql, clickhouse) {#feature-db_branches-sql-migrations}
-    ///
-    /// Schema migrations to run on the branch.
+    /// <!--${internal}-->
+    /// Documented on `DatabaseBranchConfig` (shared across SQL engines).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub migrations: Option<SqlBranchMigrationsConfig>,
 }


### PR DESCRIPTION
Issue is that because we are reusing DatabaseBranchBaseConfig for every db it had duplicated docs for every db

<!-- Thank you for contributing to mirrord! -->
<!-- Please use the checklist below as a guide for docs, tests and admin tasks for your PR -->
<!-- Feel free to ~strikethrough~ any items that you don't think apply -->

### Quality Checklist:

- [ ] I have documented new code sufficiently
- [ ] I have checked and updated the relevant existing docs in code, including removing outdated material
- [ ] I have written user-facing website docs for new features, or opened a (sub)issue to do so
- [ ] I have checked and updated existing website docs for changed features
- [ ] I have tested this change and know it succeeds and fails as expected
- [ ] I have written unit tests or purposefully omitted them
- [ ] I have written e2e tests or purposefully omitted them
- [ ] I have explained what this PR introduces and why, and linked to relevant context (e.g. linear issues, related PRs,
  documentation)
- [ ] I have introduced a short, clear and well-formatted changelog entry

<!-- need help with the changelog? see ../CONTRIBUTING.md#submitting-a-pull-request -->
<!-- Add more details of your changes below if needed -->