### PR TITLE
agent: add env flag to skip conntrack -D during connection flush

### DIFF
--- a/changelog.d/+flush-connections-conntrack.added.md
+++ b/changelog.d/+flush-connections-conntrack.added.md
@@ -1,0 +1,1 @@
+Added the `MIRRORD_AGENT_STEALER_FLUSH_CONNECTIONS_CONNTRACK` agent environment variable. When set to `false`, the connection flush performed when stealing starts skips the `conntrack -D` command and relies only on `ss -K`, avoiding a burst of dropped redirected connections (and accompanying `ENOENT` errors) on busy ports. Defaults to `true`, preserving the previous behaviour.

--- a/mirrord/agent/env/src/envs.rs
+++ b/mirrord/agent/env/src/envs.rs
@@ -25,6 +25,21 @@ pub const ISTIO_CNI: CheckedEnv<bool> = CheckedEnv::new("MIRRORD_AGENT_ISTIO_CNI
 pub const STEALER_FLUSH_CONNECTIONS: CheckedEnv<bool> =
     CheckedEnv::new("MIRRORD_AGENT_STEALER_FLUSH_CONNECTIONS");
 
+/// Controls whether the connection flush (see [`STEALER_FLUSH_CONNECTIONS`]) uses a `conntrack -D`
+/// command in addition to `ss -K`.
+///
+/// The `conntrack -D --dport <port>` call also deletes the conntrack entries of connections that
+/// were just redirected to the agent but not yet accepted. When that happens, the agent can no
+/// longer resolve their original destination via `SO_ORIGINAL_DST` (the lookup fails with
+/// `ENOENT`) and has to drop them. On busy stolen ports this produces a burst of dropped
+/// connections every time stealing starts.
+///
+/// Defaults to `true` (i.e. `conntrack -D` is used). Set to `false` to flush using only `ss -K`,
+/// avoiding the dropped-connection burst at the cost of not flushing connections that `ss` can't
+/// reach.
+pub const STEALER_FLUSH_CONNECTIONS_CONNTRACK: CheckedEnv<bool> =
+    CheckedEnv::new("MIRRORD_AGENT_STEALER_FLUSH_CONNECTIONS_CONNTRACK");
+
 /// Instructs the agent to use `iptables-nft` instead of `iptables-legacy` for manipulating
 /// iptables.
 pub const NFTABLES: CheckedEnv<bool> = CheckedEnv::new("MIRRORD_AGENT_NFTABLES");

--- a/mirrord/agent/iptables/src/flush_connections.rs
+++ b/mirrord/agent/iptables/src/flush_connections.rs
@@ -9,14 +9,29 @@
 use std::ops::Not;
 
 use async_trait::async_trait;
+use mirrord_agent_env::envs;
 use tokio::process::Command;
 use tracing::{Level, warn};
 
 use crate::{error::IPTablesResult, redirect::Redirect};
 
+/// Reads whether the flush should use `conntrack -D`.
+///
+/// Defaults to `true`; only an explicit `false` disables it. See
+/// [`STEALER_FLUSH_CONNECTIONS_CONNTRACK`](envs::STEALER_FLUSH_CONNECTIONS_CONNTRACK).
+fn conntrack_enabled() -> bool {
+    envs::STEALER_FLUSH_CONNECTIONS_CONNTRACK
+        .try_from_env()
+        .ok()
+        .flatten()
+        .unwrap_or(true)
+}
+
 #[derive(Debug)]
 pub struct FlushConnections<T> {
     inner: Box<T>,
+    /// Whether to flush existing connections with a `conntrack -D` command in addition to `ss -K`.
+    conntrack: bool,
 }
 
 impl<T> FlushConnections<T>
@@ -25,12 +40,18 @@ where
 {
     #[tracing::instrument(level = Level::TRACE, skip(inner))]
     pub fn create(inner: Box<T>) -> IPTablesResult<Self> {
-        Ok(FlushConnections { inner })
+        Ok(FlushConnections {
+            inner,
+            conntrack: conntrack_enabled(),
+        })
     }
 
     #[tracing::instrument(level = Level::TRACE, skip(inner))]
     pub fn load(inner: Box<T>) -> IPTablesResult<Self> {
-        Ok(FlushConnections { inner })
+        Ok(FlushConnections {
+            inner,
+            conntrack: conntrack_enabled(),
+        })
     }
 }
 
@@ -59,32 +80,38 @@ where
             .await?;
 
         // Update existing connections of specific port to be marked
-        // so that they will be rejected by the rule we added in `create`
-        let conntrack_output = Command::new("conntrack")
-            .args([
-                "-D",
-                "-p",
-                "tcp",
-                "--dport",
-                &redirected_port.to_string(),
-                "--state",
-                "ESTABLISHED",
-            ])
-            .output()
-            .await?;
+        // so that they will be rejected by the rule we added in `create`.
+        //
+        // Skipped when disabled, because `conntrack -D` also deletes the conntrack entries of
+        // connections that were just redirected to the agent, making the agent drop them when it
+        // fails to resolve their original destination.
+        if self.conntrack {
+            let conntrack_output = Command::new("conntrack")
+                .args([
+                    "-D",
+                    "-p",
+                    "tcp",
+                    "--dport",
+                    &redirected_port.to_string(),
+                    "--state",
+                    "ESTABLISHED",
+                ])
+                .output()
+                .await?;
 
-        if conntrack_output.status.success().not()
-            && conntrack_output
-                .stderr
-                .windows(NO_ENTRIES_DELETED_MESSAGE.len())
-                .any(|window| window == NO_ENTRIES_DELETED_MESSAGE)
-                .not()
-        {
-            warn!(
-                ?conntrack_output,
-                redirected_port,
-                "Failed to flush existing connections with a `conntrack -D` command",
-            );
+            if conntrack_output.status.success().not()
+                && conntrack_output
+                    .stderr
+                    .windows(NO_ENTRIES_DELETED_MESSAGE.len())
+                    .any(|window| window == NO_ENTRIES_DELETED_MESSAGE)
+                    .not()
+            {
+                warn!(
+                    ?conntrack_output,
+                    redirected_port,
+                    "Failed to flush existing connections with a `conntrack -D` command",
+                );
+            }
         }
 
         // ss is available from kernel 5.1 and should work way better than conntrack


### PR DESCRIPTION
## What

Adds `MIRRORD_AGENT_STEALER_FLUSH_CONNECTIONS_CONNTRACK`, an agent environment variable that controls whether the connection flush uses the `conntrack -D` command.

- **Default `true`** — existing behaviour, `conntrack -D` + `ss -K`.
- **`false`** — flush with `ss -K` only, skipping `conntrack -D`.

## Why

When stealing starts, `add_redirect` flushes existing connections so already-established flows reconnect into the redirect. Part of that flush runs:

```
conntrack -D -p tcp --dport <port> --state ESTABLISHED
```

That filter matches on the original-direction destination port, so it also deletes the conntrack entries of connections that were *just* redirected to the agent but not yet accepted. The agent resolves a redirected connection's original destination with `getsockopt(SO_ORIGINAL_DST)`, which reads from conntrack — with the entry gone, the lookup fails with `ENOENT` and the connection is dropped:

```
ERROR mirrord_agent::incoming::iptables: Failed to obtain the original destination
of a redirected TCP connection. Dropping the connection., error: ENOENT
```

On busy stolen ports (e.g. preview envs fronting a service with many health-check / mesh / pooled connections) this shows up as a **burst** of dropped connections each time stealing starts. This flag lets operators opt out of the `conntrack -D` call while keeping `ss -K`, avoiding the burst.

## Notes

- Only an explicit `false` disables `conntrack`; unset or malformed values keep it enabled, so behaviour is unchanged unless deliberately opted out.
- Scoped to the agent's `flush_connections` path; `ss -K` (kernel ≥ 5.1) still handles the intended flush of pre-existing local connections.

## Testing

- `cargo check` / `cargo clippy --deny warnings` on `mirrord-agent-iptables` (`x86_64-unknown-linux-gnu`) and `mirrord-agent-env`.
