### PR TITLE
monitor: report frontend errors with stack traces, stop chaos-load alert flood

### DIFF
--- a/changelog.d/+monitor-error-observability.internal.md
+++ b/changelog.d/+monitor-error-observability.internal.md
@@ -1,0 +1,1 @@
+`mirrord ui` now reports frontend errors to error tracking with stack traces, and no longer re-reports a chaos-rule load failure on every poll once a session has ended.

--- a/packages/monitor/src/analytics.ts
+++ b/packages/monitor/src/analytics.ts
@@ -88,6 +88,7 @@ export function emitUserBlocked(
   reason: string,
   kind: EventKind,
   properties: Record<string, unknown> = {},
+  error?: unknown,
 ): void {
   trackEvent('monitor_user_blocked', {
     reason,
@@ -95,6 +96,14 @@ export function emitUserBlocked(
     surface: 'monitor',
     ...properties,
   })
+  if (error !== undefined && initialized) {
+    posthog.captureException(error, {
+      reason,
+      kind,
+      surface: 'monitor',
+      ...properties,
+    })
+  }
 }
 
 export function emitUserSucceeded(

--- a/packages/monitor/src/api.ts
+++ b/packages/monitor/src/api.ts
@@ -157,7 +157,10 @@ export const api = {
     const r = await fetch(withToken(chaosRulesPath(sessionId)), {
       credentials: 'include',
     })
-    if (!r.ok) throw new Error(await chaosErrorMessage(r))
+    if (!r.ok) {
+      if (r.status === HTTP_NOT_FOUND) return []
+      throw new Error(await chaosErrorMessage(r))
+    }
     return (await r.json()) as ChaosRule[]
   },
 

--- a/packages/monitor/src/components/ErrorBoundary.tsx
+++ b/packages/monitor/src/components/ErrorBoundary.tsx
@@ -22,11 +22,16 @@ export class ErrorBoundary extends Component<Props, State> {
   }
 
   override componentDidCatch(error: Error, info: ErrorInfo): void {
-    emitUserBlocked('ui_crashed', 'user_action', {
-      error: error.message,
-      component: this.props.component,
-      stack: info.componentStack?.slice(0, STACK_TRACE_MAX_LEN),
-    })
+    emitUserBlocked(
+      'ui_crashed',
+      'user_action',
+      {
+        error: error.message,
+        component: this.props.component,
+        stack: info.componentStack?.slice(0, STACK_TRACE_MAX_LEN),
+      },
+      error,
+    )
   }
 
   override render(): ReactNode {

--- a/packages/monitor/src/hooks/useChaosRules.ts
+++ b/packages/monitor/src/hooks/useChaosRules.ts
@@ -109,6 +109,7 @@ export function useChaosRules(sessionId: string): UseChaosRules {
   // Poll results fetched before the latest mutation are stale — bumping this
   // sequence on every mutation lets an in-flight merge detect and drop itself.
   const mutationSeq = useRef(0)
+  const loadErrorRef = useRef(false)
   const rulesRef = useRef(rules)
   rulesRef.current = rules
 
@@ -126,12 +127,21 @@ export function useChaosRules(sessionId: string): UseChaosRules {
     try {
       serverRules = await api.listChaosRules(sessionId)
       setLoadError(false)
+      loadErrorRef.current = false
     } catch (err) {
       setLoadError(true)
-      emitUserBlocked('chaos_rules_load_failed', 'user_action', {
-        session_id: sessionId,
-        error: err instanceof Error ? err.message : String(err),
-      })
+      if (!loadErrorRef.current) {
+        loadErrorRef.current = true
+        emitUserBlocked(
+          'chaos_rules_load_failed',
+          'user_action',
+          {
+            session_id: sessionId,
+            error: err instanceof Error ? err.message : String(err),
+          },
+          err,
+        )
+      }
       return
     }
     if (seq !== mutationSeq.current) return
@@ -171,6 +181,7 @@ export function useChaosRules(sessionId: string): UseChaosRules {
   useEffect(() => {
     setRules([])
     setLoadError(false)
+    loadErrorRef.current = false
     void poll()
     const interval = setInterval(() => void poll(), POLL_INTERVAL_MS)
     return () => clearInterval(interval)

--- a/packages/monitor/src/index.tsx
+++ b/packages/monitor/src/index.tsx
@@ -17,10 +17,15 @@ function bootstrapOnce(): void {
   bootstrapped = true
 
   window.addEventListener('error', (event: ErrorEvent) => {
-    emitUserBlocked('unhandled_error', 'health', {
-      error: event.message,
-      source: 'error',
-    })
+    emitUserBlocked(
+      'unhandled_error',
+      'health',
+      {
+        error: event.message,
+        source: 'error',
+      },
+      event.error,
+    )
   })
 
   window.addEventListener(
@@ -33,10 +38,15 @@ function bootstrapOnce(): void {
           : typeof reason === 'string'
             ? reason
             : 'unknown rejection'
-      emitUserBlocked('unhandled_error', 'health', {
-        error,
-        source: 'unhandledrejection',
-      })
+      emitUserBlocked(
+        'unhandled_error',
+        'health',
+        {
+          error,
+          source: 'unhandledrejection',
+        },
+        reason,
+      )
     },
   )
 


### PR DESCRIPTION
## Summary

The `mirrord ui` session monitor recorded frontend failures as plain analytics events carrying only a `reason` and an error message string. No stack trace was captured, so these errors could not be grouped or debugged in error tracking. On top of that, a chaos-rule load failure was re-reported on **every** 2.5s poll, so a single ended session produced a continuous stream of duplicate telemetry.

This PR:

- **Captures stack traces.** Real errors are now routed through `posthog.captureException` at every monitor error site — unhandled window errors, unhandled promise rejections, the React crash boundary, and chaos-rule load failures — so they land in error tracking with a stack, alongside the existing `monitor_user_blocked` analytics events (which are unchanged, so usage metrics keep working). `emitUserBlocked` gains an optional raw-error argument for this.
- **Stops the alert flood.** `listChaosRules` now treats a `404` as a benign "session ended" (matching `getSession`) and returns an empty list instead of throwing, and the poll loop reports a load failure **at most once per failure episode** instead of once per poll.

Stack traces are minified until source-map upload is wired into the monitor build (separate follow-up).

## Test plan

- [x] `pnpm run typecheck`, `pnpm run lint`, `pnpm run format:check` all green
- [x] Exercised the real `api` / `emitUserBlocked` / `useChaosRules` modules in a browser against mocked responses:
  - [x] A persistent `404` (session ended) → **0** `monitor_user_blocked` events and **0** captured exceptions across multiple poll cycles (was: one per poll)
  - [x] A persistent non-`404` error → **exactly one** `monitor_user_blocked` event **plus one captured exception carrying a stack trace**, across multiple poll cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)
