### PR TITLE
COR-1647 Diagnostic ping

### DIFF
--- a/changelog.d/+agentless-latency-diagnostics.added.md
+++ b/changelog.d/+agentless-latency-diagnostics.added.md
@@ -1,0 +1,2 @@
+If the operator advertises the `DiagnosticsPing` feature, mirrord uses the new ping endpoint for
+diagnosing local-to-cluster latency.

--- a/mirrord/cli/src/diagnose.rs
+++ b/mirrord/cli/src/diagnose.rs
@@ -3,7 +3,8 @@ use std::{path::Path, time::Duration};
 use mirrord_analytics::NullReporter;
 use mirrord_auth::credential_store::CredentialStore;
 use mirrord_config::{LayerConfig, config::ConfigContext};
-use mirrord_progress::{Progress, ProgressTracker};
+use mirrord_operator::{client::OperatorApi, crd::NewOperatorFeature};
+use mirrord_progress::{NullProgress, Progress, ProgressTracker};
 use mirrord_protocol::{ClientMessage, DaemonMessage};
 use mirrord_protocol_io::{Client, Connection};
 use tokio::time::Instant;
@@ -42,30 +43,56 @@ async fn ping(connection: &mut Connection<Client>) -> CliResult<()> {
     }
 }
 
-/// Create a targetless session and run pings to diagnose network latency.
-#[tracing::instrument(level = Level::TRACE, ret)]
-async fn diagnose_latency(config: Option<&Path>) -> CliResult<()> {
-    let mut progress = ProgressTracker::from_env("mirrord network diagnosis");
+/// Establishes the connection used to diagnose latency.
+///
+/// When the operator advertises [`NewOperatorFeature::DiagnosticPing`], connects to its no-session
+/// ping endpoint through which the operator answers `ClientMessage::Ping` with
+/// `DaemonMessage::Pong` directly without creating any session or agent.
+///
+/// Otherwise (older operator or OSS) falls back to [`create_and_connect`], which starts a
+/// targetless session or spawns an agent as before.
+async fn diagnose_connect<P: Progress>(
+    config: &mut LayerConfig,
+    progress: &mut P,
+    analytics: &mut NullReporter,
+) -> CliResult<Connection<Client>> {
+    if config.operator != Some(false)
+        && let Some(api) = OperatorApi::try_new(config, analytics, &NullProgress).await?
+        && api
+            .operator()
+            .spec
+            .supported_features()
+            .contains(&NewOperatorFeature::DiagnosticPing)
+    {
+        let connection = api
+            .with_client_certificate(analytics, progress, config)
+            .await
+            .into_certified()?
+            .connect_diagnostic_ping()
+            .await?;
 
-    let mut context = ConfigContext::default().override_env_opt(LayerConfig::FILE_PATH_ENV, config);
-    let mut config = LayerConfig::resolve(&mut context)?;
-
-    if !config.use_proxy {
-        remove_proxy_env();
+        return Ok(Connection::from_channel(connection));
     }
 
-    let mut analytics = NullReporter::default();
-    let ConnectData { mut connection, .. } =
-        create_and_connect(&mut config, &mut progress, &mut analytics, None, None, None).await?;
+    let ConnectData { connection, .. } =
+        create_and_connect(config, progress, analytics, None, None, None).await?;
 
+    Ok(connection)
+}
+
+/// Runs 100 ping/pong round trips over `connection` and reports min/max/avg latency.
+async fn run_latency_pings<P: Progress>(
+    connection: &mut Connection<Client>,
+    progress: &mut P,
+) -> CliResult<()> {
     let mut statistics: Vec<Duration> = Vec::new();
 
     // ignore first ping as it's part of the initialization.
-    ping(&mut connection).await?;
+    ping(connection).await?;
     // run 100 iterations
     for i in 0..100 {
         let start = Instant::now();
-        ping(&mut connection).await?;
+        ping(connection).await?;
         let elapsed = start.elapsed();
         progress.info(
             format!(
@@ -87,6 +114,26 @@ async fn diagnose_latency(config: Option<&Path>) -> CliResult<()> {
         )
         .as_str(),
     ));
+
+    Ok(())
+}
+
+/// Runs pings to diagnose network latency, avoiding a full session when the operator supports it.
+#[tracing::instrument(level = Level::TRACE, ret)]
+async fn diagnose_latency(config: Option<&Path>) -> CliResult<()> {
+    let mut progress = ProgressTracker::from_env("mirrord network diagnosis");
+
+    let mut context = ConfigContext::default().override_env_opt(LayerConfig::FILE_PATH_ENV, config);
+    let mut config = LayerConfig::resolve(&mut context)?;
+
+    if !config.use_proxy {
+        remove_proxy_env();
+    }
+
+    let mut analytics = NullReporter::default();
+    let mut connection = diagnose_connect(&mut config, &mut progress, &mut analytics).await?;
+
+    run_latency_pings(&mut connection, &mut progress).await?;
 
     Ok(())
 }

--- a/mirrord/operator/src/client.rs
+++ b/mirrord/operator/src/client.rs
@@ -2279,6 +2279,33 @@ impl OperatorApi<PreparedClientCert> {
             })
             .map(OperatorConnection)
     }
+
+    /// Opens a websocket to the operator's no-session ping endpoint, used by
+    /// `mirrord diagnose latency` to measure client-to-operator latency.
+    ///
+    /// Unlike [`Self::connect_in_new_session`], this creates no session and spawns no agent - the
+    /// operator answers `ClientMessage::Ping` with `DaemonMessage::Pong` directly. Only available
+    /// when the operator advertises [`NewOperatorFeature::DiagnosticPing`].
+    #[tracing::instrument(level = Level::TRACE, skip(self), err)]
+    pub async fn connect_diagnostic_ping(&self) -> OperatorApiResult<OperatorConnection> {
+        let url_path = MirrordOperatorCrd::url_path(&(), None);
+        let connect_url = format!("{url_path}/{OPERATOR_STATUS_NAME}/ping");
+
+        let cert_header = Self::make_client_cert_header(&self.client_cert.cert)?;
+        let request = Request::builder()
+            .uri(connect_url)
+            .header(CLIENT_CERT_HEADER, cert_header)
+            .body(vec![])
+            .map_err(OperatorApiError::ConnectRequestBuildError)?;
+
+        upgrade::connect_ws(&self.client, request)
+            .await
+            .map_err(|error| OperatorApiError::KubeError {
+                error,
+                operation: OperatorOperation::WebsocketConnection,
+            })
+            .map(OperatorConnection)
+    }
 }
 
 #[cfg(test)]

--- a/mirrord/operator/src/crd.rs
+++ b/mirrord/operator/src/crd.rs
@@ -625,6 +625,12 @@ pub enum NewOperatorFeature {
     /// run the branch with the default image.
     DbBranchCustomImage,
 
+    /// This operator exposes a no-session ping endpoint used by `mirrord diagnose latency` to
+    /// measure client-to-operator latency without starting a session or spawning an agent.
+    /// Advertised so the CLI can use the lightweight probe instead of creating a full targetless
+    /// session just to run ping/pong.
+    DiagnosticPing,
+
     /// This variant is what a client sees when the operator includes a feature the client is not
     /// yet aware of, because it was introduced in a version newer than the client's.
     #[schemars(skip)]
@@ -675,6 +681,7 @@ impl Display for NewOperatorFeature {
             NewOperatorFeature::GenericDbBranching => "generic db branching",
             NewOperatorFeature::CopyTargetFilterIsolation => "copy target filter isolation",
             NewOperatorFeature::DbBranchCustomImage => "custom db branch image",
+            NewOperatorFeature::DiagnosticPing => "diagnostic ping",
             NewOperatorFeature::Unknown => "unknown feature",
         };
         f.write_str(name)


### PR DESCRIPTION
<!-- Thank you for contributing to mirrord! -->
<!-- Please use the checklist below as a guide for docs, tests and admin tasks for your PR -->
<!-- Feel free to ~strikethrough~ any items that you don't think apply -->

Change the `mirrord diagnose latency` command to use the operator's new ping endpoint if the operator supports it. This avoid creating any mirrord session or spawning any agent. The client ping message reaches the operator's endpoint which respond with daemon pong until disconnection. The OSS path is unchanged, meaning if an operator is not available, it fallbacks to the previous code path. If the user's operator does not support the new ping endpoint, CLI fallback too.

### Quality Checklist:

- [x] I have documented new code sufficiently
- [x] I have checked and updated the relevant existing docs in code, including removing outdated material
- [ ] I have written user-facing website docs for new features, or opened a (sub)issue to do so
- [ ] I have checked and updated existing website docs for changed features
- [x] I have tested this change and know it succeeds and fails as expected
- [ ] I have written unit tests or purposefully omitted them
- [ ] I have written e2e tests or purposefully omitted them
- [x] I have explained what this PR introduces and why, and linked to relevant context (e.g. linear issues, related PRs,
  documentation)
- [x] I have introduced a short, clear and well-formatted changelog entry

<!-- need help with the changelog? see ../CONTRIBUTING.md#submitting-a-pull-request -->
<!-- Add more details of your changes below if needed -->