### PR TITLE
mirrord up: infer targetpath from service key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5660,10 +5660,14 @@ version = "3.232.0"
 dependencies = [
  "assert-json-diff",
  "clap",
+ "futures",
  "inquire",
+ "k8s-openapi",
+ "kube",
  "miette",
  "mirrord-analytics",
  "mirrord-config",
+ "mirrord-kube",
  "mirrord-progress",
  "serde",
  "serde_json",
@@ -5673,6 +5677,8 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "uuid",
+ "yamlpatch",
+ "yamlpath",
 ]
 
 [[package]]

--- a/changelog.d/+mirrord-up-infer-target.added.md
+++ b/changelog.d/+mirrord-up-infer-target.added.md
@@ -1,0 +1,1 @@
+`mirrord up` now infers a service's target from its key in `mirrord-up.yaml` when `target.path` is omitted, prompting you to pick one when nothing matches.

--- a/mirrord/cli/src/up.rs
+++ b/mirrord/cli/src/up.rs
@@ -135,7 +135,14 @@ async fn run_up(args: UpArgs, analytics: &mut AnalyticsReporter) -> Result<(), U
         }
     }
 
-    let result = mirrord_up::run(up_config, key, correlation_id, ready.clone()).await;
+    let result = mirrord_up::run(
+        up_config,
+        &args.config_file,
+        key,
+        correlation_id,
+        ready.clone(),
+    )
+    .await;
 
     // Recorded whenever all sessions reached readiness, even if `run` then
     // failed, left absent otherwise (e.g. a session crashed before startup).
@@ -167,6 +174,11 @@ impl From<&UpCliError> for ErrorCategory {
             UpCliError::Up(UpError::ServiceCrashed { .. }) => Self::ServiceCrash,
             UpCliError::Up(UpError::Io(_))
             | UpCliError::Up(UpError::Panic(_))
+            | UpCliError::Up(UpError::Kube(_))
+            | UpCliError::Up(UpError::Inquire(_))
+            | UpCliError::Up(UpError::Exited)
+            | UpCliError::Up(UpError::YamlPatch(_))
+            | UpCliError::Up(UpError::YamlQuery(_))
             | UpCliError::Init(_) => Self::InternalError,
         }
     }
@@ -218,7 +230,7 @@ mod tests {
     #[test]
     fn service_crash_buckets_as_service_crash() {
         let v = category(UpCliError::Up(UpError::ServiceCrashed {
-            name: "svc".to_owned(),
+            name: "svc".into(),
             status: ExitStatus::default(),
         }));
         assert_eq!(v["error_category"], ErrorCategory::ServiceCrash as u32);

--- a/mirrord/up/Cargo.toml
+++ b/mirrord/up/Cargo.toml
@@ -16,19 +16,25 @@ categories.workspace = true
 [dependencies]
 mirrord-analytics = { path = "../analytics" }
 mirrord-config = { path = "../config" }
+mirrord-kube = { path = "../kube" }
 mirrord-progress = { path = "../progress/" }
 
-serde = { workspace = true, features = ["derive"] }
+futures.workspace = true
+k8s-openapi.workspace = true
+kube.workspace = true
+serde = { workspace = true, features = ["derive", "rc"] }
 serde_yaml.workspace = true
 serde_json.workspace = true
 miette = { workspace = true, features = ["fancy"] }
 thiserror.workspace = true
 strum_macros.workspace = true
 strum.workspace = true
-tokio = { workspace = true, features = ["process"] }
+tokio = { workspace = true, features = ["process", "rt"] }
 clap.workspace = true
 inquire.workspace = true
 uuid.workspace = true
+yamlpatch.workspace = true
+yamlpath.workspace = true
 
 [dev-dependencies]
 serde_json.workspace = true

--- a/mirrord/up/src/config.rs
+++ b/mirrord/up/src/config.rs
@@ -183,6 +183,14 @@ impl TargetConfig {
         namespace: None,
     });
 
+    #[cfg(test)]
+    fn unwrap_specified(&self) -> &SpecifiedTarget {
+        match self {
+            TargetConfig::Specified(specified_target) => specified_target,
+            _ => panic!("did not parse as TargetConfig::Specified, parsed as {self:?}"),
+        }
+    }
+
     /// Return a [`mirrord_config::target::TargetConfig`] when we have
     /// a path or are explicitly targetless, OR an
     /// [`UnresolvedTarget`] otherwise, when we need to resolve the
@@ -485,6 +493,8 @@ impl CollectAnalytics for &UpConfig {
 #[cfg(test)]
 #[allow(clippy::indexing_slicing)]
 mod tests {
+    use std::{collections::HashSet, str::FromStr};
+
     use super::*;
 
     /// Helper: parse YAML into UpConfig via the two-layer config system.
@@ -552,10 +562,18 @@ mod tests {
         let svc = &config.services["web"];
 
         assert_eq!(
-            svc.target.path.as_ref().unwrap().to_string(),
+            svc.target
+                .unwrap_specified()
+                .path
+                .as_ref()
+                .unwrap()
+                .to_string(),
             "deployment/web-app"
         );
-        assert_eq!(svc.target.namespace.as_deref(), Some("staging"));
+        assert_eq!(
+            svc.target.unwrap_specified().namespace.as_deref(),
+            Some("staging")
+        );
         assert_eq!(
             svc.env.r#override.as_ref().unwrap()["NODE_ENV"],
             "development"
@@ -631,7 +649,10 @@ mod tests {
         );
 
         let mut services = config
-            .service_configs(&EnvKey::Provided("sqs-session".to_owned()))
+            .service_configs(
+                &EnvKey::Provided("sqs-session".to_owned()),
+                &mut HashMap::new(),
+            )
             .collect::<Vec<_>>();
         assert_eq!(services.len(), 1);
 
@@ -675,7 +696,7 @@ mod tests {
     }
 
     #[test]
-    fn target_simple_string_form() {
+    fn specified_target_parses_correctly() {
         let config = parse(
             r#"
             services:
@@ -689,12 +710,293 @@ mod tests {
         assert_eq!(
             config.services["svc"]
                 .target
+                .unwrap_specified()
                 .path
                 .as_ref()
                 .unwrap()
                 .to_string(),
             "pod/my-pod/container/main"
         );
+    }
+
+    #[test]
+    fn unspecified_target_parses_correctly() {
+        let config = parse(
+            r#"
+            services:
+              svc:
+                run:
+                  command: ["echo"]
+            "#,
+        );
+        assert_eq!(config.services["svc"].target, TargetConfig::UNSPECIFIED);
+    }
+
+    /// Every [`TargetConfig`] state must survive serialize → parse
+    /// without relying on the wizard's null-pruning in between.
+    #[test]
+    fn target_round_trips() {
+        for target in [
+            TargetConfig::Targetless,
+            TargetConfig::UNSPECIFIED,
+            SpecifiedTarget {
+                path: Some(Target::from_str("deployment/web").unwrap()),
+                namespace: Some("staging".into()),
+            }
+            .into(),
+            SpecifiedTarget {
+                path: None,
+                namespace: Some("staging".into()),
+            }
+            .into(),
+        ] {
+            let yaml = serde_yaml::to_string(&target).unwrap();
+            let parsed: TargetConfig = serde_yaml::from_str(&yaml)
+                .unwrap_or_else(|e| panic!("{yaml:?} failed to parse: {e}"));
+            assert_eq!(parsed, target, "round-trip through {yaml:?}");
+        }
+    }
+
+    #[test]
+    fn none_target_parses_correctly() {
+        let config = parse(
+            r#"
+            services:
+              svc:
+                target: none
+                run:
+                  command: ["echo"]
+            "#,
+        );
+        assert_eq!(config.services["svc"].target, TargetConfig::Targetless);
+    }
+
+    // -- Target resolution --
+
+    fn env_key() -> EnvKey {
+        EnvKey::Provided("test-key".to_owned())
+    }
+
+    fn unresolved_target(workload_name: &str, namespace: Option<&str>) -> UnresolvedTarget {
+        UnresolvedTarget {
+            workload_name: workload_name.into(),
+            namespace: namespace.map(Into::into),
+        }
+    }
+
+    fn resolved_target(path: &str, namespace: Option<&str>) -> ResolvedTarget {
+        ResolvedTarget {
+            resolved: SpecifiedTarget {
+                path: Some(Target::from_str(path).unwrap()),
+                namespace: namespace.map(Into::into),
+            },
+        }
+    }
+
+    /// One service in every target state: explicit path, `none`,
+    /// inferred in the default namespace, inferred in an explicit
+    /// namespace.
+    fn resolution_fixture() -> UpConfig {
+        parse(
+            r#"
+            services:
+              explicit:
+                target:
+                  path: "deployment/web"
+                  namespace: "prod"
+                run:
+                  command: ["echo", "explicit"]
+              opted-out:
+                target: none
+                run:
+                  command: ["echo", "opted-out"]
+              inferred:
+                run:
+                  command: ["echo", "inferred"]
+              inferred-ns:
+                target:
+                  namespace: "staging"
+                run:
+                  command: ["echo", "inferred-ns"]
+            "#,
+        )
+    }
+
+    /// Only services without a `target.path` need cluster resolution;
+    /// the service key becomes the workload name and the namespace
+    /// hint (if any) is carried along.
+    #[test]
+    fn unresolved_targets_yields_only_services_needing_resolution() {
+        let config = resolution_fixture();
+
+        assert_eq!(
+            config.unresolved_targets().collect::<HashSet<_>>(),
+            HashSet::from([
+                unresolved_target("inferred", None),
+                unresolved_target("inferred-ns", Some("staging")),
+            ]),
+        );
+    }
+
+    #[test]
+    fn unresolved_targets_empty_when_no_service_needs_resolution() {
+        let config = parse(
+            r#"
+            services:
+              explicit:
+                target:
+                  path: "deployment/web"
+                run:
+                  command: ["echo"]
+              opted-out:
+                target: none
+                run:
+                  command: ["echo"]
+            "#,
+        );
+
+        assert_eq!(config.unresolved_targets().count(), 0);
+    }
+
+    /// Explicit and `none` targets pass through as-is, inferred ones
+    /// take their path/namespace from `resolved_targets`, and the used
+    /// entries are drained from the map.
+    #[test]
+    fn service_configs_resolves_and_drains() {
+        let config = resolution_fixture();
+        let key = env_key();
+        let mut resolved_targets = HashMap::from([
+            (
+                unresolved_target("inferred", None),
+                resolved_target("deployment/inferred", Some("default")),
+            ),
+            (
+                unresolved_target("inferred-ns", Some("staging")),
+                resolved_target("pod/inferred-ns-7f9d8c7df8", Some("staging")),
+            ),
+            // Not requested by any service; must survive the drain.
+            (
+                unresolved_target("unrelated", None),
+                resolved_target("deployment/unrelated", None),
+            ),
+        ]);
+
+        let subprocesses: HashMap<String, SubprocessCfg> = config
+            .service_configs(&key, &mut resolved_targets)
+            .map(|cfg| (cfg.service_name.to_string(), cfg))
+            .collect();
+
+        assert_eq!(subprocesses.len(), 4);
+
+        let explicit = &subprocesses["explicit"].config.target;
+        assert_eq!(
+            explicit.path.as_ref().unwrap().to_string(),
+            "deployment/web"
+        );
+        assert_eq!(explicit.namespace.as_deref(), Some("prod"));
+
+        let opted_out = &subprocesses["opted-out"].config.target;
+        assert_eq!(opted_out.path, None);
+        assert_eq!(opted_out.namespace, None);
+
+        let inferred = &subprocesses["inferred"].config.target;
+        assert_eq!(
+            inferred.path.as_ref().unwrap().to_string(),
+            "deployment/inferred"
+        );
+        assert_eq!(inferred.namespace.as_deref(), Some("default"));
+
+        let inferred_ns = &subprocesses["inferred-ns"].config.target;
+        assert_eq!(
+            inferred_ns.path.as_ref().unwrap().to_string(),
+            "pod/inferred-ns-7f9d8c7df8"
+        );
+        assert_eq!(inferred_ns.namespace.as_deref(), Some("staging"));
+
+        // The run config and session key pass through untouched.
+        assert_eq!(
+            subprocesses["inferred"].run.command,
+            vec!["echo".to_owned(), "inferred".to_owned()]
+        );
+        assert_eq!(subprocesses["inferred"].config.key, key);
+
+        assert_eq!(
+            resolved_targets.into_keys().collect::<Vec<_>>(),
+            vec![unresolved_target("unrelated", None)],
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "No resolved entry for `inferred`")]
+    fn service_configs_panics_on_missing_resolved_entry() {
+        let config = parse(
+            r#"
+            services:
+              inferred:
+                run:
+                  command: ["echo"]
+            "#,
+        );
+        let key = env_key();
+        let mut resolved_targets = HashMap::new();
+
+        config
+            .service_configs(&key, &mut resolved_targets)
+            .for_each(drop);
+    }
+
+    /// The resolution step must key its answers by the exact
+    /// [`UnresolvedTarget`] it was asked about -- an entry for the
+    /// right workload under the wrong namespace does not count.
+    #[test]
+    #[should_panic(expected = "No resolved entry for `inferred-ns`")]
+    fn service_configs_panics_on_namespace_mismatch() {
+        let config = parse(
+            r#"
+            services:
+              inferred-ns:
+                target:
+                  namespace: "staging"
+                run:
+                  command: ["echo"]
+            "#,
+        );
+        let key = env_key();
+        let mut resolved_targets = HashMap::from([(
+            unresolved_target("inferred-ns", None),
+            resolved_target("deployment/inferred-ns", Some("staging")),
+        )]);
+
+        config
+            .service_configs(&key, &mut resolved_targets)
+            .for_each(drop);
+    }
+
+    #[test]
+    #[should_panic(expected = "must have a non-null path")]
+    fn service_configs_panics_on_resolved_entry_without_path() {
+        let config = parse(
+            r#"
+            services:
+              inferred:
+                run:
+                  command: ["echo"]
+            "#,
+        );
+        let key = env_key();
+        let mut resolved_targets = HashMap::from([(
+            unresolved_target("inferred", None),
+            ResolvedTarget {
+                resolved: SpecifiedTarget {
+                    path: None,
+                    namespace: None,
+                },
+            },
+        )]);
+
+        config
+            .service_configs(&key, &mut resolved_targets)
+            .for_each(drop);
     }
 
     // -- Error cases --

--- a/mirrord/up/src/config.rs
+++ b/mirrord/up/src/config.rs
@@ -272,7 +272,13 @@ pub struct UpConfig {
 
 impl ServiceConfig {
     /// Build a ([`LayerConfig`], [`RunConfig`]) pair for this service.
-    fn assemble(self, defaults: &CommonConfig, key: EnvKey) -> (LayerConfig, RunConfig) {
+    fn assemble(
+        self,
+        service_name: &Arc<str>,
+        defaults: &CommonConfig,
+        key: EnvKey,
+        resolved_targets: &mut HashMap<UnresolvedTarget, ResolvedTarget>,
+    ) -> (LayerConfig, RunConfig) {
         let mut cfg = LayerFileConfig {
             accept_invalid_certificates: defaults.accept_invalid_certificates,
             operator: defaults.operator,
@@ -282,7 +288,26 @@ impl ServiceConfig {
         .generate_config(&mut ConfigContext::default())
         .unwrap();
 
-        cfg.target = self.target.into();
+        cfg.target = match self.target.as_resolved(service_name) {
+            Ok(resolved) => resolved,
+            Err(unresolved) => match resolved_targets.remove(&unresolved) {
+                Some(target) => {
+                    assert!(
+                        target.resolved.path.is_some(),
+                        "resolved workload must have a non-null path"
+                    );
+                    mirrord_config::target::TargetConfig {
+                        path: target.resolved.path,
+                        namespace: target.resolved.namespace.as_deref().map(Into::into),
+                    }
+                }
+                None => panic!(
+                    "No resolved entry for `{}` in `resolved_targets`",
+                    unresolved.workload_name
+                ),
+            },
+        };
+
         cfg.feature.env = self.env;
 
         match self.default_mode {
@@ -329,10 +354,18 @@ impl UpConfig {
         self.common.telemetry.unwrap_or(true)
     }
 
-    /// Produces an iterator of [`SubprocessCfg`]s, one per service defined in the configuration.
-    pub fn service_configs<'a>(
+    /// Produces an iterator of [`SubprocessCfg`]s, one per service
+    /// defined in the configuration.
+    ///
+    /// `resolved_targets` must be a [`HashMap`] with an entry for
+    /// every item yielded by the iterator returned from
+    /// [`Self::unresolved_targets`] -- this method will panic
+    /// otherwise. Entries that are used to resolve a target will be
+    /// removed from the `resolved_targets`.
+    pub(crate) fn service_configs<'a>(
         self,
         key: &'a EnvKey,
+        resolved_targets: &'a mut HashMap<UnresolvedTarget, ResolvedTarget>,
     ) -> impl Iterator<Item = SubprocessCfg> + use<'a> {
         let Self {
             common: defaults,
@@ -340,7 +373,8 @@ impl UpConfig {
         } = self;
 
         services.into_iter().map(move |(service_name, svc)| {
-            let (config, run) = svc.assemble(&defaults, key.clone());
+            let (config, run) =
+                svc.assemble(&service_name, &defaults, key.clone(), resolved_targets);
             SubprocessCfg {
                 config,
                 service_name,
@@ -348,6 +382,26 @@ impl UpConfig {
             }
         })
     }
+
+    /// Produces an iterator of [`UnresolvedTarget`]s that yields an
+    /// item for each service entry that requires querying the cluster
+    /// to resolve the workload.
+    pub(crate) fn unresolved_targets(&self) -> impl Iterator<Item = UnresolvedTarget> {
+        self.services
+            .iter()
+            .filter_map(|(name, svc)| svc.target.as_resolved(name).err())
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, Debug, Hash)]
+pub(crate) struct UnresolvedTarget {
+    pub(crate) workload_name: Arc<str>,
+    pub(crate) namespace: Option<Arc<str>>,
+}
+
+#[derive(Clone, PartialEq, Debug)]
+pub(crate) struct ResolvedTarget {
+    pub(crate) resolved: SpecifiedTarget,
 }
 
 impl CollectAnalytics for &CommonConfig {
@@ -391,7 +445,7 @@ impl CollectAnalytics for &UpConfig {
                 run,
             } = svc;
 
-            if *target != TargetConfig::default() {
+            if *target != TargetConfig::UNSPECIFIED {
                 count_target += 1;
             }
             if *env != EnvConfig::default() {

--- a/mirrord/up/src/config.rs
+++ b/mirrord/up/src/config.rs
@@ -85,19 +85,147 @@ pub struct CommonConfig {
     pub(crate) telemetry: Option<bool>,
 }
 
+/// A specified target for the non-targetless case.
+///
 /// Separate from [`mirrord_config::target::TargetConfig`] because we
 /// use custom serde attributes for this that we don't want on the
 /// other one.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize, Default)]
 #[serde(deny_unknown_fields)]
-pub struct TargetConfig {
+pub struct SpecifiedTarget {
     #[serde(
         default,
         deserialize_with = "mirrord_config::util::string_or_struct_option",
-        serialize_with = "serialize_path"
+        serialize_with = "serialize_path",
+        skip_serializing_if = "Option::is_none"
     )]
     pub(crate) path: Option<Target>,
-    pub(crate) namespace: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) namespace: Option<Arc<str>>,
+}
+
+/// The three states a service's `target` field can be in.
+#[derive(Clone, Debug, PartialEq)]
+pub enum TargetConfig {
+    /// `target: none`
+    Targetless,
+
+    /// Traditional `target: { path: "pod/path", namespace: "some_namespace" }` syntax
+    Specified(SpecifiedTarget),
+}
+
+impl From<SpecifiedTarget> for TargetConfig {
+    fn from(value: SpecifiedTarget) -> Self {
+        Self::Specified(value)
+    }
+}
+
+impl<'de> Deserialize<'de> for TargetConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct TargetVisitor;
+        const EXPECTED: &str = "`none`, a target mapping, or nothing at all";
+
+        impl<'de> Visitor<'de> for TargetVisitor {
+            type Value = TargetConfig;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str(EXPECTED)
+            }
+
+            fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
+            where
+                A: MapAccess<'de>,
+            {
+                SpecifiedTarget::deserialize(MapAccessDeserializer::new(map))
+                    .map(TargetConfig::Specified)
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                if v == "none" {
+                    Ok(TargetConfig::Targetless)
+                } else {
+                    Err(serde::de::Error::invalid_value(
+                        Unexpected::Str(v),
+                        &EXPECTED,
+                    ))
+                }
+            }
+
+            fn visit_none<E>(self) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(TargetConfig::UNSPECIFIED)
+            }
+
+            fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(self)
+            }
+        }
+
+        deserializer.deserialize_option(TargetVisitor)
+    }
+}
+
+impl TargetConfig {
+    pub const UNSPECIFIED: Self = Self::Specified(SpecifiedTarget {
+        path: None,
+        namespace: None,
+    });
+
+    /// Return a [`mirrord_config::target::TargetConfig`] when we have
+    /// a path or are explicitly targetless, OR an
+    /// [`UnresolvedTarget`] otherwise, when we need to resolve the
+    /// target workload by querying the cluster against `name`.
+    fn as_resolved(
+        &self,
+        name: &Arc<str>,
+    ) -> Result<mirrord_config::target::TargetConfig, UnresolvedTarget> {
+        match self {
+            Self::Targetless => Ok(mirrord_config::target::TargetConfig {
+                path: None,
+                namespace: None,
+            }),
+
+            Self::Specified(SpecifiedTarget {
+                path: None,
+                namespace,
+            }) => Err(UnresolvedTarget {
+                workload_name: Arc::clone(name),
+                namespace: namespace.clone(),
+            }),
+
+            Self::Specified(SpecifiedTarget {
+                path: path @ Some(_),
+                namespace,
+            }) => Ok(mirrord_config::target::TargetConfig {
+                path: path.clone(),
+                namespace: namespace.as_deref().map(Into::into),
+            }),
+        }
+    }
+}
+
+impl Serialize for TargetConfig {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            TargetConfig::Targetless => serializer.serialize_str("none"),
+            TargetConfig::Specified(specified) => specified.serialize(serializer),
+        }
+    }
 }
 
 fn serialize_path<S>(path: &Option<Target>, serializer: S) -> Result<S::Ok, S::Error>
@@ -110,20 +238,10 @@ where
     }
 }
 
-impl From<TargetConfig> for mirrord_config::target::TargetConfig {
-    fn from(value: TargetConfig) -> Self {
-        Self {
-            path: value.path,
-            namespace: value.namespace,
-        }
-    }
-}
-
 /// Per-service configuration.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ServiceConfig {
-    #[serde(default)]
     pub(crate) target: TargetConfig,
 
     #[serde(default)]
@@ -149,7 +267,7 @@ pub struct UpConfig {
     #[serde(default)]
     pub common: CommonConfig,
     /// Per-service configurations keyed by service name.
-    pub services: HashMap<String, ServiceConfig>,
+    pub services: HashMap<Arc<str>, ServiceConfig>,
 }
 
 impl ServiceConfig {
@@ -200,7 +318,7 @@ pub struct SubprocessCfg {
     /// The resolved layer configuration for this child process.
     pub config: LayerConfig,
     /// Name of the service this subprocess runs.
-    pub service_name: String,
+    pub service_name: Arc<str>,
     /// How to run this service (exec vs container, and the command).
     pub run: RunConfig,
 }

--- a/mirrord/up/src/config.rs
+++ b/mirrord/up/src/config.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::{BTreeSet, HashMap},
     ops::Not,
+    sync::Arc,
 };
 
 use clap::{ValueEnum, builder::PossibleValue};
@@ -15,7 +16,10 @@ use mirrord_config::{
     },
     target::Target,
 };
-use serde::{Deserialize, Serialize};
+use serde::{
+    Deserialize, Serialize,
+    de::{MapAccess, Unexpected, Visitor, value::MapAccessDeserializer},
+};
 use strum::VariantArray;
 use strum_macros::{Display, IntoStaticStr, VariantArray};
 

--- a/mirrord/up/src/init.rs
+++ b/mirrord/up/src/init.rs
@@ -18,6 +18,7 @@ use std::{
     ops::Not,
     path::PathBuf,
     str::FromStr,
+    sync::Arc,
 };
 
 use inquire::{Confirm, Select, Text, validator::Validation};
@@ -31,7 +32,8 @@ use strum::VariantArray;
 use thiserror::Error;
 
 use crate::config::{
-    CommonConfig, RunConfig, RunType, ServiceConfig, ServiceMode, TargetConfig, UpConfig,
+    CommonConfig, RunConfig, RunType, ServiceConfig, ServiceMode, SpecifiedTarget, TargetConfig,
+    UpConfig,
 };
 
 /// Errors produced by the `mirrord up init` wizard.

--- a/mirrord/up/src/init.rs
+++ b/mirrord/up/src/init.rs
@@ -178,31 +178,39 @@ fn prompt_service(
 }
 
 fn prompt_target() -> Result<TargetConfig, InitError> {
-    let path_str = Text::new("Target (e.g. `deployment/foo`, `pod/bar`; blank for targetless):")
-        .with_validator(|s: &str| {
-            let t = s.trim();
-            if t.is_empty() {
-                return Ok(Validation::Valid);
-            }
-            match Target::from_str(t) {
-                Ok(_) => Ok(Validation::Valid),
-                Err(e) => Ok(Validation::Invalid(e.to_string().into())),
-            }
-        })
+    const INFER: &str = "Infer from the service name";
+    const SPECIFY: &str = "Specify a target";
+    const TARGETLESS: &str = "Run without a target (outgoing traffic only)";
+
+    let choice = Select::new("Target:", vec![INFER, SPECIFY, TARGETLESS])
+        .with_help_message(
+            "`Infer` looks the service name up in the cluster when you run `mirrord up`.",
+        )
         .prompt()?;
 
-    let path = match path_str.trim() {
-        "" => None,
-        t => Some(Target::from_str(t).expect("validated above")),
-    };
+    if choice == TARGETLESS {
+        return Ok(TargetConfig::Targetless);
+    }
+
+    let path = (choice == SPECIFY)
+        .then(|| {
+            let path_str = Text::new("Target (e.g. `deployment/foo`, `pod/bar`):")
+                .with_validator(|s: &str| match Target::from_str(s.trim()) {
+                    Ok(_) => Ok(Validation::Valid),
+                    Err(e) => Ok(Validation::Invalid(e.to_string().into())),
+                })
+                .prompt();
+            path_str.map(|s| Target::from_str(s.trim()).expect("validated above"))
+        })
+        .transpose()?;
 
     let namespace_str = Text::new("Namespace (blank for cluster default):").prompt()?;
     let namespace = match namespace_str.trim() {
         "" => None,
-        n => Some(n.to_owned()),
+        n => Some(n.into()),
     };
 
-    Ok(TargetConfig { path, namespace })
+    Ok(SpecifiedTarget { path, namespace }.into())
 }
 
 fn prompt_mode() -> Result<ServiceMode, InitError> {

--- a/mirrord/up/src/init.rs
+++ b/mirrord/up/src/init.rs
@@ -60,7 +60,7 @@ pub fn run_wizard(default_output: PathBuf) -> Result<(), InitError> {
     let common = prompt_common()?;
 
     println!("\n--- Step 2: Services ---");
-    let mut services: HashMap<String, ServiceConfig> = HashMap::new();
+    let mut services: HashMap<Arc<str>, ServiceConfig> = HashMap::new();
     loop {
         let (name, svc) = prompt_service(&services)?;
         services.insert(name, svc);
@@ -135,8 +135,8 @@ fn prompt_common() -> Result<CommonConfig, InitError> {
 }
 
 fn prompt_service(
-    existing: &HashMap<String, ServiceConfig>,
-) -> Result<(String, ServiceConfig), InitError> {
+    existing: &HashMap<Arc<str>, ServiceConfig>,
+) -> Result<(Arc<str>, ServiceConfig), InitError> {
     let name = Text::new("Service name:")
         .with_validator(|s: &str| {
             let t = s.trim();
@@ -152,7 +152,7 @@ fn prompt_service(
         })
         .prompt()?
         .trim()
-        .to_owned();
+        .into();
 
     let target = prompt_target()?;
     let default_mode = prompt_mode()?;
@@ -222,7 +222,7 @@ fn prompt_http_filter(mode: &ServiceMode) -> Result<HttpFilterConfig, InitError>
             let filter = match s.trim() {
                 "" => HttpFilterConfig::default(),
                 hf => HttpFilterConfig {
-                    header_filter: Some(hf.to_owned()),
+                    header_filter: Some(hf.to_string()),
                     ..Default::default()
                 },
             };
@@ -294,7 +294,7 @@ fn prompt_env_overrides() -> Result<Option<HashMap<String, String>>, InitError> 
             })
             .prompt()?
             .trim()
-            .to_owned();
+            .to_string();
         let value = Text::new("  Value:").prompt()?;
         map.insert(key, value);
     }
@@ -318,7 +318,10 @@ fn prompt_run() -> Result<RunConfig, InitError> {
             }
         })
         .prompt()?;
-    let command = command_str.split_whitespace().map(str::to_owned).collect();
+    let command = command_str
+        .split_whitespace()
+        .map(ToString::to_string)
+        .collect();
 
     Ok(RunConfig { r#type, command })
 }
@@ -431,23 +434,27 @@ mod tests {
 
     fn sample_service() -> ServiceConfig {
         ServiceConfig {
-            target: TargetConfig {
+            target: TargetConfig::Specified(SpecifiedTarget {
                 path: Some(Target::from_str("deployment/api").unwrap()),
-                namespace: Some("staging".to_owned()),
-            },
+                namespace: Some("staging".into()),
+            }),
             env: EnvConfig {
-                r#override: Some([("FOO".to_owned(), "bar".to_owned())].into_iter().collect()),
+                r#override: Some(
+                    [("FOO".to_string(), "bar".to_string())]
+                        .into_iter()
+                        .collect(),
+                ),
                 ..Default::default()
             },
             default_mode: ServiceMode::default(),
             http_filter: HttpFilterConfig {
-                header_filter: Some("x-session: me".to_owned()),
+                header_filter: Some("x-session: me".to_string()),
                 ..Default::default()
             },
             ignore_ports: [9090, 15090].into_iter().collect(),
             run: RunConfig {
                 r#type: RunType::Exec,
-                command: vec!["go".to_owned(), "run".to_owned(), "./cmd/api".to_owned()],
+                command: vec!["go".to_string(), "run".to_string(), "./cmd/api".to_string()],
             },
         }
     }
@@ -460,7 +467,7 @@ mod tests {
                 accept_invalid_certificates: Some(true),
                 telemetry: None,
             },
-            services: [("api".to_owned(), sample_service())].into_iter().collect(),
+            services: [("api".into(), sample_service())].into_iter().collect(),
         };
         let rendered = render_yaml(&cfg).unwrap();
         // Target renders in its string form, not as a nested `{deployment: api}` map.
@@ -481,7 +488,7 @@ mod tests {
     fn omits_common_when_all_default() {
         let cfg = UpConfig {
             common: CommonConfig::default(),
-            services: [("svc".to_owned(), sample_service())].into_iter().collect(),
+            services: [("svc".into(), sample_service())].into_iter().collect(),
         };
         let out = render_yaml(&cfg).unwrap();
         assert!(
@@ -496,22 +503,22 @@ mod tests {
     #[test]
     fn no_nulls_or_empty_blocks() {
         let svc = ServiceConfig {
-            target: TargetConfig::default(),
+            target: TargetConfig::UNSPECIFIED,
             env: EnvConfig::default(),
             default_mode: ServiceMode::default(),
             http_filter: HttpFilterConfig {
-                header_filter: Some("x-session: me".to_owned()),
+                header_filter: Some("x-session: me".to_string()),
                 ..Default::default()
             },
             ignore_ports: BTreeSet::new(),
             run: RunConfig {
                 r#type: RunType::Exec,
-                command: vec!["echo".to_owned()],
+                command: vec!["echo".to_string()],
             },
         };
         let cfg = UpConfig {
             common: CommonConfig::default(),
-            services: [("svc".to_owned(), svc.clone())].into_iter().collect(),
+            services: [("svc".into(), svc.clone())].into_iter().collect(),
         };
         let out = render_yaml(&cfg).unwrap();
 
@@ -537,19 +544,19 @@ mod tests {
     #[test]
     fn scalar_lists_render_inline() {
         let svc = ServiceConfig {
-            target: TargetConfig::default(),
+            target: TargetConfig::UNSPECIFIED,
             env: EnvConfig::default(),
             default_mode: ServiceMode::default(),
             http_filter: HttpFilterConfig::default(),
             ignore_ports: [9090, 9091, 15090].into_iter().collect(),
             run: RunConfig {
                 r#type: RunType::Exec,
-                command: vec!["go".to_owned(), "run".to_owned(), "--opt=a,b".to_owned()],
+                command: vec!["go".to_string(), "run".to_string(), "--opt=a,b".to_string()],
             },
         };
         let cfg = UpConfig {
             common: CommonConfig::default(),
-            services: [("svc".to_owned(), svc.clone())].into_iter().collect(),
+            services: [("svc".into(), svc.clone())].into_iter().collect(),
         };
         let out = render_yaml(&cfg).unwrap();
 
@@ -577,22 +584,22 @@ mod tests {
     #[test]
     fn namespace_only_target_round_trips() {
         let svc = ServiceConfig {
-            target: TargetConfig {
+            target: TargetConfig::Specified(SpecifiedTarget {
                 path: None,
-                namespace: Some("staging".to_owned()),
-            },
+                namespace: Some("staging".into()),
+            }),
             env: EnvConfig::default(),
             default_mode: ServiceMode::default(),
             http_filter: HttpFilterConfig::default(),
             ignore_ports: BTreeSet::new(),
             run: RunConfig {
                 r#type: RunType::Exec,
-                command: vec!["echo".to_owned()],
+                command: vec!["echo".to_string()],
             },
         };
         let cfg = UpConfig {
             common: CommonConfig::default(),
-            services: [("svc".to_owned(), svc.clone())].into_iter().collect(),
+            services: [("svc".into(), svc.clone())].into_iter().collect(),
         };
         let out = render_yaml(&cfg).unwrap();
         assert!(!out.contains("path"), "path: null should be pruned:\n{out}");

--- a/mirrord/up/src/init.rs
+++ b/mirrord/up/src/init.rs
@@ -230,7 +230,7 @@ fn prompt_http_filter(mode: &ServiceMode) -> Result<HttpFilterConfig, InitError>
             let filter = match s.trim() {
                 "" => HttpFilterConfig::default(),
                 hf => HttpFilterConfig {
-                    header_filter: Some(hf.to_string()),
+                    header_filter: Some(hf.to_owned()),
                     ..Default::default()
                 },
             };
@@ -302,7 +302,7 @@ fn prompt_env_overrides() -> Result<Option<HashMap<String, String>>, InitError> 
             })
             .prompt()?
             .trim()
-            .to_string();
+            .to_owned();
         let value = Text::new("  Value:").prompt()?;
         map.insert(key, value);
     }
@@ -328,7 +328,7 @@ fn prompt_run() -> Result<RunConfig, InitError> {
         .prompt()?;
     let command = command_str
         .split_whitespace()
-        .map(ToString::to_string)
+        .map(ToOwned::to_owned)
         .collect();
 
     Ok(RunConfig { r#type, command })
@@ -447,22 +447,18 @@ mod tests {
                 namespace: Some("staging".into()),
             }),
             env: EnvConfig {
-                r#override: Some(
-                    [("FOO".to_string(), "bar".to_string())]
-                        .into_iter()
-                        .collect(),
-                ),
+                r#override: Some([("FOO".to_owned(), "bar".to_owned())].into_iter().collect()),
                 ..Default::default()
             },
             default_mode: ServiceMode::default(),
             http_filter: HttpFilterConfig {
-                header_filter: Some("x-session: me".to_string()),
+                header_filter: Some("x-session: me".to_owned()),
                 ..Default::default()
             },
             ignore_ports: [9090, 15090].into_iter().collect(),
             run: RunConfig {
                 r#type: RunType::Exec,
-                command: vec!["go".to_string(), "run".to_string(), "./cmd/api".to_string()],
+                command: vec!["go".to_owned(), "run".to_owned(), "./cmd/api".to_owned()],
             },
         }
     }
@@ -515,13 +511,13 @@ mod tests {
             env: EnvConfig::default(),
             default_mode: ServiceMode::default(),
             http_filter: HttpFilterConfig {
-                header_filter: Some("x-session: me".to_string()),
+                header_filter: Some("x-session: me".to_owned()),
                 ..Default::default()
             },
             ignore_ports: BTreeSet::new(),
             run: RunConfig {
                 r#type: RunType::Exec,
-                command: vec!["echo".to_string()],
+                command: vec!["echo".to_owned()],
             },
         };
         let cfg = UpConfig {
@@ -559,7 +555,7 @@ mod tests {
             ignore_ports: [9090, 9091, 15090].into_iter().collect(),
             run: RunConfig {
                 r#type: RunType::Exec,
-                command: vec!["go".to_string(), "run".to_string(), "--opt=a,b".to_string()],
+                command: vec!["go".to_owned(), "run".to_owned(), "--opt=a,b".to_owned()],
             },
         };
         let cfg = UpConfig {
@@ -602,7 +598,7 @@ mod tests {
             ignore_ports: BTreeSet::new(),
             run: RunConfig {
                 r#type: RunType::Exec,
-                command: vec!["echo".to_string()],
+                command: vec!["echo".to_owned()],
             },
         };
         let cfg = UpConfig {

--- a/mirrord/up/src/lib.rs
+++ b/mirrord/up/src/lib.rs
@@ -89,7 +89,7 @@ pub enum UpError {
     #[error("Service {name} crashed with exit status {status}")]
     ServiceCrashed {
         /// Name of the service that crashed.
-        name: String,
+        name: Arc<str>,
         /// Exit status of the crashed service.
         status: ExitStatus,
     },
@@ -97,12 +97,274 @@ pub enum UpError {
     /// A child process handler task panicked.
     #[error("Child process handler task panicked: {0:?}")]
     Panic(JoinError),
+
+    /// Failed to build a Kubernetes client or query the cluster while
+    /// resolving service targets.
+    #[error("failed to query the cluster: {0}")]
+    Kube(#[from] KubeApiError),
+
+    /// An interactive target-resolution prompt failed or was cancelled.
+    #[error("target resolution prompt failed: {0}")]
+    Inquire(#[from] inquire::InquireError),
+
+    /// The user chose to exit from the target-resolution wizard.
+    #[error("exited")]
+    Exited,
+
+    /// Failed to patch the `mirrord-up.yaml` when saving a chosen target.
+    #[error("failed to update config file: {0}")]
+    YamlPatch(#[from] yamlpatch::Error),
+
+    /// Failed to parse the `mirrord-up.yaml` when saving a chosen target.
+    #[error("failed to parse config file for updating: {0}")]
+    YamlQuery(#[from] yamlpath::QueryError),
 }
 
 /// Load and parse a `mirrord-up.yaml` configuration file.
 pub fn load_up_config(path: &PathBuf) -> Result<UpConfig, UpError> {
     let content = std::fs::read_to_string(path)?;
     Ok(serde_yaml::from_str(&content)?)
+}
+
+/// Workload kinds considered when inferring a target from a service key, in
+/// match-priority order: when several kinds have a workload with the same
+/// name, the first kind here wins.
+const INFERRED_TARGET_TYPES: [TargetType; 4] = [
+    TargetType::Deployment,
+    TargetType::StatefulSet,
+    TargetType::Rollout,
+    TargetType::Pod,
+];
+
+/// Resolve every service whose `target.path` is absent by looking the service
+/// key up in the cluster (see [`INFERRED_TARGET_TYPES`] for the search order).
+/// When no workload matches, an interactive wizard lets the user pick a
+/// different namespace and workload, or exit.
+async fn resolve_unresolved_workloads(
+    up_config: &UpConfig,
+    config_path: &Path,
+) -> Result<HashMap<UnresolvedTarget, ResolvedTarget>, UpError> {
+    let unresolved = up_config.unresolved_targets();
+
+    let (_, bound_max) = unresolved.size_hint();
+
+    // No unresolved
+    if bound_max == Some(0) {
+        return Ok(HashMap::new());
+    }
+
+    let kube_config = create_kube_config(
+        up_config.common.accept_invalid_certificates,
+        None::<&str>,
+        None,
+    )
+    .await?;
+    let client = kube::Client::try_from(kube_config).map_err(KubeApiError::from)?;
+
+    let mut map = HashMap::new();
+    for unresolved_target in unresolved {
+        let name = &unresolved_target.workload_name;
+        let namespace = unresolved_target
+            .namespace
+            .as_deref()
+            .unwrap_or(client.default_namespace());
+
+        let workloads = list_workloads(&client, namespace).await?;
+        let resolved = match find_by_name(&workloads, name) {
+            Some(path) => {
+                println!("{name}: using {path}");
+                ResolvedTarget {
+                    resolved: SpecifiedTarget {
+                        path: Some(Target::from_str(path)?),
+                        namespace: unresolved_target.namespace.clone(),
+                    },
+                }
+            }
+            None => {
+                println!(
+                    "{name}: No workload named \"{name}\" found in namespace \"{namespace}\"."
+                );
+                prompt_for_target(&client, name, config_path).await?
+            }
+        };
+
+        map.insert(unresolved_target, resolved);
+    }
+
+    Ok(map)
+}
+
+/// Lists workload paths (`deployment/foo`, `pod/bar/container/baz`, ...) of
+/// the kinds in [`INFERRED_TARGET_TYPES`] living in `namespace`, in priority
+/// order.
+async fn list_workloads(client: &kube::Client, namespace: &str) -> Result<Vec<String>, UpError> {
+    let seeker = KubeResourceSeeker {
+        client,
+        namespace,
+        copy_target: false,
+    };
+
+    // `operator_active: true` only lifts the seeker's restriction on listing
+    // operator-only kinds (statefulsets); the listing itself is plain
+    // Kubernetes API access.
+    Ok(seeker
+        .filtered(INFERRED_TARGET_TYPES.to_vec(), true)
+        .await?)
+}
+
+async fn list_namespaces(client: &kube::Client) -> Result<Vec<String>, UpError> {
+    let seeker = KubeResourceSeeker {
+        client,
+        namespace: client.default_namespace(),
+        copy_target: false,
+    };
+
+    let namespaces = seeker
+        .list_all_clusterwide::<Namespace>(None)
+        .try_filter_map(|namespace| std::future::ready(Ok(namespace.metadata.name)))
+        .try_collect()
+        .await
+        .map_err(KubeApiError::KubeError)?;
+    Ok(namespaces)
+}
+
+/// First path in `workloads` whose workload name matches `name` (paths look
+/// like `kind/name[/container/c]`, so the name is the second segment).
+fn find_by_name<'w>(workloads: &'w [String], name: &str) -> Option<&'w str> {
+    workloads
+        .iter()
+        .map(String::as_str)
+        .find(|path| path.split('/').nth(1) == Some(name))
+}
+
+/// Runs a blocking inquire prompt on the blocking thread pool.
+///
+/// The CLI drives this crate on a current-thread tokio runtime, so prompting
+/// directly from an async fn would freeze the entire runtime (including the
+/// kube client's background connection tasks) for as long as the user is
+/// deciding.
+async fn prompt<T: Send + 'static>(
+    prompt: impl FnOnce() -> Result<T, inquire::InquireError> + Send + 'static,
+) -> Result<T, UpError> {
+    tokio::task::spawn_blocking(prompt)
+        .await
+        .map_err(UpError::Panic)?
+        .map_err(UpError::from)
+}
+
+/// Fallback wizard for a service key with no matching workload: pick a
+/// namespace and workload from the cluster, or exit.
+///
+/// Once a workload is chosen the user is offered to persist it back to
+/// `config_path` (as `services.<service_name>.target`), so the next run uses it
+/// directly without asking again.
+async fn prompt_for_target(
+    client: &kube::Client,
+    service_name: &str,
+    config_path: &Path,
+) -> Result<ResolvedTarget, UpError> {
+    const SEARCH: &str = "Search in a different namespace";
+    const EXIT: &str = "Exit";
+
+    let choice =
+        prompt(|| Select::new("What would you like to do?", vec![SEARCH, EXIT]).prompt()).await?;
+
+    if choice == EXIT {
+        return Err(UpError::Exited);
+    }
+
+    let namespaces = list_namespaces(client).await?;
+    loop {
+        let namespace = {
+            let namespaces = namespaces.clone();
+            prompt(move || Select::new("Select a namespace:", namespaces).prompt()).await?
+        };
+
+        let workloads = list_workloads(client, &namespace).await?;
+        if workloads.is_empty() {
+            println!("No workloads found in namespace \"{namespace}\".");
+            continue;
+        }
+
+        let path = {
+            let message = format!("Select a workload in \"{namespace}\":");
+            prompt(move || Select::new(&message, workloads).prompt()).await?
+        };
+
+        offer_to_save_target(config_path, service_name, &path, &namespace).await?;
+
+        return Ok(ResolvedTarget {
+            resolved: SpecifiedTarget {
+                path: Some(Target::from_str(&path)?),
+                namespace: Some(namespace.into()),
+            },
+        });
+    }
+}
+
+/// Ask whether to persist the chosen target (`path` + `namespace`) to the
+/// service's `target` in the config, and do so if the user agrees.
+///
+/// Writing back is best-effort: a patch failure is reported but does not abort
+/// the run, since the target has already been resolved in memory.
+async fn offer_to_save_target(
+    config_path: &Path,
+    service_name: &str,
+    path: &str,
+    namespace: &str,
+) -> Result<(), UpError> {
+    let message = format!(
+        "Save target \"{path}\" in namespace \"{namespace}\" to {} for next time?",
+        config_path.display()
+    );
+    let save = prompt(move || Confirm::new(&message).with_default(true).prompt()).await?;
+    if save.not() {
+        return Ok(());
+    }
+
+    match save_target(config_path, service_name, path, namespace) {
+        Ok(()) => println!("Saved target to {}.", config_path.display()),
+        Err(error) => eprintln!("Failed to save target to config: {error}"),
+    }
+
+    Ok(())
+}
+
+/// Sets `services.<service_name>.target` to the chosen `path` and `namespace`
+/// in the config file, creating the `target` mapping if it is absent.
+///
+/// Uses `yamlpatch` so the rest of the document -- comments, key order,
+/// formatting -- is preserved instead of being rewritten by a full re-serialize.
+fn save_target(
+    config_path: &Path,
+    service_name: &str,
+    path: &str,
+    namespace: &str,
+) -> Result<(), UpError> {
+    let document = Document::new(std::fs::read_to_string(config_path)?)?;
+
+    let patch = Patch {
+        route: route!("services", service_name),
+        operation: Op::MergeInto {
+            key: "target".to_owned(),
+            updates: [
+                (
+                    "path".to_owned(),
+                    serde_yaml::Value::String(path.to_owned()),
+                ),
+                (
+                    "namespace".to_owned(),
+                    serde_yaml::Value::String(namespace.to_owned()),
+                ),
+            ]
+            .into_iter()
+            .collect(),
+        },
+    };
+
+    let patched = apply_yaml_patches(&document, &[patch])?;
+    std::fs::write(config_path, patched.source())?;
+    Ok(())
 }
 
 /// Genererate [`mirrord_config::LayerConfig`]s based on the provided [`UpConfig`] and
@@ -116,12 +378,15 @@ pub fn load_up_config(path: &PathBuf) -> Result<UpConfig, UpError> {
 /// Returns when one of the child mirrord sessions exits.
 pub async fn run(
     up_config: UpConfig,
+    config_path: &Path,
     key: EnvKey,
     correlation_id: Uuid,
     ready: ReadyTracker,
 ) -> Result<(), UpError> {
+    let mut resolved_targets = resolve_unresolved_workloads(&up_config, config_path).await?;
+
     let commands: Vec<_> = up_config
-        .service_configs(&key)
+        .service_configs(&key, &mut resolved_targets)
         .map(|config| {
             let SubprocessCfg {
                 config,

--- a/mirrord/up/src/lib.rs
+++ b/mirrord/up/src/lib.rs
@@ -6,9 +6,11 @@
 #![deny(missing_docs)]
 
 use std::{
+    collections::HashMap,
     ops::Not,
-    path::PathBuf,
+    path::{Path, PathBuf},
     process::{ExitStatus, Stdio},
+    str::FromStr,
     sync::{
         Arc, OnceLock,
         atomic::{AtomicUsize, Ordering},
@@ -16,10 +18,23 @@ use std::{
     time::{Duration, Instant},
 };
 
+use config::{ResolvedTarget, SpecifiedTarget, UnresolvedTarget};
+use futures::TryStreamExt;
+use inquire::{Confirm, Select};
+use k8s_openapi::api::core::v1::Namespace;
 use miette::Diagnostic;
 use mirrord_analytics::MIRRORD_UP_CORRELATION_ID_ENV;
-use mirrord_config::config::{ConfigError, EnvKey};
+use mirrord_config::{
+    config::{ConfigError, EnvKey},
+    target::{Target, TargetType},
+};
+use mirrord_kube::{
+    api::kubernetes::{create_kube_config, seeker::KubeResourceSeeker},
+    error::KubeApiError,
+};
 use thiserror::Error;
+use yamlpatch::{Op, Patch, apply_yaml_patches};
+use yamlpath::{Document, route};
 mod config;
 mod init;
 


### PR DESCRIPTION
<!-- Thank you for contributing to mirrord! -->
<!-- Please use the checklist below as a guide for docs, tests and admin tasks for your PR -->
<!-- Feel free to ~strikethrough~ any items that you don't think apply -->

### Quality Checklist:

- [X] I have documented new code sufficiently
- [X] I have checked and updated the relevant existing docs in code, including removing outdated material
- [x] I have written user-facing website docs for new features, or opened a (sub)issue to do so
- [x] I have checked and updated existing website docs for changed features
- [X] I have tested this change and know it succeeds and fails as expected
- [X] I have written unit tests or purposefully omitted them
- [X] I have written e2e tests or purposefully omitted them
- [X] I have explained what this PR introduces and why, and linked to relevant context (e.g. linear issues, related PRs,
  documentation)
- [X] I have introduced a short, clear and well-formatted changelog entry

<!-- need help with the changelog? see ../CONTRIBUTING.md#submitting-a-pull-request -->
<!-- Add more details of your changes below if needed -->

See: 
+ https://linear.app/metalbear/issue/COR-1499/mirrord-up-infer-targetpath-from-service-key for context
+ https://github.com/metalbear-co/docs/pull/266