### PR TITLE
Pin E2E test images by digest and pull only if not present

### DIFF
--- a/changelog.d/+pin-e2e-test-images.internal.md
+++ b/changelog.d/+pin-e2e-test-images.internal.md
@@ -1,0 +1,1 @@
+Pinned all E2E test app images by digest and deploy them with `imagePullPolicy: IfNotPresent`, so test pods no longer do a GHCR round-trip on every pod start (`:latest` implied `Always`), which caused E2E tests to flake on their startup timeout when the registry was slow.

--- a/tests/src/dirty_iptables.rs
+++ b/tests/src/dirty_iptables.rs
@@ -11,8 +11,8 @@ use rstest::*;
 use serde_json::json;
 
 use crate::utils::{
-    application::env::EnvApp, client::kube_client, operator_installed, random_string,
-    resource_guard::ResourceGuard, watch, KubeClient, PRESERVE_FAILED_ENV_NAME,
+    application::env::EnvApp, client::kube_client, images::PYTEST_IMAGE, operator_installed,
+    random_string, resource_guard::ResourceGuard, watch, KubeClient, PRESERVE_FAILED_ENV_NAME,
     TEST_RESOURCE_LABEL,
 };
 
@@ -101,7 +101,8 @@ async fn dirty_iptables_test_inner(kube_client: KubeClient) -> DirtyIptablesTest
                     "containers": [
                         {
                             "name": "py-serv",
-                            "image": "ghcr.io/metalbear-co/mirrord-pytest:latest",
+                            "image": PYTEST_IMAGE,
+                            "imagePullPolicy": "IfNotPresent",
                             "ports": [ { "containerPort": 80 } ],
                             "env": [
                                 {"name": "MIRRORD_FAKE_VAR_FIRST", "value": "mirrord.is.running"},

--- a/tests/src/http.rs
+++ b/tests/src/http.rs
@@ -9,8 +9,8 @@ use rstest::*;
 use tokio::net::TcpStream;
 
 use crate::utils::{
-    application::Application, client::kube_client, port_forwarder::PortForwarder,
-    services::basic_service, KubeClient,
+    application::Application, client::kube_client, images::HTTP_KEEP_ALIVE_IMAGE,
+    port_forwarder::PortForwarder, services::basic_service, KubeClient,
 };
 
 async fn make_http_conn(portforwarder: &PortForwarder) -> SendRequest<String> {
@@ -70,7 +70,7 @@ async fn mirror_http_traffic(
     let service = basic_service(
         &format!("e2e-{:x}-mirror-http-traffic", rand::random::<u16>(),),
         "NodePort",
-        "ghcr.io/metalbear-co/mirrord-http-keep-alive:latest",
+        HTTP_KEEP_ALIVE_IMAGE,
         "http-echo",
         false,
         std::future::ready(kube_client.clone()),
@@ -151,7 +151,7 @@ async fn concurrent_mirror_and_steal(
             rand::random::<u16>(),
         ),
         "NodePort",
-        "ghcr.io/metalbear-co/mirrord-http-keep-alive:latest",
+        HTTP_KEEP_ALIVE_IMAGE,
         "http-echo",
         false,
         std::future::ready(kube_client.clone()),

--- a/tests/src/ls.rs
+++ b/tests/src/ls.rs
@@ -4,11 +4,11 @@ use fancy_regex::Regex;
 use mirrord_test_utils::run_command::run_ls;
 use rstest::rstest;
 
-use crate::utils::client::kube_client;
 #[cfg(feature = "operator")]
 use crate::utils::services::operator::service_for_mirrord_ls;
 #[cfg(not(feature = "operator"))]
 use crate::utils::services::service_for_mirrord_ls;
+use crate::utils::{client::kube_client, images::PYTEST_IMAGE};
 
 /// Test for the `mirrord ls` command.
 #[cfg_attr(target_os = "windows", ignore)]
@@ -21,7 +21,7 @@ pub async fn mirrord_ls() {
     let _setup = service_for_mirrord_ls(
         &namespace,
         "NodePort",
-        "ghcr.io/metalbear-co/mirrord-pytest:latest",
+        PYTEST_IMAGE,
         "ls-service",
         false,
         kube_client(),

--- a/tests/src/traffic.rs
+++ b/tests/src/traffic.rs
@@ -17,6 +17,7 @@ mod traffic_tests {
     use crate::utils::{
         application::{Application, GoVersion},
         client::kube_client,
+        images::UNIX_SOCKET_SERVER_IMAGE,
         ipv6::ipv6_service,
         kube_service::KubeService,
         services::{basic_service, hostname_service, udp_logger_service},
@@ -571,12 +572,7 @@ mod traffic_tests {
     #[timeout(Duration::from_secs(60))]
     pub async fn outgoing_unix_stream_pathname(
         #[future]
-        #[with(
-            "default",
-            "ClusterIP",
-            "ghcr.io/metalbear-co/mirrord-unix-socket-server:latest",
-            "unix-echo"
-        )]
+        #[with("default", "ClusterIP", UNIX_SOCKET_SERVER_IMAGE, "unix-echo")]
         basic_service: KubeService,
     ) {
         let service = basic_service.await;

--- a/tests/src/utils.rs
+++ b/tests/src/utils.rs
@@ -14,6 +14,7 @@ use serde_json::{json, Value};
 pub mod application;
 pub mod client;
 pub mod cluster_resource;
+pub mod images;
 pub mod ipv6;
 pub mod kube_service;
 pub mod port_forwarder;

--- a/tests/src/utils/cluster_resource.rs
+++ b/tests/src/utils/cluster_resource.rs
@@ -10,7 +10,13 @@ use kube::runtime::reflector::Lookup;
 use mirrord_kube::api::kubernetes::rollout::Rollout;
 use serde_json::{json, Value};
 
-use crate::utils::{CONTAINER_NAME, TEST_RESOURCE_LABEL};
+use crate::utils::{
+    images::{
+        HTTP_KEEP_ALIVE_IMAGE, HTTP_LOGGER_IMAGE, NODE_IMAGE, PYTEST_IMAGE, TCP_ECHO_IMAGE,
+        WEBSOCKET_IMAGE,
+    },
+    CONTAINER_NAME, TEST_RESOURCE_LABEL,
+};
 
 pub(crate) mod operator;
 
@@ -20,12 +26,12 @@ pub(crate) mod operator;
 ///
 /// See [test images repo](https://github.com/metalbear-co/test-images) for reference.
 const TCP_SERVER_IMAGES: &[&str] = &[
-    "ghcr.io/metalbear-co/mirrord-pytest:latest",
-    "ghcr.io/metalbear-co/mirrord-node:latest",
-    "ghcr.io/metalbear-co/mirrord-http-logger:latest",
-    "ghcr.io/metalbear-co/mirrord-tcp-echo:latest",
-    "ghcr.io/metalbear-co/mirrord-websocket:latest",
-    "ghcr.io/metalbear-co/mirrord-http-keep-alive:latest",
+    PYTEST_IMAGE,
+    NODE_IMAGE,
+    HTTP_LOGGER_IMAGE,
+    TCP_ECHO_IMAGE,
+    WEBSOCKET_IMAGE,
+    HTTP_KEEP_ALIVE_IMAGE,
 ];
 
 pub(super) fn get_pod_template_json_value(
@@ -48,6 +54,7 @@ pub(super) fn get_pod_template_json_value(
                 {
                     "name": &CONTAINER_NAME,
                     "image": image,
+                    "imagePullPolicy": "IfNotPresent",
                     "ports": [
                         {
                             "containerPort": 80
@@ -225,6 +232,7 @@ pub fn stateful_set_from_json(name: &str, image: &str, has_pvc: bool) -> Statefu
                         {
                             "name": &CONTAINER_NAME,
                             "image": image,
+                            "imagePullPolicy": "IfNotPresent",
                             "ports": [
                                 {
                                     "containerPort": 80

--- a/tests/src/utils/cluster_resource/operator.rs
+++ b/tests/src/utils/cluster_resource/operator.rs
@@ -36,6 +36,7 @@ pub(crate) fn cron_job_from_json(name: &str, image: &str) -> CronJob {
                                 {
                                     "name": &CONTAINER_NAME,
                                     "image": image,
+                                    "imagePullPolicy": "IfNotPresent",
                                     "ports": [{ "containerPort": 80 }],
                                     "env": [
                                         {
@@ -91,6 +92,7 @@ pub(crate) fn job_from_json(name: &str, image: &str) -> Job {
                         {
                             "name": &CONTAINER_NAME,
                             "image": image,
+                            "imagePullPolicy": "IfNotPresent",
                             "ports": [{ "containerPort": 80 }],
                             "env": [
                                 {

--- a/tests/src/utils/images.rs
+++ b/tests/src/utils/images.rs
@@ -1,0 +1,39 @@
+//! Test application images deployed to the cluster by the E2E tests.
+//!
+//! All images are pinned by digest and deployed with `imagePullPolicy: IfNotPresent`, so pods
+//! never race a registry round-trip on creation (`:latest` implies `imagePullPolicy: Always`,
+//! which does a GHCR digest check on every pod start and has caused E2E tests to flake on their
+//! startup timeout whenever GHCR was slow).
+//!
+//! To bump an image after publishing a new version, update its digest here:
+//!
+//! ```sh
+//! docker buildx imagetools inspect ghcr.io/metalbear-co/<image>:latest
+//! ```
+
+pub const PYTEST_IMAGE: &str =
+    "ghcr.io/metalbear-co/mirrord-pytest@sha256:4882cbdcd240c5a0aaf1f0b8c408729dfba447eb11c187791778a446a3be50da";
+
+pub const TCP_ECHO_IMAGE: &str =
+    "ghcr.io/metalbear-co/mirrord-tcp-echo@sha256:c789fb2cdc91d6ff99deec52d8d05451bf65a6ad617ab7764f7cb82d92664f59";
+
+pub const NODE_IMAGE: &str =
+    "ghcr.io/metalbear-co/mirrord-node@sha256:6e5b34590b4604e6808cf3a01e1db7a26bab8577a3c2de43f480dda6b5b3ad3e";
+
+pub const NODE_UDP_LOGGER_IMAGE: &str =
+    "ghcr.io/metalbear-co/mirrord-node-udp-logger@sha256:acf49e2f77ea2d35655decfd90d2c059fac6984a188e24494f0afb4efaf36ea7";
+
+pub const HTTP_LOGGER_IMAGE: &str =
+    "ghcr.io/metalbear-co/mirrord-http-logger@sha256:578bd796d927b0f0581c349d40a94085155e6ca6c4e0d39d96b749e0623e9f9f";
+
+pub const HTTP_KEEP_ALIVE_IMAGE: &str =
+    "ghcr.io/metalbear-co/mirrord-http-keep-alive@sha256:0e015544035443cdc479a54b7e693759248d8dd80aa26096578dfac9ba0f947d";
+
+pub const WEBSOCKET_IMAGE: &str =
+    "ghcr.io/metalbear-co/mirrord-websocket@sha256:b36e591bbbac6aafee0e4368ad2078f32adca313e5f67bcca1b5c54a237874c5";
+
+pub const UNIX_SOCKET_SERVER_IMAGE: &str =
+    "ghcr.io/metalbear-co/mirrord-unix-socket-server@sha256:4937e4d623c34fe1a904970804e0c30629932770a1e684f6c34ddcf8ca77dc25";
+
+pub const GO_STATFS_IMAGE: &str =
+    "ghcr.io/metalbear-co/mirrord-go-statfs@sha256:83429486fc40bf4deaf9f17b968d930f03e92adeefe08bf02e76d69b37a62025";

--- a/tests/src/utils/ipv6.rs
+++ b/tests/src/utils/ipv6.rs
@@ -11,6 +11,7 @@ use rstest::fixture;
 
 use crate::utils::{
     client::kube_client,
+    images::PYTEST_IMAGE,
     kube_service::KubeService,
     services::{internal_service, TestWorkloadType},
     KubeClient,
@@ -26,7 +27,7 @@ use crate::utils::{
 pub async fn ipv6_service(
     #[default("default")] namespace: &str,
     #[default("NodePort")] service_type: &str,
-    #[default("ghcr.io/metalbear-co/mirrord-pytest:latest")] image: &str,
+    #[default(PYTEST_IMAGE)] image: &str,
     #[default("http-echo")] service_name: &str,
     #[default(true)] randomize_name: bool,
     #[future] kube_client: KubeClient,

--- a/tests/src/utils/services.rs
+++ b/tests/src/utils/services.rs
@@ -14,8 +14,12 @@ use serde_json::{json, Value};
 
 use super::{cluster_resource, kube_service, resource_guard};
 use crate::utils::{
-    client::kube_client, default_env, random_string, set_ipv6_only, watch, KubeClient,
-    PRESERVE_FAILED_ENV_NAME, TEST_RESOURCE_LABEL,
+    client::kube_client,
+    default_env,
+    images::{
+        GO_STATFS_IMAGE, NODE_UDP_LOGGER_IMAGE, PYTEST_IMAGE, TCP_ECHO_IMAGE, WEBSOCKET_IMAGE,
+    },
+    random_string, set_ipv6_only, watch, KubeClient, PRESERVE_FAILED_ENV_NAME, TEST_RESOURCE_LABEL,
 };
 
 pub(crate) mod operator;
@@ -28,7 +32,7 @@ pub(crate) mod operator;
 pub async fn basic_service(
     #[default("default")] namespace: &str,
     #[default("NodePort")] service_type: &str,
-    #[default("ghcr.io/metalbear-co/mirrord-pytest:latest")] image: &str,
+    #[default(PYTEST_IMAGE)] image: &str,
     #[default("http-echo")] service_name: &str,
     #[default(true)] randomize_name: bool,
     #[future] kube_client: KubeClient,
@@ -398,7 +402,7 @@ pub async fn internal_service(
 pub async fn service_for_mirrord_ls(
     #[default("default")] namespace: &str,
     #[default("NodePort")] service_type: &str,
-    #[default("ghcr.io/metalbear-co/mirrord-pytest:latest")] image: &str,
+    #[default(PYTEST_IMAGE)] image: &str,
     #[default("http-echo")] service_name: &str,
     #[default(true)] randomize_name: bool,
     #[future] kube_client: KubeClient,
@@ -422,7 +426,7 @@ pub async fn udp_logger_service(#[future] kube_client: KubeClient) -> KubeServic
     basic_service(
         "default",
         "ClusterIP",
-        "ghcr.io/metalbear-co/mirrord-node-udp-logger:latest",
+        NODE_UDP_LOGGER_IMAGE,
         "udp-logger",
         true,
         kube_client,
@@ -437,7 +441,7 @@ pub async fn tcp_echo_service(#[future] kube_client: KubeClient) -> KubeService 
     basic_service(
         "default",
         "NodePort",
-        "ghcr.io/metalbear-co/mirrord-tcp-echo:latest",
+        TCP_ECHO_IMAGE,
         "tcp-echo",
         true,
         kube_client,
@@ -456,7 +460,7 @@ pub async fn pod_ip_http_echo_service(#[future] kube_client: KubeClient) -> Kube
     service_with_env(
         "default",
         "NodePort",
-        "ghcr.io/metalbear-co/mirrord-pytest:latest",
+        PYTEST_IMAGE,
         "pod-ip-http-echo",
         true,
         kube_client.await,
@@ -478,7 +482,7 @@ pub async fn websocket_service(#[future] kube_client: KubeClient) -> KubeService
     basic_service(
         "default",
         "NodePort",
-        "ghcr.io/metalbear-co/mirrord-websocket:latest",
+        WEBSOCKET_IMAGE,
         "websocket",
         true,
         kube_client,
@@ -491,7 +495,7 @@ pub async fn http2_service(#[future] kube_client: KubeClient) -> KubeService {
     basic_service(
         "default",
         "NodePort",
-        "ghcr.io/metalbear-co/mirrord-pytest:latest",
+        PYTEST_IMAGE,
         "http2-echo",
         true,
         kube_client,
@@ -506,7 +510,7 @@ pub async fn hostname_service(#[future] kube_client: KubeClient) -> KubeService 
     basic_service(
         "default",
         "NodePort",
-        "ghcr.io/metalbear-co/mirrord-pytest:latest",
+        PYTEST_IMAGE,
         "hostname-echo",
         true,
         kube_client,
@@ -522,7 +526,7 @@ pub async fn random_namespace_self_deleting_service(
     basic_service(
         &namespace,
         "NodePort",
-        "ghcr.io/metalbear-co/mirrord-pytest:latest",
+        PYTEST_IMAGE,
         "pytest-echo",
         true,
         kube_client,
@@ -535,7 +539,7 @@ pub async fn go_statfs_service(#[future] kube_client: KubeClient) -> KubeService
     basic_service(
         "default",
         "ClusterIP",
-        "ghcr.io/metalbear-co/mirrord-go-statfs:latest",
+        GO_STATFS_IMAGE,
         "go-statfs",
         true,
         kube_client,
@@ -550,7 +554,7 @@ pub async fn fs_service(#[future] kube_client: KubeClient) -> KubeService {
     basic_service(
         &namespace,
         "NodePort",
-        "ghcr.io/metalbear-co/mirrord-pytest:latest",
+        PYTEST_IMAGE,
         "fs-policy-e2e-test-service",
         false,
         kube_client,
@@ -562,7 +566,7 @@ pub async fn fs_service(#[future] kube_client: KubeClient) -> KubeService {
 pub async fn rollout_service(
     #[default("default")] namespace: &str,
     #[default("NodePort")] service_type: &str,
-    #[default("ghcr.io/metalbear-co/mirrord-pytest:latest")] image: &str,
+    #[default(PYTEST_IMAGE)] image: &str,
     #[default("http-echo")] service_name: &str,
     #[default(true)] randomize_name: bool,
     #[future] kube_client: KubeClient,
@@ -587,7 +591,7 @@ pub async fn rollout_service(
 pub async fn stateful_set_service(
     #[default("default")] namespace: &str,
     #[default("NodePort")] service_type: &str,
-    #[default("ghcr.io/metalbear-co/mirrord-pytest:latest")] image: &str,
+    #[default(PYTEST_IMAGE)] image: &str,
     #[default("http-echo")] service_name: &str,
     #[default(true)] randomize_name: bool,
     #[future] kube_client: KubeClient,

--- a/tests/src/utils/services/operator.rs
+++ b/tests/src/utils/services/operator.rs
@@ -13,15 +13,15 @@ use serde_json::json;
 
 use super::{cluster_resource, kube_service, resource_guard, TestWorkloadType};
 use crate::utils::{
-    client::kube_client, default_env, random_string, watch, KubeClient, PRESERVE_FAILED_ENV_NAME,
-    TEST_RESOURCE_LABEL,
+    client::kube_client, default_env, images::PYTEST_IMAGE, random_string, watch, KubeClient,
+    PRESERVE_FAILED_ENV_NAME, TEST_RESOURCE_LABEL,
 };
 
 #[fixture]
 pub async fn service_for_mirrord_ls(
     #[default("default")] namespace: &str,
     #[default("NodePort")] service_type: &str,
-    #[default("ghcr.io/metalbear-co/mirrord-pytest:latest")] image: &str,
+    #[default(PYTEST_IMAGE)] image: &str,
     #[default("http-echo")] service_name: &str,
     #[default(true)] randomize_name: bool,
     #[future] kube_client: KubeClient,


### PR DESCRIPTION
## Problem

All E2E test app images (`mirrord-pytest`, `mirrord-tcp-echo`, `mirrord-node`, etc.) were referenced as `:latest` with no `imagePullPolicy`. In Kubernetes, `:latest` defaults the pull policy to `Always`, so **every test pod creation does a GHCR round-trip** (digest check) — even when all layers are already cached on the node. A slow or rate-limiting registry moment can eat a test's entire startup timeout; e.g. in [this run](https://github.com/metalbear-co/mirrord/actions/runs/28863534782), `outgoing_disabled_udp` timed out waiting for its `http-echo` pod after 69 earlier tests had already pulled and cached the same image.

## Change

- New `tests/src/utils/images.rs` centralizes all 9 test app image references as consts, **pinned by digest** (the digests `:latest` resolved to at time of pinning — only `latest` tags are published for these images, so digests are the only immutable ref available).
- Every pod/deployment/statefulset/cronjob/job template in the E2E utils now sets **`imagePullPolicy: IfNotPresent`**.

Together these eliminate per-pod registry round-trips: each image is pulled at most once per (ephemeral) CI cluster and served from node cache afterwards. Digest pinning also makes runs reproducible and keeps `IfNotPresent` correct (an immutable ref can't go stale in cache). Bumping an image now means updating one digest in one file (instructions in the module docs).

## Verification

`cargo check --all-targets` and `cargo clippy` pass for every e2e feature combo (`job`, `ephemeral`, `cli`, `targetless`, `operator`); no `:latest` references remain under `tests/`.