### PR TITLE
Fix bug in `AddressFilter::Name` that allowed port filters to match hostnames ports incorrectly.

### DIFF
--- a/.vale/styles/config/vocabularies/Metalbear/accept.txt
+++ b/.vale/styles/config/vocabularies/Metalbear/accept.txt
@@ -136,6 +136,7 @@ RTT
 VPN
 URI
 loopback
+hostnames?
 
 # File formats
 YAML

--- a/changelog.d/+fix-chaos-port-filter-for-hostname.changed.md
+++ b/changelog.d/+fix-chaos-port-filter-for-hostname.changed.md
@@ -1,0 +1,1 @@
+Fix bug in `AddressFilter::Name` that allowed port filters to match hostnames ports incorrectly.

--- a/mirrord/config/src/feature/network/filter.rs
+++ b/mirrord/config/src/feature/network/filter.rs
@@ -114,7 +114,8 @@ impl AddressFilter {
             }
 
             AddressFilter::Name(hostname, port) if let Some(remote_hostname) = remote_hostname => {
-                (self.port() == 0 || self.port() == *port) && remote_hostname.contains(hostname)
+                (*port == 0 || address.get_port().is_some_and(|actual| *port == actual))
+                    && remote_hostname.contains(hostname)
             }
             _ => false,
         }
@@ -525,5 +526,24 @@ mod tests {
     #[should_panic]
     fn invalid_filters(#[case] input: &'static str) {
         ProtocolAndAddressFilter::from_str(input).unwrap();
+    }
+
+    #[rstest]
+    #[case("api.example.com", 80, true)]
+    #[case("api.example.com:443", 443, true)]
+    #[case("api.example.com:443", 80, false)]
+    fn hostname_filter_matches_port(
+        #[case] filter: &str,
+        #[case] remote_port: u16,
+        #[case] expected: bool,
+    ) {
+        let filter = AddressFilter::from_str(filter).unwrap();
+        let address = SocketAddress::Ip(SocketAddr::from(([192, 0, 2, 1], remote_port)));
+        let hostname = "api.example.com".to_owned();
+
+        assert_eq!(
+            filter.matches_socket_address(&address, Some(&hostname)),
+            expected
+        );
     }
 }


### PR DESCRIPTION
- Issue: n/a

We were comparing the filter port with itself:

```
hostname = "api.example.com"
port = 443
self.port() = 443
```

```rust
443 == 0 || 443 == 443
```

This fixes that so we compare with the port that has been resolved for that hostname instead.

### Quality Checklist:

- [ ] I have documented new code sufficiently
- [ ] I have checked and updated the relevant existing docs in code, including removing outdated material
- [ ] I have written user-facing website docs for new features, or opened a (sub)issue to do so
- [ ] I have checked and updated existing website docs for changed features
- [ ] I have tested this change and know it succeeds and fails as expected
- [ ] I have written unit tests or purposefully omitted them
- [ ] I have written e2e tests or purposefully omitted them
- [ ] I have explained what this PR introduces and why, and linked to relevant context (e.g. linear issues, related PRs,
  documentation)
- [ ] I have introduced a short, clear and well-formatted changelog entry

<!-- need help with the changelog? see ../CONTRIBUTING.md#submitting-a-pull-request -->
<!-- Add more details of your changes below if needed -->