### PR TITLE
fix(ui): clean up merged session monitor header (dedupe logo + move controls to top bar)

### DIFF
--- a/changelog.d/+monitor-shell-header.fixed.md
+++ b/changelog.d/+monitor-shell-header.fixed.md
@@ -1,0 +1,3 @@
+The `mirrord ui` session monitor no longer shows a duplicate logo inside the merged UI, and its
+kube context, namespace, and account controls now share the shell's top bar instead of a separate
+row. The logo is also no longer inverted in dark mode.

--- a/changelog.d/+wizard-dark-logo.fixed.md
+++ b/changelog.d/+wizard-dark-logo.fixed.md
@@ -1,0 +1,1 @@
+The config wizard's mirrord logo is now legible in dark mode, shown on a light backdrop instead of blending into the dark card.

--- a/packages/monitor/src/App.tsx
+++ b/packages/monitor/src/App.tsx
@@ -40,9 +40,13 @@ export type MonitorProps = {
   theme: ThemePref
   isDarkMode: boolean
   onThemeChange: (theme: ThemePref) => void
+  // Whether the monitor tab is the one on screen. The monitor stays mounted while hidden, so
+  // its top-bar controls only portal into the shell when it is actually active. Defaults to
+  // true so a standalone mount still shows them.
+  active?: boolean
 }
 
-export default function App({ theme, isDarkMode, onThemeChange }: MonitorProps) {
+export default function App({ theme, isDarkMode, onThemeChange, active = true }: MonitorProps) {
   const [sessions, setSessions] = useState<SessionInfo[]>([])
   const [operatorSessions, setOperatorSessions] = useState<OperatorSessionSummary[]>([])
   const [watchStatus, setWatchStatus] = useState<OperatorWatchStatus | null>(null)
@@ -355,6 +359,7 @@ export default function App({ theme, isDarkMode, onThemeChange }: MonitorProps) 
   return (
     <div className="h-full flex flex-col bg-background text-foreground">
       <AppHeader
+        active={active}
         connected={connected}
         isDarkMode={isDarkMode}
         theme={theme}

--- a/packages/monitor/src/components/AppHeader.tsx
+++ b/packages/monitor/src/components/AppHeader.tsx
@@ -1,4 +1,4 @@
-import { Button, MirrordIcon, cn } from '@metalbear/ui'
+import { Button, cn } from '@metalbear/ui'
 import { ChevronDown, Settings, User } from 'lucide-react'
 import { useEffect, useRef, useState } from 'react'
 import { strings } from '../strings'
@@ -29,7 +29,6 @@ interface Props {
 
 export default function AppHeader({
   connected,
-  isDarkMode,
   theme,
   onThemeChange,
   telemetryEnabled,
@@ -73,23 +72,7 @@ export default function AppHeader({
           glassy finish in both themes, replacing the prior brand-colored accent line. */}
       <div className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-foreground/10 to-transparent" />
       <div className="px-4 sm:px-6 lg:px-8">
-        <div className="flex items-center justify-between h-14 gap-3">
-          <div className="flex items-center gap-3 min-w-0">
-            <img
-              src={MirrordIcon}
-              alt={strings.app.title}
-              className={cn('w-8 h-8 shrink-0', isDarkMode && 'invert')}
-            />
-            <div className="hidden sm:flex items-center gap-2 min-w-0">
-              <span className="font-semibold text-h4">{strings.app.title}</span>
-              <span className="text-foreground/30">|</span>
-              <span className="text-body-sm font-medium text-foreground/70 truncate">
-                {strings.app.subtitle}
-              </span>
-            </div>
-            <span className="font-semibold text-h4 sm:hidden">{strings.app.title}</span>
-          </div>
-
+        <div className="flex items-center justify-end h-14 gap-3">
           <div className="flex items-center gap-2 min-w-0">
             <ContextNamespacePicker
               contexts={contexts}

--- a/packages/monitor/src/components/AppHeader.tsx
+++ b/packages/monitor/src/components/AppHeader.tsx
@@ -1,6 +1,7 @@
 import { Button, cn } from '@metalbear/ui'
 import { ChevronDown, Settings, User } from 'lucide-react'
 import { useEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
 import { strings } from '../strings'
 import SettingsDialog from './SettingsDialog'
 import ContextNamespacePicker from './ContextNamespacePicker'
@@ -9,6 +10,7 @@ import type { KubeContext } from '../types'
 import type { ThemePref } from '../theme'
 
 interface Props {
+  active: boolean
   connected: boolean
   isDarkMode: boolean
   theme: ThemePref
@@ -28,6 +30,7 @@ interface Props {
 }
 
 export default function AppHeader({
+  active,
   connected,
   theme,
   onThemeChange,
@@ -47,6 +50,13 @@ export default function AppHeader({
   const [settingsOpen, setSettingsOpen] = useState(false)
   const [menuOpen, setMenuOpen] = useState(false)
   const menuRef = useRef<HTMLDivElement>(null)
+  // The shared `mirrord-ui` shell owns the top bar and exposes a slot; the monitor's chrome
+  // (kube context, namespace, account) renders into it rather than its own header row.
+  const [slot, setSlot] = useState<HTMLElement | null>(null)
+
+  useEffect(() => {
+    setSlot(document.getElementById('mirrord-topbar-slot'))
+  }, [])
 
   useEffect(() => {
     if (!menuOpen) return
@@ -66,75 +76,72 @@ export default function AppHeader({
     }
   }, [menuOpen])
 
-  return (
-    <header className="relative shrink-0 bg-background border-b border-border text-foreground shadow-[0_1px_2px_-1px_rgb(0_0_0_/_0.04)]">
-      {/* Hair-thin inner top highlight — a soft rim of light that gives the header a
-          glassy finish in both themes, replacing the prior brand-colored accent line. */}
-      <div className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-foreground/10 to-transparent" />
-      <div className="px-4 sm:px-6 lg:px-8">
-        <div className="flex items-center justify-end h-14 gap-3">
-          <div className="flex items-center gap-2 min-w-0">
-            <ContextNamespacePicker
-              contexts={contexts}
-              currentContext={currentContext}
-              selectedContext={selectedContext}
-              onSelectContext={onSelectContext}
-              namespaces={namespaces}
-              selectedNamespace={selectedNamespace}
-              onSelectNamespace={onSelectNamespace}
-              namespacesLoading={namespacesLoading}
-              namespacesError={namespacesError}
-            />
+  const controls = (
+    <div className="flex items-center gap-2 min-w-0">
+      <ContextNamespacePicker
+        contexts={contexts}
+        currentContext={currentContext}
+        selectedContext={selectedContext}
+        onSelectContext={onSelectContext}
+        namespaces={namespaces}
+        selectedNamespace={selectedNamespace}
+        onSelectNamespace={onSelectNamespace}
+        namespacesLoading={namespacesLoading}
+        namespacesError={namespacesError}
+      />
 
-            <div ref={menuRef} className="relative">
-              <button
-                type="button"
-                onClick={() => setMenuOpen((o) => !o)}
-                title={currentUser ?? undefined}
-                className="inline-flex items-center gap-1.5 rounded-full border border-border bg-muted/50 hover:bg-muted px-2.5 h-7 max-w-[240px] cursor-pointer transition-colors"
-              >
-                <span
-                  className={cn(
-                    'h-1.5 w-1.5 rounded-full shrink-0',
-                    connected ? 'bg-green-500' : 'bg-red-500'
-                  )}
-                  aria-label={connected ? strings.app.connected : strings.app.disconnected}
-                />
-                <User className="h-3 w-3 shrink-0 text-muted-foreground" />
-                <span className="font-mono text-meta text-foreground truncate">
-                  {currentUser ?? '…'}
-                </span>
-                <ChevronDown className="h-3 w-3 shrink-0 text-muted-foreground" />
-              </button>
+      <div ref={menuRef} className="relative">
+        <button
+          type="button"
+          onClick={() => setMenuOpen((o) => !o)}
+          title={currentUser ?? undefined}
+          className="inline-flex items-center gap-1.5 rounded-full border border-border bg-muted/50 hover:bg-muted px-2.5 h-7 max-w-[240px] cursor-pointer transition-colors"
+        >
+          <span
+            className={cn(
+              'h-1.5 w-1.5 rounded-full shrink-0',
+              connected ? 'bg-green-500' : 'bg-red-500'
+            )}
+            aria-label={connected ? strings.app.connected : strings.app.disconnected}
+          />
+          <User className="h-3 w-3 shrink-0 text-muted-foreground" />
+          <span className="font-mono text-meta text-foreground truncate">
+            {currentUser ?? '…'}
+          </span>
+          <ChevronDown className="h-3 w-3 shrink-0 text-muted-foreground" />
+        </button>
 
-              {menuOpen && (
-                <div className="absolute right-0 top-full mt-1.5 z-50 min-w-[220px] rounded-lg border border-border bg-popover text-popover-foreground shadow-lg p-2 flex flex-col">
-                  {currentUser && (
-                    <div className="px-2 py-1.5">
-                      <div className="text-caps text-muted-foreground">Running as</div>
-                      <div className="font-mono text-meta text-foreground truncate" title={currentUser}>
-                        {currentUser}
-                      </div>
-                    </div>
-                  )}
-
-                  <button
-                    type="button"
-                    onClick={() => {
-                      setMenuOpen(false)
-                      setSettingsOpen(true)
-                    }}
-                    className="flex items-center gap-2 px-2 py-1.5 rounded text-meta text-foreground hover:bg-muted transition-colors"
-                  >
-                    <Settings className="h-3.5 w-3.5 text-muted-foreground" />
-                    {strings.app.settings}
-                  </button>
+        {menuOpen && (
+          <div className="absolute right-0 top-full mt-1.5 z-50 min-w-[220px] rounded-lg border border-border bg-popover text-popover-foreground shadow-lg p-2 flex flex-col">
+            {currentUser && (
+              <div className="px-2 py-1.5">
+                <div className="text-caps text-muted-foreground">Running as</div>
+                <div className="font-mono text-meta text-foreground truncate" title={currentUser}>
+                  {currentUser}
                 </div>
-              )}
-            </div>
+              </div>
+            )}
+
+            <button
+              type="button"
+              onClick={() => {
+                setMenuOpen(false)
+                setSettingsOpen(true)
+              }}
+              className="flex items-center gap-2 px-2 py-1.5 rounded text-meta text-foreground hover:bg-muted transition-colors"
+            >
+              <Settings className="h-3.5 w-3.5 text-muted-foreground" />
+              {strings.app.settings}
+            </button>
           </div>
-        </div>
+        )}
       </div>
+    </div>
+  )
+
+  return (
+    <>
+      {active && slot && createPortal(controls, slot)}
 
       <SettingsDialog
         open={settingsOpen}
@@ -144,6 +151,6 @@ export default function AppHeader({
         telemetryEnabled={telemetryEnabled}
         onTelemetryChange={onTelemetryChange}
       />
-    </header>
+    </>
   )
 }

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -43,11 +43,7 @@ function TabBar({
   return (
     <header className="flex h-11 shrink-0 items-center gap-1 border-b border-border bg-background px-3">
       <div className="mr-3 flex items-center gap-2">
-        <img
-          src={MirrordIcon}
-          alt=""
-          className={`h-5 w-5 ${isDark ? 'invert' : ''}`}
-        />
+        <img src={MirrordIcon} alt="" className="h-5 w-5" />
         <span className="text-sm font-semibold text-foreground">mirrord</span>
       </div>
       <nav className="flex items-center gap-1">

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -70,15 +70,21 @@ function TabBar({
           )
         })}
       </nav>
-      <button
-        type="button"
-        onClick={onToggleTheme}
-        aria-label={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
-        title={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
-        className="ml-auto flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-      >
-        {isDark ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
-      </button>
+      {/* Right-side region: the active feature portals its own top-bar controls (kube context,
+          namespace, account) into this slot, so app-level chrome shares one bar instead of the
+          feature rendering a second header row. */}
+      <div className="ml-auto flex items-center gap-2">
+        <div id="mirrord-topbar-slot" className="flex items-center gap-2" />
+        <button
+          type="button"
+          onClick={onToggleTheme}
+          aria-label={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
+          title={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
+          className="flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+        >
+          {isDark ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
+        </button>
+      </div>
     </header>
   )
 }
@@ -147,6 +153,7 @@ export default function App() {
           <div className={active === 'monitor' ? 'h-full' : 'hidden'}>
             <Suspense fallback={null}>
               <Monitor
+                active={active === 'monitor'}
                 theme={theme}
                 isDarkMode={isDark}
                 onThemeChange={setTheme}

--- a/packages/wizard/src/components/Homepage.tsx
+++ b/packages/wizard/src/components/Homepage.tsx
@@ -28,7 +28,7 @@ const Homepage = () => {
         <CardContent className="pt-10 pb-8 px-8">
           {/* Logo */}
           <div className="flex justify-center mb-8">
-            <div className="p-4 rounded-2xl bg-primary/5 border border-primary/10">
+            <div className="p-4 rounded-2xl bg-primary/5 dark:bg-[#E4E3FD] border border-primary/10">
               <img src={MirrordLogo} alt="mirrord" className="h-12" />
             </div>
           </div>


### PR DESCRIPTION
## Summary

After #4503 merged the session monitor and config wizard into one `mirrord ui` app, the session monitor's header didn't integrate with the new shared shell:

1. **Two stacked logos** — the shell (`packages/ui`) owns the top bar with the logo and the *Session Monitor / Config Wizard* tabs, but the monitor still rendered its own logo + `mirrord | Session Monitor` title beneath it.
2. **A stranded control row** — after removing the duplicate logo, the monitor's remaining controls (kube context, namespace, account) sat alone in a near-empty full-width bar, wasting vertical space.

This reworks the monitor header to live inside the shell:

- Drops the duplicate logo/title from the monitor's `AppHeader`.
- The shell exposes a top-bar slot; the monitor **portals** its context/namespace/account controls into it, next to the tabs, so app-level chrome shares one bar. The stranded row is gone and the content reclaims the space.
- The portal is gated on the monitor tab being active, so the monitor's namespace filter doesn't leak onto the config wizard tab while the monitor stays mounted in the background.
- Session **search** stays in the sidebar where it filters the session list.

## Test plan

- `packages/monitor` and `packages/ui` typecheck clean, `prettier --check` clean, merged `mirrord-ui` frontend builds, CLI builds.
- Ran `mirrord ui` against a live session: single logo, context/namespace/account render and populate in the top bar, the account menu and context picker work from their new home, and switching to the Config Wizard tab (after the monitor mounted) shows a clean top bar with no leaked controls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)