### PR TITLE
fix(ui): wizard kube context selection and target-listing fixes

### DIFF
--- a/mirrord/cli/src/ui/wizard.rs
+++ b/mirrord/cli/src/ui/wizard.rs
@@ -119,12 +119,17 @@ fn detected_ports(containers: &[Container]) -> Vec<u16> {
 #[derive(Debug, Deserialize)]
 struct Params {
     target_type: Option<TargetType>,
+    /// Kube context to query. When absent, the kubeconfig's current context is used. The old
+    /// standalone `mirrord wizard` took this as a CLI flag; the shared server outlives any single
+    /// invocation, so the frontend selects it per request instead.
+    context: Option<String>,
 }
 
 /// Returns cluster details that are shown while the user selects a target. Also flags the user as a
 /// returning wizard user, since reaching this endpoint means they started the config flow.
 #[tracing::instrument(level = tracing::Level::TRACE, skip_all, ret)]
 async fn cluster_details(
+    Query(query_params): Query<Params>,
     State(state): State<AppState>,
 ) -> WizardResult<axum::Json<ClusterDetails>> {
     {
@@ -135,7 +140,7 @@ async fn cluster_details(
         }
     }
 
-    let client = client_for_context(None).await?;
+    let client = client_for_context(query_params.context.as_deref()).await?;
     let seeker = KubeResourceSeeker {
         client: &client,
         namespace: "default",
@@ -164,7 +169,7 @@ async fn list_targets(
     Query(query_params): Query<Params>,
     Path(namespace): Path<String>,
 ) -> WizardResult<axum::Json<Vec<TargetInfo>>> {
-    let client = client_for_context(None).await?;
+    let client = client_for_context(query_params.context.as_deref()).await?;
     let seeker = KubeResourceSeeker {
         client: &client,
         namespace: &namespace,
@@ -346,11 +351,11 @@ impl IntoTargetInfo for Rollout {
         _seeker: &KubeResourceSeeker<'_>,
         client: &Client,
     ) -> Result<Option<TargetInfo>, ApiError> {
-        fn into_info_option(job: &Rollout) -> Option<TargetInfo> {
-            let target_name = job.name()?.to_string();
-            let target_namespace = job.namespace()?.to_string();
+        fn into_info_option(rollout: &Rollout) -> Option<TargetInfo> {
+            let target_name = rollout.name()?.to_string();
+            let target_namespace = rollout.namespace()?.to_string();
             Some(TargetInfo::new(
-                TargetType::Job,
+                TargetType::Rollout,
                 target_name,
                 target_namespace,
                 vec![],
@@ -470,23 +475,28 @@ impl IntoTargetInfo for Service {
             ))
         }
         let result = into_info_option(&self);
-        let selector: Vec<_> = self
+        // A service selects pods matching ALL of its selector labels, so they go into one
+        // comma-joined label selector; querying per label would also pick up unrelated pods
+        // that share just one of the labels.
+        let label_selector = self
             .spec
             .and_then(|spec| spec.selector)
-            .map(|tree| tree.into_iter().collect())
+            .map(|tree| {
+                tree.into_iter()
+                    .map(|(key, value)| format!("{key}={value}"))
+                    .join(",")
+            })
             .unwrap_or_default();
 
-        let mut infos: Vec<TargetInfo> = vec![];
-        for (key, value) in selector {
-            let label_selector = format!("{key}={value}");
-            infos.extend(
-                seeker
-                    .list_all_namespaced::<Pod>(None, Some(&label_selector))
-                    .filter_map(|pod_res| into_info(pod_res, seeker, client))
-                    .collect::<Vec<_>>()
-                    .await,
-            );
-        }
+        let infos: Vec<TargetInfo> = if label_selector.is_empty() {
+            vec![]
+        } else {
+            seeker
+                .list_all_namespaced::<Pod>(None, Some(&label_selector))
+                .filter_map(|pod_res| into_info(pod_res, seeker, client))
+                .collect()
+                .await
+        };
 
         let (detected_ports, containers): (Vec<u16>, Vec<String>) = infos.into_iter().fold(
             (Vec::new(), Vec::new()),

--- a/packages/wizard/src/components/steps/TargetTab.tsx
+++ b/packages/wizard/src/components/steps/TargetTab.tsx
@@ -32,12 +32,20 @@ interface ClusterDetails {
   target_types: string[]
 }
 
+interface ContextsResponse {
+  contexts: string[]
+  currentContext: string | null
+}
+
 const TargetTab = ({
   setTargetPorts,
 }: {
   setTargetPorts: (ports: number[]) => void
 }) => {
   const { config, setConfig } = useContext(ConfigDataContext)!
+  const [selectedContext, setSelectedContext] = useState<string | undefined>(
+    undefined,
+  )
   const [namespace, setNamespace] = useState<string>('default')
   const [targetType, setTargetType] = useState<string>('all')
   const [targetSearchText, setTargetSearchText] = useState<string>('')
@@ -77,13 +85,34 @@ const TargetTab = ({
     }
   }, [targetDropdownOpen, containerDropdownOpen])
 
+  const contextsQuery = useQuery<ContextsResponse>({
+    staleTime: 30 * 1000,
+    queryKey: ['kubeContexts'],
+    queryFn: () =>
+      fetch(window.location.origin + ALL_API_ROUTES.contexts).then(
+        async (res) =>
+          res.ok ? await res.json() : { contexts: [], currentContext: null },
+      ),
+  })
+  const availableContexts = contextsQuery.data?.contexts ?? []
+  // Until the user picks a context, follow the kubeconfig's current one (the server also falls
+  // back to it when the param is absent, so the picker and the queries stay in agreement).
+  const context =
+    selectedContext ?? contextsQuery.data?.currentContext ?? undefined
+
+  const handleContextChange = (value: string) => {
+    setSelectedContext(value)
+    setNamespace('default')
+  }
+
   const clusterDetailsQuery = useQuery<ClusterDetails>({
     staleTime: 30 * 1000,
-    queryKey: ['clusterDetails'],
+    queryKey: ['clusterDetails', context],
     queryFn: () =>
-      fetch(window.location.origin + ALL_API_ROUTES.clusterDetails).then(
-        async (res) =>
-          res.ok ? await res.json() : { namespaces: [], target_types: [] },
+      fetch(
+        window.location.origin + ALL_API_ROUTES.clusterDetails(context),
+      ).then(async (res) =>
+        res.ok ? await res.json() : { namespaces: [], target_types: [] },
       ),
   })
 
@@ -98,13 +127,14 @@ const TargetTab = ({
       : (clusterDetailsQuery.data?.target_types ?? [])
 
   const targetsQuery = useQuery<Target[]>({
-    queryKey: ['targetDetails', namespace, targetType],
+    queryKey: ['targetDetails', context, namespace, targetType],
     queryFn: () =>
       fetch(
         window.location.origin +
           ALL_API_ROUTES.targets(
             namespace,
             targetType === 'all' ? undefined : targetType,
+            context,
           ),
       ).then(async (res) => (res.ok ? await res.json() : [])),
     enabled: !!namespace,
@@ -176,6 +206,25 @@ const TargetTab = ({
         </div>
       </div>
       <div className="space-y-5">
+        {availableContexts.length > 0 && (
+          <div className="space-y-2">
+            <Label htmlFor="kube-context" className="text-sm font-medium">
+              Kube Context
+            </Label>
+            <Select value={context} onValueChange={handleContextChange}>
+              <SelectTrigger className="h-10">
+                <SelectValue placeholder="Current context" />
+              </SelectTrigger>
+              <SelectContent className="bg-card border border-border">
+                {availableContexts.map((ctx) => (
+                  <SelectItem key={ctx} value={ctx}>
+                    {ctx}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        )}
         <div className="grid grid-cols-2 gap-4">
           <div className="space-y-2">
             <Label htmlFor="namespace" className="text-sm font-medium">

--- a/packages/wizard/src/lib/routes.ts
+++ b/packages/wizard/src/lib/routes.ts
@@ -3,12 +3,21 @@
 
 const ALL_API_ROUTES = {
   isReturning: '/api/v1/is-returning',
-  clusterDetails: '/api/v1/cluster-details',
-  targets: (namespace: string, targetType?: string) =>
-    '/api/v1/namespace/' +
-    namespace +
-    '/targets' +
-    (targetType ? '?target_type=' + targetType : ''),
+  // Served by the shared `mirrord ui` server for the monitor; the wizard reuses it for its
+  // kube context picker.
+  contexts: '/api/contexts',
+  clusterDetails: (context?: string) =>
+    '/api/v1/cluster-details' +
+    (context ? '?context=' + encodeURIComponent(context) : ''),
+  targets: (namespace: string, targetType?: string, context?: string) => {
+    const params = new URLSearchParams()
+    if (targetType) params.set('target_type', targetType)
+    if (context) params.set('context', context)
+    const query = params.toString()
+    return (
+      '/api/v1/namespace/' + namespace + '/targets' + (query ? '?' + query : '')
+    )
+  },
 }
 
 export default ALL_API_ROUTES


### PR DESCRIPTION
## Summary

Fixes into #4503.

- Restores kube context selection for the config wizard. The merge dropped the standalone wizard's `--context`, `--kubeconfig` and `--accept-invalid-certificates` flags, which pinned the wizard to the kubeconfig's current context (the shared server outlives any single CLI invocation, so flags can't come back). Instead, the wizard endpoints now accept an optional `?context=` query param and the target step gains a Kube Context picker backed by the existing `/api/contexts` endpoint, pre-selecting the kubeconfig's current context. The picker is hidden when the kubeconfig has no contexts.
- Fixes Rollout targets being listed as `job/<name>` (a `TargetType::Job` copy-paste in the Rollout impl), which produced wizard configs that do not resolve.
- Fixes Service port detection querying pods once per selector label (a union) instead of one comma-joined label selector (an intersection), which picked up containers and ports from unrelated pods sharing a single label.

The two target-listing bugs predate #4503 (they moved over from the standalone wizard); fixing them here while the code is fresh.

## Test plan

- `cargo check -p mirrord`, `cargo clippy -p mirrord -- --deny warnings` and `cargo fmt` clean; wizard vitest suite passes (131 tests) and `tsc` typecheck clean.
- Verified live against a kubeconfig with 7 contexts: `/api/v1/cluster-details?context=<ctx>` returns that cluster's namespaces while the no-param call still uses the current context; in the browser, the picker pre-selects the current context and switching it repopulates the namespace and target dropdowns from the selected cluster.
- Verified `service` targets now report only their own pods' containers and detected ports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)