### PR TITLE
MBE-1979: Add remote-layer sidecar handoff path

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-# this change will be removed - intended to make mbe-1977 run the full ci
+# this change will be removed - intended to make mbe-1979 run the full ci
 # Hello traveler!
 # This is the CI workflow for mirrord.
 # It is a bit complicated, but it is also very powerful.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5021,6 +5021,7 @@ dependencies = [
  "mirrord-nightly-polyfill",
  "mirrord-protocol",
  "mirrord-protocol-io",
+ "mirrord-remote-layer-protocol",
  "mirrord-sessions-manager-client",
  "mirrord-tls-util",
  "nix",
@@ -5560,7 +5561,37 @@ dependencies = [
  "ctor",
  "libc",
  "mirrord-layer-lib",
+ "mirrord-remote-layer-protocol",
  "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "mirrord-remote-layer"
+version = "3.234.0"
+dependencies = [
+ "ctor",
+ "libc",
+ "mirrord-intproxy-protocol",
+ "mirrord-layer-core",
+ "mirrord-layer-lib",
+ "mirrord-layer-macro",
+ "mirrord-remote-layer-protocol",
+ "nix",
+ "socket2 0.5.10",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "mirrord-remote-layer-protocol"
+version = "3.234.0"
+dependencies = [
+ "bincode",
+ "mirrord-intproxy-protocol",
+ "nix",
+ "thiserror 2.0.18",
+ "tokio",
  "tracing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,8 @@ members = [
     "mirrord/sessions-manager/client",
     "mirrord/sessions-manager/protocol",
     "mirrord/remote/bootstrap",
+    "mirrord/remote/layer",
+    "mirrord/remote/layer/protocol",
 ]
 exclude = [
     "mirrord/sessions-manager",
@@ -175,6 +177,7 @@ mirrord-session-monitor-client = { path = "mirrord/session-monitor-client" }
 mirrord-session-monitor-protocol = { path = "mirrord/session-monitor-protocol" }
 mirrord-sessions-manager-client = { path = "mirrord/sessions-manager/client" }
 mirrord-sessions-manager-protocol = { path = "mirrord/sessions-manager/protocol" }
+mirrord-remote-layer-protocol = { path = "mirrord/remote/layer/protocol" }
 mirrord-test-macros = { path = "mirrord/test-macros" }
 mockall = "0.13"
 nix = { version = "0.29", features = ["net"] }

--- a/changelog.d/+mbe-1979-remote-layer.internal.md
+++ b/changelog.d/+mbe-1979-remote-layer.internal.md
@@ -1,0 +1,1 @@
+Add the remote layer runtime for serverless sessions, including socket accept handoff, placeholder sockets, and the agent-side sidecar path that forwards bridged connections into the incoming pipeline.

--- a/mirrord/agent/Cargo.toml
+++ b/mirrord/agent/Cargo.toml
@@ -22,6 +22,7 @@ workspace = true
 mirrord-protocol = { path = "../protocol" }
 mirrord-protocol-io = { path = "../protocol-io" }
 mirrord-sessions-manager-client.workspace = true
+mirrord-remote-layer-protocol.workspace = true
 mirrord-agent-env = { path = "./env", default-features = false }
 mirrord-agent-iptables = { path = "./iptables" }
 mirrord-tls-util = { path = "../tls-util" }
@@ -41,7 +42,7 @@ tokio = { workspace = true, features = [
 async-pidfd.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-nix = { workspace = true, features = ["mount", "sched", "user"] }
+nix = { workspace = true, features = ["mount", "sched", "user", "socket", "uio"] }
 clap = { workspace = true, features = ["env"] }
 actix-codec.workspace = true
 futures.workspace = true

--- a/mirrord/agent/src/entrypoint.rs
+++ b/mirrord/agent/src/entrypoint.rs
@@ -22,6 +22,9 @@ use mirrord_agent_iptables::{
 };
 use mirrord_protocol::{ClientMessage, DaemonMessage, GetEnvVarsRequest};
 use mirrord_protocol_io::{Agent, Connection};
+use mirrord_remote_layer_protocol::{
+    ConnectionHandoffServer, handle_connection_handoff_connection,
+};
 use mirrord_sessions_manager_client::{
     connection::SessionsManagerClient, envs::sessions_manager_room_id,
 };
@@ -1133,17 +1136,25 @@ async fn start_agent(args: Args) -> AgentResult<()> {
     Ok(())
 }
 
-/// The sidecar version of start_agent
+/// The sidecar version of `start_agent`.
 ///
-/// Serves a single client through pre-connected socket fd,
-/// starts background tasks and listens for client connections.
+/// This startup path serves two kinds of connections at once:
+///
+/// - a localhost TCP listener for remote layer connections;
+/// - a sessions-manager control-plane path that serves layer-local connections.
 #[tracing::instrument(level = Level::TRACE, ret, err)]
 async fn start_agent_sidecar(args: Args) -> AgentResult<()> {
-    let state = State::new(&args).await?;
     let cancellation_token = CancellationToken::new();
+    let network_runtime = BgTaskRuntime::spawn(None).await?;
+    let state = State::new(&args).await?;
 
-    // To make sure that background tasks are cancelled when we exit early from this function.
-    let cancel_guard = cancellation_token.clone().drop_guard();
+    let room_id = sessions_manager_room_id()?;
+    let mut sessions_manager_client =
+        SessionsManagerClient::<Agent>::new(room_id, cancellation_token.clone());
+    let mut upstream_rx = sessions_manager_client
+        .start_multiplexed_control_plane()
+        .await?;
+    let connection_handoff_server = ConnectionHandoffServer::bind()?;
 
     if let Some(metrics_address) = args.metrics {
         let cancellation_token = cancellation_token.clone();
@@ -1157,114 +1168,99 @@ async fn start_agent_sidecar(args: Args) -> AgentResult<()> {
         });
     }
 
-    // sidecar doesnt support incoming for now
-    let (stealer, mirror_handle) = (BackgroundTask::Disabled, None);
+    let (steal_handle, mirror_handle, incoming_connection_sender, subscriptions) =
+        setup::start_remote_layer_ingress(&network_runtime).await?;
+    let stealer = setup::start_stealer(
+        &state.network_runtime,
+        steal_handle,
+        cancellation_token.clone(),
+    );
     let dns = setup::start_dns(&state.network_runtime, cancellation_token.clone());
 
     let bg_tasks = BackgroundTasks {
         stealer,
         dns,
-        mirror_handle,
+        mirror_handle: Some(mirror_handle),
     };
 
-    let mut clients: JoinSet<ClientId> = JoinSet::new();
+    let mut join_set: JoinSet<()> = JoinSet::new();
+    let mut upstream_closed = false;
 
-    // 1. Kick off the persistent, multiplexed control plane link.
-    let room_id = sessions_manager_room_id()?;
-    let mut sessions_manager_client =
-        SessionsManagerClient::<Agent>::new(room_id, cancellation_token.clone());
-
-    // This returns a continuous stream of fresh data plane tunnels.
-    let mut dataplane_stream = sessions_manager_client
-        .start_multiplexed_control_plane()
-        .await?;
-
-    // todo - remove!!
-    let communication_timeout = Duration::from_hours(1);
-    // Wait for the first client until communication_timeout elapses
-    let first_connection = tokio::time::timeout(
-        communication_timeout,
-        // todo - revert to this -> Duration::from_secs(args.communication_timeout.into()),
-        dataplane_stream.recv(),
-    )
-    .await;
-
-    match first_connection {
-        Ok(Some(connection)) => {
-            trace!("start_agent -> Sidecar first multiplexed data plane connection accepted");
-            clients.spawn(state.clone().serve_client_connection_protocol(
-                connection,
-                bg_tasks.clone(),
-                cancellation_token.clone(),
-            ));
-        }
-        Ok(None) => {
-            error!(
-                "start_agent -> Control plane stream closed prematurely before first client connection"
-            );
-            return Err(AgentError::FirstConnectionTimeout); // Or a custom matching error enum
-        }
-        Err(..) => {
-            error!("start_agent -> Failed to accept first connection: timeout");
-            return Err(AgentError::FirstConnectionTimeout);
-        }
-    }
-
-    let idle_ttl = Duration::from_secs(envs::IDDLE_TTL.from_env_or_default());
     loop {
-        let exit_idle =
-            OptionFuture::from(clients.is_empty().then_some(tokio::time::sleep(idle_ttl)));
         select! {
-            // Continuously listen for dataplane streams as pushed in the bg by the control plane stream.
-            maybe_conn = dataplane_stream.recv() => {
-                match maybe_conn {
+            _ = cancellation_token.cancelled() => {
+                join_set.abort_all();
+                return Ok(());
+            }
+
+            joined = join_set.join_next(), if !join_set.is_empty() => {
+                match joined {
+                    Some(Ok(())) => {}
+                    Some(Err(error)) => {
+                        if error.is_panic() {
+                            tracing::error!(%error, "sidecar child task panicked");
+                        } else {
+                            tracing::error!(%error, "sidecar child task failed to join");
+                        }
+                    }
+                    None => {}
+                }
+            }
+
+            maybe_upstream = upstream_rx.recv(), if !upstream_closed => {
+                match maybe_upstream {
                     Some(connection) => {
-                        trace!("start_agent -> Sidecar subsequent multiplexed data plane connection accepted");
-                        clients.spawn(state.clone().serve_client_connection_protocol(
-                            connection,
-                            bg_tasks.clone(),
-                            cancellation_token.clone(),
-                        ));
+                        let state = state.clone();
+                        let bg_tasks = bg_tasks.clone();
+                        let cancellation_token = cancellation_token.clone();
+                        join_set.spawn(async move {
+                            let _ = state
+                                .serve_client_connection_protocol(
+                                    connection,
+                                    bg_tasks,
+                                    cancellation_token,
+                                )
+                                .await;
+                        });
                     }
                     None => {
-                        warn!("start_agent -> Data plane control channel vanished abruptly. Stopping poll.");
-                        break;
-                    }
-                }
-            },
-
-            Some(client) = clients.join_next() => {
-                match client {
-                    Ok(client) => {
-                        trace!(client, "start_agent -> Client finished");
-                    }
-                    Err(error) => {
-                        error!(%error, "start_agent -> Failed to join client handler task");
+                        upstream_closed = true;
                     }
                 }
             }
 
-            Some(..) = exit_idle => {
-                trace!(
-                    ?idle_ttl,
-                    "start_agent -> All clients finished and idle ttl expired, exiting main agent loop"
-                );
-                break;
+            // A new remote-accept handoff arrived from the layer.
+            remote_accept_result = connection_handoff_server.accept() => {
+                match remote_accept_result {
+                    Ok((stream, peer)) => {
+                        tracing::trace!(peer = ?peer, "accepted connection handoff connection");
+                        let incoming_connection_sender = incoming_connection_sender.clone();
+                        let subscriptions = subscriptions.clone();
+                        join_set.spawn(async move {
+                            match handle_connection_handoff_connection(
+                                stream,
+                                subscriptions,
+                            )
+                            .await {
+                                Ok(Some(conn_handoff)) => {
+                                    if let Err(error) = incoming_connection_sender.send(conn_handoff.into()).await {
+                                        tracing::error!(%error, "bridge ingress channel closed");
+                                    }
+                                }
+                                Ok(None) => {
+                                    tracing::trace!("declined remote accept handoff");
+                                }
+                                Err(error) => {
+                                    tracing::error!(%error, "connection handoff handling failed");
+                                }
+                            }
+                        });
+                    }
+                    Err(error) => return Err(error.into()),
+                }
             }
         }
     }
-
-    trace!("start_agent -> Agent shutting down, dropping cancellation token for background tasks");
-    mem::drop(cancel_guard);
-
-    let dns = tokio::join!(bg_tasks.dns.wait().inspect_err(|error| {
-        error!(%error, "start_agent -> DNS task failed");
-    }),);
-    debug!(?dns, "BackgroundTasks have finished.");
-
-    trace!("start_agent -> Agent shutdown");
-
-    Ok(())
 }
 
 async fn clear_iptable_chain(

--- a/mirrord/agent/src/entrypoint/setup.rs
+++ b/mirrord/agent/src/entrypoint/setup.rs
@@ -1,4 +1,5 @@
 use mirrord_agent_env::envs;
+use mirrord_remote_layer_protocol::RemoteLayerSubscriptionsView;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
@@ -10,6 +11,7 @@ use crate::{
         self, MirrorHandle, RedirectorTask, RedirectorTaskConfig, StealHandle,
         tls::StealTlsHandlerStore,
     },
+    sidecar::{IncomingConnectionSender, RemoteLayerPortRedirector},
     steal::{StealerCommand, TcpStealerTask},
     task::{BgTaskRuntime, status::IntoStatus},
     util::path_resolver::InTargetPathResolver,
@@ -57,6 +59,39 @@ pub(super) async fn start_traffic_redirector(
     tokio::spawn(task.run());
 
     Ok((steal_handle, mirror_handle))
+}
+
+/// Starts the remote-layer incoming redirector used by sidecar mode.
+///
+/// Returns the handles that keep the redirector task alive together with the sender used by the
+/// remote-layer handoff path to inject accepted connections into the incoming pipeline.
+pub(super) async fn start_remote_layer_ingress(
+    runtime: &BgTaskRuntime,
+) -> AgentResult<(
+    StealHandle,
+    MirrorHandle,
+    IncomingConnectionSender,
+    RemoteLayerSubscriptionsView,
+)> {
+    let _rt = runtime.handle().enter();
+
+    let tls_steal_config = envs::STEAL_TLS_CONFIG.from_env_or_default();
+    let target_pid = runtime.target_pid().unwrap_or(1);
+    let tls_handler_store =
+        StealTlsHandlerStore::new(tls_steal_config, InTargetPathResolver::new(target_pid));
+    let redirector_task_config = RedirectorTaskConfig::from_env();
+    let (redirector, incoming_connection_sender, subscriptions) = RemoteLayerPortRedirector::new();
+    let (task, steal_handle, mirror_handle) =
+        RedirectorTask::new(redirector, tls_handler_store, redirector_task_config);
+
+    tokio::spawn(task.run());
+
+    Ok((
+        steal_handle,
+        mirror_handle,
+        incoming_connection_sender,
+        subscriptions,
+    ))
 }
 
 pub(super) fn start_stealer(

--- a/mirrord/agent/src/error.rs
+++ b/mirrord/agent/src/error.rs
@@ -1,5 +1,6 @@
 use std::{process::ExitStatus, sync::Arc};
 
+use mirrord_remote_layer_protocol::error::RemoteLayerProtocolError;
 use mirrord_sessions_manager_client::error::SessionsManagerClientError;
 use thiserror::Error;
 
@@ -72,6 +73,9 @@ pub(crate) enum AgentError {
 
     #[error("Failed to create connection from sessions-manager: {0}")]
     SessionsManagerClientError(#[from] SessionsManagerClientError),
+
+    #[error(transparent)]
+    RemoteLayerProtocolError(#[from] RemoteLayerProtocolError),
 }
 
 pub(crate) type AgentResult<T, E = AgentError> = std::result::Result<T, E>;

--- a/mirrord/agent/src/incoming.rs
+++ b/mirrord/agent/src/incoming.rs
@@ -25,6 +25,7 @@ pub use connection::{
 pub use error::{ConnError, RedirectorTaskError};
 use iptables::IpTablesRedirector;
 pub use mirror_handle::{MirrorHandle, MirroredTraffic};
+use mirrord_remote_layer_protocol::ConnectionHandoff;
 pub use steal_handle::{StealHandle, StolenTraffic};
 pub use task::{RedirectorTask, RedirectorTaskConfig};
 use tokio::net::TcpStream;
@@ -77,6 +78,11 @@ pub struct Redirected {
     ///
     /// Note that this address might be different than the local address of [`Self::stream`].
     destination: SocketAddr,
+    /// Prepared passthrough socket for this connection, if available.
+    ///
+    /// `ConnectionInfo::connect_passthrough` consumes this stream once and falls back to
+    /// connecting on demand when it is not present.
+    passthrough_stream: Option<TcpStream>,
 }
 
 impl fmt::Debug for Redirected {
@@ -85,6 +91,27 @@ impl fmt::Debug for Redirected {
             .field("source", &self.source)
             .field("destination", &self.destination)
             .finish()
+    }
+}
+
+impl Redirected {
+    pub(crate) fn source(&self) -> SocketAddr {
+        self.source
+    }
+
+    pub(crate) fn destination(&self) -> SocketAddr {
+        self.destination
+    }
+}
+
+impl From<ConnectionHandoff> for Redirected {
+    fn from(value: ConnectionHandoff) -> Self {
+        Self {
+            stream: value.original_stream,
+            source: value.info.peer_address,
+            destination: value.info.listener_address,
+            passthrough_stream: Some(value.passthrough_stream),
+        }
     }
 }
 
@@ -313,6 +340,7 @@ pub mod test {
                 stream: server_stream,
                 source: peer_addr,
                 destination: original_destination,
+                passthrough_stream: None,
             };
             self.tx.send(redirected).await.unwrap();
 

--- a/mirrord/agent/src/incoming/connection.rs
+++ b/mirrord/agent/src/incoming/connection.rs
@@ -3,6 +3,7 @@ use std::{
     net::{Ipv4Addr, Ipv6Addr, SocketAddr},
     ops::Not,
     pin::Pin,
+    sync::{Arc, Mutex},
     task::{Context, Poll},
     time::Duration,
 };
@@ -62,6 +63,11 @@ pub struct ConnectionInfo {
     /// Set from [`EXTERNAL_IP_FIX`](mirrord_agent_env::envs::EXTERNAL_IP_FIX). See
     /// [`Self::pass_through_connect`].
     pub passthrough_original_dst: bool,
+    /// Optional prepared stream for passthrough connections.
+    ///
+    /// [`Self::connect_passthrough`] consumes this stream once and otherwise opens a new
+    /// connection to [`Self::pass_through_address`].
+    pub(crate) passthrough_stream: Arc<Mutex<Option<TcpStream>>>,
 }
 
 impl ConnectionInfo {
@@ -89,10 +95,22 @@ impl ConnectionInfo {
 
     /// Makes the passthrough TCP connection to [`Self::pass_through_address`].
     ///
+    /// If a prepared stream was provided for this connection, such as the sidecar handoff stream,
+    /// we consume and return it the first time this method is called.
+    ///
     /// When passing through to the original destination IP (the `external_ip_fix` feature), the
     /// socket is marked with [`envs::PASSTHROUGH_FWMARK`] before connecting, so the redirect
     /// iptables rules `RETURN` it instead of looping it back into the agent.
     pub async fn pass_through_connect(&self) -> io::Result<TcpStream> {
+        if let Some(prepared_stream) = {
+            self.passthrough_stream
+                .lock()
+                .expect("connection passthrough stream lock failed")
+                .take()
+        } {
+            return Ok(prepared_stream);
+        }
+
         let address = self.pass_through_address();
 
         if self.passthrough_original_dst.not() {
@@ -221,6 +239,7 @@ impl MaybeHttp {
 
         let original_destination = redirected.destination;
         let peer_addr = redirected.source;
+        let passthrough_stream = redirected.passthrough_stream;
         let local_addr = redirected
             .stream
             .local_addr()
@@ -245,6 +264,7 @@ impl MaybeHttp {
                     peer_addr,
                     tls_connector: None,
                     passthrough_original_dst,
+                    passthrough_stream: Arc::new(Mutex::new(passthrough_stream)),
                 },
             });
         };
@@ -302,6 +322,7 @@ impl MaybeHttp {
                 peer_addr,
                 tls_connector: Some(tls_connector),
                 passthrough_original_dst,
+                passthrough_stream: Arc::new(Mutex::new(passthrough_stream)),
             },
         })
     }

--- a/mirrord/agent/src/incoming/iptables.rs
+++ b/mirrord/agent/src/incoming/iptables.rs
@@ -189,6 +189,7 @@ impl PortRedirector for IpTablesRedirector {
                         stream,
                         source,
                         destination,
+                        passthrough_stream: None,
                     });
                 }
                 Err(error) => {

--- a/mirrord/agent/src/incoming/task.rs
+++ b/mirrord/agent/src/incoming/task.rs
@@ -4,7 +4,7 @@ use std::{
     fmt,
     ops::Not,
     pin::Pin,
-    sync::Arc,
+    sync::{Arc, Mutex},
     time::Duration,
 };
 
@@ -219,12 +219,14 @@ where
                 }
             };
 
+            let passthrough_stream = Arc::new(Mutex::new(conn.passthrough_stream));
             let info = ConnectionInfo {
                 original_destination: destination,
                 local_addr,
                 peer_addr: source,
                 tls_connector: None,
                 passthrough_original_dst: self.config.passthrough_original_dst,
+                passthrough_stream,
             };
 
             let shutdown = state.shutdown.child_token();

--- a/mirrord/agent/src/main.rs
+++ b/mirrord/agent/src/main.rs
@@ -40,6 +40,8 @@ mod reverse_dns;
 #[cfg(target_os = "linux")]
 mod runtime;
 #[cfg(target_os = "linux")]
+mod sidecar;
+#[cfg(target_os = "linux")]
 mod steal;
 #[cfg(target_os = "linux")]
 mod task;

--- a/mirrord/agent/src/sidecar/incoming.rs
+++ b/mirrord/agent/src/sidecar/incoming.rs
@@ -1,0 +1,156 @@
+use std::{
+    collections::{HashSet, VecDeque},
+    error::Error,
+    fmt, io,
+    sync::{Arc, Mutex},
+};
+
+use mirrord_remote_layer_protocol::RemoteLayerSubscriptionsView;
+use tokio::sync::mpsc;
+use tracing::trace;
+
+use crate::incoming::{PortRedirector, Redirected};
+
+/// Sender used by the sidecar bridge/router to inject bridged connections into the existing
+/// incoming pipeline.
+#[derive(Clone, Debug)]
+pub(crate) struct IncomingConnectionSender {
+    tx: mpsc::Sender<Redirected>,
+}
+
+impl IncomingConnectionSender {
+    pub(crate) async fn send(
+        &self,
+        conn: Redirected,
+    ) -> Result<(), mpsc::error::SendError<Redirected>> {
+        trace!(source = %conn.source(), destination = %conn.destination(), "queue bridged incoming connection");
+        self.tx.send(conn).await
+    }
+}
+
+#[derive(Debug)]
+pub struct RemoteLayerPortRedirectorError(Box<dyn Error + Send + Sync + 'static>);
+
+impl fmt::Display for RemoteLayerPortRedirectorError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl Error for RemoteLayerPortRedirectorError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        self.0.source()
+    }
+}
+
+impl From<io::Error> for RemoteLayerPortRedirectorError {
+    fn from(value: io::Error) -> Self {
+        Self(Box::new(value))
+    }
+}
+
+impl From<RemoteLayerPortRedirectorError> for Arc<dyn Error + Send + Sync + 'static> {
+    fn from(value: RemoteLayerPortRedirectorError) -> Self {
+        value.0.into()
+    }
+}
+
+/// [`PortRedirector`] implementation that receives redirected connections from the sidecar bridge
+/// instead of from iptables.
+#[derive(Debug)]
+pub(crate) struct RemoteLayerPortRedirector {
+    rx: mpsc::Receiver<Redirected>,
+    subscriptions: Arc<Mutex<HashSet<u16>>>,
+    pending: VecDeque<Redirected>,
+}
+
+impl RemoteLayerPortRedirector {
+    pub fn new() -> (Self, IncomingConnectionSender, RemoteLayerSubscriptionsView) {
+        let (tx, rx) = mpsc::channel(32);
+        let subscriptions = Arc::new(Mutex::new(HashSet::new()));
+
+        (
+            Self {
+                rx,
+                subscriptions: Arc::clone(&subscriptions),
+                pending: VecDeque::new(),
+            },
+            IncomingConnectionSender { tx },
+            RemoteLayerSubscriptionsView::new(subscriptions),
+        )
+    }
+
+    fn take_pending_connection(&mut self) -> Option<Redirected> {
+        let pending = self.pending.len();
+
+        for _ in 0..pending {
+            let Some(conn) = self.pending.pop_front() else {
+                break;
+            };
+
+            let subscriptions = self
+                .subscriptions
+                .lock()
+                .expect("remote-layer subscription lock failed");
+            if subscriptions.contains(&conn.destination().port()) {
+                return Some(conn);
+            }
+
+            drop(subscriptions);
+            self.pending.push_back(conn);
+        }
+
+        None
+    }
+}
+
+impl PortRedirector for RemoteLayerPortRedirector {
+    type Error = RemoteLayerPortRedirectorError;
+
+    async fn add_redirection(&mut self, from_port: u16) -> Result<(), Self::Error> {
+        self.subscriptions
+            .lock()
+            .expect("remote-layer subscription lock failed")
+            .insert(from_port);
+        Ok(())
+    }
+
+    async fn remove_redirection(&mut self, from_port: u16) -> Result<(), Self::Error> {
+        self.subscriptions
+            .lock()
+            .expect("remote-layer subscription lock failed")
+            .remove(&from_port);
+        Ok(())
+    }
+
+    async fn cleanup(&mut self) -> Result<(), Self::Error> {
+        self.subscriptions
+            .lock()
+            .expect("remote-layer subscription lock failed")
+            .clear();
+        self.pending.clear();
+        Ok(())
+    }
+
+    async fn next_connection(&mut self) -> Result<Redirected, Self::Error> {
+        loop {
+            if let Some(conn) = self.take_pending_connection() {
+                return Ok(conn);
+            }
+
+            match self.rx.recv().await {
+                Some(conn) => self.pending.push_back(conn),
+                None => {
+                    if let Some(conn) = self.take_pending_connection() {
+                        return Ok(conn);
+                    }
+
+                    return Err(RemoteLayerPortRedirectorError::from(io::Error::new(
+                        io::ErrorKind::BrokenPipe,
+                        "bridge ingress channel closed",
+                    )));
+                }
+            }
+        }
+    }
+}

--- a/mirrord/agent/src/sidecar/mod.rs
+++ b/mirrord/agent/src/sidecar/mod.rs
@@ -1,0 +1,3 @@
+mod incoming;
+
+pub(crate) use incoming::{IncomingConnectionSender, RemoteLayerPortRedirector};

--- a/mirrord/layer-lib/src/detour.rs
+++ b/mirrord/layer-lib/src/detour.rs
@@ -248,6 +248,9 @@ pub enum Bypass {
     /// Invalid argument value
     #[cfg(target_os = "macos")]
     InvalidArgValue,
+
+    /// Remote incoming traffic should fall back to the original accepted fd.
+    RemoteIncomingFallback,
 }
 
 #[cfg(unix)]

--- a/mirrord/remote/bootstrap/Cargo.toml
+++ b/mirrord/remote/bootstrap/Cargo.toml
@@ -19,6 +19,7 @@ workspace = true
 [dependencies]
 libc.workspace = true
 mirrord-layer-lib = { path = "../../layer-lib" }
+mirrord-remote-layer-protocol.workspace = true
 ctor.workspace = true
 tracing.workspace = true
 thiserror.workspace = true

--- a/mirrord/remote/bootstrap/build.rs
+++ b/mirrord/remote/bootstrap/build.rs
@@ -14,9 +14,13 @@ fn binary_env(var_name: &str) -> String {
 
 fn main() {
     println!("cargo:rerun-if-env-changed=MIRRORD_AGENT_BINARY");
+    println!("cargo:rerun-if-env-changed=MIRRORD_REMOTE_LAYER_BINARY");
 
     let agent_binary = binary_env("MIRRORD_AGENT_BINARY");
+    let remote_layer_binary = binary_env("MIRRORD_REMOTE_LAYER_BINARY");
 
     println!("cargo:rerun-if-changed={agent_binary}");
+    println!("cargo:rerun-if-changed={remote_layer_binary}");
     println!("cargo:rustc-env=MIRRORD_AGENT_BINARY={agent_binary}");
+    println!("cargo:rustc-env=MIRRORD_REMOTE_LAYER_BINARY={remote_layer_binary}");
 }

--- a/mirrord/remote/bootstrap/src/error.rs
+++ b/mirrord/remote/bootstrap/src/error.rs
@@ -1,10 +1,19 @@
+use mirrord_remote_layer_protocol::error::RemoteLayerProtocolError;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum RemoteBootstrapError {
+    #[error("Layer Protocol Error: {0}")]
+    Protocol(#[from] RemoteLayerProtocolError),
     #[error("IO Error: {0}")]
     IO(#[from] std::io::Error),
     #[error("Null error {0}")]
     Null(#[from] std::ffi::NulError),
+    #[error("Error loading remote-layer: {0}")]
+    LayerLoad(String),
+    #[error(
+        "Waiting for agent sidecar timed-out after {1} seconds for creation of socket file {0}"
+    )]
+    AgentTimeout(std::path::PathBuf, u64),
 }
 pub(crate) type Result<T> = std::result::Result<T, RemoteBootstrapError>;

--- a/mirrord/remote/bootstrap/src/extract.rs
+++ b/mirrord/remote/bootstrap/src/extract.rs
@@ -9,6 +9,8 @@ use crate::error::Result;
 
 const AGENT_BINARY_ENV: &str = "MIRRORD_REMOTE_AGENT_SIDECAR_BINARY";
 const DEFAULT_AGENT_BINARY: &str = "/tmp/mirrord/mirrord-agent";
+const REMOTE_LAYER_BINARY_ENV: &str = "MIRRORD_REMOTE_LAYER_BINARY";
+const DEFAULT_REMOTE_LAYER_BINARY: &str = "/tmp/mirrord/libmirrord_remote_layer.so";
 
 pub(crate) fn extract_agent_binary() -> Result<PathBuf> {
     extract_binary(
@@ -16,6 +18,15 @@ pub(crate) fn extract_agent_binary() -> Result<PathBuf> {
         DEFAULT_AGENT_BINARY,
         include_bytes!(env!("MIRRORD_AGENT_BINARY")),
         "agent",
+    )
+}
+
+pub(crate) fn extract_remote_layer_binary() -> Result<PathBuf> {
+    extract_binary(
+        REMOTE_LAYER_BINARY_ENV,
+        DEFAULT_REMOTE_LAYER_BINARY,
+        include_bytes!(env!("MIRRORD_REMOTE_LAYER_BINARY")),
+        "remote layer",
     )
 }
 

--- a/mirrord/remote/bootstrap/src/lib.rs
+++ b/mirrord/remote/bootstrap/src/lib.rs
@@ -1,14 +1,18 @@
 #![cfg(target_os = "linux")]
 use std::{
-    os::unix::process::CommandExt,
-    path::Path,
+    ffi::{CStr, CString},
+    os::unix::{ffi::OsStrExt, process::CommandExt},
+    path::{Path, PathBuf},
     process::{Command, Stdio},
+    thread::sleep,
+    time::{Duration, Instant},
 };
 
 use ctor::ctor;
 use mirrord_layer_lib::logging::init_tracing;
+use mirrord_remote_layer_protocol::connection_handoff::prepare_handoff_socket;
 
-use crate::error::Result;
+use crate::error::{RemoteBootstrapError, Result};
 
 mod error;
 mod extract;
@@ -28,11 +32,37 @@ fn mirrord_layer_bootstrap_entry_point() {
 }
 
 fn spawn_remote_flow() -> Result<()> {
+    let connection_handoff_socket = prepare_handoff_socket()?;
     let agent_binary = extract::extract_agent_binary()?;
 
-    tracing::info!(agent_binary = %agent_binary.display(), "Launching sidecar agent");
+    tracing::info!(agent_binary = %agent_binary.display(), ?connection_handoff_socket, "Launching sidecar agent");
 
     spawn_agent(&agent_binary)?;
+    wait_for_file(&connection_handoff_socket)?;
+
+    let remote_layer_binary = extract::extract_remote_layer_binary()?;
+    load_remote_layer(&remote_layer_binary)?;
+
+    Ok(())
+}
+
+fn load_remote_layer(binary: &Path) -> Result<()> {
+    let binary_display = binary.display().to_string();
+    tracing::info!(remote_layer_binary = %binary_display, "Loading remote layer");
+
+    let binary = CString::new(binary.as_os_str().as_bytes())?;
+    let handle = unsafe { libc::dlopen(binary.as_ptr(), libc::RTLD_NOW | libc::RTLD_GLOBAL) };
+    if handle.is_null() {
+        let error = unsafe { libc::dlerror() };
+        let err_msg = {
+            if error.is_null() {
+                "unknown dlopen error".to_string()
+            } else {
+                unsafe { CStr::from_ptr(error).to_string_lossy().into_owned() }
+            }
+        };
+        return Err(RemoteBootstrapError::LayerLoad(err_msg));
+    };
 
     Ok(())
 }
@@ -60,4 +90,24 @@ fn spawn_agent(binary: &Path) -> Result<()> {
     let child = command.spawn()?;
     tracing::info!(pid = child.id(), "Spawned sidecar agent");
     Ok(())
+}
+
+fn wait_for_file(path_buf: &PathBuf) -> Result<()> {
+    let duration = Duration::from_secs(30);
+    let deadline = Instant::now() + duration;
+
+    let path = Path::new(&path_buf);
+    while Instant::now() < deadline {
+        if path.exists() {
+            tracing::debug!(file = %path.display(), "File is ready");
+            return Ok(());
+        }
+
+        sleep(Duration::from_millis(100));
+    }
+
+    Err(RemoteBootstrapError::AgentTimeout(
+        path_buf.to_owned(),
+        duration.as_secs(),
+    ))
 }

--- a/mirrord/remote/layer/Cargo.toml
+++ b/mirrord/remote/layer/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "mirrord-remote-layer"
+version.workspace = true
+authors.workspace = true
+description.workspace = true
+documentation.workspace = true
+readme.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+publish.workspace = true
+edition.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+mirrord-intproxy-protocol = { path = "../../intproxy/protocol", features = ["codec"] }
+mirrord-layer-core = { path = "../../layer/core" }
+mirrord-layer-lib = { path = "../../layer-lib" }
+mirrord-layer-macro = { path = "../../layer/macro" }
+mirrord-remote-layer-protocol.workspace = true
+
+ctor.workspace = true
+libc.workspace = true
+nix = { workspace = true, features = ["net", "process", "signal", "socket", "uio"] }
+socket2.workspace = true
+tracing.workspace = true
+thiserror.workspace = true
+
+[lib]
+crate-type = ["cdylib"]

--- a/mirrord/remote/layer/protocol/Cargo.toml
+++ b/mirrord/remote/layer/protocol/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "mirrord-remote-layer-protocol"
+version.workspace = true
+authors.workspace = true
+description.workspace = true
+documentation.workspace = true
+readme.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+publish.workspace = true
+edition.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+bincode.workspace = true
+mirrord-intproxy-protocol = { path = "../../../intproxy/protocol", features = ["codec"] }
+thiserror.workspace = true
+nix = { workspace = true, features = ["net", "socket", "uio"] }
+tokio = { workspace = true, features = ["net"] }
+tracing.workspace = true

--- a/mirrord/remote/layer/protocol/src/connection_handoff.rs
+++ b/mirrord/remote/layer/protocol/src/connection_handoff.rs
@@ -1,0 +1,290 @@
+use std::{
+    collections::HashSet,
+    io::{Cursor, Error, ErrorKind, Read, Write},
+    mem::ManuallyDrop,
+    net::{Ipv4Addr, Ipv6Addr, SocketAddr, TcpStream as StdTcpStream},
+    os::unix::{
+        io::{AsRawFd, FromRawFd, RawFd},
+        net::UnixStream,
+    },
+    path::PathBuf,
+    sync::{Arc, Mutex},
+};
+
+use tokio::net::{
+    unix::SocketAddr as UnixSocketAddr, TcpListener, TcpStream as TokioTcpStream, UnixListener,
+    UnixStream as TokioUnixStream,
+};
+
+use crate::{
+    error::Result, ConnectionHandoffRequest, ConnectionHandoffResponse, ConnectionHandoffVerdict,
+};
+
+/// Environment variable used by the layer and sidecar to exchange accepted sockets over the
+/// connection handoff socket.
+pub const CONNECTION_HANDOFF_SOCKET_ENV: &str = "MIRRORD_REMOTE_HANDOFF_SOCKET";
+
+/// Default location of the connection handoff socket. see [`CONNECTION_HANDOFF_SOCKET_ENV`]
+const DEFAULT_CONNECTION_HANDOFF_SOCKET: &str = "/tmp/mirrord-remote-handoff.sock";
+
+/// Shared read-only view of the destination ports currently subscribed for remote-layer traffic.
+#[derive(Clone, Debug)]
+pub struct RemoteLayerSubscriptionsView(Arc<Mutex<HashSet<u16>>>);
+
+impl RemoteLayerSubscriptionsView {
+    pub fn new(subscriptions: Arc<Mutex<HashSet<u16>>>) -> Self {
+        Self(subscriptions)
+    }
+
+    pub fn contains(&self, port: u16) -> bool {
+        self.0
+            .lock()
+            .expect("remote-layer subscription lock failed")
+            .contains(&port)
+    }
+}
+
+/// Owns the Unix listener used for connection handoff traffic.
+pub struct ConnectionHandoffServer {
+    listener: UnixListener,
+    socket_path: PathBuf,
+}
+
+pub struct ConnectionHandoff {
+    pub original_stream: TokioTcpStream,
+    pub info: ConnectionHandoffRequest,
+    pub passthrough_stream: TokioTcpStream,
+}
+
+impl ConnectionHandoffServer {
+    pub fn bind() -> Result<Self> {
+        let socket_path = std::env::var(CONNECTION_HANDOFF_SOCKET_ENV).map_err(|error| {
+            Error::new(
+                ErrorKind::NotFound,
+                format!(
+                    "missing {} environment variable: {error}",
+                    CONNECTION_HANDOFF_SOCKET_ENV
+                ),
+            )
+        })?;
+
+        let _ = std::fs::remove_file(&socket_path);
+        let listener = UnixListener::bind(&socket_path)?;
+
+        Ok(Self {
+            listener,
+            socket_path: socket_path.into(),
+        })
+    }
+
+    pub async fn accept(&self) -> Result<(TokioUnixStream, UnixSocketAddr)> {
+        Ok(self.listener.accept().await?)
+    }
+}
+
+pub async fn handle_connection_handoff_connection(
+    stream: TokioUnixStream,
+    subscriptions: RemoteLayerSubscriptionsView,
+) -> Result<Option<ConnectionHandoff>> {
+    let unix_stream = stream.into_std()?;
+    let ReceivedConnectionHandoff {
+        request,
+        accepted_fd,
+    } = receive_connection_handoff_with_fd(&unix_stream)?;
+
+    // Take ownership of the transferred raw fd so this function controls when it is closed
+    // and we do not leak the accepted socket.
+    let std_stream = unsafe { StdTcpStream::from_raw_fd(accepted_fd) };
+
+    let local_address = socket_local_addr(accepted_fd)?;
+    if local_address != request.local_address {
+        tracing::trace!(
+            accept_id = request.accept_id,
+            expected_local_address = %request.local_address,
+            observed_local_address = %local_address,
+            "connection handoff local address differs from transferred metadata"
+        );
+    }
+
+    // If the agent is not listening on this port, tell the layer to keep the socket
+    // locally instead of creating a placeholder listener for it.
+    if !subscriptions.contains(request.listener_address.port()) {
+        send_connection_handoff_response(
+            &unix_stream,
+            &request,
+            ConnectionHandoffVerdict::Rejected,
+            local_address,
+        )?;
+
+        return Ok(None);
+    }
+
+    std_stream.set_nonblocking(true)?;
+    let original_stream = TokioTcpStream::from_std(std_stream)?;
+
+    let passthrough_stream = {
+        let listener = create_placeholder_listener(request.listener_address).await?;
+        let placeholder_address = listener.local_addr()?;
+        send_connection_handoff_response(
+            &unix_stream,
+            &request,
+            ConnectionHandoffVerdict::Accepted {
+                placeholder_address,
+            },
+            local_address,
+        )?;
+
+        let (passthrough_stream, _) = listener.accept().await?;
+        passthrough_stream
+    };
+
+    Ok(Some(ConnectionHandoff {
+        original_stream,
+        info: request,
+        passthrough_stream,
+    }))
+}
+
+impl Drop for ConnectionHandoffServer {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.socket_path);
+    }
+}
+
+struct ReceivedConnectionHandoff {
+    request: ConnectionHandoffRequest,
+    accepted_fd: RawFd,
+}
+
+fn receive_connection_handoff_with_fd(stream: &UnixStream) -> Result<ReceivedConnectionHandoff> {
+    let mut buffer = vec![0u8; 8192];
+    let (accepted_fd, bytes) = {
+        let mut cmsgspace = nix::cmsg_space!([RawFd; 1]);
+        let mut iov = [std::io::IoSliceMut::new(&mut buffer)];
+
+        let message = nix::sys::socket::recvmsg::<()>(
+            stream.as_raw_fd(),
+            &mut iov,
+            Some(&mut cmsgspace),
+            nix::sys::socket::MsgFlags::empty(),
+        )?;
+
+        let accepted_fd = message
+            .cmsgs()?
+            .find_map(|control_message| match control_message {
+                nix::sys::socket::ControlMessageOwned::ScmRights(fds) => fds.into_iter().next(),
+                _ => None,
+            })
+            .ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "missing accepted socket fd",
+                )
+            })?;
+
+        (accepted_fd, message.bytes)
+    };
+
+    let mut decoder = mirrord_intproxy_protocol::codec::SyncDecoder::new(PrefixedReader::new(
+        &buffer[..bytes],
+        stream.try_clone()?,
+    ));
+    let request = decoder.receive()?.ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::UnexpectedEof,
+            "missing connection handoff request",
+        )
+    })?;
+
+    Ok(ReceivedConnectionHandoff {
+        request,
+        accepted_fd,
+    })
+}
+
+fn send_connection_handoff_response(
+    stream: &UnixStream,
+    request: &ConnectionHandoffRequest,
+    verdict: ConnectionHandoffVerdict,
+    local_address: SocketAddr,
+) -> Result<()> {
+    let cursor = Cursor::new(Vec::new());
+    let mut encoder = mirrord_intproxy_protocol::codec::SyncEncoder::new(cursor);
+    encoder.send(&ConnectionHandoffResponse {
+        accept_id: request.accept_id,
+        verdict,
+        listener_address: request.listener_address,
+        local_address,
+        peer_address: request.peer_address,
+    })?;
+
+    let frame = encoder.into_inner().into_inner();
+    let mut writer = stream.try_clone()?;
+    writer.write_all(&frame)?;
+    writer.flush()?;
+    Ok(())
+}
+
+fn socket_local_addr(fd: RawFd) -> Result<SocketAddr> {
+    let stream = ManuallyDrop::new(unsafe { StdTcpStream::from_raw_fd(fd) });
+    Ok(stream.local_addr()?)
+}
+
+async fn create_placeholder_listener(address: SocketAddr) -> Result<TcpListener> {
+    let localhost = if address.is_ipv4() {
+        Ipv4Addr::LOCALHOST.into()
+    } else {
+        Ipv6Addr::LOCALHOST.into()
+    };
+
+    Ok(TcpListener::bind(SocketAddr::new(localhost, 0)).await?)
+}
+
+struct PrefixedReader<'a, R> {
+    prefix: Cursor<&'a [u8]>,
+    reader: R,
+}
+
+impl<'a, R> PrefixedReader<'a, R> {
+    fn new(prefix: &'a [u8], reader: R) -> Self {
+        Self {
+            prefix: Cursor::new(prefix),
+            reader,
+        }
+    }
+}
+
+impl<R: Read> Read for PrefixedReader<'_, R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let read = self.prefix.read(buf)?;
+        if read > 0 {
+            return Ok(read);
+        }
+
+        self.reader.read(buf)
+    }
+}
+
+pub fn prepare_handoff_socket() -> Result<PathBuf> {
+    let path = std::env::var(CONNECTION_HANDOFF_SOCKET_ENV).unwrap_or_else(|_| {
+        let default = DEFAULT_CONNECTION_HANDOFF_SOCKET.to_owned();
+        // set default value into the env var for later spawn to inherit it
+        unsafe { std::env::set_var(CONNECTION_HANDOFF_SOCKET_ENV, &default) };
+        default
+    });
+    let path = PathBuf::from(&path);
+    // if a stale version exists, remove it for the UnixListener::bind to create it
+    match path.try_exists() {
+        Ok(true) => {
+            tracing::debug!(?path, "removing stale connection handoff socket");
+            let _ = std::fs::remove_file(&path).inspect_err(
+                |err| tracing::error!(%err, ?path, "failed to remove stale connection handoff socket"),
+            );
+        }
+        Ok(false) => {
+            tracing::trace!("verified connection handoff socket doesnt exist successfully");
+        }
+        Err(err) => tracing::warn!(%err, "error ensuring connection handoff socket doesnt exist"),
+    };
+    Ok(path)
+}

--- a/mirrord/remote/layer/protocol/src/error.rs
+++ b/mirrord/remote/layer/protocol/src/error.rs
@@ -1,0 +1,17 @@
+use mirrord_intproxy_protocol::codec::CodecError;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum RemoteLayerProtocolError {
+    #[error("io error: {0}")]
+    IO(#[from] std::io::Error),
+    #[error("Env var error: {0}")]
+    EnvVar(#[from] std::env::VarError),
+    #[error("Handoff Socket is missing: {0}")]
+    HandoffSocketMissing(String),
+    #[error("nix error: {0}")]
+    Nix(#[from] nix::Error),
+    #[error("codec error: {0}")]
+    Codec(#[from] CodecError),
+}
+pub(crate) type Result<T> = std::result::Result<T, RemoteLayerProtocolError>;

--- a/mirrord/remote/layer/protocol/src/lib.rs
+++ b/mirrord/remote/layer/protocol/src/lib.rs
@@ -1,0 +1,51 @@
+use std::net::SocketAddr;
+
+use bincode::{Decode, Encode};
+
+pub mod connection_handoff;
+pub mod error;
+
+pub use connection_handoff::{
+    handle_connection_handoff_connection, ConnectionHandoff, ConnectionHandoffServer,
+    RemoteLayerSubscriptionsView, CONNECTION_HANDOFF_SOCKET_ENV,
+};
+
+/// Metadata sent alongside a transferred accepted socket fd on the connection handoff side channel.
+#[derive(Encode, Decode, Debug, Eq, PartialEq, Hash, Clone)]
+pub struct ConnectionHandoffRequest {
+    /// Stable identifier for the accepted socket origin record.
+    pub accept_id: u64,
+    /// Address of the listener that accepted the connection.
+    pub listener_address: SocketAddr,
+    /// Address of the accepted socket on the local host.
+    pub local_address: SocketAddr,
+    /// Address of connection peer.
+    pub peer_address: SocketAddr,
+}
+
+/// Verdict sent over the connection handoff side channel.
+#[derive(Encode, Decode, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConnectionHandoffVerdict {
+    /// The remote-layer sidecar does not want to take this accepted connection, so the layer
+    /// keeps the original accepted socket and falls back to local handling.
+    Rejected,
+    /// The remote-layer sidecar accepted the connection and created a local placeholder listener
+    /// at this address. The layer should connect a replacement placeholder socket here and return
+    /// that fd to the application instead of the original accepted socket fd.
+    Accepted { placeholder_address: SocketAddr },
+}
+
+/// A response to the connection handoff request.
+#[derive(Encode, Decode, Debug, Clone, PartialEq, Eq)]
+pub struct ConnectionHandoffResponse {
+    /// Identifier of the accepted socket origin record.
+    pub accept_id: u64,
+    /// Final sidecar verdict for this accepted socket.
+    pub verdict: ConnectionHandoffVerdict,
+    /// Address of the listener that accepted the connection.
+    pub listener_address: SocketAddr,
+    /// Address of the accepted socket on the local host.
+    pub local_address: SocketAddr,
+    /// Address of connection peer.
+    pub peer_address: SocketAddr,
+}

--- a/mirrord/remote/layer/src/error.rs
+++ b/mirrord/remote/layer/src/error.rs
@@ -1,0 +1,19 @@
+use std::env::VarError;
+
+use mirrord_remote_layer_protocol::error::RemoteLayerProtocolError;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub(crate) enum RemoteLayerError {
+    #[error("io error: {0}")]
+    IO(#[from] std::io::Error),
+    #[error("Env var error: {0}")]
+    EnvVar(#[from] VarError),
+    #[error("RemoteLayer protocol error: {0}")]
+    RemoteLayerProtocol(#[from] RemoteLayerProtocolError),
+    #[error("Handoff socket codec error: {0}")]
+    Codec(#[from] mirrord_intproxy_protocol::codec::CodecError),
+    #[error("Handoff socket sendmsg error: {0}")]
+    NixErrno(#[from] nix::errno::Errno),
+}
+pub(crate) type Result<T> = std::result::Result<T, RemoteLayerError>;

--- a/mirrord/remote/layer/src/lib.rs
+++ b/mirrord/remote/layer/src/lib.rs
@@ -1,0 +1,26 @@
+#![cfg(unix)]
+#![warn(clippy::indexing_slicing)]
+#![deny(unused_crate_dependencies)]
+
+use ctor::ctor;
+use mirrord_layer_core::hooks::HookManager;
+use mirrord_layer_lib::logging::init_tracing;
+use tracing::trace;
+
+use crate::socket::hooks::enable_socket_hooks;
+
+mod error;
+mod socket;
+
+#[ctor]
+fn mirrord_layer_entry_point() {
+    if cfg!(test) {
+        return;
+    }
+    init_tracing();
+
+    trace!("remote-layer initializing socket hooks");
+    let mut hook_manager = HookManager::default();
+    unsafe { enable_socket_hooks(&mut hook_manager) };
+    trace!("remote-layer socket hooks installed");
+}

--- a/mirrord/remote/layer/src/socket.rs
+++ b/mirrord/remote/layer/src/socket.rs
@@ -1,0 +1,3 @@
+mod connection_handoff;
+pub(crate) mod hooks;
+pub(crate) mod ops;

--- a/mirrord/remote/layer/src/socket/connection_handoff.rs
+++ b/mirrord/remote/layer/src/socket/connection_handoff.rs
@@ -1,0 +1,110 @@
+use std::{
+    io::{self, Cursor, Write},
+    net::SocketAddr,
+    os::unix::{io::AsRawFd, net::UnixStream},
+    sync::atomic::{AtomicU64, Ordering},
+};
+
+use mirrord_intproxy_protocol::codec::{SyncDecoder, SyncEncoder};
+use mirrord_remote_layer_protocol::{
+    ConnectionHandoffRequest, ConnectionHandoffResponse, CONNECTION_HANDOFF_SOCKET_ENV,
+};
+use nix::sys::socket::{ControlMessage, MsgFlags, sendmsg};
+use tracing::trace;
+
+use crate::error::Result;
+
+static NEXT_CONNECTION_HANDOFF_ID: AtomicU64 = AtomicU64::new(1);
+
+fn next_connection_handoff_id() -> u64 {
+    NEXT_CONNECTION_HANDOFF_ID.fetch_add(1, Ordering::Relaxed)
+}
+
+pub(crate) fn handoff_remote_connection(
+    listener_address: SocketAddr,
+    local_address: SocketAddr,
+    peer_address: SocketAddr,
+    accepted_fd: i32,
+) -> Result<ConnectionHandoffResponse> {
+    let socket_path = std::env::var(CONNECTION_HANDOFF_SOCKET_ENV)?;
+
+    let stream = UnixStream::connect(socket_path)?;
+    let mut stream_reader = stream.try_clone()?;
+    let request = ConnectionHandoffRequest {
+        accept_id: next_connection_handoff_id(),
+        listener_address,
+        local_address,
+        peer_address,
+    };
+
+    send_connection_handoff_request(&stream, &request, accepted_fd)?;
+    let response = receive_connection_handoff_response(&mut stream_reader)?;
+
+    trace!(
+        accept_id = request.accept_id,
+        listener_address = %request.listener_address,
+        peer_address = %request.peer_address,
+        verdict = ?response.verdict,
+        "remote-layer accept hook completed connection handoff negotiation"
+    );
+
+    Ok(response)
+}
+
+fn send_connection_handoff_request(
+    stream: &UnixStream,
+    request: &ConnectionHandoffRequest,
+    accepted_fd: i32,
+) -> Result<()> {
+    trace!(
+        accept_id = request.accept_id,
+        listener_address = %request.listener_address,
+        peer_address = %request.peer_address,
+        accepted_fd,
+        "remote-layer sending connection handoff request"
+    );
+
+    let frame = encode_connection_handoff_request(request)?;
+    let iov = [std::io::IoSlice::new(&frame)];
+    let rights = [accepted_fd];
+    let written = sendmsg::<()>(
+        stream.as_raw_fd(),
+        &iov,
+        &[ControlMessage::ScmRights(&rights)],
+        MsgFlags::empty(),
+        None,
+    )?;
+
+    if written < frame.len() {
+        let mut stream = stream;
+        stream.write_all(frame.get(written..).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "failed to slice connection-handoff frame",
+            )
+        })?)?;
+    }
+
+    Ok(())
+}
+
+fn receive_connection_handoff_response(stream: &mut UnixStream) -> Result<ConnectionHandoffResponse> {
+    trace!("remote-layer waiting for connection handoff response");
+    let mut decoder = SyncDecoder::<ConnectionHandoffResponse, _>::new(stream.try_clone()?);
+    let response = decoder.receive()?.ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::UnexpectedEof,
+            "missing connection-handoff response",
+        )
+    })?;
+
+    Ok(response)
+}
+
+fn encode_connection_handoff_request(value: &ConnectionHandoffRequest) -> Result<Vec<u8>> {
+    let cursor = Cursor::new(Vec::new());
+    let mut encoder = SyncEncoder::new(cursor);
+    encoder.send(value)?;
+
+    Ok(encoder.into_inner().into_inner())
+}

--- a/mirrord/remote/layer/src/socket/hooks.rs
+++ b/mirrord/remote/layer/src/socket/hooks.rs
@@ -1,0 +1,256 @@
+use std::os::fd::{AsRawFd, FromRawFd, IntoRawFd, OwnedFd};
+
+use libc::{c_int, sockaddr, socklen_t};
+use mirrord_layer_core::{hooks::HookManager, replace};
+use mirrord_layer_lib::detour::{Bypass, Detour};
+use mirrord_layer_macro::hook_guard_fn;
+use mirrord_remote_layer_protocol::ConnectionHandoffVerdict;
+use tracing::{trace, warn};
+
+use super::connection_handoff::handoff_remote_connection;
+use crate::socket::ops::{
+    claim_placeholder_socket, claimed_socket, fill_address, remove_claimed_socket,
+    socket_addr_from_fd, socket_peer_addr_from_fd,
+};
+
+#[hook_guard_fn]
+pub(crate) unsafe extern "C" fn close_detour(fd: c_int) -> c_int {
+    remove_claimed_socket(fd);
+
+    unsafe { FN_CLOSE(fd) }
+}
+
+#[hook_guard_fn]
+pub(crate) unsafe extern "C" fn getsockname_detour(
+    sockfd: c_int,
+    address: *mut sockaddr,
+    address_len: *mut socklen_t,
+) -> c_int {
+    if let Some(claimed_socket) = claimed_socket(sockfd) {
+        return fill_address(address, address_len, claimed_socket.local_address.into())
+            .unwrap_or_bypass_with(|_| unsafe { FN_GETSOCKNAME(sockfd, address, address_len) });
+    }
+
+    unsafe { FN_GETSOCKNAME(sockfd, address, address_len) }
+}
+
+#[hook_guard_fn]
+pub(crate) unsafe extern "C" fn getpeername_detour(
+    sockfd: c_int,
+    address: *mut sockaddr,
+    address_len: *mut socklen_t,
+) -> c_int {
+    if let Some(claimed_socket) = claimed_socket(sockfd) {
+        return fill_address(address, address_len, claimed_socket.peer_address.into())
+            .unwrap_or_bypass_with(|_| unsafe { FN_GETPEERNAME(sockfd, address, address_len) });
+    }
+
+    unsafe { FN_GETPEERNAME(sockfd, address, address_len) }
+}
+
+#[hook_guard_fn]
+pub(crate) unsafe extern "C" fn accept_detour(
+    sockfd: c_int,
+    address: *mut sockaddr,
+    address_len: *mut socklen_t,
+) -> c_int {
+    unsafe {
+        let accepted_fd = FN_ACCEPT(sockfd, address, address_len);
+        if accepted_fd == -1 {
+            return accepted_fd;
+        }
+
+        let accepted_fd = OwnedFd::from_raw_fd(accepted_fd);
+        accept(sockfd, &accepted_fd).unwrap_or_bypass_with(|_| accepted_fd.into_raw_fd())
+    }
+}
+
+#[cfg(target_os = "linux")]
+#[hook_guard_fn]
+pub(crate) unsafe extern "C" fn accept4_detour(
+    sockfd: c_int,
+    address: *mut sockaddr,
+    address_len: *mut socklen_t,
+    flags: c_int,
+) -> c_int {
+    unsafe {
+        let accepted_fd = FN_ACCEPT4(sockfd, address, address_len, flags);
+        if accepted_fd == -1 {
+            trace!(sockfd, flags, "remote-layer accept4 hook returned -1");
+            return accepted_fd;
+        }
+
+        let accepted_fd = OwnedFd::from_raw_fd(accepted_fd);
+        accept(sockfd, &accepted_fd).unwrap_or_bypass_with(|_| accepted_fd.into_raw_fd())
+    }
+}
+
+#[cfg(target_os = "linux")]
+#[hook_guard_fn]
+#[allow(non_snake_case)]
+pub(super) unsafe extern "C" fn uv__accept4_detour(
+    sockfd: c_int,
+    address: *mut sockaddr,
+    address_len: *mut socklen_t,
+    flags: c_int,
+) -> c_int {
+    unsafe { accept4_detour(sockfd, address, address_len, flags) }
+}
+
+#[cfg(target_os = "macos")]
+#[hook_guard_fn]
+pub(super) unsafe extern "C" fn accept_nocancel_detour(
+    sockfd: c_int,
+    address: *mut sockaddr,
+    address_len: *mut socklen_t,
+) -> c_int {
+    unsafe {
+        let accepted_fd = FN_ACCEPT_NOCANCEL(sockfd, address, address_len);
+        if accepted_fd == -1 {
+            return accepted_fd;
+        }
+
+        let accepted_fd = OwnedFd::from_raw_fd(accepted_fd);
+        accept(sockfd, &accepted_fd).unwrap_or_bypass_with(|_| accepted_fd.into_raw_fd())
+    }
+}
+
+/// Runs the remote incoming handoff for an accepted socket.
+///
+/// The syscall hook converts the raw fd returned by `accept*` into an `OwnedFd`
+/// before calling this helper, so ownership stays explicit while we decide
+/// whether to hand the connection off to the agent or fall back locally.
+///
+/// If this helper returns [`Detour::Success`], the hook wrapper should return
+/// the fd carried by the `Success` variant. In the claim path, that is a
+/// placeholder socket fd created by [`claim_placeholder_socket`], not the
+/// original accepted fd.
+///
+/// If it returns [`Detour::Bypass`], the hook wrapper must turn the `OwnedFd`
+/// back into the original raw fd with `into_raw_fd()` so the caller keeps the
+/// socket it accepted.
+#[mirrord_layer_macro::instrument(level = tracing::Level::DEBUG)]
+fn accept(sockfd: c_int, accepted_fd: &OwnedFd) -> Detour<c_int> {
+    trace!(
+        sockfd,
+        accepted_fd = accepted_fd.as_raw_fd(),
+        "remote-layer connection handoff path starting"
+    );
+
+    let listener_address = match socket_addr_from_fd(sockfd) {
+        Ok(address) => address,
+        Err(error) => {
+            warn!(%error, sockfd, "failed to read accepted listener address");
+            return Detour::Bypass(Bypass::RemoteIncomingFallback);
+        }
+    };
+
+    let local_address = match socket_addr_from_fd(accepted_fd.as_raw_fd()) {
+        Ok(address) => address,
+        Err(error) => {
+            warn!(%error, sockfd, "failed to read accepted local address");
+            return Detour::Bypass(Bypass::RemoteIncomingFallback);
+        }
+    };
+
+    let peer_address = match socket_peer_addr_from_fd(accepted_fd.as_raw_fd()) {
+        Ok(address) => address,
+        Err(error) => {
+            warn!(%error, sockfd, "failed to read accepted peer address");
+            return Detour::Bypass(Bypass::RemoteIncomingFallback);
+        }
+    };
+
+    match handoff_remote_connection(
+        listener_address,
+        local_address,
+        peer_address,
+        accepted_fd.as_raw_fd(),
+    ) {
+        Ok(response) => match response.verdict {
+            ConnectionHandoffVerdict::Rejected => {
+                trace!(
+                    sockfd,
+                    accepted_fd = accepted_fd.as_raw_fd(),
+                    "remote-layer connection handoff declined"
+                );
+                Detour::Bypass(Bypass::RemoteIncomingFallback)
+            }
+            ConnectionHandoffVerdict::Accepted {
+                placeholder_address,
+            } => match claim_placeholder_socket(
+                accepted_fd,
+                placeholder_address,
+                local_address,
+                peer_address,
+            ) {
+                Ok(placeholder_fd) => {
+                    trace!(
+                        sockfd,
+                        placeholder_fd = placeholder_fd.as_raw_fd(),
+                        "remote-layer connection handoff accepted with placeholder socket"
+                    );
+                    Detour::Success(placeholder_fd.into_raw_fd())
+                }
+                Err(error) => {
+                    warn!(%error, sockfd, "failed to create placeholder socket");
+                    Detour::Bypass(Bypass::RemoteIncomingFallback)
+                }
+            },
+        },
+        Err(error) => {
+            warn!(%error, sockfd, "connection handoff for accepted fd failed");
+            Detour::Bypass(Bypass::RemoteIncomingFallback)
+        }
+    }
+}
+
+pub(crate) unsafe fn enable_socket_hooks(hook_manager: &mut HookManager) {
+    unsafe {
+        replace!(hook_manager, "close", close_detour, FnClose, FN_CLOSE);
+        replace!(
+            hook_manager,
+            "getsockname",
+            getsockname_detour,
+            FnGetsockname,
+            FN_GETSOCKNAME
+        );
+        replace!(
+            hook_manager,
+            "getpeername",
+            getpeername_detour,
+            FnGetpeername,
+            FN_GETPEERNAME
+        );
+        replace!(hook_manager, "accept", accept_detour, FnAccept, FN_ACCEPT);
+
+        #[cfg(target_os = "linux")]
+        {
+            replace!(
+                hook_manager,
+                "accept4",
+                accept4_detour,
+                FnAccept4,
+                FN_ACCEPT4
+            );
+            replace!(
+                hook_manager,
+                "uv__accept4",
+                uv__accept4_detour,
+                FnUv__accept4,
+                FN_UV__ACCEPT4
+            );
+        }
+
+        #[cfg(target_os = "macos")]
+        {
+            replace!(
+                hook_manager,
+                "accept$NOCANCEL",
+                accept_nocancel_detour,
+                FnAccept_nocancel,
+                FN_ACCEPT_NOCANCEL
+            );
+        }
+    }
+}

--- a/mirrord/remote/layer/src/socket/ops.rs
+++ b/mirrord/remote/layer/src/socket/ops.rs
@@ -1,0 +1,150 @@
+use std::{
+    collections::HashMap,
+    io,
+    net::{SocketAddr, SocketAddrV4, SocketAddrV6},
+    os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd},
+    ptr,
+    sync::{Mutex, OnceLock},
+};
+
+use libc::{sockaddr, socklen_t};
+use mirrord_layer_lib::{detour::Detour, error::HookError};
+use nix::sys::socket::SockaddrStorage;
+use socket2::SockAddr;
+
+#[derive(Clone, Copy)]
+pub(crate) struct ClaimedSocket {
+    pub(crate) local_address: SocketAddr,
+    pub(crate) peer_address: SocketAddr,
+}
+
+static CLAIMED_SOCKETS: OnceLock<Mutex<HashMap<RawFd, ClaimedSocket>>> = OnceLock::new();
+
+pub(crate) fn claimed_sockets() -> &'static Mutex<HashMap<RawFd, ClaimedSocket>> {
+    CLAIMED_SOCKETS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+pub(crate) fn claimed_socket(fd: RawFd) -> Option<ClaimedSocket> {
+    claimed_sockets()
+        .lock()
+        .expect("claimed socket lock failed")
+        .get(&fd)
+        .copied()
+}
+
+pub(crate) fn remove_claimed_socket(fd: RawFd) {
+    claimed_sockets()
+        .lock()
+        .expect("claimed socket lock failed")
+        .remove(&fd);
+}
+
+pub(crate) fn connect_placeholder_socket(
+    address: SocketAddr,
+    accepted_fd: &OwnedFd,
+) -> io::Result<OwnedFd> {
+    let (domain, type_, protocol) = match address {
+        SocketAddr::V4(_) => (libc::AF_INET, libc::SOCK_STREAM, 0),
+        SocketAddr::V6(_) => (libc::AF_INET6, libc::SOCK_STREAM, 0),
+    };
+
+    let raw_fd = unsafe { libc::socket(domain, type_, protocol) };
+    if raw_fd == -1 {
+        return Err(io::Error::last_os_error());
+    }
+
+    let fd = unsafe { OwnedFd::from_raw_fd(raw_fd) };
+
+    let address = SockaddrStorage::from(address);
+    nix::sys::socket::connect(fd.as_raw_fd(), &address).map_err(io::Error::from)?;
+
+    let fd_flags = unsafe { libc::fcntl(accepted_fd.as_raw_fd(), libc::F_GETFD) };
+    if fd_flags == -1 {
+        return Err(io::Error::last_os_error());
+    }
+
+    if unsafe { libc::fcntl(fd.as_raw_fd(), libc::F_SETFD, fd_flags) } == -1 {
+        return Err(io::Error::last_os_error());
+    }
+
+    let status_flags = unsafe { libc::fcntl(accepted_fd.as_raw_fd(), libc::F_GETFL) };
+    if status_flags == -1 {
+        return Err(io::Error::last_os_error());
+    }
+
+    if unsafe { libc::fcntl(fd.as_raw_fd(), libc::F_SETFL, status_flags) } == -1 {
+        return Err(io::Error::last_os_error());
+    }
+
+    Ok(fd)
+}
+
+pub(crate) fn claim_placeholder_socket(
+    accepted_fd: &OwnedFd,
+    placeholder_address: SocketAddr,
+    local_address: SocketAddr,
+    peer_address: SocketAddr,
+) -> io::Result<OwnedFd> {
+    let placeholder_fd = connect_placeholder_socket(placeholder_address, accepted_fd)?;
+
+    claimed_sockets()
+        .lock()
+        .expect("claimed socket lock failed")
+        .insert(
+            placeholder_fd.as_raw_fd(),
+            ClaimedSocket {
+                local_address,
+                peer_address,
+            },
+        );
+
+    Ok(placeholder_fd)
+}
+
+pub(crate) fn socket_addr_from_fd(fd: RawFd) -> io::Result<SocketAddr> {
+    let address = nix::sys::socket::getsockname::<SockaddrStorage>(fd).map_err(io::Error::other)?;
+    socket_addr_from_storage(address)
+}
+
+pub(crate) fn socket_peer_addr_from_fd(fd: RawFd) -> io::Result<SocketAddr> {
+    let address = nix::sys::socket::getpeername::<SockaddrStorage>(fd).map_err(io::Error::other)?;
+    socket_addr_from_storage(address)
+}
+
+pub(crate) fn socket_addr_from_storage(address: SockaddrStorage) -> io::Result<SocketAddr> {
+    if let Some(ipv4) = address.as_sockaddr_in() {
+        Ok(SocketAddrV4::from(*ipv4).into())
+    } else if let Some(ipv6) = address.as_sockaddr_in6() {
+        Ok(SocketAddrV6::from(*ipv6).into())
+    } else {
+        Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "expected an IPv4 or IPv6 socket address",
+        ))
+    }
+}
+
+pub(crate) fn fill_address(
+    address: *mut sockaddr,
+    address_len: *mut socklen_t,
+    new_address: SockAddr,
+) -> Detour<i32> {
+    let result = if address.is_null() {
+        Ok(0)
+    } else if address_len.is_null() {
+        Err(HookError::NullPointer)
+    } else {
+        unsafe {
+            let len = std::cmp::min(*address_len as usize, new_address.len() as usize);
+            ptr::copy_nonoverlapping(new_address.as_ptr() as *const u8, address as *mut u8, len);
+            *address_len = new_address.len();
+        }
+
+        Ok(0)
+    };
+
+    match result {
+        Ok(value) => Detour::Success(value),
+        Err(error) => Detour::Error(error),
+    }
+}

--- a/xtask/src/tasks/doc.rs
+++ b/xtask/src/tasks/doc.rs
@@ -19,6 +19,7 @@ pub fn run(extra_args: Vec<String>) -> Result<()> {
 
     if env::consts::OS == "linux" {
         cmd.env("MIRRORD_AGENT_BINARY", &dummy);
+        cmd.env("MIRRORD_REMOTE_LAYER_BINARY", &dummy);
     }
 
     let status = cmd.status().context("Failed to run cargo doc")?;

--- a/xtask/src/tasks/remote.rs
+++ b/xtask/src/tasks/remote.rs
@@ -23,6 +23,7 @@ pub fn build_remote_bootstrap(
 
     let mode = if release { "release" } else { "debug" };
     let agent_binary = build_agent_binary(target, release, cargo_args)?;
+    let remote_layer_binary = build_remote_layer_binary(target, release, cargo_args)?;
 
     let mut cmd = Command::new("cargo");
     cmd.arg("build");
@@ -39,6 +40,12 @@ pub fn build_remote_bootstrap(
         agent_binary
             .canonicalize()
             .context("Failed to canonicalize mirrord-agent binary path")?,
+    );
+    cmd.env(
+        "MIRRORD_REMOTE_LAYER_BINARY",
+        remote_layer_binary
+            .canonicalize()
+            .context("Failed to canonicalize mirrord remote layer binary path")?,
     );
     cmd.args(cargo_args);
 
@@ -95,4 +102,45 @@ fn build_agent_binary(target: Target, release: bool, cargo_args: &[String]) -> R
 
     println!("✓ mirrord-agent built: {}", agent_binary.display());
     Ok(agent_binary)
+}
+
+fn build_remote_layer_binary(
+    target: Target,
+    release: bool,
+    cargo_args: &[String],
+) -> Result<PathBuf> {
+    println!("Building mirrord-remote-layer for mirrord remote bootstrap...");
+
+    let mut cmd = Command::new("cargo");
+    cmd.arg("build");
+    cmd.arg("-p").arg("mirrord-remote-layer");
+
+    if release {
+        cmd.arg("--release");
+    }
+
+    let target_triple = target.triple();
+    cmd.arg("--target").arg(target_triple);
+    cmd.args(cargo_args);
+
+    let status = cmd.status().context("Failed to run cargo build")?;
+
+    if !status.success() {
+        anyhow::bail!("cargo build failed for mirrord-remote-layer");
+    }
+
+    let mode = if release { "release" } else { "debug" };
+    let remote_layer_binary = relative_to_root(
+        Path::new("target")
+            .join(target_triple)
+            .join(mode)
+            .join("libmirrord_remote_layer.so")
+            .as_path(),
+    );
+
+    println!(
+        "✓ mirrord-remote-layer built: {}",
+        remote_layer_binary.display()
+    );
+    Ok(remote_layer_binary)
 }


### PR DESCRIPTION
> [!WARNING]
> This is ready for review but requires #4545 for CI, so should be opened after that is merged 

## Description

This PR implements the remote-layer side of the sidecar flow used by the serverless bootstrap path.

### What changed

#### New `mirrord-remote-layer` crate
- Adds `mirrord/remote/layer` as a Linux-only shared library crate.
- Introduces a protocol crate for the connection handoff flow:
  - `AcceptHandoffRequest`
  - `AcceptHandoffResponse`
  - `RemoteAcceptVerdict`
  - shared socket handoff helpers

#### Remote-layer socket interception
- Adds remote-layer hooks for accepted incoming sockets.
- The remote layer can now:
  - inspect accepted socket metadata
  - decide whether a connection should be claimed or declined
  - create a placeholder socket for claimed connections
  - preserve passthrough behavior for the agent sidecar path

#### Agent sidecar ingress
- Extends the agent with a sidecar startup path that:
  - listens for sessions-manager-backed multiplexed connections
  - accepts remote-layer handoff connections over a Unix socket
  - bridges accepted connections into the existing incoming pipeline
- Updates incoming connection handling so passthrough connections can reuse a prepared stream when one is provided by the sidecar handoff.

#### Bootstrap/runtime integration
- Updates the remote bootstrap flow so it:
  - starts the sidecar agent
  - waits for the handoff socket to appear
  - loads the remote-layer shared library with `dlopen`
  - passes both the agent and remote-layer binary paths in via build-time environment variables

#### Build plumbing
- Extends `xtask` so the remote bootstrap build now packages both:
  - the agent sidecar binary
  - the remote-layer shared library
- Adds the corresponding workspace/build wiring and dependency updates.

#### CI / changelog
- Adds a changelog entry for the remote-layer work.
- Updates CI/build config to account for the new packaging path.

### Notes
This PR is focused on the remote-layer implementation and the connection handoff bridge needed for the sidecar flow. It builds on the earlier sessions-manager and bootstrap work, but does not change the baseline sessions-manager control-plane contract itself.


### Quality Checklist:

- [ ] I have documented new code sufficiently
- [ ] I have checked and updated the relevant existing docs in code, including removing outdated material
- [ ] I have written user-facing website docs for new features, or opened a (sub)issue to do so
- [ ] I have checked and updated existing website docs for changed features
- [ ] I have tested this change and know it succeeds and fails as expected
- [ ] I have written unit tests or purposefully omitted them
- [ ] I have written e2e tests or purposefully omitted them
- [ ] I have explained what this PR introduces and why, and linked to relevant context (e.g. linear issues, related PRs,
  documentation)
- [ ] I have introduced a short, clear and well-formatted changelog entry

<!-- need help with the changelog? see ../CONTRIBUTING.md#submitting-a-pull-request -->
<!-- Add more details of your changes below if needed -->

<!-- GitButler Footer Boundary Top -->
---
This is **part 3 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #4559 👈 
- <kbd>&nbsp;2&nbsp;</kbd> #4542 
- <kbd>&nbsp;1&nbsp;</kbd> #4541 
<!-- GitButler Footer Boundary Bottom -->

- Additionally relies on #4545