### PR TITLE
Show transient operator status 503 as reconnecting in session monitor

### DIFF
--- a/changelog.d/+ui-operator-reconnect.fixed.md
+++ b/changelog.d/+ui-operator-reconnect.fixed.md
@@ -1,0 +1,3 @@
+The `mirrord ui` session monitor no longer shows an operator error when the operator's status
+service is momentarily unavailable (e.g. during a pod restart). It now keeps the last-known team
+sessions on screen and displays a "Reconnecting to operator…" hint instead.

--- a/packages/monitor/src/components/SessionSidebar.tsx
+++ b/packages/monitor/src/components/SessionSidebar.tsx
@@ -139,7 +139,12 @@ export default function SessionSidebar({
   }
 
   const teamUnavailable = watchStatus?.status === 'unavailable'
-  const teamError = watchStatus?.status === 'error'
+  const errorMessage = watchStatus?.status === 'error' ? watchStatus.message : ''
+  // A transient 503 from the operator's status APIService (typically the pod
+  // restarting) shouldn't read as a hard failure: keep the last-known sessions
+  // on screen and show a soft "reconnecting" hint instead of the error box.
+  const teamReconnecting = /503|service unavailable/i.test(errorMessage)
+  const teamError = watchStatus?.status === 'error' && !teamReconnecting
   const teamConnecting = watchStatus?.status === 'not_started'
 
   return (
@@ -270,13 +275,21 @@ export default function SessionSidebar({
             Connecting to operator…
           </div>
         ) : (
-          <OperatorList
-            sessions={operatorSessions}
-            selectedId={selectedOperatorId}
-            onSelect={onSelectOperator}
-            joinedKey={joinedKey}
-            query={query}
-          />
+          <>
+            {teamReconnecting && (
+              <div className="text-meta text-muted-foreground px-1 -mb-1 flex items-center gap-1.5">
+                <Loader size="sm" />
+                <span>Reconnecting to operator…</span>
+              </div>
+            )}
+            <OperatorList
+              sessions={operatorSessions}
+              selectedId={selectedOperatorId}
+              onSelect={onSelectOperator}
+              joinedKey={joinedKey}
+              query={query}
+            />
+          </>
         )}
       </div>
 


### PR DESCRIPTION
The `mirrord ui` session monitor polls the operator's status APIService every 5s. When that service is briefly unreachable (typically the operator pod restarting) the poll returns `503 service unavailable`, which the Team panel rendered as a red "Operator error" box with the raw kube error string.

Treat that transient case as a soft reconnecting state instead: the last-known team sessions stay on screen and a muted "Reconnecting to operator…" hint is shown, rather than an alarming error.

Frontend-only change: the transient case is detected from the existing error message; genuine (non-503) operator errors still surface as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)