### PR TITLE
ci: cluster-side frontend e2e harness (ephemeral namespaces, echo fixture, reaper)

### DIFF
--- a/changelog.d/+frontend-e2e-harness.internal.md
+++ b/changelog.d/+frontend-e2e-harness.internal.md
@@ -1,0 +1,1 @@
+Added the cluster-side frontend e2e harness under `ci/frontend-e2e`: an ephemeral-namespace provisioner with an echo fixture workload and resource quota, plus a reaper CronJob that deletes stale CI namespaces as the cleanup guarantee.

--- a/ci/frontend-e2e/README.md
+++ b/ci/frontend-e2e/README.md
@@ -1,0 +1,28 @@
+# Frontend e2e harness
+
+Cluster-side fixtures for the cross-repo frontend test harness (session monitor,
+config wizard, browser extension). Runs on the `han-dev` cluster in the
+`mirrord-test` GCP project, never on the shared playground.
+
+Every run provisions its own state under a unique run ID and asserts protocol
+outcomes, never pre-existing sessions or a developer's current kube context.
+
+## Pieces
+
+- `provision.sh <run-id> [context]` creates the `ci-fe-<run-id>` namespace
+  (labelled `mirrord-ci=frontend-e2e`) with an echo workload and quota, and
+  prints the target coordinates for `mirrord exec`.
+- `teardown.sh <run-id> [context]` deletes the namespace.
+- `echo.yaml` is the fixture workload: an echo server that reflects request
+  headers, so tests can assert both traffic directions (the staging service
+  receives the mirrord header; the local process receives the mirrored copy).
+- `reaper.yaml` is a cluster-side CronJob (namespace `ci-frontend`) that
+  deletes any `mirrord-ci=frontend-e2e` namespace older than two hours.
+  CI teardown is best-effort; the reaper is the guarantee. Apply once per
+  cluster: `kubectl apply -f reaper.yaml`.
+
+## Probe rules
+
+Service networking and DNS in a fresh namespace can lag pod readiness by a few
+seconds. Every request a test makes must carry a timeout (`curl -m`) and retry;
+a first-shot request without one can hang forever on a blackholed SYN.

--- a/ci/frontend-e2e/echo.yaml
+++ b/ci/frontend-e2e/echo.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: echo
+  labels:
+    app: echo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: echo
+  template:
+    metadata:
+      labels:
+        app: echo
+    spec:
+      containers:
+        - name: echo
+          image: ealen/echo-server:0.9.2
+          ports:
+            - containerPort: 80
+          env:
+            - name: PORT
+              value: "80"
+          resources:
+            requests:
+              cpu: 25m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo
+spec:
+  selector:
+    app: echo
+  ports:
+    - port: 80
+      targetPort: 80
+---
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: ci-quota
+spec:
+  hard:
+    pods: "10"
+    requests.cpu: "1"
+    requests.memory: 1Gi

--- a/ci/frontend-e2e/provision.sh
+++ b/ci/frontend-e2e/provision.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")"
+
+RUN_ID=${1:?usage: provision.sh <run-id> [kube-context]}
+CONTEXT=${2:-${MIRRORD_E2E_CONTEXT:-gke_mirrord-test_us-central1-a_han-dev}}
+NAMESPACE="ci-fe-${RUN_ID}"
+
+kubectl --context "$CONTEXT" create namespace "$NAMESPACE"
+kubectl --context "$CONTEXT" label namespace "$NAMESPACE" \
+    mirrord-ci=frontend-e2e "run-id=${RUN_ID}"
+
+kubectl --context "$CONTEXT" -n "$NAMESPACE" apply -f echo.yaml
+kubectl --context "$CONTEXT" -n "$NAMESPACE" rollout status deployment/echo --timeout=120s
+
+echo "namespace=${NAMESPACE}"
+echo "target=deployment/echo"
+echo "service=echo.${NAMESPACE}.svc.cluster.local"

--- a/ci/frontend-e2e/reaper.yaml
+++ b/ci/frontend-e2e/reaper.yaml
@@ -1,0 +1,69 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ci-frontend
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ci-namespace-reaper
+  namespace: ci-frontend
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ci-namespace-reaper
+rules:
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ci-namespace-reaper
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ci-namespace-reaper
+subjects:
+  - kind: ServiceAccount
+    name: ci-namespace-reaper
+    namespace: ci-frontend
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: ci-namespace-reaper
+  namespace: ci-frontend
+spec:
+  schedule: "*/15 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: 300
+      template:
+        spec:
+          serviceAccountName: ci-namespace-reaper
+          restartPolicy: Never
+          containers:
+            - name: reaper
+              image: bitnami/kubectl:1.35
+              command:
+                - /bin/bash
+                - -c
+                - |
+                  set -euo pipefail
+                  cutoff=$(date -u -d '2 hours ago' +%s)
+                  kubectl get namespaces -l mirrord-ci=frontend-e2e \
+                    -o jsonpath='{range .items[*]}{.metadata.name} {.metadata.creationTimestamp}{"\n"}{end}' |
+                  while read -r name created; do
+                    [ -z "$name" ] && continue
+                    created_epoch=$(date -u -d "$created" +%s)
+                    if [ "$created_epoch" -lt "$cutoff" ]; then
+                      echo "reaping stale CI namespace $name (created $created)"
+                      kubectl delete namespace "$name" --wait=false
+                    fi
+                  done

--- a/ci/frontend-e2e/teardown.sh
+++ b/ci/frontend-e2e/teardown.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RUN_ID=${1:?usage: teardown.sh <run-id> [kube-context]}
+CONTEXT=${2:-${MIRRORD_E2E_CONTEXT:-gke_mirrord-test_us-central1-a_han-dev}}
+NAMESPACE="ci-fe-${RUN_ID}"
+
+kubectl --context "$CONTEXT" delete namespace "$NAMESPACE" --ignore-not-found --wait=false


### PR DESCRIPTION
## Summary

First cluster-side piece of the cross-repo frontend test harness (session monitor, wizard, browser extension), per the frontend testing plan:

- `ci/frontend-e2e/provision.sh <run-id>` creates a `ci-fe-<run-id>` namespace labelled `mirrord-ci=frontend-e2e` with an echo fixture workload (reflects request headers, so tests can assert both traffic directions) and a resource quota
- `teardown.sh` deletes it; a reaper CronJob (`reaper.yaml`, applied per cluster) deletes any harness namespace older than two hours as the cleanup guarantee, since CI teardown is best-effort
- Runs on the han-dev cluster in the mirrord-test project, never the shared playground

## Test plan

Full cycle verified live on han-dev: provision -> rollout -> in-cluster probe confirms the echo reflects an injected `baggage: mirrord-session=...` header -> teardown. The quota correctly rejects unquoted pods. The reaper CronJob is deployed and scheduled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)