### PR TITLE
feat(ui): report unhandled frontend errors when telemetry is enabled

### DIFF
--- a/changelog.d/+ui-error-tracking.internal.md
+++ b/changelog.d/+ui-error-tracking.internal.md
@@ -1,0 +1,1 @@
+The `mirrord ui` frontend now reports unhandled errors to our product analytics when telemetry is enabled, so crashes in the wild surface in error tracking.

--- a/packages/monitor/src/analytics.ts
+++ b/packages/monitor/src/analytics.ts
@@ -11,6 +11,7 @@ export function initAnalytics(telemetryEnabled: boolean) {
     api_host: POSTHOG_HOST,
     ui_host: 'https://us.posthog.com',
     person_profiles: 'identified_only',
+    capture_exceptions: true,
     autocapture: false,
     capture_pageview: false,
     // The session monitor UI renders file paths, pod names, DNS hostnames, HTTP URLs, and


### PR DESCRIPTION
## Summary

The `mirrord ui` frontend initializes analytics (telemetry-gated, opt-out respected) but never captures exceptions, so frontend crashes in the wild are invisible. One-line change: enable exception autocapture in the existing init in the monitor package. That init runs page wide for the merged app, so the shell, session monitor, and wizard are all covered; nothing changes for users with telemetry disabled.

The session-replay masking already in this init (`maskTextSelector: '*'`, `maskAllInputs`) is unrelated to exception events; exception messages come from our own frontend code paths.

## Test plan

- [x] `pnpm --filter session-monitor-frontend run lint` and `run typecheck` green (CI `ui-frontend-lint` job runs these plus format and build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)