### PR TITLE
Inject `mirrord-key` into all forwarded messages

### DIFF
--- a/changelog.d/+mirrord-key.added.md
+++ b/changelog.d/+mirrord-key.added.md
@@ -1,0 +1,1 @@
+Inject `mirrord-key` into all forwarded messages.

--- a/mirrord/cli/src/main.rs
+++ b/mirrord/cli/src/main.rs
@@ -740,7 +740,8 @@ pub(crate) fn print_config<P>(
     if operator_used {
         progress.info(&format!(
             "Session key: {}\nIf enabled, a `mirrord-key` header with this value will be injected \
-into redirected HTTP requests before they're routed to the target.",
+into redirected HTTP requests and their responses, and into the queue-split messages routed to \
+this session.",
             config.key.as_str()
         ));
     }


### PR DESCRIPTION
Resolves INT-497.