### PR TITLE
chaos: Allow the latency direction to be defined in rule effect

### DIFF
--- a/changelog.d/+chaos-latency-direction.changed.md
+++ b/changelog.d/+chaos-latency-direction.changed.md
@@ -1,0 +1,2 @@
+Requests for chaos rules with a latency effect now specify `"read_ms"` and `"write_ms"` instead of
+`"delay_ms"`. They are applied in the read and write directions respectively and cannot both be 0.

--- a/changelog.d/+chaos-routes-moved.changed.md
+++ b/changelog.d/+chaos-routes-moved.changed.md
@@ -1,0 +1,1 @@
+API routes for managing chaos rules are now under `/api/chaos/rules` instead of `/chaos/rules`.

--- a/mirrord/cli/src/ui/chaos.rs
+++ b/mirrord/cli/src/ui/chaos.rs
@@ -15,7 +15,7 @@ mod error;
 /// Alias for the return type of the chaos route handlers.
 type ChaosResult<T> = Result<T, ChaosApiError>;
 
-/// Routes for `/chaos/rules/{...}`, authenticated like every other API route via the
+/// Routes for `/api/chaos/rules/{...}`, authenticated like every other API route via the
 /// `mirrord_token` cookie or the `x-auth-token` header (see `server::token_auth`).
 ///
 /// These routes are sort of a proxy between user requests and the intproxy session monitor server

--- a/mirrord/cli/src/ui/chaos/api.rs
+++ b/mirrord/cli/src/ui/chaos/api.rs
@@ -62,8 +62,8 @@ pub(super) async fn get_session_client_middleware(
     }
 }
 
-/// - `POST /chaos/rules/{session_id}`: forwards the [`ChaosRule`] creation to the intproxy session
-///   monitor, and returns the `ChaosRule` that was created;
+/// - `POST /api/chaos/rules/{session_id}`: forwards the [`ChaosRule`] creation to the intproxy
+///   session monitor, and returns the `ChaosRule` that was created;
 #[tracing::instrument(level = Level::DEBUG, ret, err)]
 pub(super) async fn post_create_rule(
     Extension(client): Extension<SessionClient>,
@@ -80,7 +80,7 @@ pub(super) async fn post_create_rule(
     Ok(Json(created_rule))
 }
 
-/// - `DELETE /chaos/rules/{session_id}`: forwards the deletion of every [`ChaosRule`] for this
+/// - `DELETE /api/chaos/rules/{session_id}`: forwards the deletion of every [`ChaosRule`] for this
 ///   `session_id` to the session monitor.
 #[tracing::instrument(level = Level::DEBUG, ret, err)]
 pub(super) async fn delete_clear_session_rules(
@@ -94,7 +94,7 @@ pub(super) async fn delete_clear_session_rules(
     Ok(())
 }
 
-/// - `GET /chaos/rules/{session_id}`: gets every [`ChaosRule`] of this `session_id` from the
+/// - `GET /api/chaos/rules/{session_id}`: gets every [`ChaosRule`] of this `session_id` from the
 ///   session monitor.
 #[tracing::instrument(level = Level::DEBUG, ret, err)]
 pub(super) async fn get_list_active_rules_for_session(
@@ -110,8 +110,8 @@ pub(super) async fn get_list_active_rules_for_session(
     Ok(Json(response))
 }
 
-/// - `PUT /chaos/rules/{session_id}/{rule_id}`: forwards the [`ChaosRule`] update to the session
-///   monitor for this `session_id` and `rule_id`.
+/// - `PUT /api/chaos/rules/{session_id}/{rule_id}`: forwards the [`ChaosRule`] update to the
+///   session monitor for this `session_id` and `rule_id`.
 #[tracing::instrument(level = Level::DEBUG, ret, err)]
 pub(super) async fn put_update_rule(
     Path(RulePath { rule_id }): Path<RulePath>,
@@ -129,8 +129,8 @@ pub(super) async fn put_update_rule(
     Ok(Json(old_rule))
 }
 
-/// - `DELETE /chaos/rules/{session_id}/{rule_id}`: forwards the deletion of a [`ChaosRule`] with
-///   `id == rule_id` to the session monitor. [`ChaosRule`] with `id == rule_id`.
+/// - `DELETE /api/chaos/rules/{session_id}/{rule_id}`: forwards the deletion of a [`ChaosRule`]
+///   with `id == rule_id` to the session monitor. [`ChaosRule`] with `id == rule_id`.
 #[tracing::instrument(level = Level::DEBUG, ret, err)]
 pub(super) async fn delete_rule(
     Path(RulePath { rule_id }): Path<RulePath>,
@@ -146,8 +146,8 @@ pub(super) async fn delete_rule(
     Ok(Json(deleted_rule))
 }
 
-/// - `GET /chaos/rules/{session_id}/{rule_id}`: gets the [`ChaosRule`] with `id == rule_id` from
-///   the session monitor.
+/// - `GET /api/chaos/rules/{session_id}/{rule_id}`: gets the [`ChaosRule`] with `id == rule_id`
+///   from the session monitor.
 #[tracing::instrument(level = Level::DEBUG, ret, err)]
 pub(super) async fn get_rule(
     Path(RulePath { rule_id }): Path<RulePath>,

--- a/mirrord/cli/src/ui/server.rs
+++ b/mirrord/cli/src/ui/server.rs
@@ -996,10 +996,10 @@ pub(crate) fn build_router(state: AppState) -> Router {
         .route("/contexts", get(list_contexts))
         .route("/namespaces", get(list_namespaces))
         .route("/me", get(current_user))
-        .route("/token", get(auth_token));
+        .route("/token", get(auth_token))
+        .nest("/chaos/rules", chaos_router(state.clone()));
 
     let authenticated_routes = Router::new()
-        .nest("/chaos/rules", chaos_router(state.clone()))
         .nest("/api/v1", wizard_router())
         .nest("/api", api_routes)
         .route("/ws", get(ws_handler))

--- a/mirrord/intproxy/src/proxies/outgoing.rs
+++ b/mirrord/intproxy/src/proxies/outgoing.rs
@@ -349,7 +349,7 @@ impl OutgoingProxy {
         }
 
         let delay = self
-            .chaos_latency_for_connection(id)
+            .chaos_read_latency_for_connection(id)
             .unwrap_or_else(|| Duration::from_millis(self.receive_delay_ms));
         if self
             .queue_interceptor_command(id, InterceptorCommand::Data(bytes.0), delay)
@@ -880,7 +880,7 @@ impl BackgroundTask for OutgoingProxy {
                         }
 
                         let delay = self
-                            .chaos_latency_for_connection(id)
+                            .chaos_write_latency_for_connection(id)
                             .unwrap_or_else(|| Duration::from_millis(self.transmit_delay_ms));
                         let msg = id.protocol.wrap_agent_write(id.connection_id, bytes);
                         self.queue_agent_message(id, msg, delay, Some(permit)).await;

--- a/mirrord/intproxy/src/proxies/outgoing/chaos.rs
+++ b/mirrord/intproxy/src/proxies/outgoing/chaos.rs
@@ -22,6 +22,13 @@ use crate::{
     },
 };
 
+/// Helper type for distinguishing between `ChaosEffectLatency.read` and `write` directions.
+#[derive(Debug, Clone, Copy)]
+enum ChaosLatencyDirection {
+    Read,
+    Write,
+}
+
 impl OutgoingProxy {
     /// Checks if the `ChaosRule` (stored in `self.chaos_rx`) applies to either of
     /// `remote_address`, `protocol`, or `hostname`.
@@ -140,7 +147,7 @@ impl OutgoingProxy {
                 ChaosSelector::Tcp {
                     effect: TcpChaosEffect::Latency(effect),
                     ..
-                } => Some(effect.latency_duration()),
+                } => effect.connection_latency_duration(),
                 _ => None,
             },
         );
@@ -174,15 +181,34 @@ impl OutgoingProxy {
         }
     }
 
-    /// Latency to apply to an intercepted connection's data messages, in either direction
-    /// (Layer → Agent writes and Agent → Layer reads), if a `ChaosRule` with a latency effect
-    /// matches this connection.
-    ///
-    /// Exists mainly to help with the [`ChaosSelector`] matching.
-    #[tracing::instrument(level = Level::DEBUG, skip(self), ret)]
-    pub(super) fn chaos_latency_for_connection(
+    /// Latency to apply to an intercepted connection's data messages, if a `ChaosRule` with a
+    /// *read* latency effect matches this connection.
+    pub(super) fn chaos_read_latency_for_connection(
         &self,
         interceptor_id: InterceptorId,
+    ) -> Option<Duration> {
+        self.chaos_latency_for_connection(interceptor_id, ChaosLatencyDirection::Read)
+    }
+
+    /// Latency to apply to an intercepted connection's data messages, if a `ChaosRule` with a
+    /// *write* latency effect matches this connection.
+    pub(super) fn chaos_write_latency_for_connection(
+        &self,
+        interceptor_id: InterceptorId,
+    ) -> Option<Duration> {
+        self.chaos_latency_for_connection(interceptor_id, ChaosLatencyDirection::Write)
+    }
+
+    /// Call [`chaos_read_latency_for_connection()`] or [`chaos_write_latency_for_connection()`]
+    /// instead.
+    ///
+    /// Exists mainly to help with the [`ChaosSelector`] matching, and also distinguishes between
+    /// read and write directions.
+    #[tracing::instrument(level = Level::DEBUG, skip(self), ret)]
+    fn chaos_latency_for_connection(
+        &self,
+        interceptor_id: InterceptorId,
+        direction: ChaosLatencyDirection,
     ) -> Option<Duration> {
         let connection_info = self.connection_info(interceptor_id)?;
 
@@ -194,7 +220,10 @@ impl OutgoingProxy {
                 ChaosSelector::Tcp {
                     effect: TcpChaosEffect::Latency(effect),
                     ..
-                } => Some(effect.latency_duration()),
+                } => match direction {
+                    ChaosLatencyDirection::Read => effect.read_latency_duration(),
+                    ChaosLatencyDirection::Write => effect.write_latency_duration(),
+                },
                 _ => None,
             },
         )

--- a/mirrord/intproxy/src/proxies/outgoing/chaos.rs
+++ b/mirrord/intproxy/src/proxies/outgoing/chaos.rs
@@ -199,7 +199,7 @@ impl OutgoingProxy {
         self.chaos_latency_for_connection(interceptor_id, ChaosLatencyDirection::Write)
     }
 
-    /// Call [`chaos_read_latency_for_connection()`] or [`chaos_write_latency_for_connection()`]
+    /// Call `chaos_read_latency_for_connection()` or `chaos_write_latency_for_connection()`
     /// instead.
     ///
     /// Exists mainly to help with the [`ChaosSelector`] matching, and also distinguishes between

--- a/mirrord/intproxy/src/session_monitor/chaos.rs
+++ b/mirrord/intproxy/src/session_monitor/chaos.rs
@@ -33,7 +33,7 @@ use rules::*;
 
 use crate::session_monitor::{api::AppState, chaos::api::*};
 
-/// Routes for `/chaos/rules`.
+/// Routes for `/api/chaos/rules`.
 ///
 /// - `POST /`: creates a new rule **unconditionally** for the session;
 /// - `DELETE /`: deletes every rule of the session;

--- a/mirrord/intproxy/src/session_monitor/chaos/analytics.rs
+++ b/mirrord/intproxy/src/session_monitor/chaos/analytics.rs
@@ -183,8 +183,9 @@ mod test {
             percentage: Percentage::from(100),
             effect: TcpChaosEffect::Latency(ChaosEffectLatency::new(
                 Duration::from_millis(200),
-                Duration::from_millis(50),)
-            ),
+                Duration::from_millis(200),
+                Duration::from_millis(50),
+            )),
         },
         priority: 0,
         hit_count: Arc::new(AtomicU32::from(33)),

--- a/mirrord/intproxy/src/session_monitor/chaos/analytics.rs
+++ b/mirrord/intproxy/src/session_monitor/chaos/analytics.rs
@@ -185,7 +185,7 @@ mod test {
                 Duration::from_millis(200),
                 Duration::from_millis(200),
                 Duration::from_millis(50),
-            )),
+            ).expect("read and write defined")),
         },
         priority: 0,
         hit_count: Arc::new(AtomicU32::from(33)),

--- a/mirrord/intproxy/src/session_monitor/chaos/rules.rs
+++ b/mirrord/intproxy/src/session_monitor/chaos/rules.rs
@@ -197,12 +197,22 @@ impl TryFrom<ChaosEffectRequest> for TcpChaosEffect {
     fn try_from(value: ChaosEffectRequest) -> Result<Self, Self::Error> {
         match value {
             ChaosEffectRequest::Latency {
-                delay_ms,
+                read_ms,
+                write_ms,
                 jitter_ms,
-            } => Ok(Self::Latency(ChaosEffectLatency {
-                delay: Duration::from_millis(delay_ms),
-                jitter: jitter_ms.map(Duration::from_millis).unwrap_or_default(),
-            })),
+            } => {
+                if read_ms.is_none() && write_ms.is_none() {
+                    return Err(ChaosRuleError::Invalid(anyhow!(
+                        "either 'effect.latency.read_ms' or 'effect.latency.write_ms' must be specified"
+                    )));
+                }
+
+                Ok(Self::Latency(ChaosEffectLatency {
+                    read: read_ms.map(Duration::from_millis).unwrap_or_default(),
+                    write: write_ms.map(Duration::from_millis).unwrap_or_default(),
+                    jitter: jitter_ms.map(Duration::from_millis).unwrap_or_default(),
+                }))
+            }
 
             ChaosEffectRequest::ConnectionError {
                 error_type,
@@ -358,7 +368,8 @@ pub struct ChaosRuleRequest {
 #[repr(u8)]
 pub enum ChaosEffectRequest {
     Latency {
-        delay_ms: u64,
+        read_ms: Option<u64>,
+        write_ms: Option<u64>,
         jitter_ms: Option<u64>,
     } = 0,
     ConnectionError {
@@ -498,27 +509,56 @@ pub enum FsChaosEffect {
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Hash)]
 pub struct ChaosEffectLatency {
     #[serde_as(as = "serde_with::DurationMilliSeconds<u64>")]
-    #[serde(rename = "delay_ms")]
-    delay: Duration,
+    #[serde(rename = "read_ms")]
+    #[serde(default, skip_serializing_if = "Duration::is_zero")]
+    read: Duration,
+    #[serde_as(as = "serde_with::DurationMilliSeconds<u64>")]
+    #[serde(rename = "write_ms")]
+    #[serde(default, skip_serializing_if = "Duration::is_zero")]
+    write: Duration,
     #[serde_as(as = "serde_with::DurationMilliSeconds<u64>")]
     #[serde(rename = "jitter_ms")]
+    #[serde(default, skip_serializing_if = "Duration::is_zero")]
     jitter: Duration,
 }
 
 impl ChaosEffectLatency {
-    pub fn new(delay: Duration, jitter: Duration) -> Self {
-        Self { delay, jitter }
+    pub fn new(read: Duration, write: Duration, jitter: Duration) -> Self {
+        Self {
+            read,
+            write,
+            jitter,
+        }
     }
-    pub fn latency_duration(&self) -> Duration {
-        if self.jitter.is_zero() {
-            return self.delay;
+
+    pub fn read_latency_duration(&self) -> Option<Duration> {
+        self.latency_duration(self.read)
+    }
+
+    pub fn write_latency_duration(&self) -> Option<Duration> {
+        self.latency_duration(self.write)
+    }
+
+    pub fn connection_latency_duration(&self) -> Option<Duration> {
+        self.latency_duration(self.write + self.read)
+    }
+
+    fn latency_duration(&self, latency: Duration) -> Option<Duration> {
+        if latency.is_zero() {
+            return None;
         }
 
-        self.delay
-            + self
-                .jitter
-                .div_f32(100.)
-                .saturating_mul(random_range(0..=100))
+        if self.jitter.is_zero() {
+            return Some(latency);
+        }
+
+        Some(
+            latency
+                + self
+                    .jitter
+                    .div_f32(100.)
+                    .saturating_mul(random_range(0..=100)),
+        )
     }
 }
 
@@ -664,7 +704,8 @@ mod test {
       "name": "rust-connect-slow",
       "effect": {
         "latency": {
-          "delay_ms": 200,
+          "read_ms": 200,
+          "write_ms": 300,
           "jitter_ms": 50,
         }
       },
@@ -675,7 +716,8 @@ mod test {
         name: Some("rust-connect-slow".to_owned()),
         priority: None,
         effect: ChaosEffectRequest::Latency {
-            delay_ms: 200,
+            read_ms: Some(200),
+            write_ms: Some(300),
             jitter_ms: Some(50)
         },
         selector: ChaosSelectorRequest {
@@ -689,7 +731,8 @@ mod test {
             upstream: AddressFilter::Name("rust-lang.org".to_owned(), 0),
             percentage: Percentage::from(100),
             effect: TcpChaosEffect::Latency(ChaosEffectLatency {
-                delay: Duration::from_millis(200),
+                read: Duration::from_millis(200),
+                write: Duration::from_millis(300),
                 jitter: Duration::from_millis(50),
             }),
         },
@@ -700,7 +743,7 @@ mod test {
       "name": "file-connect-slow",
       "effect": {
         "latency": {
-          "delay_ms": 250,
+          "read_ms": 250,
         }
       },
       "selector": {
@@ -710,7 +753,8 @@ mod test {
         name: Some("file-connect-slow".to_owned()),
         priority: None,
         effect: ChaosEffectRequest::Latency {
-            delay_ms: 250,
+            read_ms: Some(250),
+            write_ms: None,
             jitter_ms: None
         },
         selector: ChaosSelectorRequest {
@@ -724,7 +768,8 @@ mod test {
             file_path: vec![".+\\.json".to_owned()],
             percentage: Percentage::from(100),
             effect: FsChaosEffect::Latency(ChaosEffectLatency {
-                delay: Duration::from_millis(250),
+                read: Duration::from_millis(250),
+                write: Duration::default(),
                 jitter: Duration::default(),
             }),
         },
@@ -735,7 +780,7 @@ mod test {
       "name": "http-connect-slow",
       "effect": {
         "latency": {
-          "delay_ms": 200,
+          "write_ms": 200,
           "jitter_ms": 50,
         }
       },
@@ -747,7 +792,8 @@ mod test {
         name: Some("http-connect-slow".to_owned()),
         priority: None,
         effect: ChaosEffectRequest::Latency {
-            delay_ms: 200,
+            read_ms: None,
+            write_ms: Some(200),
             jitter_ms: Some(50)
         },
         selector: ChaosSelectorRequest {
@@ -763,7 +809,8 @@ mod test {
             filter: Some(HttpFilter::Path(Filter::new("^/api/".to_owned()).unwrap())),
             percentage: Percentage::from(100),
             effect: HttpChaosEffect::Latency(ChaosEffectLatency {
-                delay: Duration::from_millis(200),
+                read: Duration::default(),
+                write: Duration::from_millis(200),
                 jitter: Duration::from_millis(50),
             }),
         },
@@ -830,7 +877,7 @@ mod test {
     #[case::invalid_selector_too_many_fields(json!({
       "effect": {
         "latency": {
-          "delay_ms": 200,
+          "read_ms": 200,
           "jitter_ms": 50,
         }
       },
@@ -843,7 +890,8 @@ mod test {
         name: None,
         priority: None,
         effect: ChaosEffectRequest::Latency {
-            delay_ms: 200,
+            read_ms: Some(200),
+            write_ms: None,
             jitter_ms: Some(50)
         },
         selector: ChaosSelectorRequest {
@@ -856,7 +904,7 @@ mod test {
     #[case::invalid_selector_missing_minimum(json!({
       "effect": {
         "latency": {
-          "delay_ms": 200,
+          "read_ms": 200,
           "jitter_ms": 50,
         }
       },
@@ -867,7 +915,8 @@ mod test {
         name: None,
         priority: None,
         effect: ChaosEffectRequest::Latency {
-            delay_ms: 200,
+            read_ms: Some(200),
+            write_ms: None,
             jitter_ms: Some(50)
         },
         selector: ChaosSelectorRequest {
@@ -945,7 +994,7 @@ mod test {
       "name" : "the-crocodile-is-called-vector-apparently",
       "effect": {
         "latency": {
-          "delay_ms": 200,
+          "read_ms": 200,
           "jitter_ms": 50,
         }
       }
@@ -962,7 +1011,7 @@ mod test {
             "after_ms": 750
           },
           "latency": {
-            "delay_ms": 200,
+            "read_ms": 200,
           }
         }
     }))]
@@ -998,7 +1047,8 @@ mod test {
                 upstream: AddressFilter::Name("zamki.pl".to_owned(), 443),
                 percentage: Percentage::from(25),
                 effect: TcpChaosEffect::Latency(ChaosEffectLatency {
-                    delay: Duration::from_millis(100),
+                    read: Duration::from_millis(100),
+                    write: Duration::from_millis(100),
                     jitter: Duration::from_millis(50),
                 }),
             },

--- a/mirrord/intproxy/src/session_monitor/chaos/rules.rs
+++ b/mirrord/intproxy/src/session_monitor/chaos/rules.rs
@@ -531,29 +531,39 @@ impl ChaosEffectLatency {
         }
     }
 
+    /// Returns the duration of read latency applied by the effect, plus random jitter (if set).
+    /// Returns `None` if duration is 0.
     pub fn read_latency_duration(&self) -> Option<Duration> {
-        self.latency_duration(self.read)
+        self.add_latency_jitter(self.read)
     }
 
+    /// Returns the duration of write latency applied by the effect, plus random jitter (if set).
+    /// Returns `None` if duration is 0.
     pub fn write_latency_duration(&self) -> Option<Duration> {
-        self.latency_duration(self.write)
+        self.add_latency_jitter(self.write)
     }
 
+    /// Returns the duration of read+write latency applied by the effect to simulate connection
+    /// latency, plus random jitter (if set). Will always return `Some(_)` because either read or
+    /// write latency must be non-zero in a valid effect, but returns an `Option` for convenience.
     pub fn connection_latency_duration(&self) -> Option<Duration> {
-        self.latency_duration(self.write + self.read)
+        self.add_latency_jitter(self.write + self.read)
     }
 
-    fn latency_duration(&self, latency: Duration) -> Option<Duration> {
-        if latency.is_zero() {
+    /// Calculates a final latency to be applied by the effect by adding jitter to the given
+    /// `Duration`. Will not add jitter to a `Duration` of 0, which may occur when either read
+    /// or write latency is 0.
+    fn add_latency_jitter(&self, base_delay: Duration) -> Option<Duration> {
+        if base_delay.is_zero() {
             return None;
         }
 
         if self.jitter.is_zero() {
-            return Some(latency);
+            return Some(base_delay);
         }
 
         Some(
-            latency
+            base_delay
                 + self
                     .jitter
                     .div_f32(100.)

--- a/mirrord/intproxy/src/session_monitor/chaos/rules.rs
+++ b/mirrord/intproxy/src/session_monitor/chaos/rules.rs
@@ -200,19 +200,11 @@ impl TryFrom<ChaosEffectRequest> for TcpChaosEffect {
                 read_ms,
                 write_ms,
                 jitter_ms,
-            } => {
-                if read_ms.is_none() && write_ms.is_none() {
-                    return Err(ChaosRuleError::Invalid(anyhow!(
-                        "either 'effect.latency.read_ms' or 'effect.latency.write_ms' must be specified"
-                    )));
-                }
-
-                Ok(Self::Latency(ChaosEffectLatency {
-                    read: read_ms.map(Duration::from_millis).unwrap_or_default(),
-                    write: write_ms.map(Duration::from_millis).unwrap_or_default(),
-                    jitter: jitter_ms.map(Duration::from_millis).unwrap_or_default(),
-                }))
-            }
+            } => Ok(Self::Latency(ChaosEffectLatency::new(
+                read_ms.map(Duration::from_millis).unwrap_or_default(),
+                write_ms.map(Duration::from_millis).unwrap_or_default(),
+                jitter_ms.map(Duration::from_millis).unwrap_or_default(),
+            )?)),
 
             ChaosEffectRequest::ConnectionError {
                 error_type,
@@ -523,12 +515,18 @@ pub struct ChaosEffectLatency {
 }
 
 impl ChaosEffectLatency {
-    pub fn new(read: Duration, write: Duration, jitter: Duration) -> Self {
-        Self {
+    pub fn new(read: Duration, write: Duration, jitter: Duration) -> Result<Self, ChaosRuleError> {
+        if read.is_zero() && write.is_zero() {
+            return Err(ChaosRuleError::Invalid(anyhow!(
+                "either 'effect.latency.read_ms' or 'effect.latency.write_ms' must be non-zero"
+            )));
+        }
+
+        Ok(Self {
             read,
             write,
             jitter,
-        }
+        })
     }
 
     /// Returns the duration of read latency applied by the effect, plus random jitter (if set).


### PR DESCRIPTION
Issue: https://linear.app/metalbear/issue/COR-1627/allow-latency-direction-to-be-defined-in-rule-effect

- chaos rules for latency can specify read, write or both to apply latency in those directions
- jitter is applied only if the latency for a given direction is not 0
- connection latency is read latency + write latency, plus jitter (if defined)
- chaos routes are now nested under `/api`

_As usual, I recommend reviewing this commit by commit_