### PR TITLE
ci: pass matrix target to Clippy

### DIFF
--- a/.github/workflows/check-lint.yaml
+++ b/.github/workflows/check-lint.yaml
@@ -161,7 +161,7 @@ jobs:
         run: cargo fmt --all -- --check
       - if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}
         run: cargo check -p mirrord-operator --features crd --target ${{ matrix.target }}
-      - run: cargo clippy --all-targets --all-features -- "-Wclippy::indexing_slicing" -D warnings
+      - run: cargo clippy --all-targets --all-features --target ${{ matrix.target }} -- "-Wclippy::indexing_slicing" -D warnings
   shear:
     if: ${{ inputs.run_rust }}
     name: 'cargo shear'

--- a/changelog.d/+clippy-matrix-target.internal.md
+++ b/changelog.d/+clippy-matrix-target.internal.md
@@ -1,0 +1,1 @@
+Run Clippy against each target selected by the CI matrix.


### PR DESCRIPTION
The lint matrix declares and installs multiple different rust targets, but doesn't pass `--target` to clippy. Cargo therefore uses the runner host target. So we check the same the arch target in the [x86_64 job](https://github.com/metalbear-co/mirrord/actions/runs/29751915140/job/88384404135#step:10:1) and [aarch64 job](https://github.com/metalbear-co/mirrord/actions/runs/29751915140/job/88384404232#step:10:1), instead of running clippy on two archs, as probably intended.

## Fix

Pass the matrix target to Clippy. Each job now lints its declared target. The target argument was previously removed in [this commit](https://github.com/metalbear-co/mirrord/commit/bf421d964e777bdd7b97f4e9d99e48608823a45a#diff-8a025d062b2b1ed8d6f6bf798e774c9f10ab9c085506caee01748ee3feab1d21L52), probably not intentionally.
