### PR TITLE
preview: don't delete sessions that failed during startup

### DIFF
--- a/changelog.d/+preview-startup-deletion.changed.md
+++ b/changelog.d/+preview-startup-deletion.changed.md
@@ -1,0 +1,1 @@
+Preview sessions that fail to start are no longer immediately deleted, to allow further inspection of why they failed.

--- a/mirrord/cli/src/preview.rs
+++ b/mirrord/cli/src/preview.rs
@@ -379,16 +379,6 @@ async fn preview_start(
                                 }
                                 PreviewSessionPhase::Failed => {
                                     let failure_message = status.failure_message.clone().expect("Failed session must have failure_message");
-                                    // Sessions that fail to spawn should not be retained —
-                                    // delete the CRD so the operator can clean up and the
-                                    // user can retry without stale resources blocking them.
-                                    if let Err(err) = delete::delete_and_finalize(api, &session.name_any(), &DeleteParams::default()).await {
-                                        subtask.warning(&format!(
-                                            "failed to delete failed session '{}': {err}, \
-                                             you may need to delete it manually or with `mirrord preview stop`",
-                                            session.name_any(),
-                                        ));
-                                    }
                                     subtask.failure(None);
                                     return Err(CliError::PreviewSessionFailed(failure_message));
                                 }


### PR DESCRIPTION
# Summary

Preview sessions that have failed during startup, before becoming ready, are currently immediately deleted by the CLI. This was done for two reasons:

- Failed sessions used to stick around indefinitely (but with no pods) until being manually stopped; this was changed in <https://github.com/metalbear-co/operator/pull/1527> - failed sessions are now automatically cleaned up after 15mins.
- Starting a session using the same target and key as an existing session required the `--force` flag (even if the existing session was failed); this was changed in <https://github.com/metalbear-co/mirrord/pull/4518> - starting a session replaces the existing session by default.

Essentially, the idea behind the current behavior was to not allow a failed session to prevent starting a new session, but because of the two changes mentioned above that's not really a concern anymore and, in the worst case scenario, we have a harder time debugging why a session isn't starting because we don't have easy access to it's logs/status anymore.
