### PR TITLE
ci: Increase cargo shear job timeout

### DIFF
--- a/.github/workflows/check-lint.yaml
+++ b/.github/workflows/check-lint.yaml
@@ -132,7 +132,7 @@ jobs:
   shear:
     if: ${{ inputs.run_rust }}
     name: 'cargo shear'
-    timeout-minutes: 10
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -149,4 +149,4 @@ jobs:
         uses: metalbear-co/install-action@c127aaa0fa8c555cbfb72bfa29b29a692d25d267 # v2.75.16
         with:
           tool: cargo-shear
-      - run: cargo shear --deny-warnings
+      - run: ./scripts/cargo-shear.sh --deny-warnings

--- a/.github/workflows/check-lint.yaml
+++ b/.github/workflows/check-lint.yaml
@@ -54,8 +54,8 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: metalbear-co/markdownlint-cli2-action@4db3dfc2cb719a5a152cb38efef6e2e50db98973
         with:
-          config: ".markdownlint.json"
-          globs: "README.md"
+          config: '.markdownlint.json'
+          globs: 'README.md'
   wizard-frontend-lint:
     if: ${{ inputs.run_wizard_frontend }}
     runs-on: ubuntu-24.04
@@ -131,7 +131,7 @@ jobs:
       - run: cargo clippy --workspace --lib --bins --all-features --tests -- "-Wclippy::indexing_slicing" -D warnings
   shear:
     if: ${{ inputs.run_rust }}
-    name: "cargo shear"
+    name: 'cargo shear'
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
@@ -145,8 +145,8 @@ jobs:
       - uses: metalbear-co/setup-protoc@770e54d44679c8e1d8fdc06d1d9268fa79fbefb4
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: "Install cargo shear"
+      - name: 'Install cargo shear'
         uses: metalbear-co/install-action@c127aaa0fa8c555cbfb72bfa29b29a692d25d267 # v2.75.16
         with:
           tool: cargo-shear
-      - run: ./scripts/cargo-shear.sh --deny-warnings
+      - run: cargo shear --deny-warnings

--- a/changelog.d/+cargo-shear-timeout.internal.md
+++ b/changelog.d/+cargo-shear-timeout.internal.md
@@ -1,0 +1,1 @@
+Increased cargo shear job timeout from 10 > 20 minutes.


### PR DESCRIPTION
- increase timeout from 10 > 20 mins
- short term fix only, long term fix will include removing `--expand` flag to skip full compilation