### PR TITLE
Support custom image per DB branch (INT-476)

### DIFF
--- a/changelog.d/+db-branch-custom-image.added.md
+++ b/changelog.d/+db-branch-custom-image.added.md
@@ -1,0 +1,1 @@
+Add support for specifying a custom image per db branch via the `image` field in `feature.db_branches` (all db types).

--- a/mirrord-schema.json
+++ b/mirrord-schema.json
@@ -1172,7 +1172,7 @@
       ]
     },
     "DatabaseBranchConfig": {
-      "description": "Configuration for a database branch.\n\nExample:\n\n```json\n{\n  \"id\": \"my-branch-db\",\n  \"name\": \"my-database-name\",\n  \"ttl_secs\": 120,\n  \"type\": \"mysql\",\n  \"version\": \"8.0\",\n  \"connection\": {\n    \"url\": {\n      \"type\": \"env\",\n      \"variable\": \"DB_CONNECTION_URL\"\n    }\n  }\n}\n```\n\nThe fields below are shared by every engine. Engine-specific fields (copy modes,\n`iam_auth`, `connection_settings`, `emulator_host`) are documented under each `type`.\n\n#### feature.db_branches[].id (type: mysql, mariadb, pg, mongodb, mssql, redis) {#feature-db_branches-sql-id}\n\nUsers can choose to specify a unique `id`. This is useful for reusing or sharing\nthe same database branch among Kubernetes users.\n\n#### feature.db_branches[].name (type: mysql, mariadb, pg, mongodb, mssql, redis) {#feature-db_branches-sql-name}\n\nWhen source database connection detail is not accessible to mirrord operator, users\ncan specify the database `name` so it is included in the connection options mirrord\nuses as the override.\n\n#### feature.db_branches[].ttl_secs (type: mysql, mariadb, pg, mongodb, mssql, redis) {#feature-db_branches-sql-ttl_secs}\n\nMirrord operator starts counting the TTL when a branch is no longer used by any session.\nThe time-to-live (TTL) for the branch database is set to 300 seconds by default.\nUsers can set `ttl_secs` to customize this value according to their need. Please note\nthat longer TTL paired with frequent mirrord session turnover can result in increased\nresource usage. For this reason, branch database TTL caps out at 15 min.\n\nMutually exclusive with [`ttl_mins`](#feature-db_branches-sql-ttl_mins).\n\n#### feature.db_branches[].ttl_mins (type: mysql, mariadb, pg, mongodb, mssql, redis) {#feature-db_branches-sql-ttl_mins}\n\nSame as [`ttl_secs`](#feature-db_branches-sql-ttl_secs) but expressed in minutes.\n\nMutually exclusive with [`ttl_secs`](#feature-db_branches-sql-ttl_secs).\n\n#### feature.db_branches[].creation_timeout_secs (type: mysql, mariadb, pg, mongodb, mssql, redis) {#feature-db_branches-sql-creation_timeout_secs}\n\nThe timeout in seconds to wait for a database branch to become ready after creation.\nDefaults to 60 seconds. Adjust this value based on your database size and cluster\nperformance.\n\n#### feature.db_branches[].version (type: mysql, mariadb, pg, mongodb, mssql, redis) {#feature-db_branches-sql-version}\n\nMirrord operator uses a default version of the database image unless `version` is given.\n\n#### feature.db_branches[].connection (type: mysql, mariadb, pg, mongodb, mssql, redis) {#feature-db_branches-sql-connection}\n\n`connection` describes how to get the connection information to the source database.\nWhen the branch database is ready for use, Mirrord operator will replace the connection\ninformation with the branch database's. It accepts a connection URL or individual params:\n\n```json\n{ \"url\": { \"type\": \"env\", \"variable\": \"DB_CONNECTION_URL\" } }\n```\n```json\n{ \"type\": \"env\", \"url\": \"DB_CONNECTION_URL\" }\n```\n```json\n{ \"type\": \"env\", \"params\": { \"host\": \"DB_HOST\", \"port\": \"DB_PORT\", \"user\": \"DB_USER\", \"password\": \"DB_PASSWORD\", \"database\": \"DB_NAME\" } }\n```\n\nAny param can also be read from a Kubernetes Secret instead of a target-pod env var:\n\n```json\n{ \"type\": \"env\", \"params\": { \"host\": \"DB_HOST\", \"password\": { \"secret\": \"my-secret\", \"key\": \"password\" }, \"database\": \"DB_NAME\" } }\n```\n\n#### feature.db_branches[].migrations (type: mysql, mariadb, pg, mssql, clickhouse) {#feature-db_branches-sql-migrations}\n\nSchema migrations to run on the branch after it is created. Currently supports\n[Flyway](https://documentation.red-gate.com/flyway):\n\n```json\n{ \"migrations\": { \"flavor\": \"flyway\", \"path\": \"./migrations\" } }\n```\n\n- `path`: local directory holding the migration files, resolved relative to the working\n  directory.\n- `image`: optional container image override for the migration runner.\n\nRequires [`name`](#feature-db_branches-sql-name) to be set.",
+      "description": "Configuration for a database branch.\n\nExample:\n\n```json\n{\n  \"id\": \"my-branch-db\",\n  \"name\": \"my-database-name\",\n  \"ttl_secs\": 120,\n  \"type\": \"mysql\",\n  \"version\": \"8.0\",\n  \"connection\": {\n    \"url\": {\n      \"type\": \"env\",\n      \"variable\": \"DB_CONNECTION_URL\"\n    }\n  }\n}\n```\n\nThe fields below are shared by every engine. Engine-specific fields (copy modes,\n`iam_auth`, `connection_settings`, `emulator_host`) are documented under each `type`.\n\n#### feature.db_branches[].id (type: mysql, mariadb, pg, mongodb, mssql, redis) {#feature-db_branches-sql-id}\n\nUsers can choose to specify a unique `id`. This is useful for reusing or sharing\nthe same database branch among Kubernetes users.\n\n#### feature.db_branches[].name (type: mysql, mariadb, pg, mongodb, mssql, redis) {#feature-db_branches-sql-name}\n\nWhen source database connection detail is not accessible to mirrord operator, users\ncan specify the database `name` so it is included in the connection options mirrord\nuses as the override.\n\n#### feature.db_branches[].ttl_secs (type: mysql, mariadb, pg, mongodb, mssql, redis) {#feature-db_branches-sql-ttl_secs}\n\nMirrord operator starts counting the TTL when a branch is no longer used by any session.\nThe time-to-live (TTL) for the branch database is set to 300 seconds by default.\nUsers can set `ttl_secs` to customize this value according to their need. Please note\nthat longer TTL paired with frequent mirrord session turnover can result in increased\nresource usage. For this reason, branch database TTL caps out at 15 min.\n\nMutually exclusive with [`ttl_mins`](#feature-db_branches-sql-ttl_mins).\n\n#### feature.db_branches[].ttl_mins (type: mysql, mariadb, pg, mongodb, mssql, redis) {#feature-db_branches-sql-ttl_mins}\n\nSame as [`ttl_secs`](#feature-db_branches-sql-ttl_secs) but expressed in minutes.\n\nMutually exclusive with [`ttl_secs`](#feature-db_branches-sql-ttl_secs).\n\n#### feature.db_branches[].creation_timeout_secs (type: mysql, mariadb, pg, mongodb, mssql, redis) {#feature-db_branches-sql-creation_timeout_secs}\n\nThe timeout in seconds to wait for a database branch to become ready after creation.\nDefaults to 60 seconds. Adjust this value based on your database size and cluster\nperformance.\n\n#### feature.db_branches[].version (type: mysql, mariadb, pg, mongodb, mssql, redis) {#feature-db_branches-sql-version}\n\nMirrord operator uses a default version of the database image unless `version` is given.\n\nMutually exclusive with [`image`](#feature-db_branches-sql-image).\n\n#### feature.db_branches[].image (type: mysql, mariadb, pg, mongodb, mssql, redis) {#feature-db_branches-sql-image}\n\nFull image reference for the branch database container, including the tag\n(e.g. `registry.example.com/postgresql:15-partman`). Setting `image` overrides both the\noperator's built-in default image and any registry configured cluster-wide by the operator\nadmin. Cluster admins can restrict which images are accepted with the per-database\n`dbPod.allowedImages` list in the operator's Helm values; when that list is not set, any\nimage is allowed.\n\nMutually exclusive with [`version`](#feature-db_branches-sql-version), as the image\nreference already carries the tag.\n\n#### feature.db_branches[].connection (type: mysql, mariadb, pg, mongodb, mssql, redis) {#feature-db_branches-sql-connection}\n\n`connection` describes how to get the connection information to the source database.\nWhen the branch database is ready for use, Mirrord operator will replace the connection\ninformation with the branch database's. It accepts a connection URL or individual params:\n\n```json\n{ \"url\": { \"type\": \"env\", \"variable\": \"DB_CONNECTION_URL\" } }\n```\n```json\n{ \"type\": \"env\", \"url\": \"DB_CONNECTION_URL\" }\n```\n```json\n{ \"type\": \"env\", \"params\": { \"host\": \"DB_HOST\", \"port\": \"DB_PORT\", \"user\": \"DB_USER\", \"password\": \"DB_PASSWORD\", \"database\": \"DB_NAME\" } }\n```\n\nAny param can also be read from a Kubernetes Secret instead of a target-pod env var:\n\n```json\n{ \"type\": \"env\", \"params\": { \"host\": \"DB_HOST\", \"password\": { \"secret\": \"my-secret\", \"key\": \"password\" }, \"database\": \"DB_NAME\" } }\n```\n\n#### feature.db_branches[].migrations (type: mysql, mariadb, pg, mssql, clickhouse) {#feature-db_branches-sql-migrations}\n\nSchema migrations to run on the branch after it is created. Currently supports\n[Flyway](https://documentation.red-gate.com/flyway):\n\n```json\n{ \"migrations\": { \"flavor\": \"flyway\", \"path\": \"./migrations\" } }\n```\n\n- `path`: local directory holding the migration files, resolved relative to the working\n  directory.\n- `image`: optional container image override for the migration runner.\n\nRequires [`name`](#feature-db_branches-sql-name) to be set.",
       "oneOf": [
         {
           "description": "When configuring a branch for ClickHouse, set `type` to `clickhouse`.",
@@ -1198,6 +1198,13 @@
             },
             "id": {
               "description": "Optional stable id for reusing or sharing a branch across users.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "image": {
+              "description": "Full image reference for the branch container, including the tag. Overrides the\noperator-configured registry entirely. Mutually exclusive with `version`.",
               "type": [
                 "string",
                 "null"
@@ -1287,6 +1294,13 @@
                 "null"
               ]
             },
+            "image": {
+              "description": "Full image reference for the branch container, including the tag. Overrides the\noperator-configured registry entirely. Mutually exclusive with `version`.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
             "name": {
               "description": "Source database name, used when the operator cannot read it from the connection.",
               "type": [
@@ -1331,7 +1345,7 @@
           ]
         },
         {
-          "description": "When branching a database, cache, or any other stateful service that mirrord has no built-in\nengine for, set `type` to `generic`.\n\nA generic branch runs the container image you supply, starting empty - there are no copy\nmodes, IAM auth, or schema handling. The operator resolves each parameter you declare under\n`connection.params` from the target pod and injects it into the branch container as an env\nvar named `MIRRORD_PARAM_<NAME>` (a Secret-backed param arrives as a `secretKeyRef`; the\noperator never reads its value). Reference these in `command`, `args`, and `env` with\nKubernetes' native `$(VAR)` syntax so the branch bootstraps itself with the *same* values the\napp already uses. mirrord then only redirects the app's `host`/`port` vars to the branch -\neverything else in the app's environment keeps working unchanged.\n\nTwo built-ins are always available alongside the params: `MIRRORD_BRANCH_ID` and, when the\nshared `name` field is set, `MIRRORD_DATABASE_NAME`.\n\n#### feature.db_branches[].image (type: generic) {#feature-db_branches-generic-image}\n\nFull image reference for the branch container, including the tag\n(e.g. `docker.io/library/influxdb:2.7`). Required. The shared `version` field is not\nallowed for generic branches - the tag lives here.\n\n#### feature.db_branches[].port (type: generic) {#feature-db_branches-generic-port}\n\nThe port the branched service listens on. Required. Used as the default readiness probe\ntarget and as the port the app's connection is redirected to.\n\n#### feature.db_branches[].command / args (type: generic) {#feature-db_branches-generic-command}\n\nOptional entrypoint override for the branch container. Values may reference declared params\nwith `$(MIRRORD_PARAM_<NAME>)`; use `$$(...)` for a literal `$(...)`. Values written\ndirectly into `args` are visible in the pod spec - reference params via `$(VAR)` instead of\ninlining secrets.\n\n#### feature.db_branches[].env (type: generic) {#feature-db_branches-generic-env}\n\nExtra environment variables for the branch container. Values support the same\n`$(MIRRORD_PARAM_<NAME>)` references as `command`/`args`. Keys must not start with\n`MIRRORD_PARAM_` or collide with the built-ins.\n\n#### feature.db_branches[].readiness (type: generic) {#feature-db_branches-generic-readiness}\n\nReadiness check for the branch container. Defaults to a TCP probe on `port`.\n\n```json\n{ \"readiness\": { \"type\": \"http_get\", \"path\": \"/health\" } }\n```\n```json\n{ \"readiness\": { \"type\": \"exec\", \"command\": [\"redis-cli\", \"ping\"] } }\n```\n\nExample - an empty InfluxDB branch, bootstrapped with the app's own token/org/bucket so the\napp's untouched credential vars stay valid against the branch:\n\n```json\n{\n  \"type\": \"generic\",\n  \"id\": \"my-influx-branch\",\n  \"image\": \"docker.io/library/influxdb:2.7\",\n  \"port\": 8086,\n  \"connection\": {\n    \"params\": {\n      \"host\": { \"env_var_name\": \"INFLUXDB_URL\", \"value_pattern\": \"https?://([^:/]+)\" },\n      \"port\": { \"env_var_name\": \"INFLUXDB_URL\", \"value_pattern\": \":([0-9]+)\" },\n      \"token\": { \"secret\": \"influx-creds\", \"key\": \"token\" },\n      \"org\": \"INFLUXDB_ORG\",\n      \"bucket\": \"INFLUXDB_BUCKET\"\n    }\n  },\n  \"env\": {\n    \"DOCKER_INFLUXDB_INIT_MODE\": \"setup\",\n    \"DOCKER_INFLUXDB_INIT_USERNAME\": \"admin\",\n    \"DOCKER_INFLUXDB_INIT_PASSWORD\": \"mirrord-branch\",\n    \"DOCKER_INFLUXDB_INIT_ADMIN_TOKEN\": \"$(MIRRORD_PARAM_TOKEN)\",\n    \"DOCKER_INFLUXDB_INIT_ORG\": \"$(MIRRORD_PARAM_ORG)\",\n    \"DOCKER_INFLUXDB_INIT_BUCKET\": \"$(MIRRORD_PARAM_BUCKET)\"\n  }\n}\n```\n\n`token`, `org`, and `bucket` are custom params - any key works under `connection.params`,\nnot just the fixed `host`/`port`/`user`/`password`/`database` slots. The connection must use\nparams mode (URL-shaped env vars are covered by `value_pattern` on `host`/`port`), and\n`gcp_secret_manager` sources are not supported for generic branches.",
+          "description": "When branching a database, cache, or any other stateful service that mirrord has no built-in\nengine for, set `type` to `generic`.\n\nA generic branch runs the container image you supply, starting empty - there are no copy\nmodes, IAM auth, or schema handling. The operator resolves each parameter you declare under\n`connection.params` from the target pod and injects it into the branch container as an env\nvar named `MIRRORD_PARAM_<NAME>` (a Secret-backed param arrives as a `secretKeyRef`; the\noperator never reads its value). Reference these in `command`, `args`, and `env` with\nKubernetes' native `$(VAR)` syntax so the branch bootstraps itself with the *same* values the\napp already uses. mirrord then only redirects the app's `host`/`port` vars to the branch -\neverything else in the app's environment keeps working unchanged.\n\nTwo built-ins are always available alongside the params: `MIRRORD_BRANCH_ID` and, when the\nshared `name` field is set, `MIRRORD_DATABASE_NAME`.\n\n#### feature.db_branches[].image (type: generic) {#feature-db_branches-generic-image}\n\nFull image reference for the branch container, including the tag\n(e.g. `docker.io/library/influxdb:2.7`). This is the shared `image` field, but unlike the\nbuilt-in engines a generic branch has no default image, so here it is required. The shared\n`version` field is not allowed for generic branches - the tag lives here.\n\n#### feature.db_branches[].port (type: generic) {#feature-db_branches-generic-port}\n\nThe port the branched service listens on. Required. Used as the default readiness probe\ntarget and as the port the app's connection is redirected to.\n\n#### feature.db_branches[].command / args (type: generic) {#feature-db_branches-generic-command}\n\nOptional entrypoint override for the branch container. Values may reference declared params\nwith `$(MIRRORD_PARAM_<NAME>)`; use `$$(...)` for a literal `$(...)`. Values written\ndirectly into `args` are visible in the pod spec - reference params via `$(VAR)` instead of\ninlining secrets.\n\n#### feature.db_branches[].env (type: generic) {#feature-db_branches-generic-env}\n\nExtra environment variables for the branch container. Values support the same\n`$(MIRRORD_PARAM_<NAME>)` references as `command`/`args`. Keys must not start with\n`MIRRORD_PARAM_` or collide with the built-ins.\n\n#### feature.db_branches[].readiness (type: generic) {#feature-db_branches-generic-readiness}\n\nReadiness check for the branch container. Defaults to a TCP probe on `port`.\n\n```json\n{ \"readiness\": { \"type\": \"http_get\", \"path\": \"/health\" } }\n```\n```json\n{ \"readiness\": { \"type\": \"exec\", \"command\": [\"redis-cli\", \"ping\"] } }\n```\n\nExample - an empty InfluxDB branch, bootstrapped with the app's own token/org/bucket so the\napp's untouched credential vars stay valid against the branch:\n\n```json\n{\n  \"type\": \"generic\",\n  \"id\": \"my-influx-branch\",\n  \"image\": \"docker.io/library/influxdb:2.7\",\n  \"port\": 8086,\n  \"connection\": {\n    \"params\": {\n      \"host\": { \"env_var_name\": \"INFLUXDB_URL\", \"value_pattern\": \"https?://([^:/]+)\" },\n      \"port\": { \"env_var_name\": \"INFLUXDB_URL\", \"value_pattern\": \":([0-9]+)\" },\n      \"token\": { \"secret\": \"influx-creds\", \"key\": \"token\" },\n      \"org\": \"INFLUXDB_ORG\",\n      \"bucket\": \"INFLUXDB_BUCKET\"\n    }\n  },\n  \"env\": {\n    \"DOCKER_INFLUXDB_INIT_MODE\": \"setup\",\n    \"DOCKER_INFLUXDB_INIT_USERNAME\": \"admin\",\n    \"DOCKER_INFLUXDB_INIT_PASSWORD\": \"mirrord-branch\",\n    \"DOCKER_INFLUXDB_INIT_ADMIN_TOKEN\": \"$(MIRRORD_PARAM_TOKEN)\",\n    \"DOCKER_INFLUXDB_INIT_ORG\": \"$(MIRRORD_PARAM_ORG)\",\n    \"DOCKER_INFLUXDB_INIT_BUCKET\": \"$(MIRRORD_PARAM_BUCKET)\"\n  }\n}\n```\n\n`token`, `org`, and `bucket` are custom params - any key works under `connection.params`,\nnot just the fixed `host`/`port`/`user`/`password`/`database` slots. The connection must use\nparams mode (URL-shaped env vars are covered by `value_pattern` on `host`/`port`), and\n`gcp_secret_manager` sources are not supported for generic branches.",
           "type": "object",
           "properties": {
             "args": {
@@ -1380,8 +1394,11 @@
               ]
             },
             "image": {
-              "description": "Full image reference for the branch container, including the tag.",
-              "type": "string"
+              "description": "Full image reference for the branch container, including the tag. Overrides the\noperator-configured registry entirely. Mutually exclusive with `version`.",
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "name": {
               "description": "Source database name, used when the operator cannot read it from the connection.",
@@ -1442,7 +1459,6 @@
           "required": [
             "type",
             "connection",
-            "image",
             "port"
           ]
         },
@@ -1482,6 +1498,13 @@
             },
             "id": {
               "description": "Optional stable id for reusing or sharing a branch across users.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "image": {
+              "description": "Full image reference for the branch container, including the tag. Overrides the\noperator-configured registry entirely. Mutually exclusive with `version`.",
               "type": [
                 "string",
                 "null"
@@ -1570,6 +1593,13 @@
                 "null"
               ]
             },
+            "image": {
+              "description": "Full image reference for the branch container, including the tag. Overrides the\noperator-configured registry entirely. Mutually exclusive with `version`.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
             "name": {
               "description": "Source database name, used when the operator cannot read it from the connection.",
               "type": [
@@ -1637,6 +1667,13 @@
             },
             "id": {
               "description": "Optional stable id for reusing or sharing a branch across users.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "image": {
+              "description": "Full image reference for the branch container, including the tag. Overrides the\noperator-configured registry entirely. Mutually exclusive with `version`.",
               "type": [
                 "string",
                 "null"
@@ -1732,6 +1769,13 @@
             },
             "id": {
               "description": "Optional stable id for reusing or sharing a branch across users.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "image": {
+              "description": "Full image reference for the branch container, including the tag. Overrides the\noperator-configured registry entirely. Mutually exclusive with `version`.",
               "type": [
                 "string",
                 "null"
@@ -1835,6 +1879,13 @@
             },
             "id": {
               "description": "Optional stable id for reusing or sharing a branch across users.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "image": {
+              "description": "Full image reference for the branch container, including the tag. Overrides the\noperator-configured registry entirely. Mutually exclusive with `version`.",
               "type": [
                 "string",
                 "null"
@@ -1984,6 +2035,13 @@
                     "null"
                   ]
                 },
+                "image": {
+                  "description": "Full image reference for the branch container, including the tag. Overrides the\noperator-configured registry entirely. Mutually exclusive with `version`.",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
                 "location": {
                   "description": "#### feature.db_branches[].location (type: redis) {#feature-db_branches-redis-location}\nWhere the Redis instance should run.\n- `local`: Spawns a local instance.\n- `remote`: Uses a remote instance (default).",
                   "type": "string",
@@ -2061,6 +2119,13 @@
             },
             "id": {
               "description": "Optional stable id for reusing or sharing a branch across users.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "image": {
+              "description": "Full image reference for the branch container, including the tag. Overrides the\noperator-configured registry entirely. Mutually exclusive with `version`.",
               "type": [
                 "string",
                 "null"

--- a/mirrord/cli/src/internal_proxy/db_portforwards.rs
+++ b/mirrord/cli/src/internal_proxy/db_portforwards.rs
@@ -562,6 +562,7 @@ mod tests {
             ttl_mins: None,
             creation_timeout_secs: 60,
             version: None,
+            image: None,
             connection,
         }
     }

--- a/mirrord/config/src/feature/database_branches.rs
+++ b/mirrord/config/src/feature/database_branches.rs
@@ -435,6 +435,26 @@ impl DatabaseBranchesConfig {
 }
 
 impl DatabaseBranchConfig {
+    /// The shared base config of this branch, when the variant has one (local Redis
+    /// branches don't - they never reach the operator).
+    pub fn base(&self) -> Option<&DatabaseBranchBaseConfig> {
+        match self {
+            DatabaseBranchConfig::Clickhouse(cfg) => Some(&cfg.base),
+            DatabaseBranchConfig::Dynamodb(cfg) => Some(&cfg.base),
+            DatabaseBranchConfig::Generic(cfg) => Some(&cfg.base),
+            DatabaseBranchConfig::Mariadb(cfg) => Some(&cfg.base),
+            DatabaseBranchConfig::Mongodb(cfg) => Some(&cfg.base),
+            DatabaseBranchConfig::Mssql(cfg) => Some(&cfg.base),
+            DatabaseBranchConfig::Mysql(cfg) => Some(&cfg.base),
+            DatabaseBranchConfig::Pg(cfg) => Some(&cfg.base),
+            DatabaseBranchConfig::Redis(cfg) => match &**cfg {
+                RedisBranchConfig::Local(_) => None,
+                RedisBranchConfig::Remote(remote) => Some(&remote.base),
+            },
+            DatabaseBranchConfig::Spanner(cfg) => Some(&cfg.base),
+        }
+    }
+
     /// Names of target-pod env vars that the operator uses to redirect this branch's
     /// connection. Locally overriding any of these (via `feature.env.override`) would
     /// fight the operator's redirection, so [`LayerConfig::verify`] rejects such configs.
@@ -581,6 +601,20 @@ impl ConnectionParamsVars {
 ///
 /// Mirrord operator uses a default version of the database image unless `version` is given.
 ///
+/// Mutually exclusive with [`image`](#feature-db_branches-sql-image).
+///
+/// #### feature.db_branches[].image (type: mysql, mariadb, pg, mongodb, mssql, redis) {#feature-db_branches-sql-image}
+///
+/// Full image reference for the branch database container, including the tag
+/// (e.g. `registry.example.com/postgresql:15-partman`). Setting `image` overrides both the
+/// operator's built-in default image and any registry configured cluster-wide by the operator
+/// admin. Cluster admins can restrict which images are accepted with the per-database
+/// `dbPod.allowedImages` list in the operator's Helm values; when that list is not set, any
+/// image is allowed.
+///
+/// Mutually exclusive with [`version`](#feature-db_branches-sql-version), as the image
+/// reference already carries the tag.
+///
 /// #### feature.db_branches[].connection (type: mysql, mariadb, pg, mongodb, mssql, redis) {#feature-db_branches-sql-connection}
 ///
 /// `connection` describes how to get the connection information to the source database.
@@ -662,6 +696,11 @@ pub struct DatabaseBranchBaseConfig {
     /// Source database image version. Defaults to the operator's built-in version.
     pub version: Option<String>,
 
+    /// Full image reference for the branch container, including the tag. Overrides the
+    /// operator-configured registry entirely. Mutually exclusive with `version`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub image: Option<String>,
+
     /// How to source the connection info for the source database. The operator swaps it for
     /// the branch's connection once the branch is ready.
     pub connection: ConnectionSource,
@@ -687,6 +726,13 @@ impl DatabaseBranchBaseConfig {
             return Err(ConfigError::Conflict(
                 "`feature.db_branches[].ttl_secs` and `feature.db_branches[].ttl_mins` \
                  cannot both be set."
+                    .to_owned(),
+            ));
+        }
+        if self.image.is_some() && self.version.is_some() {
+            return Err(ConfigError::Conflict(
+                "`feature.db_branches[].image` and `feature.db_branches[].version` cannot \
+                 both be set; the image reference includes the tag."
                     .to_owned(),
             ));
         }
@@ -1555,6 +1601,7 @@ mod tests {
             ttl_mins,
             creation_timeout_secs: 60,
             version: None,
+            image: None,
             connection: ConnectionSource::FlatUrl {
                 source_type: None,
                 url: "DB_URL".to_owned().into(),
@@ -1589,6 +1636,16 @@ mod tests {
         assert!(matches!(base.verify(), Err(ConfigError::Conflict(_))));
     }
 
+    #[test]
+    fn db_branch_verify_rejects_image_with_version() {
+        let mut base = base_with_ttl(None, None);
+        base.image = Some("registry.example.com/postgresql:15-partman".to_owned());
+        base.verify().expect("image alone should verify");
+
+        base.version = Some("15".to_owned());
+        assert!(matches!(base.verify(), Err(ConfigError::Conflict(_))));
+    }
+
     fn pg_branch_with_connection(connection: ConnectionSource) -> DatabaseBranchConfig {
         DatabaseBranchConfig::Pg(Box::new(pg::PgBranchConfig {
             base: DatabaseBranchBaseConfig {
@@ -1598,6 +1655,7 @@ mod tests {
                 ttl_mins: None,
                 creation_timeout_secs: 60,
                 version: None,
+                image: None,
                 connection,
             },
             copy: Default::default(),

--- a/mirrord/config/src/feature/database_branches/generic.rs
+++ b/mirrord/config/src/feature/database_branches/generic.rs
@@ -203,8 +203,8 @@ impl GenericBranchConfig {
 
         if self.base.image.is_none() {
             return Err(ConfigError::Conflict(
-                "`feature.db_branches[].image` is required for generic branches; mirrord has \
-                 no built-in image for them."
+                "`feature.db_branches[].image` is required when \
+                    `feature.db_branches[].type` is `generic`."
                     .to_owned(),
             ));
         }

--- a/mirrord/config/src/feature/database_branches/generic.rs
+++ b/mirrord/config/src/feature/database_branches/generic.rs
@@ -34,8 +34,9 @@ pub const BUILTIN_DATABASE_NAME_VAR: &str = "MIRRORD_DATABASE_NAME";
 /// #### feature.db_branches[].image (type: generic) {#feature-db_branches-generic-image}
 ///
 /// Full image reference for the branch container, including the tag
-/// (e.g. `docker.io/library/influxdb:2.7`). Required. The shared `version` field is not
-/// allowed for generic branches - the tag lives here.
+/// (e.g. `docker.io/library/influxdb:2.7`). This is the shared `image` field, but unlike the
+/// built-in engines a generic branch has no default image, so here it is required. The shared
+/// `version` field is not allowed for generic branches - the tag lives here.
 ///
 /// #### feature.db_branches[].port (type: generic) {#feature-db_branches-generic-port}
 ///
@@ -104,9 +105,6 @@ pub const BUILTIN_DATABASE_NAME_VAR: &str = "MIRRORD_DATABASE_NAME";
 pub struct GenericBranchConfig {
     #[serde(flatten)]
     pub base: DatabaseBranchBaseConfig,
-
-    /// Full image reference for the branch container, including the tag.
-    pub image: String,
 
     /// The port the branched service listens on.
     pub port: u16,
@@ -193,8 +191,8 @@ impl GenericBranchConfig {
     }
 
     pub fn verify(&self, context: &mut ConfigContext) -> Result<(), ConfigError> {
-        self.base.verify()?;
-
+        // The generic-specific image/version rules come before `base.verify()` so their
+        // messages win over the base's engine-agnostic image/version conflict.
         if self.base.version.is_some() {
             return Err(ConfigError::Conflict(
                 "`feature.db_branches[].version` is not allowed for generic branches; \
@@ -202,6 +200,16 @@ impl GenericBranchConfig {
                     .to_owned(),
             ));
         }
+
+        if self.base.image.is_none() {
+            return Err(ConfigError::Conflict(
+                "`feature.db_branches[].image` is required for generic branches; mirrord has \
+                 no built-in image for them."
+                    .to_owned(),
+            ));
+        }
+
+        self.base.verify()?;
 
         let params = match &self.base.connection {
             ConnectionSource::Params(config) => &config.params,
@@ -592,7 +600,10 @@ mod tests {
     #[test]
     fn deserialize_and_verify_influx_example() {
         let config = parse(influx_config());
-        assert_eq!(config.image, "docker.io/library/influxdb:2.7");
+        assert_eq!(
+            config.base.image.as_deref(),
+            Some("docker.io/library/influxdb:2.7")
+        );
         assert_eq!(config.port, 8086);
         assert_eq!(
             config.declared_params(),
@@ -610,6 +621,15 @@ mod tests {
         json["version"] = "2.7".into();
         let mut context = ConfigContext::default();
         parse(json).verify(&mut context).unwrap_err();
+    }
+
+    #[test]
+    fn missing_image_is_rejected() {
+        let mut json = influx_config();
+        json.as_object_mut().unwrap().remove("image");
+        let mut context = ConfigContext::default();
+        let error = parse(json).verify(&mut context).unwrap_err();
+        assert!(error.to_string().contains("image"), "{error}");
     }
 
     #[test]

--- a/mirrord/operator/src/client.rs
+++ b/mirrord/operator/src/client.rs
@@ -752,24 +752,27 @@ where
             .unwrap_or(default_creation_timeout_secs());
         let timeout = std::time::Duration::from_secs(timeout_secs);
 
-        // Generic branches must fail fast on operators that don't support them. Without this
-        // gate, an old operator (or a new one with `genericBranching` disabled) never reads
-        // `genericOptions`, fails dialect validation, and deletes the CRD without writing a
-        // `Failed` status - the session would then hang until a bare timeout with no diagnosis.
+        // A custom image on a built-in engine must fail fast too: an older operator's CRD schema
+        // doesn't have the `image` field, so the API server would prune it and the branch would
+        // silently run the default image instead of the requested one. This is orthogonal to the
+        // per-dialect gate above (it keys on the `image` field, not the engine). Generic branches
+        // are exempt - their image lives in `genericOptions`, already covered by the dialect gate.
         if layer_config
             .feature
             .db_branches
             .iter()
             .any(|branch_config| {
-                matches!(
+                !matches!(
                     branch_config,
                     mirrord_config::feature::database_branches::DatabaseBranchConfig::Generic(_)
-                )
+                ) && branch_config
+                    .base()
+                    .is_some_and(|base| base.image.is_some())
             })
         {
             self.operator
                 .spec
-                .require_feature(NewOperatorFeature::GenericDbBranching)?;
+                .require_feature(NewOperatorFeature::DbBranchCustomImage)?;
         }
 
         let use_unified_crd = self

--- a/mirrord/operator/src/client/database_branches.rs
+++ b/mirrord/operator/src/client/database_branches.rs
@@ -1666,6 +1666,7 @@ impl UnifiedBranchParams {
             target: session_target.clone(),
             ttl_secs: config.base.resolved_ttl_secs(),
             version: config.base.version.clone(),
+            image: config.base.image.clone(),
             postgres_options: Some(PostgresOptions {
                 copy: SqlBranchCopyConfig::from(config.copy.clone()),
                 iam_auth,
@@ -1713,6 +1714,7 @@ impl UnifiedBranchParams {
             target: session_target.clone(),
             ttl_secs: config.base.resolved_ttl_secs(),
             version: config.base.version.clone(),
+            image: config.base.image.clone(),
             postgres_options: None,
             mysql_options: Some(MysqlOptions {
                 copy: SqlBranchCopyConfig::from(config.copy.clone()),
@@ -1759,6 +1761,7 @@ impl UnifiedBranchParams {
             target: session_target.clone(),
             ttl_secs: config.base.resolved_ttl_secs(),
             version: config.base.version.clone(),
+            image: config.base.image.clone(),
             postgres_options: None,
             mysql_options: None,
             mariadb_options: Some(MariadbOptions {
@@ -1803,6 +1806,7 @@ impl UnifiedBranchParams {
             target: session_target.clone(),
             ttl_secs: config.base.resolved_ttl_secs(),
             version: config.base.version.clone(),
+            image: config.base.image.clone(),
             postgres_options: None,
             mysql_options: None,
             mariadb_options: None,
@@ -1848,6 +1852,7 @@ impl UnifiedBranchParams {
             target: session_target.clone(),
             ttl_secs: config.base.resolved_ttl_secs(),
             version: config.base.version.clone(),
+            image: config.base.image.clone(),
             postgres_options: None,
             mysql_options: None,
             mariadb_options: None,
@@ -1892,6 +1897,7 @@ impl UnifiedBranchParams {
             target: session_target.clone(),
             ttl_secs: config.base.resolved_ttl_secs(),
             version: config.base.version.clone(),
+            image: config.base.image.clone(),
             postgres_options: None,
             mysql_options: None,
             mariadb_options: None,
@@ -1936,6 +1942,7 @@ impl UnifiedBranchParams {
             target: session_target.clone(),
             ttl_secs: config.base.resolved_ttl_secs(),
             version: config.base.version.clone(),
+            image: config.base.image.clone(),
             postgres_options: None,
             mysql_options: None,
             mariadb_options: None,
@@ -1979,6 +1986,7 @@ impl UnifiedBranchParams {
             target: session_target.clone(),
             ttl_secs: config.base.resolved_ttl_secs(),
             version: config.base.version.clone(),
+            image: config.base.image.clone(),
             postgres_options: None,
             mysql_options: None,
             mariadb_options: None,
@@ -2030,6 +2038,7 @@ impl UnifiedBranchParams {
             target: session_target.clone(),
             ttl_secs: config.base.resolved_ttl_secs(),
             version: config.base.version.clone(),
+            image: config.base.image.clone(),
             postgres_options: None,
             mysql_options: None,
             mariadb_options: None,
@@ -2098,8 +2107,10 @@ impl UnifiedBranchParams {
             target: session_target.clone(),
             ttl_secs: config.base.resolved_ttl_secs(),
             // `version` is rejected for generic branches by config verification; the image tag
-            // lives in `image`.
+            // lives in `image`, which a generic branch carries in `genericOptions` (where it is
+            // required) rather than in the optional spec-level field.
             version: None,
+            image: None,
             postgres_options: None,
             mysql_options: None,
             mariadb_options: None,
@@ -2110,7 +2121,8 @@ impl UnifiedBranchParams {
             spanner_options: None,
             clickhouse_options: None,
             generic_options: Some(GenericOptions {
-                image: config.image.clone(),
+                // Required for generic branches; config verification rejects its absence.
+                image: config.base.image.clone().unwrap_or_default(),
                 port: config.port,
                 command: config.command.clone(),
                 args: config.args.clone(),

--- a/mirrord/operator/src/crd.rs
+++ b/mirrord/operator/src/crd.rs
@@ -619,6 +619,12 @@ pub enum NewOperatorFeature {
     /// silently delete.
     MariaDbBranching,
 
+    /// This operator honors the `image` field on the unified `BranchDatabase` CRD, letting the
+    /// user supply a full image reference for a built-in engine's branch pod. Gated so the CLI
+    /// can fail fast on older operators, whose CRD schema would silently prune the field and
+    /// run the branch with the default image.
+    DbBranchCustomImage,
+
     /// This variant is what a client sees when the operator includes a feature the client is not
     /// yet aware of, because it was introduced in a version newer than the client's.
     #[schemars(skip)]
@@ -668,6 +674,7 @@ impl Display for NewOperatorFeature {
             NewOperatorFeature::BullMqQueueSplitting => "BullMQ queue splitting",
             NewOperatorFeature::GenericDbBranching => "generic db branching",
             NewOperatorFeature::CopyTargetFilterIsolation => "copy target filter isolation",
+            NewOperatorFeature::DbBranchCustomImage => "custom db branch image",
             NewOperatorFeature::Unknown => "unknown feature",
         };
         f.write_str(name)

--- a/mirrord/operator/src/crd/db_branching/branch_database.rs
+++ b/mirrord/operator/src/crd/db_branching/branch_database.rs
@@ -39,8 +39,16 @@ pub struct BranchDatabaseSpec {
     /// The duration in seconds this branch database will live idling.
     pub ttl_secs: u64,
     /// Database server image version (e.g. "16" for PostgreSQL, "8.0" for MySQL).
+    /// Mutually exclusive with `image`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub version: Option<String>,
+    /// Full image reference for the branch database container, including the tag.
+    /// Overrides the operator-configured registry and the built-in default entirely; the
+    /// operator validates it against the admin's per-database `allowedImages` list. Mutually
+    /// exclusive with `version`. Generic branches carry their image in `genericOptions`
+    /// instead.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub image: Option<String>,
     /// PostgreSQL-specific options.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub postgres_options: Option<PostgresOptions>,
@@ -405,6 +413,7 @@ pub struct CommonFieldsRef<'a> {
     pub target: &'a SessionTarget,
     pub ttl_secs: u64,
     pub version: Option<&'a str>,
+    pub image: Option<&'a str>,
 }
 
 impl BranchDatabaseSpec {
@@ -519,6 +528,7 @@ impl BranchDatabaseSpec {
             target: &self.target,
             ttl_secs: self.ttl_secs,
             version: self.version.as_deref(),
+            image: self.image.as_deref(),
         }
     }
 }


### PR DESCRIPTION
Adds an `image` field to the shared db-branch config (mutually exclusive with `version`), carried on the unified BranchDatabase CRD. Generic branches keep their required image, now read from the shared field. Gated behind the new DbBranchCustomImage operator feature so the CLI fails fast against old operators whose CRD schema would silently prune the field.

<!-- Thank you for contributing to mirrord! -->
<!-- Please use the checklist below as a guide for docs, tests and admin tasks for your PR -->
<!-- Feel free to ~strikethrough~ any items that you don't think apply -->

### Quality Checklist:

- [x] I have documented new code sufficiently
- [x] I have checked and updated the relevant existing docs in code, including removing outdated material
- [x] I have written user-facing website docs for new features, or opened a (sub)issue to do so
- [x] I have checked and updated existing website docs for changed features
- [x] I have tested this change and know it succeeds and fails as expected
- [x] I have written unit tests or purposefully omitted them
- [x] I have written e2e tests or purposefully omitted them
- [x] I have explained what this PR introduces and why, and linked to relevant context (e.g. linear issues, related PRs,
  documentation)
- [x] I have introduced a short, clear and well-formatted changelog entry

<!-- need help with the changelog? see ../CONTRIBUTING.md#submitting-a-pull-request -->
<!-- Add more details of your changes below if needed -->