### PR TITLE
Refactor layer Detour type using stable Rust only

### DIFF
--- a/changelog.d/+detour-stable-rust.internal.md
+++ b/changelog.d/+detour-stable-rust.internal.md
@@ -1,0 +1,1 @@
+Refactored `Detour` result type by using stable Rust.

--- a/mirrord/layer-lib/src/detour.rs
+++ b/mirrord/layer-lib/src/detour.rs
@@ -4,10 +4,6 @@
 //! Here we also have the convenient detour helpers that are used by the hooks to either return a
 //! [`Result`]-like value, or the special [`Bypass`] case, which makes the _detour_ function call
 //! the original [`libc`] equivalent, stored in a hook function pointer.
-use core::{
-    convert,
-    ops::{FromResidual, Residual, Try},
-};
 #[cfg(unix)]
 use std::{cell::RefCell, ffi::CString, ops::Deref, path::PathBuf};
 use std::{net::SocketAddr, sync::OnceLock};
@@ -261,164 +257,117 @@ impl Bypass {
     }
 }
 
-/// [`ControlFlow`](std::ops::ControlFlow)-like enum to be used by hooks.
+/// The failure half of a [`Detour`].
 ///
-/// Conversion from `Result`:
-/// - `Result::Ok` -> `Detour::Success`
-/// - `Result::Err` -> `Detour::Error`
-///
-/// Conversion from `Option`:
-/// - `Option::Some` -> `Detour::Success`
-/// - `Option::None` -> `Detour::Bypass`
-#[must_use = "this `Detour` may be an `Error` or a `Bypass` variant, which should be handled"]
+/// Either a recoverable [`Bypass`] (the hook should defer to the original libc function) or a hard
+/// [`HookError`] that gets surfaced to the user application as a libc error code.
 #[derive(Debug)]
-pub enum Detour<S = ()> {
-    /// Equivalent to `Result::Ok`
-    Success(S),
-    /// Useful for operations with parameters that are ignored by `mirrord`, or for soft-failures
-    /// (errors that can be recovered from in the hook FFI).
+pub enum DetourError {
+    /// Soft-failure that can be recovered from by calling the raw libc function.
     Bypass(Bypass),
-    /// Equivalent to `Result::Err`
+    /// Unrecoverable error.
     Error(HookError),
 }
 
-impl<S> Try for Detour<S> {
-    type Output = S;
-
-    type Residual = Detour<convert::Infallible>;
-
-    fn from_output(output: Self::Output) -> Self {
-        Detour::Success(output)
-    }
-
-    fn branch(self) -> std::ops::ControlFlow<Self::Residual, Self::Output> {
-        match self {
-            Detour::Success(s) => core::ops::ControlFlow::Continue(s),
-            Detour::Bypass(b) => core::ops::ControlFlow::Break(Detour::Bypass(b)),
-            Detour::Error(e) => core::ops::ControlFlow::Break(Detour::Error(e)),
-        }
+impl From<Bypass> for DetourError {
+    fn from(bypass: Bypass) -> Self {
+        DetourError::Bypass(bypass)
     }
 }
 
-impl<S> FromResidual<Detour<convert::Infallible>> for Detour<S> {
-    fn from_residual(residual: Detour<convert::Infallible>) -> Self {
-        match residual {
-            Detour::Bypass(b) => Detour::Bypass(b),
-            Detour::Error(e) => Detour::Error(e),
-        }
+impl From<HookError> for DetourError {
+    fn from(error: HookError) -> Self {
+        DetourError::Error(error)
     }
 }
 
-impl<S, E> FromResidual<Result<convert::Infallible, E>> for Detour<S>
-where
-    E: Into<HookError>,
-{
-    fn from_residual(Err(e): Result<convert::Infallible, E>) -> Self {
-        Detour::Error(e.into())
-    }
-}
+/// Control flow type alias used by the layer's hooks.
+///
+/// - `Ok(value)` is a success, and the hook shall continue;
+/// - `Err(DetourError::Bypass(_))` asks the hook to call the original libc function;
+/// - `Err(DetourError::Error(_))` is a hard error surfaced to the user application.
+///
+/// The `?` operator works as the following:
+/// - `?` on a nested [`Detour`] forwards its [`DetourError`];
+/// - `?` on any error convertible into [`HookError`] maps to [`DetourError::Error`] (see the `From`
+///   impls in [`crate::error`]);
+/// - `?` on a [`Bypass`] maps to [`DetourError::Bypass`].
+///
+/// To turn a [`None`] into a bypass, use [`OptionExt::bypass`]; the bare `?` on an [`Option`] does
+/// **not** produce a bypass.
+pub type Detour<S = ()> = Result<S, DetourError>;
 
-impl<S> FromResidual<Result<convert::Infallible, Bypass>> for Detour<S> {
-    fn from_residual(Err(e): Result<convert::Infallible, Bypass>) -> Self {
-        Detour::Bypass(e)
-    }
-}
-
-impl<S> FromResidual<Option<convert::Infallible>> for Detour<S> {
-    fn from_residual(_none_residual: Option<convert::Infallible>) -> Self {
-        Detour::Bypass(Bypass::EmptyOption)
-    }
-}
-
-impl<S> Residual<S> for Detour<convert::Infallible> {
-    type TryType = Detour<S>;
-}
-
-impl<S> Detour<S> {
-    /// Calls `op` if the result is `Success`, otherwise returns the `Bypass` or `Error` value of
-    /// self.
+/// Extension methods on [`Detour`] that need to tell [`DetourError::Bypass`] apart from
+/// [`DetourError::Error`].
+pub trait DetourExt<S> {
+    /// Calls `op` only on [`DetourError::Error`], leaving `Ok` and [`DetourError::Bypass`]
+    /// untouched.
     ///
-    /// This function can be used for control flow based on `Detour` values.
-    pub fn and_then<U, F: FnOnce(S) -> Detour<U>>(self, op: F) -> Detour<U> {
-        match self {
-            Detour::Success(s) => op(s),
-            Detour::Bypass(b) => Detour::Bypass(b),
-            Detour::Error(e) => Detour::Error(e),
-        }
-    }
+    /// Named `on_error` (not `or_else`) so it does not silently shadow [`Result::or_else`], which
+    /// would fire on a [`DetourError::Bypass`] too.
+    fn on_error<O: FnOnce(HookError) -> Detour<S>>(self, op: O) -> Detour<S>;
 
-    /// Maps a `Detour<S>` to `Detour<U>` by applying a function to a contained `Success` value,
-    /// leaving a `Bypass` or `Error` value untouched.
-    ///
-    /// This function can be used to compose the results of two functions.
-    pub fn map<U, F: FnOnce(S) -> U>(self, op: F) -> Detour<U> {
-        match self {
-            Detour::Success(s) => Detour::Success(op(s)),
-            Detour::Bypass(b) => Detour::Bypass(b),
-            Detour::Error(e) => Detour::Error(e),
-        }
-    }
+    /// Calls `op` only on [`DetourError::Bypass`], leaving `Ok` and [`DetourError::Error`]
+    /// untouched.
+    fn or_bypass<O: FnOnce(Bypass) -> Detour<S>>(self, op: O) -> Detour<S>;
 
-    /// Return the contained `Success` value or a provided default if `Bypass` or `Error`.
+    /// Helper function for returning a detour return value from a hook.
     ///
-    /// To be used in hooks that are deemed non-essential, and the run should continue even if they
-    /// fail.
-    /// Currently defined only on macos because it is only used in macos-only code.
-    /// Remove the cfg attribute to enable using in other code.
-    #[cfg(target_os = "macos")]
-    pub fn unwrap_or(self, default: S) -> S {
+    /// - `Ok` -> return the contained value;
+    /// - `Bypass` -> call `op` and return its value;
+    /// - `Error` -> convert to a libc value and return it.
+    fn unwrap_or_bypass_with<F: FnOnce(Bypass) -> S>(self, op: F) -> S
+    where
+        S: From<HookError>;
+
+    /// Helper function for returning a detour return value from a hook.
+    ///
+    /// - `Ok` -> return the contained value;
+    /// - `Bypass` -> return the provided `value`;
+    /// - `Error` -> convert to a libc value and return it.
+    fn unwrap_or_bypass(self, value: S) -> S
+    where
+        S: From<HookError>;
+}
+
+impl<S> DetourExt<S> for Detour<S> {
+    #[inline]
+    fn on_error<O: FnOnce(HookError) -> Detour<S>>(self, op: O) -> Detour<S> {
         match self {
-            Detour::Success(s) => s,
-            _ => default,
+            Ok(s) => Ok(s),
+            Err(DetourError::Bypass(b)) => Err(DetourError::Bypass(b)),
+            Err(DetourError::Error(e)) => op(e),
         }
     }
 
     #[inline]
-    pub fn or_else<O: FnOnce(HookError) -> Detour<S>>(self, op: O) -> Detour<S> {
+    fn or_bypass<O: FnOnce(Bypass) -> Detour<S>>(self, op: O) -> Detour<S> {
         match self {
-            Detour::Success(s) => Detour::Success(s),
-            Detour::Bypass(b) => Detour::Bypass(b),
-            Detour::Error(e) => op(e),
+            Ok(s) => Ok(s),
+            Err(DetourError::Bypass(b)) => op(b),
+            Err(DetourError::Error(e)) => Err(DetourError::Error(e)),
         }
     }
 
-    #[inline]
-    pub fn or_bypass<O: FnOnce(Bypass) -> Detour<S>>(self, op: O) -> Detour<S> {
+    fn unwrap_or_bypass_with<F: FnOnce(Bypass) -> S>(self, op: F) -> S
+    where
+        S: From<HookError>,
+    {
         match self {
-            Detour::Success(s) => Detour::Success(s),
-            Detour::Bypass(b) => op(b),
-            Detour::Error(e) => Detour::Error(e),
-        }
-    }
-}
-
-impl<S> Detour<S>
-where
-    S: From<HookError>,
-{
-    /// Helper function for returning a detour return value from a hook.
-    ///
-    /// - `Success` -> Return the contained value.
-    /// - `Bypass` -> Call the bypass and return its value.
-    /// - `Error` -> Convert to libc value and return it.
-    pub fn unwrap_or_bypass_with<F: FnOnce(Bypass) -> S>(self, op: F) -> S {
-        match self {
-            Detour::Success(s) => s,
-            Detour::Bypass(b) => op(b),
-            Detour::Error(e) => e.into(),
+            Ok(s) => s,
+            Err(DetourError::Bypass(b)) => op(b),
+            Err(DetourError::Error(e)) => e.into(),
         }
     }
 
-    /// Helper function for returning a detour return value from a hook.
-    ///
-    /// `Success` -> Return the contained value.
-    /// `Bypass` -> Return provided value.
-    /// `Error` -> Convert to libc value and return it.
-    pub fn unwrap_or_bypass(self, value: S) -> S {
+    fn unwrap_or_bypass(self, value: S) -> S
+    where
+        S: From<HookError>,
+    {
         match self {
-            Detour::Success(s) => s,
-            Detour::Bypass(_) => value,
-            Detour::Error(e) => e.into(),
+            Ok(s) => s,
+            Err(DetourError::Bypass(_)) => value,
+            Err(DetourError::Error(e)) => e.into(),
         }
     }
 }
@@ -435,49 +384,13 @@ pub trait OptionExt {
     fn bypass(self, value: Bypass) -> Detour<Self::Opt>;
 }
 
-/// Extends `Option<T>` with `Detour<T>` conversion methods.
-#[cfg(target_os = "linux")]
-pub trait OptionDetourExt<T>: OptionExt {
-    /// Transposes an `Option` of a [`Detour`] into a [`Detour`] of an `Option`.
-    ///
-    /// - [`None`] will be mapped to `Success(None)`;
-    /// - `Some(Success)` will be mapped to `Success(Some)`;
-    /// - `Some(Error)` will be mapped to `Error`;
-    /// - `Some(Bypass)` will be mapped to `Bypass`;
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// use mirrord_layer_lib::detour::{Detour, OptionDetourExt};
-    /// let result: Option<Detour<i32>> = Some(Detour::Success(5));
-    /// match result.transpose() {
-    ///     Detour::Success(inner) => assert_eq!(inner, Some(5)),
-    ///     _ => unreachable!(),
-    /// };
-    /// ```
-    fn transpose(self) -> Detour<Option<T>>;
-}
-
 impl<T> OptionExt for Option<T> {
     type Opt = T;
 
     fn bypass(self, value: Bypass) -> Detour<T> {
         match self {
-            Some(v) => Detour::Success(v),
-            None => Detour::Bypass(value),
-        }
-    }
-}
-
-#[cfg(target_os = "linux")]
-impl<T> OptionDetourExt<T> for Option<Detour<T>> {
-    #[inline]
-    fn transpose(self) -> Detour<Option<T>> {
-        match self {
-            Some(Detour::Success(s)) => Detour::Success(Some(s)),
-            Some(Detour::Error(e)) => Detour::Error(e),
-            Some(Detour::Bypass(b)) => Detour::Bypass(b),
-            None => Detour::Success(None),
+            Some(v) => Ok(v),
+            None => Err(DetourError::Bypass(value)),
         }
     }
 }
@@ -496,11 +409,11 @@ impl<T> OnceLockExt<T> for OnceLock<T> {
         F: FnOnce() -> Detour<T>,
     {
         if let Some(value) = self.get() {
-            Detour::Success(value)
+            Ok(value)
         } else {
             let value = f()?;
 
-            Detour::Success(self.get_or_init(|| value))
+            Ok(self.get_or_init(|| value))
         }
     }
 }
@@ -566,25 +479,36 @@ impl_windows_detour_return!(WinSocket, SOCKET, |_| INVALID_SOCKET);
 #[cfg(windows)]
 impl_windows_detour_return!(WinGetAddrInfoInt, INT, |errno: i32| errno as INT);
 
+/// Windows-only [`Detour`] helper for turning a hook result into an ABI-specific return value.
+///
+/// Lives on its own trait (rather than as an inherent method) because [`Detour`] is a [`Result`]
+/// alias, which cannot carry inherent `impl`s.
 #[cfg(windows)]
-impl<S> Detour<S> {
-    /// Windows helper for hooks, using a type parameter to define return ABI semantics.
+pub trait DetourWindowsExt<S> {
+    /// Turns the hook result into a return value using `K`'s Windows return ABI semantics.
     ///
-    /// `K` controls how `Success` and `Error` are converted into return values and how
-    /// errors are surfaced to the caller.
-    ///
-    /// Use this for Windows hooks instead of relying on generic `From<HookError>`
-    /// conversions.
-    pub fn unwrap_or_bypass_windows_as<K, F>(self, op: F) -> K::Return
+    /// `K` controls how `Ok` and [`DetourError::Error`] are converted into return values and how
+    /// errors are surfaced to the caller. Use this for Windows hooks instead of relying on generic
+    /// `From<HookError>` conversions.
+    fn unwrap_or_bypass_windows_as<K, F>(self, op: F) -> K::Return
+    where
+        K: WindowsDetourReturn<S>,
+        S: Into<K::Return>,
+        F: FnOnce(Bypass) -> K::Return;
+}
+
+#[cfg(windows)]
+impl<S> DetourWindowsExt<S> for Detour<S> {
+    fn unwrap_or_bypass_windows_as<K, F>(self, op: F) -> K::Return
     where
         K: WindowsDetourReturn<S>,
         S: Into<K::Return>,
         F: FnOnce(Bypass) -> K::Return,
     {
         match self {
-            Detour::Success(value) => K::from_success(value),
-            Detour::Bypass(reason) => op(reason),
-            Detour::Error(error) => K::from_error(error),
+            Ok(value) => K::from_success(value),
+            Err(DetourError::Bypass(reason)) => op(reason),
+            Err(DetourError::Error(error)) => K::from_error(error),
         }
     }
 }

--- a/mirrord/layer-lib/src/error.rs
+++ b/mirrord/layer-lib/src/error.rs
@@ -134,7 +134,7 @@ pub enum SendToError {
 /// These errors are converted to `libc` error codes, and are also used to `Errno::set_raw`.
 ///
 /// When you add a new `#[from] E` or `From<E>` conversion, add `E` in
-/// [`detour_error_from_hook_error`] too so `?` keeps working inside hooks.
+/// `detour_error_from_hook_error` too so `?` keeps working inside hooks.
 #[derive(Error, Debug)]
 pub enum HookError {
     #[error("mirrord-layer: `{0}`")]

--- a/mirrord/layer-lib/src/error.rs
+++ b/mirrord/layer-lib/src/error.rs
@@ -29,7 +29,8 @@ use tracing::{error, info};
 use winapi::shared::winerror::{WSAHOST_NOT_FOUND, WSANO_RECOVERY, WSATRY_AGAIN};
 
 use crate::{
-    graceful_exit, proxy_connection::ProxyError, setup::setup, socket::sockets::SocketDescriptor,
+    detour::DetourError, graceful_exit, proxy_connection::ProxyError, setup::setup,
+    socket::sockets::SocketDescriptor,
 };
 
 mod ignore_codes {
@@ -131,6 +132,9 @@ pub enum SendToError {
 /// Errors that occur in the layer's hook functions, and will reach the user's application.
 ///
 /// These errors are converted to `libc` error codes, and are also used to `Errno::set_raw`.
+///
+/// When you add a new `#[from] E` or `From<E>` conversion, add `E` in
+/// [`detour_error_from_hook_error`] too so `?` keeps working inside hooks.
 #[derive(Error, Debug)]
 pub enum HookError {
     #[error("mirrord-layer: `{0}`")]
@@ -363,6 +367,49 @@ impl From<SerializationError> for HookError {
 impl<T> From<PoisonError<MutexGuard<'_, T>>> for HookError {
     fn from(_: PoisonError<MutexGuard<'_, T>>) -> Self {
         HookError::LockError
+    }
+}
+
+/// Forwards every error type convertible into [`HookError`] into [`DetourError::Error`].
+///
+/// A [`Detour`](crate::detour::Detour) is a `Result<_, DetourError>`, so the `?` operator relies on
+/// `From` for error conversion. A blanket `impl<E: Into<HookError>> From<E> for DetourError` is
+/// rejected by coherence (it overlaps the reflexive `From<T> for T`), so each convertible error
+/// type is listed explicitly here, mirroring the `#[from]`/`From` conversions on [`HookError`]
+/// above.
+macro_rules! detour_error_from_hook_error {
+    ($($ty:ty),* $(,)?) => {
+        $(
+            impl From<$ty> for DetourError {
+                fn from(error: $ty) -> Self {
+                    DetourError::Error(HookError::from(error))
+                }
+            }
+        )*
+    };
+}
+
+detour_error_from_hook_error!(
+    ResponseError,
+    std::io::Error,
+    std::num::TryFromIntError,
+    std::ffi::NulError,
+    std::str::Utf8Error,
+    ProxyError,
+    bincode::error::EncodeError,
+    ConnectError,
+    SendToError,
+    HostnameResolveError,
+    SerializationError,
+);
+
+#[cfg(target_os = "macos")]
+detour_error_from_hook_error!(SipError);
+
+// Generic, like the `HookError` impl above; cannot go through the macro.
+impl<T> From<PoisonError<MutexGuard<'_, T>>> for DetourError {
+    fn from(error: PoisonError<MutexGuard<'_, T>>) -> Self {
+        DetourError::Error(HookError::from(error))
     }
 }
 

--- a/mirrord/layer-lib/src/lib.rs
+++ b/mirrord/layer-lib/src/lib.rs
@@ -1,6 +1,4 @@
 //! Common layer functionality shared between Unix layer and Windows layer-win.
-#![feature(try_trait_v2)]
-#![feature(try_trait_v2_residual)]
 #![feature(return_type_notation)]
 
 extern crate alloc;

--- a/mirrord/layer-lib/src/socket/dns/unix.rs
+++ b/mirrord/layer-lib/src/socket/dns/unix.rs
@@ -145,5 +145,5 @@ pub fn getaddrinfo(
 
     trace!("getaddrinfo -> result {:#?}", result);
 
-    Detour::Success(result)
+    Ok(result)
 }

--- a/mirrord/layer-lib/src/socket/dns/windows.rs
+++ b/mirrord/layer-lib/src/socket/dns/windows.rs
@@ -96,7 +96,7 @@ pub fn resolve_to_managed<T: WindowsAddrInfo>(
     // Convert response back to Windows ADDRINFO structures using trait method
     let mut managed = ManagedAddrInfo::<T>::try_from(resolved_addr)?;
     managed.apply_port(port);
-    Detour::Success(managed)
+    Ok(managed)
 }
 
 /// Safely deallocates ADDRINFOA structures that were allocated by our getaddrinfo_detour.
@@ -167,7 +167,9 @@ pub fn check_address_reachability(socket: SOCKET, remote_addr: &SocketAddr) -> D
             unsafe { WSAGetLastError() }
         );
         // on failure, GetNameInfoW sets WSALastError
-        return Detour::Error(ConnectError::AddressUnreachable(remote_addr.to_string()).into());
+        return Err(DetourError::Error(
+            ConnectError::AddressUnreachable(remote_addr.to_string()).into(),
+        ));
     }
 
     // Successfully resolved - address is reachable
@@ -177,5 +179,5 @@ pub fn check_address_reachability(socket: SOCKET, remote_addr: &SocketAddr) -> D
         unsafe { str_win::u16_buffer_to_string(PCWSTR(node_buffer.as_ptr()).as_wide()) }
     );
 
-    Detour::Success(())
+    Ok(())
 }

--- a/mirrord/layer-lib/src/socket/dns/windows.rs
+++ b/mirrord/layer-lib/src/socket/dns/windows.rs
@@ -15,7 +15,7 @@ use winapi::{
 use windows_strings::PCWSTR;
 
 use crate::{
-    detour::{Bypass, Detour, OptionExt},
+    detour::{Bypass, Detour, DetourError, OptionExt},
     error::ConnectError,
     setup::setup,
     socket::dns::remote_getaddrinfo,

--- a/mirrord/layer-lib/src/socket/dns_selector.rs
+++ b/mirrord/layer-lib/src/socket/dns_selector.rs
@@ -5,7 +5,7 @@ use mirrord_config::feature::network::{
     filter::AddressFilter,
 };
 
-use crate::detour::{Bypass, Detour};
+use crate::detour::{Bypass, Detour, DetourError};
 
 /// Generated from [`DnsConfig`] provided in the [`LayerConfig`](mirrord_config::LayerConfig).
 /// Decides whether DNS queries are done locally or remotely.
@@ -45,9 +45,9 @@ impl DnsSelector {
             });
 
         if matched == self.filter_is_local {
-            Detour::Bypass(Bypass::LocalDns)
+            Err(DetourError::Bypass(Bypass::LocalDns))
         } else {
-            Detour::Success(())
+            Ok(())
         }
     }
 }

--- a/mirrord/layer-lib/src/socket/ops.rs
+++ b/mirrord/layer-lib/src/socket/ops.rs
@@ -24,7 +24,7 @@ use tracing::{debug, trace};
 use winapi::um::winsock2::{WSA_IO_PENDING, WSAEINPROGRESS, WSAEINTR, WSAEWOULDBLOCK};
 
 use crate::{
-    detour::{Bypass, Detour},
+    detour::{Bypass, Detour, DetourError},
     error::{HookError, HookResult},
     proxy_connection::make_proxy_request_with_response,
     setup::setup,
@@ -187,7 +187,7 @@ where
     }?;
 
     if domain == AF_INET6 && setup().layer_config().feature.network.ipv6.not() {
-        return Detour::Error(HookError::SocketUnsuportedIpv6);
+        return Err(DetourError::Error(HookError::SocketUnsuportedIpv6));
     }
 
     let socket_fd = call_original()?;
@@ -196,7 +196,7 @@ where
 
     SOCKETS.lock()?.insert(socket_fd, Arc::new(new_socket));
 
-    Detour::Success(socket_fd)
+    Ok(socket_fd)
 }
 
 pub fn nop_connect_fn(_addr: SockAddr) -> ConnectResult {
@@ -220,37 +220,35 @@ where
     F: FnOnce(SockAddr) -> ConnectResult,
 {
     if setup().outgoing_config().ignore_localhost {
-        Detour::Bypass(Bypass::IgnoredInIncoming(ip_address))
+        Err(DetourError::Bypass(Bypass::IgnoredInIncoming(ip_address)))
     } else {
-        Detour::Success(
-            SOCKETS
-                .lock()?
-                .iter()
-                .find_map(|(_, socket)| match socket.state {
-                    SocketState::Listening(Bound {
-                        requested_address,
-                        address,
-                    }) => {
-                        let is_same_target = requested_address.port() == ip_address.port();
+        Ok(SOCKETS
+            .lock()?
+            .iter()
+            .find_map(|(_, socket)| match socket.state {
+                SocketState::Listening(Bound {
+                    requested_address,
+                    address,
+                }) => {
+                    let is_same_target = requested_address.port() == ip_address.port();
 
-                        // Windows edge case - Python's socketpair is emulated by a loopback
-                        // listener bound to port 0. The connect target uses
-                        // the actual bound port, so we must match against
-                        // it.
-                        #[cfg(windows)]
-                        let is_same_target = is_same_target
-                            || (requested_address.is_emulated_socketpair()
-                                && address.port() == ip_address.port());
+                    // Windows edge case - Python's socketpair is emulated by a loopback
+                    // listener bound to port 0. The connect target uses
+                    // the actual bound port, so we must match against
+                    // it.
+                    #[cfg(windows)]
+                    let is_same_target = is_same_target
+                        || (requested_address.is_emulated_socketpair()
+                            && address.port() == ip_address.port());
 
-                        (is_same_target && socket.protocol == user_socket_info.protocol)
-                            .then(|| SockAddr::from(address))
-                    }
-                    SocketState::Bound { .. }
-                    | SocketState::Initialized
-                    | SocketState::Connected(_) => None,
-                })
-                .map(connect_fn),
-        )
+                    (is_same_target && socket.protocol == user_socket_info.protocol)
+                        .then(|| SockAddr::from(address))
+                }
+                SocketState::Bound { .. }
+                | SocketState::Initialized
+                | SocketState::Connected(_) => None,
+            })
+            .map(connect_fn))
     }
 }
 
@@ -297,7 +295,7 @@ where
 
     if let Some(ip_address) = optional_ip_address {
         if setup().experimental().tcp_ping4_mock && ip_address.port() == 7 {
-            return Detour::Success(ConnectResult::from(0));
+            return Ok(ConnectResult::from(0));
         }
 
         // Handle localhost/unspecified addresses first -
@@ -309,17 +307,17 @@ where
         {
             // `result` here is always a success, as error and bypass are returned on the `?`
             // above.
-            return Detour::Success(result);
+            return Ok(result);
         }
 
         if is_ignored_port(&ip_address) {
-            return Detour::Bypass(Bypass::IgnoredInIncoming(ip_address));
+            return Err(DetourError::Bypass(Bypass::IgnoredInIncoming(ip_address)));
         }
 
         // Ports 50000 and 50001 are commonly used to communicate with sidecar containers.
         let bypass_debugger_check = ip_address.port() == 50000 || ip_address.port() == 50001;
         if bypass_debugger_check.not() && setup().is_debugger_port(&ip_address) {
-            return Detour::Bypass(Bypass::IgnoredInIncoming(ip_address));
+            return Err(DetourError::Bypass(Bypass::IgnoredInIncoming(ip_address)));
         }
     } else if remote_address.is_unix() {
         #[cfg(unix)]
@@ -357,17 +355,19 @@ where
                 .map(|addr| unix_streams.is_match(addr))
                 .unwrap_or(false);
             if !handle_remotely {
-                return Detour::Bypass(Bypass::UnixSocket(address));
+                return Err(DetourError::Bypass(Bypass::UnixSocket(address)));
             }
         }
         #[cfg(windows)]
         {
             mirrord_layer_macro::debug!("bypassing unix socket, not supported on windows");
-            return Detour::Bypass(Bypass::UnixSocket(None));
+            return Err(DetourError::Bypass(Bypass::UnixSocket(None)));
         }
     } else {
         // We do not hijack connections of this address type - Bypass!
-        return Detour::Bypass(Bypass::Domain(remote_address.domain().into()));
+        return Err(DetourError::Bypass(Bypass::Domain(
+            remote_address.domain().into(),
+        )));
     }
 
     tracing::info!("intercepting connection to {:?}", remote_address);
@@ -398,7 +398,7 @@ where
                 )
             }
 
-            _ => Detour::Bypass(Bypass::DisabledOutgoing),
+            _ => Err(DetourError::Bypass(Bypass::DisabledOutgoing)),
         },
 
         NetProtocol::Seqpacket => match user_socket_info.state {
@@ -414,10 +414,10 @@ where
                 )
             }
 
-            _ => Detour::Bypass(Bypass::DisabledOutgoing),
+            _ => Err(DetourError::Bypass(Bypass::DisabledOutgoing)),
         },
 
-        _ => Detour::Bypass(Bypass::DisabledOutgoing),
+        _ => Err(DetourError::Bypass(Bypass::DisabledOutgoing)),
     }
 }
 
@@ -541,7 +541,7 @@ where
                 "Failed to connect to an internal proxy socket. \
                 This is most likely a bug, please report it.",
             );
-            return Detour::Error(error.into());
+            return Err(DetourError::Error(error.into()));
         }
 
         let connected = Connected {
@@ -555,7 +555,7 @@ where
 
         Arc::get_mut(&mut user_socket_info).unwrap().state = SocketState::Connected(connected);
         SOCKETS.lock()?.insert(sockfd, user_socket_info);
-        Detour::Success(connect_result)
+        Ok(connect_result)
     };
 
     let connect_result = if remote_address.is_unix() {
@@ -581,7 +581,7 @@ where
             }
         }
     };
-    Detour::Success(connect_result)
+    Ok(connect_result)
 }
 
 /// Checks if an address should be handled as a Unix socket
@@ -753,7 +753,7 @@ where
             NetProtocol::Datagrams,
             nop_connect_fn,
         ) {
-            Detour::Success(..) => {}
+            Ok(..) => {}
             _ => {
                 return Err(ConnectError::Fallback.into());
             }

--- a/mirrord/layer-lib/src/socket/sockets.rs
+++ b/mirrord/layer-lib/src/socket/sockets.rs
@@ -22,7 +22,7 @@ use winapi::{
 };
 
 use super::{SocketKind, SocketState, UserSocket};
-use crate::detour::{Bypass, Detour};
+use crate::detour::{Bypass, Detour, DetourError};
 
 // Platform-specific socket descriptors
 // RawFd
@@ -143,7 +143,7 @@ pub fn reconstruct_user_socket(sockfd: SocketDescriptor) -> Detour<Arc<UserSocke
                 .map(|family| family as i32)
                 .unwrap_or(-1);
             if domain != libc::AF_INET && domain != libc::AF_UNIX {
-                return Detour::Bypass(Bypass::Domain(domain));
+                return Err(DetourError::Bypass(Bypass::Domain(domain)));
             }
             // I really hate it, but nix seems to really make this API bad :(
             let borrowed_fd = unsafe { BorrowedFd::borrow_raw(sockfd) };
@@ -166,14 +166,14 @@ pub fn reconstruct_user_socket(sockfd: SocketDescriptor) -> Detour<Arc<UserSocke
                 )
             };
             if result == SOCKET_ERROR {
-                return Detour::Error(io::Error::last_os_error().into());
+                return Err(DetourError::Error(io::Error::last_os_error().into()));
             }
 
             let proto_info = unsafe { proto_info.assume_init() };
             let domain = proto_info.iAddressFamily;
             // currently only support reconstruction of AF_INET sockets
             if domain != AF_INET {
-                return Detour::Bypass(Bypass::Domain(domain));
+                return Err(DetourError::Bypass(Bypass::Domain(domain)));
             }
 
             let socket_type = proto_info.iSocketType;
@@ -182,7 +182,7 @@ pub fn reconstruct_user_socket(sockfd: SocketDescriptor) -> Detour<Arc<UserSocke
     };
 
     let kind = SocketKind::try_from(type_)?;
-    Detour::Success(Arc::new(UserSocket::new(
+    Ok(Arc::new(UserSocket::new(
         domain,
         type_,
         0,

--- a/mirrord/layer-win/src/hooks/socket/addrinfo_ex.rs
+++ b/mirrord/layer-win/src/hooks/socket/addrinfo_ex.rs
@@ -41,7 +41,7 @@ use std::{
 };
 
 use mirrord_layer_lib::{
-    detour::Detour,
+    detour::{Detour, DetourError},
     error::HookError,
     socket::dns::windows::{
         MANAGED_ADDRINFO, resolve_to_managed,
@@ -352,8 +352,8 @@ pub(crate) unsafe fn begin(
             fired: false,
         };
         match resolve_to_managed::<ADDRINFOEXW>(node, port, ai_family, ai_socktype, ai_protocol) {
-            Detour::Success(managed) => guard.succeed(managed),
-            Detour::Bypass(reason) => {
+            Ok(managed) => guard.succeed(managed),
+            Err(DetourError::Bypass(reason)) => {
                 // The selector check already ran synchronously before `begin`,
                 // so a bypass here is unexpected; treat as "not found".
                 tracing::debug!(
@@ -362,7 +362,7 @@ pub(crate) unsafe fn begin(
                 );
                 guard.fail(WSAHOST_NOT_FOUND as DWORD);
             }
-            Detour::Error(err) => {
+            Err(DetourError::Error(err)) => {
                 // Distinguish a genuine empty result (the name truly has no
                 // records -> host-not-found, terminal) from a transient proxy/
                 // comms failure (-> try-again, so the caller can retry rather

--- a/mirrord/layer-win/src/hooks/socket/addrinfo_ex.rs
+++ b/mirrord/layer-win/src/hooks/socket/addrinfo_ex.rs
@@ -41,7 +41,7 @@ use std::{
 };
 
 use mirrord_layer_lib::{
-    detour::{Detour, DetourError},
+    detour::DetourError,
     error::HookError,
     socket::dns::windows::{
         MANAGED_ADDRINFO, resolve_to_managed,

--- a/mirrord/layer-win/src/hooks/socket/mod.rs
+++ b/mirrord/layer-win/src/hooks/socket/mod.rs
@@ -21,7 +21,7 @@ use mirrord_intproxy_protocol::{
     ConnMetadataRequest, ConnMetadataResponse, OutgoingConnMetadataRequest, PortSubscribe,
 };
 use mirrord_layer_lib::{
-    detour::{Detour, WinGetAddrInfoInt, WinSocket},
+    detour::{Detour, DetourError, DetourWindowsExt, WinGetAddrInfoInt, WinSocket},
     error::{ConnectError, HookError, HookResult, LayerResult, SendToError, windows::WindowsError},
     proxy_connection::make_proxy_request_with_response,
     setup::{LayerSetup, NetworkHookConfig, setup},
@@ -249,9 +249,11 @@ unsafe extern "system" fn socket_detour(af: INT, type_: INT, protocol: INT) -> S
     let call_original = || -> Detour<SocketDescriptor> {
         let socket_result = unsafe { original(af, type_, protocol) };
         if socket_result == INVALID_SOCKET {
-            Detour::Error(std::io::Error::from_raw_os_error(get_last_error()).into())
+            Err(DetourError::Error(
+                std::io::Error::from_raw_os_error(get_last_error()).into(),
+            ))
         } else {
-            Detour::Success(socket_result)
+            Ok(socket_result)
         }
     };
     socket(call_original, af, type_, protocol)
@@ -273,9 +275,11 @@ unsafe extern "system" fn wsa_socket_detour(
         let socket_result =
             unsafe { original(af, socket_type, protocol, lpProtocolInfo, g, dwFlags) };
         if socket_result == INVALID_SOCKET {
-            Detour::Error(std::io::Error::from_raw_os_error(get_last_error()).into())
+            Err(DetourError::Error(
+                std::io::Error::from_raw_os_error(get_last_error()).into(),
+            ))
         } else {
-            Detour::Success(socket_result)
+            Ok(socket_result)
         }
     };
     socket(call_original, af, socket_type, protocol).unwrap_or_bypass_windows_as::<WinSocket, _>(
@@ -297,9 +301,11 @@ unsafe extern "system" fn wsa_socket_w_detour(
         let socket_result =
             unsafe { original(af, socket_type, protocol, lpProtocolInfo, g, dwFlags) };
         if socket_result == INVALID_SOCKET {
-            Detour::Error(std::io::Error::from_raw_os_error(get_last_error()).into())
+            Err(DetourError::Error(
+                std::io::Error::from_raw_os_error(get_last_error()).into(),
+            ))
         } else {
-            Detour::Success(socket_result)
+            Ok(socket_result)
         }
     };
     socket(call_original, af, socket_type, protocol).unwrap_or_bypass_windows_as::<WinSocket, _>(
@@ -1522,7 +1528,7 @@ unsafe extern "system" fn gethostbyname_detour(name: *const i8) -> *mut HOSTENT 
     }
 
     // Check if we should resolve this hostname remotely using the DNS selector
-    if let Detour::Bypass(reason) = setup()
+    if let Err(DetourError::Bypass(reason)) = setup()
         .dns_selector()
         .check_query(hostname_cstr.as_ref(), 0)
     {
@@ -1787,7 +1793,7 @@ unsafe extern "system" fn getaddrinfoexw_detour(
         // the caller's borrowed args are valid. If local, hand the whole async
         // call to the OS unchanged (true passthrough — the OS fires the
         // caller's completion, we add nothing, so there's no double-fire).
-        if let Detour::Bypass(reason) = setup().dns_selector().check_query(&node, port) {
+        if let Err(DetourError::Bypass(reason)) = setup().dns_selector().check_query(&node, port) {
             tracing::debug!(?reason, %node, "GetAddrInfoExW async: selector says local, bypassing");
             return original();
         }

--- a/mirrord/layer-win/src/hooks/socket/ops.rs
+++ b/mirrord/layer-win/src/hooks/socket/ops.rs
@@ -1,7 +1,7 @@
 use std::{net::SocketAddr, sync::OnceLock};
 
 use mirrord_layer_lib::{
-    detour::Detour,
+    detour::{Detour, DetourError},
     error::{ConnectError, HookResult},
     socket::{
         SocketAddrExt,
@@ -260,8 +260,8 @@ where
     // Try to connect through the mirrord proxy using layer-lib integration
     // Temporary workaround until all socket ops are unified - WIN-85
     match connect_common(socket, SockAddr::from(remote_addr), connect_fn) {
-        Detour::Success(res) => Ok(res),
-        Detour::Bypass(_) => Err(ConnectError::Fallback.into()),
-        Detour::Error(err) => Err(err),
+        Ok(res) => Ok(res),
+        Err(DetourError::Bypass(_)) => Err(ConnectError::Fallback.into()),
+        Err(DetourError::Error(err)) => Err(err),
     }
 }

--- a/mirrord/layer-win/src/hooks/socket/ops.rs
+++ b/mirrord/layer-win/src/hooks/socket/ops.rs
@@ -1,7 +1,7 @@
 use std::{net::SocketAddr, sync::OnceLock};
 
 use mirrord_layer_lib::{
-    detour::{Detour, DetourError},
+    detour::DetourError,
     error::{ConnectError, HookResult},
     socket::{
         SocketAddrExt,

--- a/mirrord/layer/src/common.rs
+++ b/mirrord/layer/src/common.rs
@@ -2,8 +2,10 @@
 use std::{ffi::CStr, ops::Not, path::PathBuf};
 
 use libc::c_char;
+#[cfg(target_os = "macos")]
+use mirrord_layer_lib::detour::DetourError;
 pub use mirrord_layer_lib::{
-    detour::{Bypass, Detour},
+    detour::{Bypass, Detour, OptionExt},
     proxy_connection::{make_proxy_request_no_response, make_proxy_request_with_response},
 };
 use mirrord_protocol::file::OpenOptionsInternal;
@@ -35,13 +37,14 @@ impl<'a> CheckedInto<&'a str> for *const c_char {
     fn checked_into(self) -> Detour<&'a str> {
         let converted = (!self.is_null())
             .then(|| unsafe { CStr::from_ptr(self) })
-            .map(CStr::to_str)?
+            .map(CStr::to_str)
+            .bypass(Bypass::EmptyOption)?
             .map_err(|fail| {
                 warn!("Failed converting `value` from `CStr` with {:#?}", fail);
                 Bypass::CStrConversion
             })?;
 
-        Detour::Success(converted)
+        Ok(converted)
     }
 }
 
@@ -89,11 +92,11 @@ impl CheckedInto<PathBuf> for *const c_char {
                 // `stripped_path` is a reference to a later character in the same string as
                 // `path_str`, `stripped_path.as_ptr()` returns a pointer to a later index
                 // in the same string owned by the caller (the hooked program).
-                Detour::Bypass(Bypass::FileOperationInMirrordBinTempDir(
-                    stripped_path.as_ptr() as _,
+                Err(DetourError::Bypass(
+                    Bypass::FileOperationInMirrordBinTempDir(stripped_path.as_ptr() as _),
                 ))
             } else {
-                Detour::Success(path_str) // strip is None, path not in temp dir.
+                Ok(path_str) // strip is None, path not in temp dir.
             }
         });
         str_det.map(From::from)
@@ -108,7 +111,8 @@ impl CheckedInto<Argv> for *const *const c_char {
         let c_list = self
             .is_null()
             .not()
-            .then(|| unsafe { Nul::new_unchecked(self) })?;
+            .then(|| unsafe { Nul::new_unchecked(self) })
+            .bypass(Bypass::EmptyOption)?;
 
         let list = c_list
             .iter()
@@ -118,7 +122,7 @@ impl CheckedInto<Argv> for *const *const c_char {
             .filter(|value| !value.to_string_lossy().starts_with(SHARED_SOCKETS_ENV_VAR))
             .collect::<Argv>();
 
-        Detour::Success(list)
+        Ok(list)
     }
 }
 

--- a/mirrord/layer/src/exec_hooks/hooks.rs
+++ b/mirrord/layer/src/exec_hooks/hooks.rs
@@ -1,6 +1,6 @@
 use base64::prelude::*;
 use libc::{c_char, c_int};
-use mirrord_layer_lib::detour::{Bypass, Detour};
+use mirrord_layer_lib::detour::{Bypass, Detour, DetourError, DetourExt};
 #[cfg(not(target_os = "macos"))]
 use mirrord_layer_macro::hook_fn;
 #[cfg(target_os = "macos")]
@@ -20,13 +20,11 @@ use crate::{
 /// Converts the [`SOCKETS`] map into a vector of pairs `(Fd, UserSocket)`, so we can rebuild
 /// it as a map.
 fn shared_sockets() -> Detour<Vec<(i32, UserSocket)>> {
-    Detour::Success(
-        SOCKETS
-            .lock()?
-            .iter()
-            .map(|(key, value)| (*key, value.as_ref().clone()))
-            .collect::<Vec<_>>(),
-    )
+    Ok(SOCKETS
+        .lock()?
+        .iter()
+        .map(|(key, value)| (*key, value.as_ref().clone()))
+        .collect::<Vec<_>>())
 }
 
 /// Takes an [`Argv`] with the enviroment variables from an `exec` call, extending it with
@@ -36,8 +34,8 @@ fn shared_sockets() -> Detour<Vec<(i32, UserSocket)>> {
 /// by the child process.
 pub(crate) fn prepare_execve_envp(env_vars: Detour<Argv>) -> Detour<Argv> {
     let mut env_vars = env_vars.or_bypass(|reason| match reason {
-        Bypass::EmptyOption => Detour::Success(Argv(Vec::new())),
-        other => Detour::Bypass(other),
+        Bypass::EmptyOption => Ok(Argv(Vec::new())),
+        other => Err(DetourError::Bypass(other)),
     })?;
 
     let encoded = bincode::encode_to_vec(shared_sockets()?, bincode::config::standard())
@@ -45,7 +43,7 @@ pub(crate) fn prepare_execve_envp(env_vars: Detour<Argv>) -> Detour<Argv> {
 
     env_vars.insert_env(SHARED_SOCKETS_ENV_VAR, &encoded)?;
 
-    Detour::Success(env_vars)
+    Ok(env_vars)
 }
 
 #[cfg(not(target_os = "macos"))]
@@ -69,7 +67,7 @@ unsafe extern "C" fn execv_detour(path: *const c_char, argv: *const *const c_cha
     unsafe {
         let envp = environ();
         match prepare_execve_envp(envp.checked_into()) {
-            Detour::Success(envp) => FN_EXECVE(path, argv, envp.leak()),
+            Ok(envp) => FN_EXECVE(path, argv, envp.leak()),
             _ => FN_EXECVE(path, argv, envp),
         }
     }
@@ -87,7 +85,7 @@ pub(crate) unsafe extern "C" fn execve_detour(
 ) -> c_int {
     unsafe {
         match prepare_execve_envp(envp.checked_into()) {
-            Detour::Success(envp) => FN_EXECVE(path, argv, envp.leak()),
+            Ok(envp) => FN_EXECVE(path, argv, envp.leak()),
             _ => FN_EXECVE(path, argv, envp),
         }
     }
@@ -125,14 +123,10 @@ pub(crate) unsafe extern "C" fn execve_detour(
 ) -> c_int {
     unsafe {
         match patch_sip_for_new_process(path, argv, envp) {
-            Detour::Success((path, argv, envp)) => {
-                match prepare_execve_envp(Detour::Success(envp.clone())) {
-                    Detour::Success(envp) => {
-                        FN_EXECVE(path.into_raw().cast_const(), argv.leak(), envp.leak())
-                    }
-                    _ => FN_EXECVE(path.into_raw().cast_const(), argv.leak(), envp.leak()),
-                }
-            }
+            Ok((path, argv, envp)) => match prepare_execve_envp(Ok(envp.clone())) {
+                Ok(envp) => FN_EXECVE(path.into_raw().cast_const(), argv.leak(), envp.leak()),
+                _ => FN_EXECVE(path.into_raw().cast_const(), argv.leak(), envp.leak()),
+            },
             _ => FN_EXECVE(path, argv, envp),
         }
     }

--- a/mirrord/layer/src/exec_utils.rs
+++ b/mirrord/layer/src/exec_utils.rs
@@ -11,7 +11,7 @@ use mirrord_layer_lib::{
         Bypass::{
             ExecOnNonExistingFile, FileOperationInMirrordBinTempDir, NoSipDetected, TooManyArgs,
         },
-        Detour::{self, Bypass, Error, Success},
+        Detour, DetourError,
     },
     error::HookError,
 };
@@ -102,8 +102,8 @@ pub(super) fn patch_if_sip(path: &str) -> Detour<String> {
         },
         log_info,
     ) {
-        Ok(None) => Bypass(NoSipDetected(path.to_owned())),
-        Ok(Some(new_path)) => Success(new_path),
+        Ok(None) => Err(DetourError::Bypass(NoSipDetected(path.to_owned()))),
+        Ok(Some(new_path)) => Ok(new_path),
         Err(SipError::FileNotFound(non_existing_bin)) => {
             trace!(
                 "The application wants to execute {}, SIP check got FileNotFound for {}. \
@@ -111,7 +111,7 @@ pub(super) fn patch_if_sip(path: &str) -> Detour<String> {
                 from FS ops.",
                 path, non_existing_bin
             );
-            Bypass(ExecOnNonExistingFile(non_existing_bin))
+            Err(DetourError::Bypass(ExecOnNonExistingFile(non_existing_bin)))
         }
         ref sip_error @ Err(SipError::TooManyFilesOpen(..)) => {
             // we can't recover from hitting the fd limit, so we have to exit fully
@@ -130,7 +130,7 @@ pub(super) fn patch_if_sip(path: &str) -> Detour<String> {
                 executed locally if its execution without mirrord indeed succeeds.",
                 path, sip_error
             );
-            Error(HookError::FailedSipPatch(sip_error))
+            Err(DetourError::Error(HookError::FailedSipPatch(sip_error)))
         }
     }
 }
@@ -150,7 +150,7 @@ fn intercept_tmp_dir(argv_arr: &Nul<*const c_char>) -> Detour<Argv> {
         if i > MAX_ARGC {
             // the iterator will go until there is a null pointer, so stop after MAX_ARGC so
             // that we don't just keep going indefinitely if a bad argv was passed.
-            return Bypass(TooManyArgs);
+            return Err(DetourError::Bypass(TooManyArgs));
         }
         let arg_str: &str = arg.checked_into()?;
         trace!("exec arg: {arg_str}");
@@ -175,7 +175,7 @@ fn intercept_tmp_dir(argv_arr: &Nul<*const c_char>) -> Detour<Argv> {
 
         c_string_vec.push(CString::new(stripped)?)
     }
-    Success(c_string_vec)
+    Ok(c_string_vec)
 }
 
 /// Verifies that mirrord environment is passed to child process
@@ -184,7 +184,7 @@ fn intercept_environment(envp_arr: &Nul<*const c_char>) -> Detour<Argv> {
 
     let mut found_dyld = false;
     for arg in envp_arr.iter() {
-        let Detour::Success(arg_str): Detour<&str> = arg.checked_into() else {
+        let Ok(arg_str): Detour<&str> = arg.checked_into() else {
             tracing::debug!("Failed to convert envp argument to string. Skipping.");
             c_string_vec.push(unsafe { CStr::from_ptr(*arg).to_owned() });
             continue;
@@ -202,7 +202,7 @@ fn intercept_environment(envp_arr: &Nul<*const c_char>) -> Detour<Argv> {
             c_string_vec.push(CString::new(format!("{key}={value}"))?);
         }
     }
-    Success(c_string_vec)
+    Ok(c_string_vec)
 }
 
 /// Patch the new executable for SIP if necessary. Also: if mirrord's temporary directory appears
@@ -229,7 +229,7 @@ pub(crate) unsafe fn patch_sip_for_new_process(
         // that patched executable will be used.
         let path_str = strip_mirrord_path(path_str).unwrap_or(path_str);
         let path_c_string = patch_if_sip(path_str)
-            .and_then(|new_path| Success(CString::new(new_path)?))
+            .and_then(|new_path| Ok(CString::new(new_path)?))
             // Continue also on error, use original path, don't bypass yet, try cleaning argv.
             .unwrap_or(CString::new(path_str.to_owned())?);
 
@@ -238,7 +238,7 @@ pub(crate) unsafe fn patch_sip_for_new_process(
 
         let argv_vec = intercept_tmp_dir(argv_arr)?;
         let envp_vec = intercept_environment(envp_arr)?;
-        Success((path_c_string, argv_vec, envp_vec))
+        Ok((path_c_string, argv_vec, envp_vec))
     }
 }
 
@@ -256,26 +256,24 @@ pub(crate) unsafe extern "C" fn posix_spawn_detour(
 ) -> c_int {
     unsafe {
         match patch_sip_for_new_process(path, argv, envp) {
-            Detour::Success((path, argv, envp)) => {
-                match hooks::prepare_execve_envp(Detour::Success(envp.clone())) {
-                    Detour::Success(envp) => FN_POSIX_SPAWN(
-                        pid,
-                        path.into_raw().cast_const(),
-                        file_actions,
-                        attrp,
-                        argv.leak(),
-                        envp.leak(),
-                    ),
-                    _ => FN_POSIX_SPAWN(
-                        pid,
-                        path.into_raw().cast_const(),
-                        file_actions,
-                        attrp,
-                        argv.leak(),
-                        envp.leak(),
-                    ),
-                }
-            }
+            Ok((path, argv, envp)) => match hooks::prepare_execve_envp(Ok(envp.clone())) {
+                Ok(envp) => FN_POSIX_SPAWN(
+                    pid,
+                    path.into_raw().cast_const(),
+                    file_actions,
+                    attrp,
+                    argv.leak(),
+                    envp.leak(),
+                ),
+                _ => FN_POSIX_SPAWN(
+                    pid,
+                    path.into_raw().cast_const(),
+                    file_actions,
+                    attrp,
+                    argv.leak(),
+                    envp.leak(),
+                ),
+            },
             _ => FN_POSIX_SPAWN(pid, path, file_actions, attrp, argv, envp),
         }
     }
@@ -290,7 +288,9 @@ pub(crate) unsafe extern "C" fn _nsget_executable_path_detour(
         let res = FN__NSGET_EXECUTABLE_PATH(path, buflen);
         if res == 0 {
             let path_buf_detour = CheckedInto::<PathBuf>::checked_into(path as *const c_char);
-            if let Bypass(FileOperationInMirrordBinTempDir(later_ptr)) = path_buf_detour {
+            if let Err(DetourError::Bypass(FileOperationInMirrordBinTempDir(later_ptr))) =
+                path_buf_detour
+            {
                 // SAFETY: If we're here, the original function was passed this pointer and was
                 //         successful, so this pointer must be valid.
                 let old_len = *buflen;
@@ -335,7 +335,9 @@ pub(crate) unsafe extern "C" fn dlopen_detour(
         // we hold the guard manually for tracing/internal code
         let guard = mirrord_layer_lib::detour::DetourGuard::new();
         let detour: Detour<PathBuf> = raw_path.checked_into();
-        let raw_path = if let Bypass(FileOperationInMirrordBinTempDir(ptr)) = detour {
+        let raw_path = if let Err(DetourError::Bypass(FileOperationInMirrordBinTempDir(ptr))) =
+            detour
+        {
             trace!("dlopen called with a path inside our patch dir, switching with fixed pointer.");
             ptr
         } else {

--- a/mirrord/layer/src/file/hooks.rs
+++ b/mirrord/layer/src/file/hooks.rs
@@ -22,7 +22,7 @@ use libc::{dirent64, stat64, statx};
 #[cfg(target_os = "linux")]
 use mirrord_layer_lib::error::HookError::ResponseError;
 use mirrord_layer_lib::{
-    detour::{Bypass, Detour, DetourGuard},
+    detour::{Bypass, Detour, DetourError, DetourExt, DetourGuard},
     error::HookError,
 };
 use mirrord_layer_macro::{hook_fn, hook_guard_fn};
@@ -164,15 +164,15 @@ pub(super) unsafe extern "C" fn opendir_detour(raw_filename: *const c_char) -> u
     unsafe {
         open_logic(raw_filename, O_RDONLY, O_DIRECTORY)
             .and_then(|fd| match fdopendir(fd) {
-                Detour::Success(success) => Detour::Success(success),
-                Detour::Bypass(bypass) => {
+                Ok(success) => Ok(success),
+                Err(DetourError::Bypass(bypass)) => {
                     // this shouldn't happen, but if it does we shouldn't leak fd
                     close_layer_fd(fd);
-                    Detour::Bypass(bypass)
+                    Err(DetourError::Bypass(bypass))
                 }
-                Detour::Error(fail) => {
+                Err(DetourError::Error(fail)) => {
                     close_layer_fd(fd);
-                    Detour::Error(fail)
+                    Err(DetourError::Error(fail))
                 }
             })
             .unwrap_or_bypass_with(|bypass| {
@@ -434,9 +434,9 @@ pub(crate) unsafe extern "C" fn readdir64_r_detour(
 pub(crate) unsafe extern "C" fn readdir64_detour(dirp: *mut DIR) -> usize {
     unsafe {
         match OPEN_DIRS.read64(dirp as usize) {
-            Detour::Success(entry) => entry as usize,
-            Detour::Bypass(..) => FN_READDIR64(dirp),
-            Detour::Error(e) => {
+            Ok(entry) => entry as usize,
+            Err(DetourError::Bypass(..)) => FN_READDIR64(dirp),
+            Err(DetourError::Error(e)) => {
                 Errno::set_raw(e.into());
                 std::ptr::null::<dirent64>() as usize
             }
@@ -448,9 +448,9 @@ pub(crate) unsafe extern "C" fn readdir64_detour(dirp: *mut DIR) -> usize {
 pub(crate) unsafe extern "C" fn readdir_detour(dirp: *mut DIR) -> usize {
     unsafe {
         match OPEN_DIRS.read(dirp as usize) {
-            Detour::Success(entry) => entry as usize,
-            Detour::Bypass(..) => FN_READDIR(dirp),
-            Detour::Error(e) => {
+            Ok(entry) => entry as usize,
+            Err(DetourError::Bypass(..)) => FN_READDIR(dirp),
+            Err(DetourError::Error(e)) => {
                 Errno::set_raw(e.into());
                 std::ptr::null::<dirent>() as usize
             }
@@ -552,7 +552,7 @@ pub(crate) unsafe extern "C" fn getdents64_detour(
 ) -> c_ssize_t {
     unsafe {
         match getdents64(fd, buf_size as u64) {
-            Detour::Success(res) => {
+            Ok(res) => {
                 let mut next = dirent_buf as *mut dirent;
                 let end = next.byte_add(buf_size);
                 for dent in res.entries {
@@ -583,13 +583,13 @@ pub(crate) unsafe extern "C" fn getdents64_detour(
                 }
                 res.result_size as c_ssize_t
             }
-            Detour::Bypass(_) => {
+            Err(DetourError::Bypass(_)) => {
                 mirrord_layer_macro::trace!(
                     "bypassing getdents64: calling syscall locally (fd: {fd})."
                 );
                 libc::syscall(libc::SYS_getdents64, fd, dirent_buf, buf_size) as c_ssize_t
             }
-            Detour::Error(ResponseError(NotFound(not_found_fd))) => {
+            Err(DetourError::Error(ResponseError(NotFound(not_found_fd)))) => {
                 info!(
                     "Go application tried to read a directory and mirrord carried out that read on the \
                 remote destination, however that directory was not found over there (local fd: \
@@ -598,7 +598,7 @@ pub(crate) unsafe extern "C" fn getdents64_detour(
                 Errno::ENOENT.set(); // "No such directory."
                 -1
             }
-            Detour::Error(ResponseError(NotDirectory(file_fd))) => {
+            Err(DetourError::Error(ResponseError(NotDirectory(file_fd)))) => {
                 warn!(
                     "Go application tried to read a directory and mirrord carried out that read on the \
                 remote destination, however the type of that file on the remote destination is not \
@@ -607,7 +607,7 @@ pub(crate) unsafe extern "C" fn getdents64_detour(
                 Errno::ENOTDIR.set(); // "Not a directory."
                 -1
             }
-            Detour::Error(err) => {
+            Err(DetourError::Error(err)) => {
                 error!("Encountered error in getdents64 detour: {err:?}");
                 // There is no appropriate error code for "We hijacked this operation to a remote
                 // agent and the agent returned an error". We could try to map more
@@ -988,7 +988,7 @@ fn stat_logic<const FOLLOW_SYMLINK: bool>(
     out_stat: *mut stat64,
 ) -> Detour<c_int> {
     if out_stat.is_null() {
-        Detour::Error(HookError::BadPointer)
+        Err(DetourError::Error(HookError::BadPointer))
     } else {
         let path = raw_path.map(CheckedInto::checked_into);
 
@@ -1126,7 +1126,7 @@ pub(crate) unsafe fn fstatat_logic(
 ) -> Detour<i32> {
     unsafe {
         if out_stat.is_null() {
-            return Detour::Error(HookError::BadPointer);
+            return Err(DetourError::Error(HookError::BadPointer));
         }
 
         let follow_symlink = (flag & libc::AT_SYMLINK_NOFOLLOW) == 0;
@@ -1359,7 +1359,7 @@ pub(crate) unsafe extern "C" fn readv_detour(
         let iovs = (!iovecs.is_null()).then(|| slice::from_raw_parts(iovecs, iovec_count as usize));
 
         readv(iovs)
-            .and_then(|(iovs, read_size)| Detour::Success((read(fd, read_size)?, iovs)))
+            .and_then(|(iovs, read_size)| Ok((read(fd, read_size)?, iovs)))
             .map(|(read_file, iovs)| {
                 let ReadFileResponse { bytes, .. } = read_file;
 
@@ -1387,7 +1387,7 @@ pub(crate) unsafe extern "C" fn readv_nocancel_detour(
         let iovs = (!iovecs.is_null()).then(|| slice::from_raw_parts(iovecs, iovec_count as usize));
 
         readv(iovs)
-            .and_then(|(iovs, read_size)| Detour::Success((read(fd, read_size)?, iovs)))
+            .and_then(|(iovs, read_size)| Ok((read(fd, read_size)?, iovs)))
             .map(|(read_file, iovs)| {
                 let ReadFileResponse { bytes, .. } = read_file;
 
@@ -1416,9 +1416,7 @@ pub(crate) unsafe extern "C" fn preadv_detour(
         let iovs = (!iovecs.is_null()).then(|| slice::from_raw_parts(iovecs, iovec_count as usize));
 
         readv(iovs)
-            .and_then(|(iovs, read_size)| {
-                Detour::Success((pread(fd, read_size, offset as u64)?, iovs))
-            })
+            .and_then(|(iovs, read_size)| Ok((pread(fd, read_size, offset as u64)?, iovs)))
             .map(|(read_file, iovs)| {
                 let ReadFileResponse { bytes, .. } = read_file;
 
@@ -1448,9 +1446,7 @@ pub(crate) unsafe extern "C" fn preadv_nocancel_detour(
         let iovs = (!iovecs.is_null()).then(|| slice::from_raw_parts(iovecs, iovec_count as usize));
 
         readv(iovs)
-            .and_then(|(iovs, read_size)| {
-                Detour::Success((pread(fd, read_size, offset as u64)?, iovs))
-            })
+            .and_then(|(iovs, read_size)| Ok((pread(fd, read_size, offset as u64)?, iovs)))
             .map(|(read_file, iovs)| {
                 let ReadFileResponse { bytes, .. } = read_file;
 

--- a/mirrord/layer/src/file/open_dirs.rs
+++ b/mirrord/layer/src/file/open_dirs.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use mirrord_layer_lib::{
-    detour::{Bypass, Detour},
+    detour::{Bypass, Detour, DetourError},
     error::HookError,
     mutex::Mutex,
 };
@@ -49,7 +49,7 @@ impl OpenDirs {
             local_dir_fd,
             Mutex::new(OpenDir::new(local_dir_fd, remote_fd, base_fd)).into(),
         );
-        Detour::Success(())
+        Ok(())
     }
 
     /// Reads next entry from the open directory with the given [`DirStreamFd`].
@@ -77,7 +77,7 @@ impl OpenDirs {
 
         let guard = dir.lock().expect("lock poisoned");
 
-        Detour::Success(guard.get_base_fd())
+        Ok(guard.get_base_fd())
     }
 
     /// Reads next entry from the open directory with the given [`DirStreamFd`] and copies the data
@@ -103,12 +103,12 @@ impl OpenDirs {
         let mut guard = dir.lock().expect("lock poisoned");
 
         let Some(entry) = guard.read_r()? else {
-            return Detour::Success(std::ptr::null());
+            return Ok(std::ptr::null());
         };
 
         assign_direntry(entry, &mut guard.dirent, false)?;
 
-        Detour::Success(&guard.dirent)
+        Ok(&guard.dirent)
     }
 
     /// Reads next entry from the open directory with the given [`DirStreamFd`] and copies the data
@@ -135,12 +135,12 @@ impl OpenDirs {
         let mut guard = dir.lock().expect("lock poisoned");
 
         let Some(entry) = guard.read_r()? else {
-            return Detour::Success(std::ptr::null());
+            return Ok(std::ptr::null());
         };
 
         assign_direntry64(entry, &mut guard.dirent64, false)?;
 
-        Detour::Success(&guard.dirent64)
+        Ok(&guard.dirent64)
     }
 
     /// Closes the open directory with the given [`DirStreamFd`].
@@ -158,7 +158,7 @@ impl OpenDirs {
             remote_fd: guard.remote_fd,
         })?;
 
-        Detour::Success(0)
+        Ok(0)
     }
 }
 
@@ -215,14 +215,16 @@ impl OpenDir {
     fn read_r(&self) -> Detour<Option<DirEntryInternal>> {
         if self.closed {
             // This thread got this struct from `OpenDirs` before `close` removed it.
-            return Detour::Bypass(Bypass::LocalDirStreamNotFound(self.local_fd));
+            return Err(DetourError::Bypass(Bypass::LocalDirStreamNotFound(
+                self.local_fd,
+            )));
         }
 
         let ReadDirResponse { direntry } =
             common::make_proxy_request_with_response(ReadDirRequest {
                 remote_fd: self.remote_fd,
             })??;
-        Detour::Success(direntry)
+        Ok(direntry)
     }
 
     fn get_base_fd(&self) -> LocalFd {

--- a/mirrord/layer/src/file/ops.rs
+++ b/mirrord/layer/src/file/ops.rs
@@ -49,7 +49,7 @@ const MAX_READ_SIZE: u64 = 1024 * 1024;
 /// Convenience extension for verifying that a [`Path`] is not relative.
 trait PathExt {
     /// If this [`Path`] is relative and is not present in the `fs.not_found` filters, returns a
-    /// [`Detour::Bypass`], otherwise errors with [`HookError::FileNotFound`].
+    /// [`Bypass`], otherwise errors with [`HookError::FileNotFound`].
     fn ensure_not_relative_or_not_found(&self) -> Detour<()>;
 }
 

--- a/mirrord/layer/src/file/ops.rs
+++ b/mirrord/layer/src/file/ops.rs
@@ -18,7 +18,7 @@ use libc::{AT_FDCWD, c_int, iovec};
 use libc::{c_char, statx, statx_timestamp};
 use mirrord_config::feature::fs::FsModeConfig;
 use mirrord_layer_lib::{
-    detour::{Bypass, Detour},
+    detour::{Bypass, Detour, DetourError, DetourExt, OptionExt},
     error::{HookError, HookResult as Result},
     file::filter::FileFilter,
 };
@@ -57,12 +57,16 @@ impl PathExt for Path {
     fn ensure_not_relative_or_not_found(&self) -> Detour<()> {
         if self.is_relative() {
             if crate::setup().file_filter().check_not_found(self) {
-                Detour::Error(HookError::FileNotFound(self.to_string_lossy().to_string()))
+                Err(DetourError::Error(HookError::FileNotFound(
+                    self.to_string_lossy().to_string(),
+                )))
             } else {
-                Detour::Bypass(Bypass::relative_path(self.to_str().unwrap_or_default()))
+                Err(DetourError::Bypass(Bypass::relative_path(
+                    self.to_str().unwrap_or_default(),
+                )))
             }
         } else {
-            Detour::Success(())
+            Ok(())
         }
     }
 }
@@ -74,28 +78,32 @@ pub fn ensure_remote(file_filter: &FileFilter, path: &Path, write: bool) -> Deto
     let text = path.to_str().unwrap_or_default();
 
     match file_filter.mode {
-        FsModeConfig::Local => Detour::Bypass(Bypass::ignored_file(text)),
+        FsModeConfig::Local => Err(DetourError::Bypass(Bypass::ignored_file(text))),
         _ if file_filter.not_found.is_match(text) => {
-            Detour::Error(HookError::FileNotFound(text.to_owned()))
+            Err(DetourError::Error(HookError::FileNotFound(text.to_owned())))
         }
-        _ if file_filter.read_write.is_match(text) => Detour::Success(()),
+        _ if file_filter.read_write.is_match(text) => Ok(()),
         _ if file_filter.read_only.is_match(text) => {
             if write {
-                Detour::Bypass(Bypass::ignored_file(text))
+                Err(DetourError::Bypass(Bypass::ignored_file(text)))
             } else {
-                Detour::Success(())
+                Ok(())
             }
         }
-        _ if file_filter.local.is_match(text) => Detour::Bypass(Bypass::ignored_file(text)),
-        _ if file_filter.default_not_found.is_match(text) => {
-            Detour::Error(HookError::FileNotFound(text.to_owned()))
+        _ if file_filter.local.is_match(text) => {
+            Err(DetourError::Bypass(Bypass::ignored_file(text)))
         }
-        _ if file_filter.default_remote_ro.is_match(text) && !write => Detour::Success(()),
-        _ if file_filter.default_local.is_match(text) => Detour::Bypass(Bypass::ignored_file(text)),
-        FsModeConfig::LocalWithOverrides => Detour::Bypass(Bypass::ignored_file(text)),
-        FsModeConfig::Write => Detour::Success(()),
-        FsModeConfig::Read if write => Detour::Bypass(Bypass::ReadOnly(text.into())),
-        FsModeConfig::Read => Detour::Success(()),
+        _ if file_filter.default_not_found.is_match(text) => {
+            Err(DetourError::Error(HookError::FileNotFound(text.to_owned())))
+        }
+        _ if file_filter.default_remote_ro.is_match(text) && !write => Ok(()),
+        _ if file_filter.default_local.is_match(text) => {
+            Err(DetourError::Bypass(Bypass::ignored_file(text)))
+        }
+        FsModeConfig::LocalWithOverrides => Err(DetourError::Bypass(Bypass::ignored_file(text))),
+        FsModeConfig::Write => Ok(()),
+        FsModeConfig::Read if write => Err(DetourError::Bypass(Bypass::ReadOnly(text.into()))),
+        FsModeConfig::Read => Ok(()),
     }
 }
 
@@ -112,7 +120,7 @@ fn common_path_check(path: PathBuf, write: bool) -> Detour<PathBuf> {
 
     let path = crate::setup().file_remapper().change_path(path);
     ensure_remote(crate::setup().file_filter(), &path, write)?;
-    Detour::Success(path)
+    Ok(path)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -136,7 +144,7 @@ impl RemoteFile {
 
         let response = common::make_proxy_request_with_response(requesting_file)??;
 
-        Detour::Success(response)
+        Ok(response)
     }
 
     /// Sends a [`ReadFileRequest`] message, reading the file in the agent.
@@ -154,7 +162,7 @@ impl RemoteFile {
 
         let response = common::make_proxy_request_with_response(reading_file)??;
 
-        Detour::Success(response)
+        Ok(response)
     }
 
     /// Sends a [`CloseFileRequest`] message, closing the file in the agent.
@@ -185,14 +193,12 @@ impl Drop for RemoteFile {
 /// `mirrord_agent::util::IndexAllocator`).
 fn get_remote_fd(local_fd: RawFd) -> Detour<u64> {
     // don't add a trace here since it causes deadlocks in some cases.
-    Detour::Success(
-        OPEN_FILES
-            .lock()?
-            .get(&local_fd)
-            .map(|remote_file| remote_file.fd)
-            // Bypass if we're not managing the relative part.
-            .ok_or(Bypass::LocalFdNotFound(local_fd))?,
-    )
+    Ok(OPEN_FILES
+        .lock()?
+        .get(&local_fd)
+        .map(|remote_file| remote_file.fd)
+        // Bypass if we're not managing the relative part.
+        .ok_or(Bypass::LocalFdNotFound(local_fd))?)
 }
 
 /// Create temporary local file to get a valid local fd.
@@ -211,10 +217,12 @@ fn create_local_fake_file(remote_fd: u64) -> Detour<RawFd> {
         let error = Errno::last_raw();
         // Close the remote file if creating a tmp local file failed and we have an invalid local fd
         close_remote_file_on_failure(remote_fd)?;
-        Detour::Error(HookError::LocalFileCreation(remote_fd, error))
+        Err(DetourError::Error(HookError::LocalFileCreation(
+            remote_fd, error,
+        )))
     } else {
         unsafe { libc::unlink(file_path_ptr) };
-        Detour::Success(local_file_fd)
+        Ok(local_file_fd)
     }
 }
 
@@ -228,9 +236,11 @@ fn create_local_devnull_file(remote_fd: u64) -> Detour<RawFd> {
         let error = Errno::last_raw();
         // Close the remote file if creating a tmp local file failed and we have an invalid local fd
         close_remote_file_on_failure(remote_fd)?;
-        Detour::Error(HookError::LocalFileCreation(remote_fd, error))
+        Err(DetourError::Error(HookError::LocalFileCreation(
+            remote_fd, error,
+        )))
     } else {
-        Detour::Success(local_file_fd)
+        Ok(local_file_fd)
     }
 }
 
@@ -257,10 +267,12 @@ pub(crate) fn open(path: Detour<PathBuf>, open_options: OpenOptionsInternal) -> 
     let path = common_path_check(path?, open_options.is_write())?;
 
     let OpenFileResponse { fd: remote_fd } = RemoteFile::remote_open(path.clone(), open_options)
-        .or_else(|fail| match fail {
+        .on_error(|fail| match fail {
             // The operator has a policy that matches this `path` as local-only.
-            HookError::ResponseError(ResponseError::OpenLocal) => Detour::Bypass(Bypass::OpenLocal),
-            other => Detour::Error(other),
+            HookError::ResponseError(ResponseError::OpenLocal) => {
+                Err(DetourError::Bypass(Bypass::OpenLocal))
+            }
+            other => Err(DetourError::Error(other)),
         })?;
 
     // TODO: Need a way to say "open a directory", right now `is_dir` always returns false.
@@ -273,7 +285,7 @@ pub(crate) fn open(path: Detour<PathBuf>, open_options: OpenOptionsInternal) -> 
         Arc::new(RemoteFile::new(remote_fd, path.display().to_string())),
     );
 
-    Detour::Success(local_file_fd)
+    Ok(local_file_fd)
 }
 
 /// creates a directory stream for the `remote_fd` in the agent
@@ -299,7 +311,7 @@ pub(crate) fn fdopendir(fd: RawFd) -> Detour<usize> {
 
     // Let it stay in OPEN_FILES, as some functions might use it in comibination with dirfd
 
-    Detour::Success(local_dir_fd as usize)
+    Ok(local_dir_fd as usize)
 }
 
 #[mirrord_layer_macro::instrument(level = "trace", ret)]
@@ -313,7 +325,7 @@ pub(crate) fn openat(
     // `openat` behaves the same as `open` when the path is absolute. When called with AT_FDCWD, the
     // call is propagated to `open`.
     if path.is_absolute() || fd == AT_FDCWD {
-        return open(Detour::Success(path), open_options);
+        return open(Ok(path), open_options);
     }
 
     // Relative path requires special handling, we must identify the relative part
@@ -336,7 +348,7 @@ pub(crate) fn openat(
         Arc::new(RemoteFile::new(remote_fd, path.display().to_string())),
     );
 
-    Detour::Success(local_file_fd)
+    Ok(local_file_fd)
 }
 
 /// Blocking wrapper around [`libc::read`] call.
@@ -350,10 +362,10 @@ pub(crate) fn read(local_fd: RawFd, read_amount: u64) -> Detour<ReadFileResponse
 /// Helper for dealing with a potential null pointer being passed to `*const iovec` from
 /// `readv_detour` and `preadv_detour`.
 pub(crate) fn readv(iovs: Option<&[iovec]>) -> Detour<(&[iovec], u64)> {
-    let iovs = iovs?;
+    let iovs = iovs.bypass(Bypass::EmptyOption)?;
     let read_size: u64 = iovs.iter().fold(0, |sum, iov| sum + iov.iov_len as u64);
 
-    Detour::Success((iovs, read_size))
+    Ok((iovs, read_size))
 }
 
 #[mirrord_layer_macro::instrument(level = "trace")]
@@ -369,7 +381,7 @@ pub(crate) fn pread(local_fd: RawFd, buffer_size: u64, offset: u64) -> Detour<Re
 
     let response = common::make_proxy_request_with_response(reading_file)??;
 
-    Detour::Success(response)
+    Ok(response)
 }
 
 /// Resolves the symbolic link `path`.
@@ -381,9 +393,9 @@ pub(crate) fn read_link(path: Detour<PathBuf>) -> Detour<ReadLinkFileResponse> {
 
     // `NotImplemented` error here means that the protocol doesn't support it.
     match common::make_proxy_request_with_response(requesting_path)? {
-        Ok(response) => Detour::Success(response),
-        Err(ResponseError::NotImplemented) => Detour::Bypass(Bypass::NotImplemented),
-        Err(fail) => Detour::Error(fail.into()),
+        Ok(response) => Ok(response),
+        Err(ResponseError::NotImplemented) => Err(DetourError::Bypass(Bypass::NotImplemented)),
+        Err(fail) => Err(DetourError::Error(fail.into())),
     }
 }
 
@@ -398,9 +410,9 @@ pub(crate) fn mkdir(path: Detour<PathBuf>, mode: u32) -> Detour<()> {
 
     // `NotImplemented` error here means that the protocol doesn't support it.
     match common::make_proxy_request_with_response(mkdir)? {
-        Ok(response) => Detour::Success(response),
-        Err(ResponseError::NotImplemented) => Detour::Bypass(Bypass::NotImplemented),
-        Err(fail) => Detour::Error(fail.into()),
+        Ok(response) => Ok(response),
+        Err(ResponseError::NotImplemented) => Err(DetourError::Bypass(Bypass::NotImplemented)),
+        Err(fail) => Err(DetourError::Error(fail.into())),
     }
 }
 
@@ -409,7 +421,7 @@ pub(crate) fn mkdirat(dirfd: RawFd, path: Detour<PathBuf>, mode: u32) -> Detour<
     let path = path?;
 
     if path.is_absolute() || dirfd == AT_FDCWD {
-        return mkdir(Detour::Success(path), mode);
+        return mkdir(Ok(path), mode);
     }
 
     // Relative path requires special handling, we must identify the relative part (relative to
@@ -424,9 +436,9 @@ pub(crate) fn mkdirat(dirfd: RawFd, path: Detour<PathBuf>, mode: u32) -> Detour<
 
     // `NotImplemented` error here means that the protocol doesn't support it.
     match common::make_proxy_request_with_response(mkdir)? {
-        Ok(response) => Detour::Success(response),
-        Err(ResponseError::NotImplemented) => Detour::Bypass(Bypass::NotImplemented),
-        Err(fail) => Detour::Error(fail.into()),
+        Ok(response) => Ok(response),
+        Err(ResponseError::NotImplemented) => Err(DetourError::Bypass(Bypass::NotImplemented)),
+        Err(fail) => Err(DetourError::Error(fail.into())),
     }
 }
 
@@ -438,9 +450,9 @@ pub(crate) fn rmdir(path: Detour<PathBuf>) -> Detour<()> {
 
     // `NotImplemented` error here means that the protocol doesn't support it.
     match common::make_proxy_request_with_response(rmdir)? {
-        Ok(response) => Detour::Success(response),
-        Err(ResponseError::NotImplemented) => Detour::Bypass(Bypass::NotImplemented),
-        Err(fail) => Detour::Error(fail.into()),
+        Ok(response) => Ok(response),
+        Err(ResponseError::NotImplemented) => Err(DetourError::Bypass(Bypass::NotImplemented)),
+        Err(fail) => Err(DetourError::Error(fail.into())),
     }
 }
 
@@ -452,9 +464,9 @@ pub(crate) fn unlink(path: Detour<PathBuf>) -> Detour<()> {
 
     // `NotImplemented` error here means that the protocol doesn't support it.
     match common::make_proxy_request_with_response(unlink)? {
-        Ok(response) => Detour::Success(response),
-        Err(ResponseError::NotImplemented) => Detour::Bypass(Bypass::NotImplemented),
-        Err(fail) => Detour::Error(fail.into()),
+        Ok(response) => Ok(response),
+        Err(ResponseError::NotImplemented) => Err(DetourError::Bypass(Bypass::NotImplemented)),
+        Err(fail) => Err(DetourError::Error(fail.into())),
     }
 }
 
@@ -489,9 +501,9 @@ pub(crate) fn unlinkat(dirfd: RawFd, path: Detour<PathBuf>, flags: u32) -> Detou
 
     // `NotImplemented` error here means that the protocol doesn't support it.
     match common::make_proxy_request_with_response(unlink)? {
-        Ok(response) => Detour::Success(response),
-        Err(ResponseError::NotImplemented) => Detour::Bypass(Bypass::NotImplemented),
-        Err(fail) => Detour::Error(fail.into()),
+        Ok(response) => Ok(response),
+        Err(ResponseError::NotImplemented) => Err(DetourError::Bypass(Bypass::NotImplemented)),
+        Err(fail) => Err(DetourError::Error(fail.into())),
     }
 }
 
@@ -507,7 +519,7 @@ pub(crate) fn pwrite(local_fd: RawFd, buffer: &[u8], offset: u64) -> Detour<Writ
 
     let response = common::make_proxy_request_with_response(writing_file)??;
 
-    Detour::Success(response)
+    Ok(response)
 }
 
 #[mirrord_layer_macro::instrument(level = "trace")]
@@ -524,7 +536,7 @@ pub(crate) fn lseek(local_fd: RawFd, offset: i64, whence: i32) -> Detour<u64> {
                 invalid,
                 whence
             );
-            return Detour::Bypass(Bypass::CStrConversion);
+            return Err(DetourError::Bypass(Bypass::CStrConversion));
         }
     };
 
@@ -536,7 +548,7 @@ pub(crate) fn lseek(local_fd: RawFd, offset: i64, whence: i32) -> Detour<u64> {
     let SeekFileResponse { result_offset } =
         common::make_proxy_request_with_response(seeking_file)??;
 
-    Detour::Success(result_offset)
+    Ok(result_offset)
 }
 
 pub(crate) fn write(local_fd: RawFd, write_bytes: Option<Vec<u8>>) -> Detour<isize> {
@@ -549,7 +561,7 @@ pub(crate) fn write(local_fd: RawFd, write_bytes: Option<Vec<u8>>) -> Detour<isi
 
     let WriteFileResponse { written_amount } =
         common::make_proxy_request_with_response(writing_file)??;
-    Detour::Success(written_amount.try_into()?)
+    Ok(written_amount.try_into()?)
 }
 
 #[mirrord_layer_macro::instrument(level = "trace")]
@@ -567,7 +579,7 @@ pub(crate) fn access(path: Detour<PathBuf>, mode: c_int) -> Detour<c_int> {
 
     let _ = common::make_proxy_request_with_response(access)??;
 
-    Detour::Success(0)
+    Ok(0)
 }
 
 /// Original function _flushes_ data from `fd` to disk, but we don't really do any of this
@@ -575,7 +587,7 @@ pub(crate) fn access(path: Detour<PathBuf>, mode: c_int) -> Detour<c_int> {
 #[mirrord_layer_macro::instrument(level = "trace", ret)]
 pub(crate) fn fsync(fd: RawFd) -> Detour<c_int> {
     get_remote_fd(fd)?;
-    Detour::Success(0)
+    Ok(0)
 }
 
 /// General stat function that can be used for lstat, fstat, stat and fstatat.
@@ -623,7 +635,7 @@ pub(crate) fn xstat(
         (None, Some(fd)) => (None, Some(get_remote_fd(fd)?)),
 
         // can't happen
-        (None, None) => return Detour::Error(HookError::NullPointer),
+        (None, None) => return Err(DetourError::Error(HookError::NullPointer)),
     };
 
     let xstat = XstatRequest {
@@ -634,7 +646,7 @@ pub(crate) fn xstat(
 
     let response = common::make_proxy_request_with_response(xstat)??;
 
-    Detour::Success(response)
+    Ok(response)
 }
 
 /// Logic for the `libc::statx` function.
@@ -665,12 +677,10 @@ pub(crate) fn statx_logic(
 
     use std::{mem, ops::Not};
 
-    use mirrord_layer_lib::detour::OptionDetourExt;
-
     let statx_buf = unsafe { statx_buf.as_mut().ok_or(HookError::BadPointer)? };
 
     if (mask & libc::STATX__RESERVED) != 0 {
-        return Detour::Error(HookError::BadFlag);
+        return Err(DetourError::Error(HookError::BadFlag));
     }
 
     let mut path: Option<PathBuf> = path_name
@@ -679,18 +689,18 @@ pub(crate) fn statx_logic(
         .then(|| path_name.checked_into())
         .transpose()?;
     if path.is_none() && (flags & libc::AT_EMPTY_PATH) == 0 {
-        return Detour::Error(HookError::BadPointer);
+        return Err(DetourError::Error(HookError::BadPointer));
     }
 
     path = path.filter(|p| p.as_os_str().is_empty().not());
     if path.is_none() && (flags & libc::AT_EMPTY_PATH) == 0 {
-        return Detour::Error(HookError::EmptyPath);
+        return Err(DetourError::Error(HookError::EmptyPath));
     }
 
     let fd = (dirfd != libc::AT_FDCWD).then_some(dirfd);
 
     let (fd, path) = match (fd, path) {
-        (None, None) => return Detour::Bypass(Bypass::LocalFdNotFound(dirfd)),
+        (None, None) => return Err(DetourError::Bypass(Bypass::LocalFdNotFound(dirfd))),
         (Some(fd), None) => (Some(get_remote_fd(fd)?), None),
         (Some(fd), Some(path)) if path.is_relative() => {
             let fd = get_remote_fd(fd)?;
@@ -771,7 +781,7 @@ pub(crate) fn statx_logic(
     statx_buf.stx_dev_major = major;
     statx_buf.stx_dev_minor = minor;
 
-    Detour::Success(0)
+    Ok(0)
 }
 
 #[mirrord_layer_macro::instrument(level = "trace")]
@@ -784,7 +794,7 @@ pub(crate) fn xstatfs(fd: RawFd) -> Detour<XstatFsResponseV2> {
 
     let response = common::make_proxy_request_with_response(xstatfs)??;
 
-    Detour::Success(response)
+    Ok(response)
 }
 
 /// Gets all the data for statfs64, but can be used also for statfs.
@@ -798,7 +808,7 @@ pub(crate) fn statfs(path: Detour<PathBuf>) -> Detour<XstatFsResponseV2> {
 
     let response = common::make_proxy_request_with_response(statfs)??;
 
-    Detour::Success(response)
+    Ok(response)
 }
 
 #[cfg(target_os = "linux")]
@@ -814,7 +824,7 @@ pub(crate) fn getdents64(fd: RawFd, buffer_size: u64) -> Detour<GetDEnts64Respon
 
     let response = common::make_proxy_request_with_response(getdents64)??;
 
-    Detour::Success(response)
+    Ok(response)
 }
 
 /// Resolves ./ and ../ in the path, and returns an absolute path.
@@ -843,9 +853,9 @@ pub(crate) fn realpath(path: Detour<PathBuf>) -> Detour<PathBuf> {
     let realpath = absolute_path(path);
 
     // check that file exists
-    xstat(Some(Detour::Success(realpath.clone())), None, true)?;
+    xstat(Some(Ok(realpath.clone())), None, true)?;
 
-    Detour::Success(realpath)
+    Ok(realpath)
 }
 
 /// Renames a file/dir from `old_path` to `new_path`, replacing the original.
@@ -860,26 +870,27 @@ pub(crate) fn rename(old_path: Detour<PathBuf>, new_path: Detour<PathBuf>) -> De
 
     // We need to remap both `old_path` and `new_path` on bypass.
     let (old_path, new_path) = match (old_path, new_path) {
-        (Detour::Success(old_path), Detour::Success(new_path)) => {
-            Detour::Success((old_path, new_path))
-        }
+        (Ok(old_path), Ok(new_path)) => Ok((old_path, new_path)),
         (
-            Detour::Bypass(Bypass::IgnoredFile(old_path)),
-            Detour::Bypass(Bypass::IgnoredFile(new_path)),
-        ) => Detour::Bypass(Bypass::IgnoredFiles(Some(old_path), Some(new_path))),
-        (Detour::Bypass(Bypass::IgnoredFile(old_path)), Detour::Success(..)) => {
-            Detour::Bypass(Bypass::IgnoredFiles(Some(old_path), None))
-        }
-        (Detour::Success(..), Detour::Bypass(Bypass::IgnoredFile(new_path))) => {
-            Detour::Bypass(Bypass::IgnoredFiles(None, Some(new_path)))
-        }
-        (old, new) => Detour::Success((old?, new?)),
+            Err(DetourError::Bypass(Bypass::IgnoredFile(old_path))),
+            Err(DetourError::Bypass(Bypass::IgnoredFile(new_path))),
+        ) => Err(DetourError::Bypass(Bypass::IgnoredFiles(
+            Some(old_path),
+            Some(new_path),
+        ))),
+        (Err(DetourError::Bypass(Bypass::IgnoredFile(old_path))), Ok(..)) => Err(
+            DetourError::Bypass(Bypass::IgnoredFiles(Some(old_path), None)),
+        ),
+        (Ok(..), Err(DetourError::Bypass(Bypass::IgnoredFile(new_path)))) => Err(
+            DetourError::Bypass(Bypass::IgnoredFiles(None, Some(new_path))),
+        ),
+        (old, new) => Ok((old?, new?)),
     }?;
 
     let old_path = absolute_path(old_path);
     let new_path = absolute_path(new_path);
 
-    Detour::Success(common::make_proxy_request_with_response(RenameRequest {
+    Ok(common::make_proxy_request_with_response(RenameRequest {
         old_path,
         new_path,
     })??)
@@ -887,21 +898,21 @@ pub(crate) fn rename(old_path: Detour<PathBuf>, new_path: Detour<PathBuf>) -> De
 
 pub(crate) fn ftruncate(fd: RawFd, length: i64) -> Detour<()> {
     let fd = get_remote_fd(fd)?;
-    Detour::Success(common::make_proxy_request_with_response(
+    Ok(common::make_proxy_request_with_response(
         FtruncateRequest { fd, length },
     )??)
 }
 
 pub(crate) fn futimens(fd: RawFd, times: Option<[Timespec; 2]>) -> Detour<()> {
     let fd = get_remote_fd(fd)?;
-    Detour::Success(common::make_proxy_request_with_response(
+    Ok(common::make_proxy_request_with_response(
         FutimensRequest { fd, times },
     )??)
 }
 
 pub(crate) fn fchown(fd: RawFd, owner: u32, group: u32) -> Detour<()> {
     let fd = get_remote_fd(fd)?;
-    Detour::Success(common::make_proxy_request_with_response(FchownRequest {
+    Ok(common::make_proxy_request_with_response(FchownRequest {
         fd,
         owner,
         group,
@@ -910,7 +921,7 @@ pub(crate) fn fchown(fd: RawFd, owner: u32, group: u32) -> Detour<()> {
 
 pub(crate) fn fchmod(fd: RawFd, mode: u32) -> Detour<()> {
     let fd = get_remote_fd(fd)?;
-    Detour::Success(common::make_proxy_request_with_response(FchmodRequest {
+    Ok(common::make_proxy_request_with_response(FchmodRequest {
         fd,
         mode,
     })??)
@@ -952,9 +963,9 @@ mod test {
     impl<S> From<&Detour<S>> for DetourKind {
         fn from(detour: &Detour<S>) -> Self {
             match detour {
-                Detour::Bypass(..) => DetourKind::Bypass,
-                Detour::Error(..) => DetourKind::Error,
-                Detour::Success(..) => DetourKind::Success,
+                Err(DetourError::Bypass(..)) => DetourKind::Bypass,
+                Err(DetourError::Error(..)) => DetourKind::Error,
+                Ok(..) => DetourKind::Success,
             }
         }
     }

--- a/mirrord/layer/src/go/mod.rs
+++ b/mirrord/layer/src/go/mod.rs
@@ -5,6 +5,7 @@
 use std::ffi::CStr;
 
 use frida_gum::NativePointer;
+use mirrord_layer_lib::detour::DetourExt;
 use nix::errno::Errno;
 
 use crate::{close_detour, file::hooks::*, hooks::HookManager, socket::hooks::*};

--- a/mirrord/layer/src/lib.rs
+++ b/mirrord/layer/src/lib.rs
@@ -3,8 +3,6 @@
 #![cfg(unix)]
 #![feature(c_variadic)]
 #![feature(io_error_uncategorized)]
-#![feature(try_trait_v2)]
-#![feature(try_trait_v2_residual)]
 #![feature(c_size_t)]
 #![feature(once_cell_try)]
 #![allow(rustdoc::private_intra_doc_links)]

--- a/mirrord/layer/src/socket.rs
+++ b/mirrord/layer/src/socket.rs
@@ -4,7 +4,7 @@ use std::net::SocketAddr;
 
 use libc::{sockaddr, socklen_t};
 pub use mirrord_layer_lib::{
-    detour::{Bypass, Detour},
+    detour::Detour,
     error::HookError,
     socket::{SHARED_SOCKETS_ENV_VAR, SOCKETS, UserSocket},
 };
@@ -44,5 +44,5 @@ fn fill_address(
         Ok(0)
     }?;
 
-    Detour::Success(result)
+    Ok(result)
 }

--- a/mirrord/layer/src/socket/hooks.rs
+++ b/mirrord/layer/src/socket/hooks.rs
@@ -9,7 +9,7 @@ use mirrord_config::experimental::ExperimentalConfig;
 #[cfg(target_os = "macos")]
 use mirrord_layer_lib::socket::apple_dnsinfo::*;
 use mirrord_layer_lib::{
-    detour::{Detour, DetourGuard},
+    detour::{DetourError, DetourExt, DetourGuard},
     error::getaddrinfo_error_code,
     mutex::Mutex,
     socket::ops::socket,
@@ -35,9 +35,9 @@ pub(crate) unsafe extern "C" fn socket_detour(
         let call_original = || {
             let socket_result = FN_SOCKET(domain, type_, protocol);
             if socket_result == -1 {
-                Detour::Error(std::io::Error::last_os_error().into())
+                Err(DetourError::Error(std::io::Error::last_os_error().into()))
             } else {
-                Detour::Success(socket_result)
+                Ok(socket_result)
             }
         };
         socket(call_original, domain, type_, protocol)
@@ -343,7 +343,7 @@ unsafe extern "C" fn getaddrinfo_detour(
         let rawish_hints = raw_hints.as_ref();
 
         match getaddrinfo(rawish_node, rawish_service, rawish_hints) {
-            Detour::Success(c_addr_info_ptr) => {
+            Ok(c_addr_info_ptr) => {
                 out_addr_info.copy_from_nonoverlapping(&c_addr_info_ptr, 1);
                 MANAGED_ADDRINFO
                     .lock()
@@ -351,8 +351,10 @@ unsafe extern "C" fn getaddrinfo_detour(
                     .insert(c_addr_info_ptr as usize);
                 0
             }
-            Detour::Bypass(_) => FN_GETADDRINFO(raw_node, raw_service, raw_hints, out_addr_info),
-            Detour::Error(error) => getaddrinfo_error_code(error),
+            Err(DetourError::Bypass(_)) => {
+                FN_GETADDRINFO(raw_node, raw_service, raw_hints, out_addr_info)
+            }
+            Err(DetourError::Error(error)) => getaddrinfo_error_code(error),
         }
     }
 }
@@ -603,8 +605,8 @@ unsafe extern "C" fn dns_configuration_copy_detour() -> *mut dns_config_t {
     };
 
     match remote_dns_configuration_copy() {
-        Detour::Success(config) => config,
-        Detour::Bypass(_) | Detour::Error(_) => empty_config(),
+        Ok(config) => config,
+        Err(DetourError::Bypass(_)) | Err(DetourError::Error(_)) => empty_config(),
     }
 }
 

--- a/mirrord/layer/src/socket/ops.rs
+++ b/mirrord/layer/src/socket/ops.rs
@@ -26,7 +26,7 @@ use mirrord_intproxy_protocol::{
 #[cfg(target_os = "macos")]
 use mirrord_layer_lib::socket::apple_dnsinfo::*;
 use mirrord_layer_lib::{
-    detour::{Detour, OnceLockExt, OptionExt},
+    detour::{Bypass, Detour, DetourError, OnceLockExt, OptionExt},
     error::{HookError, HookResult},
     graceful_exit,
     proxy_connection::make_proxy_request_with_response,
@@ -114,18 +114,18 @@ fn bind_similar_address(
 ) -> Detour<()> {
     let address = SockaddrStorage::from(requested);
     if nix::sys::socket::bind(sockfd, &address).is_ok() {
-        return Detour::Success(());
+        return Ok(());
     };
 
     if can_use_random_port {
         let address = SockaddrStorage::from(SocketAddr::new(requested.ip(), 0));
         if nix::sys::socket::bind(sockfd, &address).is_ok() {
-            return Detour::Success(());
+            return Ok(());
         };
     }
 
     if requested.ip().is_loopback() || requested.ip().is_unspecified() {
-        return Detour::Error(io::Error::last_os_error().into());
+        return Err(DetourError::Error(io::Error::last_os_error().into()));
     }
 
     let new_ip = if requested.ip().is_ipv4() {
@@ -135,17 +135,17 @@ fn bind_similar_address(
     };
     let address = SockaddrStorage::from(SocketAddr::new(new_ip, requested.port()));
     if nix::sys::socket::bind(sockfd, &address).is_ok() {
-        return Detour::Success(());
+        return Ok(());
     }
 
     if can_use_random_port {
         let address = SockaddrStorage::from(SocketAddr::new(new_ip, 0));
         if nix::sys::socket::bind(sockfd, &address).is_ok() {
-            return Detour::Success(());
+            return Ok(());
         }
     }
 
-    Detour::Error(io::Error::last_os_error().into())
+    Err(DetourError::Error(io::Error::last_os_error().into()))
 }
 
 /// Checks if given TCP port needs to be ignored based on ports logic
@@ -235,7 +235,9 @@ pub(super) fn bind(
             || incoming_config.ignore_ports.contains(&requested_port));
 
     if will_not_trigger_subscription && listen_port.is_none() {
-        return Detour::Bypass(Bypass::IgnoredInIncoming(requested_address));
+        return Err(DetourError::Bypass(Bypass::IgnoredInIncoming(
+            requested_address,
+        )));
     }
 
     #[cfg(target_os = "macos")]
@@ -278,7 +280,7 @@ pub(super) fn bind(
             %error,
             "Failed to retrieve socket local address after intercepted bind."
         );
-        return Detour::Error(error.into());
+        return Err(DetourError::Error(error.into()));
     };
     let address: SocketAddr = if let Some(ipv4) = address.as_sockaddr_in() {
         SocketAddrV4::from(*ipv4).into()
@@ -291,7 +293,7 @@ pub(super) fn bind(
             "Failed to retrieve socket local address after intercepted bind. \
             Should be an IPv4 or IPv6 address.",
         );
-        return Detour::Bypass(Bypass::AddressConversion);
+        return Err(DetourError::Bypass(Bypass::AddressConversion));
     };
 
     Arc::get_mut(&mut socket).unwrap().state = SocketState::Bound {
@@ -307,7 +309,7 @@ pub(super) fn bind(
     // node reads errno to check if bind was successful and doesn't care about the return value
     // (???)
     Errno::set_raw(0);
-    Detour::Success(0)
+    Ok(0)
 }
 
 /// Subscribe to the agent on the real port. Messages received from the agent on the real port will
@@ -315,13 +317,13 @@ pub(super) fn bind(
 #[mirrord_layer_macro::instrument(level = Level::TRACE, fields(pid = std::process::id()), ret)]
 pub(super) fn listen(sockfd: RawFd, backlog: c_int) -> Detour<i32> {
     let Some(mut socket) = SOCKETS.lock()?.remove(&sockfd) else {
-        return Detour::Bypass(Bypass::LocalFdNotFound(sockfd));
+        return Err(DetourError::Bypass(Bypass::LocalFdNotFound(sockfd)));
     };
 
     let setup = crate::setup();
 
     if matches!(setup.incoming_config().mode, IncomingMode::Off) {
-        return Detour::Bypass(Bypass::DisabledIncoming);
+        return Err(DetourError::Bypass(Bypass::DisabledIncoming));
     }
 
     if setup.targetless() {
@@ -330,7 +332,7 @@ pub(super) fn listen(sockfd: RawFd, backlog: c_int) -> Detour<i32> {
         any service. Therefore, letting this port bind happen locally instead of on the \
         cluster.",
         );
-        return Detour::Bypass(Bypass::BindWhenTargetless);
+        return Err(DetourError::Bypass(Bypass::BindWhenTargetless));
     }
 
     match socket.state {
@@ -372,7 +374,7 @@ pub(super) fn listen(sockfd: RawFd, backlog: c_int) -> Detour<i32> {
 
             SOCKETS.lock()?.insert(sockfd, socket);
 
-            Detour::Success(listen_result)
+            Ok(listen_result)
         }
         SocketState::Listening(_) => {
             tracing::debug!("second listen called");
@@ -386,10 +388,10 @@ pub(super) fn listen(sockfd: RawFd, backlog: c_int) -> Detour<i32> {
                 Err(error)?
             }
 
-            Detour::Success(listen_result)
+            Ok(listen_result)
         }
         SocketState::Bound { .. } | SocketState::Initialized | SocketState::Connected(_) => {
-            Detour::Bypass(Bypass::InvalidState(sockfd))
+            Err(DetourError::Bypass(Bypass::InvalidState(sockfd)))
         }
     }
 }
@@ -416,7 +418,7 @@ pub(super) fn connectx(
     connid: *mut sae_connid_t,
 ) -> Detour<ConnectResult> {
     if endpoints.is_null() {
-        return Detour::Error(HookError::NullPointer);
+        return Err(DetourError::Error(HookError::NullPointer));
     }
 
     // The parameter associd is reserved for future use, and must always be set to SAE_ASSOCID_ANY.
@@ -434,7 +436,7 @@ pub(super) fn connectx(
         // Destination address must be specified.
         if eps.sae_dstaddr.is_null() {
             warn!("destination address is null");
-            return Detour::Bypass(Bypass::InvalidArgValue);
+            return Err(DetourError::Bypass(Bypass::InvalidArgValue));
         }
 
         eps
@@ -559,13 +561,15 @@ pub(super) fn getpeername(
             .get(&sockfd)
             .bypass(Bypass::LocalFdNotFound(sockfd))
             .and_then(|socket| match &socket.state {
-                SocketState::Connected(connected) => Detour::Success(map_socketaddress_ipv64(
+                SocketState::Connected(connected) => Ok(map_socketaddress_ipv64(
                     socket.domain,
                     connected.remote_address.clone(),
                 )),
                 SocketState::Bound { .. }
                 | SocketState::Initialized
-                | SocketState::Listening(_) => Detour::Bypass(Bypass::InvalidState(sockfd)),
+                | SocketState::Listening(_) => {
+                    Err(DetourError::Bypass(Bypass::InvalidState(sockfd)))
+                }
             })?
     };
 
@@ -601,7 +605,8 @@ pub(super) fn getsockname(
             ..
         }) => {
             let response =
-                make_proxy_request_with_response(OutgoingConnMetadataRequest { conn_id: *id })??;
+                make_proxy_request_with_response(OutgoingConnMetadataRequest { conn_id: *id })?
+                    .bypass(Bypass::EmptyOption)?;
             map_ipv64(socket.domain, response.in_cluster_address).into()
         }
         SocketState::Bound {
@@ -623,7 +628,7 @@ pub(super) fn getsockname(
         }
 
         SocketState::Initialized | SocketState::Connected(_) => {
-            return Detour::Bypass(Bypass::InvalidState(sockfd));
+            return Err(DetourError::Bypass(Bypass::InvalidState(sockfd)));
         }
     };
 
@@ -650,7 +655,7 @@ pub(super) fn accept(
                 SocketState::Listening(Bound {
                     requested_address,
                     address,
-                }) => Detour::Success((
+                }) => Ok((
                     socket.domain,
                     socket.protocol,
                     socket.type_,
@@ -659,7 +664,9 @@ pub(super) fn accept(
                 )),
                 SocketState::Bound { .. }
                 | SocketState::Initialized
-                | SocketState::Connected(_) => Detour::Bypass(Bypass::InvalidState(sockfd)),
+                | SocketState::Connected(_) => {
+                    Err(DetourError::Bypass(Bypass::InvalidState(sockfd)))
+                }
             })?
     };
 
@@ -691,7 +698,7 @@ pub(super) fn accept(
 
     SOCKETS.lock()?.insert(new_fd, Arc::new(new_socket));
 
-    Detour::Success(new_fd)
+    Ok(new_fd)
 }
 
 #[mirrord_layer_macro::instrument(level = "trace")]
@@ -760,7 +767,7 @@ pub(super) fn getaddrinfo(
 /// Retrieves the `hostname` from the agent's `/etc/hostname` to be used by [`gethostname`]
 fn remote_hostname_string() -> Detour<CString> {
     if crate::setup().local_hostname() {
-        Detour::Bypass(Bypass::LocalHostname)?;
+        Err(DetourError::Bypass(Bypass::LocalHostname))?;
     }
 
     let hostname_path = PathBuf::from("/etc/hostname");
@@ -786,7 +793,7 @@ fn remote_hostname_string() -> Detour<CString> {
             .take(read_amount as usize - 1)
             .collect::<Vec<_>>(),
     )
-    .map(Detour::Success)?
+    .map(Ok)?
 }
 
 /// Resolves a hostname and set result to static global like the original `gethostbyname` does.
@@ -817,7 +824,7 @@ pub(super) fn gethostbyname(raw_name: Option<&CStr>) -> Detour<*mut hostent> {
 
     if hosts_and_ips.is_empty() {
         Errno::set_raw(libc::EAI_NODATA);
-        return Detour::Success(ptr::null_mut());
+        return Ok(ptr::null_mut());
     }
 
     // We need `*mut _` at the end, so `ips` has to be `mut`.
@@ -871,7 +878,7 @@ pub(super) fn gethostbyname(raw_name: Option<&CStr>) -> Detour<*mut hostent> {
             GETHOSTBYNAME_ADDRESSES_PTR.as_ref().unwrap().as_ptr() as *mut *mut libc::c_char;
     }
 
-    Detour::Success(std::ptr::addr_of!(GETHOSTBYNAME_HOSTENT) as _)
+    Ok(std::ptr::addr_of!(GETHOSTBYNAME_HOSTENT) as _)
 }
 
 /// Resolve hostname from remote host with caching for the result
@@ -900,13 +907,11 @@ pub(super) fn read_remote_resolv_conf() -> Detour<Vec<u8>> {
         trace!("Leaking remote file fd (should be harmless) due to {fail:#?}!")
     });
 
-    Detour::Success(
-        bytes
-            .into_vec()
-            .into_iter()
-            .take(read_amount as usize)
-            .collect::<Vec<_>>(),
-    )
+    Ok(bytes
+        .into_vec()
+        .into_iter()
+        .take(read_amount as usize)
+        .collect::<Vec<_>>())
 }
 
 /// ## DNS resolution on port `53`
@@ -953,11 +958,12 @@ pub(super) fn recv_from(
                 None
             }
         })
-        .map(SocketAddress::try_into)?
+        .map(SocketAddress::try_into)
+        .bypass(Bypass::EmptyOption)?
         .map(|address| fill_address(raw_source, source_length, address))??;
 
     Errno::set_raw(0);
-    Detour::Success(recv_from_result)
+    Ok(recv_from_result)
 }
 
 /// Helps manually resolving DNS on port `53` with UDP, see [`send_to`] and [`sendmsg`].
@@ -1009,9 +1015,10 @@ fn send_dns_patch(
                 }
             }
             SocketState::Listening(_) | SocketState::Initialized => None,
-        })?;
+        })
+        .bypass(Bypass::EmptyOption)?;
 
-    Detour::Success(SockAddr::from(destination))
+    Ok(SockAddr::from(destination))
 }
 
 /// ## DNS resolution on port `53`
@@ -1061,7 +1068,7 @@ pub(super) fn send_to(
     if (destination.is_unix() || user_socket_info.domain == AF_UNIX)
         && !matches!(user_socket_info.state, SocketState::Connected(_))
     {
-        return Detour::Bypass(Bypass::Domain(AF_UNIX));
+        return Err(DetourError::Bypass(Bypass::Domain(AF_UNIX)));
     }
 
     // Currently this flow only handles DNS resolution.
@@ -1107,7 +1114,8 @@ pub(super) fn send_to(
                     unreachable!()
                 }
             })
-            .map(SocketAddress::try_into)??;
+            .map(SocketAddress::try_into)
+            .bypass(Bypass::EmptyOption)??;
 
         let raw_interceptor_address = layer_address.as_ptr();
         let raw_interceptor_length = layer_address.len();
@@ -1124,7 +1132,7 @@ pub(super) fn send_to(
         }
     };
 
-    Detour::Success(sent_result)
+    Ok(sent_result)
 }
 
 /// Same behavior as [`send_to`], the only difference is that here we deal with [`libc::msghdr`],
@@ -1136,11 +1144,13 @@ pub(super) fn sendmsg(
     flags: i32,
 ) -> Detour<isize> {
     // We have a destination, so apply our fake `connect` patch.
-    let destination = (!unsafe { *raw_message_header }.msg_name.is_null()).then(|| {
-        let raw_destination = unsafe { *raw_message_header }.msg_name as *const libc::sockaddr;
-        let destination_length = unsafe { *raw_message_header }.msg_namelen;
-        SockAddr::try_from_raw(raw_destination, destination_length)
-    })??;
+    let destination = (!unsafe { *raw_message_header }.msg_name.is_null())
+        .then(|| {
+            let raw_destination = unsafe { *raw_message_header }.msg_name as *const libc::sockaddr;
+            let destination_length = unsafe { *raw_message_header }.msg_namelen;
+            SockAddr::try_from_raw(raw_destination, destination_length)
+        })
+        .bypass(Bypass::EmptyOption)??;
 
     trace!("destination {:?}", destination.as_socket());
 
@@ -1154,7 +1164,7 @@ pub(super) fn sendmsg(
     if (destination.is_unix() || user_socket_info.domain == AF_UNIX)
         && !matches!(user_socket_info.state, SocketState::Connected(_))
     {
-        return Detour::Bypass(Bypass::Domain(AF_UNIX));
+        return Err(DetourError::Bypass(Bypass::Domain(AF_UNIX)));
     }
 
     // Currently this flow only handles DNS resolution.
@@ -1204,7 +1214,8 @@ pub(super) fn sendmsg(
                     unreachable!()
                 }
             })
-            .map(SocketAddress::try_into)??;
+            .map(SocketAddress::try_into)
+            .bypass(Bypass::EmptyOption)??;
 
         let raw_interceptor_address = layer_address.as_ptr() as *const _;
         let raw_interceptor_length = layer_address.len();
@@ -1221,7 +1232,7 @@ pub(super) fn sendmsg(
         unsafe { FN_SENDMSG(sockfd, true_message_header.as_ref(), flags) }
     };
 
-    Detour::Success(sent_result)
+    Ok(sent_result)
 }
 
 /// helper to reconstruct a [`dns_resolver_t`] for [`remote_dns_configuration_copy`]
@@ -1354,7 +1365,7 @@ pub(super) fn remote_dns_configuration_copy() -> Detour<*mut dns_config_t> {
     }));
 
     tracing::debug!("remote_dns_configuration_copy success");
-    Detour::Success(config)
+    Ok(config)
 }
 
 /// Calls [`libc::getifaddrs`] and removes IPv6 addresses from the list.


### PR DESCRIPTION
<!-- Thank you for contributing to mirrord! -->
<!-- Please use the checklist below as a guide for docs, tests and admin tasks for your PR -->
<!-- Feel free to ~strikethrough~ any items that you don't think apply -->

Goal of this PR is to use only stable Rust when implementing the `Detour` result type, while keeping the detour result layers as-is and making as little call site changes as possible.

Before this PR, a function `fn foo() -> Detour<S>` can have the following at any point and use ? to bail early:
* `Err(Bypass::Variant)?` - `?` bails early on `Result::Err`, and the inner `Bypass::Variant` gets mapped to `Detour::Bypass(Bypass::Variant)` because the `FromResidual` impl [here](https://github.com/metalbear-co/mirrord/blob/main/mirrord/layer-lib/src/detour.rs#L312-L319).
* `Err(HookError)?`  - similar as above, but the mapping is done by this `FromResidual` impl [here](https://github.com/metalbear-co/mirrord/blob/main/mirrord/layer-lib/src/detour.rs#L294-L300)
* `Detour::Error(HookError)?` and `Detour::Bypass(Bypass)?` bails early because our own `Try` branch logic [here](https://github.com/metalbear-co/mirrord/blob/main/mirrord/layer-lib/src/detour.rs#L294), and with nightly, `?` can desugar `Detour`.
* `Option::None` gets mapped to `Detour::Bypass(Bypass::EmptyOption)`, because of `FromResidual` impl again [here](https://github.com/metalbear-co/mirrord/blob/main/mirrord/layer-lib/src/detour.rs#L327).

Socket ops is a pretty good example of all these cases ([code link](https://github.com/metalbear-co/mirrord/blob/main/mirrord/layer/src/socket/ops.rs)).

The caller (top level detour function) then calls those helper member methods of Detour to map a Detour into a libc function result. In `bind()`'s case, it uses the `Detour::unwrap_or_bypass_with` thingy [here](https://github.com/metalbear-co/mirrord/blob/main/mirrord/layer/src/socket/hooks.rs#L55-L56).

After this PR, all of the above still work with little changes needed in detour and hook functions.
`Err(Bypass::Variant)` and `Err(HookError)` still bails early and get mapped to `Detour`, because now `Detour` is `Result<S, DetourError>`. And we impl `From<Bypass> for DetourError` and `From<HookError> for DetourError`. so we can avoid relying on `FromResidual` unstable trait.
`Detour::Error(HookError)` and `Detour::Bypass(Bypass)` all become `Err(..)`, most of the changes on call sites are these basically.
The top level detour function can still use the same helper function (`unwrap_or_bypass_with`) to map `Detour` into libc result. The helper function is provided now by extension traits, because `Detour` is essentially std lib `Result`.

Worth noting that a little help is needed for `?` to convert an `inner` error to `HookError(inner)` and then to `DetourError::Error(HookError(inner))`. The `detour_error_from_hook_error` macro is made for avoiding boilerplate.
A blanket impl would be nice, `impl<E: Into<HookError>> From<E> for DetourError { ... }`, but it conflicts with std lib's `impl<T> From<T> for T`, when T is `DetourError` :sob: . Nightly doesn't have this problem because it uses `FromResidual` rather than `From` so no clash, amazing.

### Quality Checklist:

- [x] I have documented new code sufficiently
- [x] I have checked and updated the relevant existing docs in code, including removing outdated material
- [ ] I have written user-facing website docs for new features, or opened a (sub)issue to do so
- [ ] I have checked and updated existing website docs for changed features
- [x] I have tested this change and know it succeeds and fails as expected
- [ ] I have written unit tests or purposefully omitted them
- [ ] I have written e2e tests or purposefully omitted them
- [x] I have explained what this PR introduces and why, and linked to relevant context (e.g. linear issues, related PRs,
  documentation)
- [x] I have introduced a short, clear and well-formatted changelog entry

<!-- need help with the changelog? see ../CONTRIBUTING.md#submitting-a-pull-request -->
<!-- Add more details of your changes below if needed -->