### PR TITLE
fix(ui): JSON 404 for unknown API routes, context placeholder, pathless events, dev-proxy auth

### DIFF
--- a/changelog.d/+monitor-ui-dx.fixed.md
+++ b/changelog.d/+monitor-ui-dx.fixed.md
@@ -1,0 +1,1 @@
+Fixed the `mirrord ui` server answering unknown `/api` routes with the SPA page instead of a JSON 404, the monitor context picker showing "default" before contexts load, file events without a path rendering as "?", and the frontend dev proxy missing the `/auth` route needed to authenticate against the server.

--- a/mirrord/cli/src/ui/server.rs
+++ b/mirrord/cli/src/ui/server.rs
@@ -815,6 +815,15 @@ fn get_asset(path: &str) -> Option<Vec<u8>> {
 async fn static_handler(uri: axum::http::Uri) -> impl IntoResponse {
     let path = uri.path().trim_start_matches('/');
 
+    if path == "api" || path.starts_with("api/") {
+        return (
+            StatusCode::NOT_FOUND,
+            [(header::CONTENT_TYPE, "application/json")],
+            r#"{"error":"unknown API route"}"#,
+        )
+            .into_response();
+    }
+
     if let Some(data) = get_asset(path) {
         let mime = guess_mime(path);
         return ([(header::CONTENT_TYPE, mime)], data).into_response();

--- a/packages/monitor/src/components/ContextNamespacePicker.tsx
+++ b/packages/monitor/src/components/ContextNamespacePicker.tsx
@@ -261,7 +261,7 @@ export default function ContextNamespacePicker({
     <div className="hidden md:flex items-center gap-2 min-w-0">
       <Dropdown
         label="Context"
-        value={effectiveContext ?? 'default'}
+        value={effectiveContext ?? '…'}
         options={contextOptions}
         selected={effectiveContext}
         onSelect={onSelectContext}

--- a/packages/monitor/src/components/events/parseEvent.ts
+++ b/packages/monitor/src/components/events/parseEvent.ts
@@ -1,6 +1,5 @@
 import type { MonitorEvent } from '../../types'
 import { EventType, type EventTypeValue } from '../../eventTypes'
-import { strings } from '../../strings'
 
 export interface ParsedEvent {
   type: EventTypeValue
@@ -14,7 +13,10 @@ export function parseEvent(event: MonitorEvent): ParsedEvent | null {
   try {
     switch (event.type) {
       case EventType.FileOp:
-        return { type: EventType.FileOp, summary: `${event.operation}: ${event.path || strings.events.unknownPath}` }
+        return {
+          type: EventType.FileOp,
+          summary: event.path ? `${event.operation}: ${event.path}` : event.operation,
+        }
       case EventType.DnsQuery:
         return { type: EventType.DnsQuery, summary: `DNS lookup: ${event.host}` }
       case EventType.IncomingRequest:

--- a/packages/monitor/src/strings.ts
+++ b/packages/monitor/src/strings.ts
@@ -23,7 +23,6 @@ export const strings = {
     outgoing: 'Outgoing',
     dns: 'DNS',
     fileOps: 'File Ops',
-    unknownPath: '?',
     labels: {
       file: 'File',
       dns: 'DNS',

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -22,6 +22,7 @@ export default defineConfig({
     port: 5173,
     proxy: {
       // Point these at a running `mirrord ui` server (default port 59281).
+      '/auth': 'http://localhost:59281',
       '/api': 'http://localhost:59281',
       '/ws': {
         target: 'ws://localhost:59281',


### PR DESCRIPTION
## Summary

Four small fixes for issues found while exercising `mirrord ui` end to end against a live cluster session:

- **Unknown `/api` routes returned 200 with the SPA's HTML** (the static fallback swallowed them). Any client version skew produced confusing JSON parse errors instead of a clean failure. The fallback now answers `/api*` misses with a JSON 404 before falling back to assets.
- **The monitor's context picker displayed "default"** (a namespace name, not a context) before contexts loaded or when the fetch failed. It now shows an ellipsis placeholder, matching the account chip's loading affordance.
- **File events without a path rendered as `stat: ?`** in the events feed. Pathless operations now render as just the operation name.
- **`pnpm dev` could never authenticate**: the server moved auth to the `/auth` cookie bootstrap, but the Vite dev proxy only forwarded `/api` and `/ws`, so every request 401'd with no way to log in. `/auth` is now proxied.

## Test plan

- Built the CLI and ran `mirrord ui` locally: `GET /api/v2/nonexistent` returns 404 `application/json` (`{"error":"unknown API route"}`), real API routes still 200 JSON, the SPA still serves at `/`, and `/auth` still 303s with the cookie.
- With the proxied `/auth`, `pnpm dev` on 5173 authenticates and renders a live session against a running `mirrord ui` daemon (verified against a playground cluster session with mirrored traffic).
- `cargo fmt --check` and `cargo clippy -p mirrord --no-deps` clean; monitor `tsc -b` and the mirrord-ui package typecheck + build pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)