### PR TITLE
Container host gateway detection

### DIFF
--- a/changelog.d/+container-gateway-detection.added.md
+++ b/changelog.d/+container-gateway-detection.added.md
@@ -1,0 +1,2 @@
+Added `container.host_gateway_detection`, enabled by default, which makes mirrord container detects
+and connects through host gateway.

--- a/mirrord-schema.json
+++ b/mirrord-schema.json
@@ -1054,6 +1054,14 @@
             "null"
           ]
         },
+        "host_gateway_detection": {
+          "title": "container.host_gateway_detection {#container-host_gateway_detection}",
+          "description": "Connects the internal proxy sidecar to the external proxy through the container\nruntime's host-gateway mechanism, instead of dialing a detected host IP.\n\nThe sidecar container is started with `--add-host mirrord-external-proxy:host-gateway`,\nand the internal proxy connects to that hostname. The external proxy also binds all\ninterfaces by default so it's reachable through the container runtime's gateway.\n\nWhen enabled, `container.override_host_ip` and the WSL-specific auto-adjustment of\n`external_proxy.host_ip` are no longer needed and are ignored.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "override_host_ip": {
           "title": "container.override_host_ip {#container-override_host_ip}",
           "description": "Allows to override the IP address for the internal proxy to use\nwhen connecting to the host machine from within the container.\n\n```json5\n{\n  \"container\": {\n    \"override_host_ip\": \"172.17.0.1\" // usual resolution of value from `host.docker.internal`\n  }\n}\n```\n\nThis should be useful if your host machine is exposed with a different IP address than the\none bound as host.\n\n- If you're running inside WSL, and encountering problems, try setting\n  `external_proxy.host_ip` to `0.0.0.0`, and this to the internal container runtime address\n  (for docker, this  would be what `host.docker.internal` resolved to, which by default is\n  `192.168.65.254`). You can find this ip by resolving it from inside a running container,\n  e.g. `docker run --rm -it {image-with-nslookup} nslookup host.docker.internal`",

--- a/mirrord/cli/src/container.rs
+++ b/mirrord/cli/src/container.rs
@@ -1,6 +1,11 @@
 #[cfg(not(target_os = "windows"))]
 use std::os::unix::process::ExitStatusExt;
-use std::{net::SocketAddr, ops::Not, path::PathBuf, process::Stdio};
+use std::{
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    ops::Not,
+    path::PathBuf,
+    process::Stdio,
+};
 
 use clap::ValueEnum;
 pub use command_display::CommandDisplay;
@@ -146,6 +151,23 @@ struct PreparedProxies {
     sidecar_container: MirrordCiManagedContainer,
 }
 
+/// Prepares [`LayerConfig`] for the sidecar's connection to the external proxy.
+///
+/// When `container.host_gateway_detection` is enabled, the sidecar connects to the external proxy
+/// through the container runtime's host-gateway mapping (added unconditionally in
+/// [`IntproxySidecar::create`]) instead of a detected host IP, so the WSL-specific
+/// `container.override_host_ip` auto-adjustment is skipped as it's no longer needed. The
+/// external proxy still needs to listen on all interfaces to be reachable through that mapping.
+fn adjust_container_config_for_networking(runtime: ContainerRuntime, config: &mut LayerConfig) {
+    if config.container.host_gateway_detection {
+        if config.external_proxy.host_ip.is_none() {
+            config.external_proxy.host_ip = Some(IpAddr::V4(Ipv4Addr::UNSPECIFIED));
+        }
+    } else {
+        adjust_container_config_for_wsl(runtime, config);
+    }
+}
+
 /// Makes the agent connection, spawns the native `mirrord-extproxy` process,
 /// and starts the `mirrord-intproxy` sidecar container.
 ///
@@ -266,7 +288,7 @@ pub(crate) async fn container_command<P: Progress>(
     let (mut config, mut analytics) =
         create_config_and_analytics(progress, cfg_context, watch, user_data).await?;
 
-    adjust_container_config_for_wsl(runtime_args.runtime, &mut config);
+    adjust_container_config_for_networking(runtime_args.runtime, &mut config);
 
     let PreparedProxies {
         runtime_command,
@@ -379,7 +401,7 @@ pub async fn container_ext_command<P: Progress>(
         .and_then(|value| ContainerRuntime::from_str(&value, true).ok())
         .unwrap_or(ContainerRuntime::Docker);
 
-    adjust_container_config_for_wsl(container_runtime, &mut config);
+    adjust_container_config_for_networking(container_runtime, &mut config);
 
     let PreparedProxies {
         runtime_command,

--- a/mirrord/cli/src/container/command_builder.rs
+++ b/mirrord/cli/src/container/command_builder.rs
@@ -77,6 +77,15 @@ impl RuntimeCommandBuilder {
         }
     }
 
+    pub fn add_host(&mut self, hostname: &str, ip_or_special_flag: &str) {
+        match self.runtime {
+            ContainerRuntime::Podman | ContainerRuntime::Docker | ContainerRuntime::Nerdctl => {
+                self.push_arg("--add-host");
+                self.push_arg(format!("{hostname}:{ip_or_special_flag}"));
+            }
+        }
+    }
+
     pub fn add_network<N>(&mut self, network: N)
     where
         N: Into<String>,

--- a/mirrord/cli/src/container/sidecar.rs
+++ b/mirrord/cli/src/container/sidecar.rs
@@ -3,7 +3,8 @@ use std::{fmt, io, net::SocketAddr, ops::Not, process::Stdio, time::Duration};
 use futures::{FutureExt, Stream};
 use mirrord_analytics::ExecutionKind;
 use mirrord_config::{
-    LayerConfig, config::ConfigError, internal_proxy::MIRRORD_INTPROXY_CONTAINER_MODE_ENV,
+    LayerConfig, config::ConfigError, container::MIRRORD_EXTERNAL_PROXY_HOSTNAME,
+    internal_proxy::MIRRORD_INTPROXY_CONTAINER_MODE_ENV,
 };
 use mirrord_intproxy::agent_conn::AgentConnectInfo;
 use mirrord_progress::MIRRORD_PROGRESS_ENV;
@@ -196,6 +197,8 @@ impl IntproxySidecar {
         tls: Option<&SecureChannelSetup>,
     ) -> Result<Self, IntproxySidecarError> {
         let mut sidecar_command = RuntimeCommandBuilder::new(container_runtime);
+
+        sidecar_command.add_host(MIRRORD_EXTERNAL_PROXY_HOSTNAME, "host-gateway");
 
         sidecar_command.add_env(LayerConfig::RESOLVED_CONFIG_ENV, &config.encode()?);
 

--- a/mirrord/config/src/container.rs
+++ b/mirrord/config/src/container.rs
@@ -44,6 +44,11 @@ static DEFAULT_CLI_IMAGE: &str = concat!(
     env!("CARGO_PKG_VERSION")
 );
 
+/// Hostname mapped to the container runtime's `host-gateway` address (via `--add-host`) in the
+/// intproxy sidecar container, used by the internal proxy to reach the external proxy when
+/// [`ContainerConfig::host_gateway_detection`] is enabled.
+pub const MIRRORD_EXTERNAL_PROXY_HOSTNAME: &str = "mirrord-external-proxy";
+
 /// Unstable: `mirrord container` command specific config.
 #[derive(MirrordConfig, Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[config(map_to = "ContainerFileConfig", derive = "JsonSchema")]
@@ -106,6 +111,20 @@ pub struct ContainerConfig {
     ///   `192.168.65.254`). You can find this ip by resolving it from inside a running container,
     ///   e.g. `docker run --rm -it {image-with-nslookup} nslookup host.docker.internal`
     pub override_host_ip: Option<IpAddr>,
+
+    /// ### container.host_gateway_detection {#container-host_gateway_detection}
+    ///
+    /// Connects the internal proxy sidecar to the external proxy through the container
+    /// runtime's host-gateway mechanism, instead of dialing a detected host IP.
+    ///
+    /// The sidecar container is started with `--add-host mirrord-external-proxy:host-gateway`,
+    /// and the internal proxy connects to that hostname. The external proxy also binds all
+    /// interfaces by default so it's reachable through the container runtime's gateway.
+    ///
+    /// When enabled, `container.override_host_ip` and the WSL-specific auto-adjustment of
+    /// `external_proxy.host_ip` are no longer needed and are ignored.
+    #[config(default = true)]
+    pub host_gateway_detection: bool,
 
     /// ### container.cli_tls_path {#container-cli_tls_path}
     ///

--- a/mirrord/intproxy/src/agent_conn.rs
+++ b/mirrord/intproxy/src/agent_conn.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use mirrord_analytics::{NullReporter, Reporter};
-use mirrord_config::LayerConfig;
+use mirrord_config::{LayerConfig, container::MIRRORD_EXTERNAL_PROXY_HOSTNAME};
 use mirrord_kube::{api::kubernetes::AgentKubernetesConnectInfo, error::KubeApiError, kube};
 use mirrord_operator::{
     client::{
@@ -199,11 +199,23 @@ impl AgentConnection {
                     .take(3);
 
                 let conn = Retry::start(retry_strategy, || async {
-                    let socket = TcpSocket::new_v4()?;
-                    socket.set_keepalive(true)?;
-                    socket.set_nodelay(true)?;
-
-                    let stream = socket.connect(proxy_addr).await?;
+                    let stream = if config.container.host_gateway_detection {
+                        // The sidecar container is always started with
+                        // `--add-host mirrord-external-proxy:host-gateway`, so this resolves
+                        // through `/etc/hosts` rather than a detected host IP.
+                        let stream = TcpStream::connect((
+                            MIRRORD_EXTERNAL_PROXY_HOSTNAME,
+                            proxy_addr.port(),
+                        ))
+                        .await?;
+                        stream.set_nodelay(true)?;
+                        stream
+                    } else {
+                        let socket = TcpSocket::new_v4()?;
+                        socket.set_keepalive(true)?;
+                        socket.set_nodelay(true)?;
+                        socket.connect(proxy_addr).await?
+                    };
 
                     let conn: Connection<Client> = match &tls_pem {
                         Some(tls_pem) => {


### PR DESCRIPTION
<!-- Thank you for contributing to mirrord! -->
<!-- Please use the checklist below as a guide for docs, tests and admin tasks for your PR -->
<!-- Feel free to ~strikethrough~ any items that you don't think apply -->

Added container host gateway auto detection for `mirrord container`. By using the container argument `--add-host mirrord-external-proxy:host-gateway` for the intproxy sidecar, intproxy is able to resolve `mirrord-external-proxy` to the container runtime's host gateway IP address.
When connecting to the external proxy, which has the actual agent connection running on the host machine, intproxy sidecar no longer needs to rely on the external proxy IP address. Instead, it connects to `mirrord-external-proxy` hostname directly. To make sure the resolved IP address is handled by external proxy, when this flag is set to true, external proxy binds UNSPECIFIED (all interfaces).

The feature flag `container.host_gateway_detection` is set to `true` by default, because `--add-host <myhostname>:host-gateway` is a well documented way to allow containers to connect host machine using custom DNS.

* podman: https://docs.podman.io/en/latest/markdown/podman-run.1.html#add-host-hostname-hostname-ip
* nerdctl: https://github.com/containerd/nerdctl/blob/main/docs/command-reference.md?plain=1#L203
* docker: https://docs.docker.com/compose/how-tos/networking/#custom-dns-with-extra_hosts

Worst case, the feature can be disabled by setting `container.host_gateway_detection` to `false` :D

### Quality Checklist:

- [x] I have documented new code sufficiently
- [x] I have checked and updated the relevant existing docs in code, including removing outdated material
- [x] I have written user-facing website docs for new features, or opened a (sub)issue to do so
- [x] I have checked and updated existing website docs for changed features
- [x] I have tested this change and know it succeeds and fails as expected
- [ ] I have written unit tests or purposefully omitted them
- [ ] I have written e2e tests or purposefully omitted them
- [x] I have explained what this PR introduces and why, and linked to relevant context (e.g. linear issues, related PRs,
  documentation)
- [x] I have introduced a short, clear and well-formatted changelog entry

<!-- need help with the changelog? see ../CONTRIBUTING.md#submitting-a-pull-request -->
<!-- Add more details of your changes below if needed -->