### PR TITLE
fix(wizard): render the mirrord wordmark the same way in both themes

### DIFF
--- a/changelog.d/+wizard-dark-mode-logo.fixed.md
+++ b/changelog.d/+wizard-dark-mode-logo.fixed.md
@@ -1,0 +1,1 @@
+Made the mirrord wordmark on the config wizard homepage render identically in both themes, on its own periwinkle chip, instead of only getting the chip in dark mode.

--- a/changelog.d/+wizard-dark-mode-logo.fixed.md
+++ b/changelog.d/+wizard-dark-mode-logo.fixed.md
@@ -1,1 +1,1 @@
-Made the mirrord wordmark on the config wizard homepage render identically in both themes, on its own periwinkle chip, instead of only getting the chip in dark mode.
+Made the mirrord logo on the config wizard homepage render identically in both themes, on its own periwinkle chip, instead of only getting the chip in dark mode.

--- a/packages/wizard/src/components/Homepage.tsx
+++ b/packages/wizard/src/components/Homepage.tsx
@@ -29,7 +29,7 @@ const Homepage = () => {
         <CardContent className="px-8 pb-8 pt-10">
           {/* Logo */}
           <div className="mb-8 flex justify-center">
-            <div className="bg-primary/5 border-primary/10 rounded-2xl border p-4 dark:bg-[#E4E3FD]">
+            <div className="border-primary/10 rounded-2xl border bg-[#E4E3FD] p-4">
               <img src={MirrordLogo} alt="mirrord" className="h-12" />
             </div>
           </div>


### PR DESCRIPTION
## Summary

The config wizard homepage wordmark only got its periwinkle chip in dark mode (`dark:bg-[#E4E3FD]`), so the lockup changed shape between themes. This applies the chip unconditionally, so the mark renders identically in both themes with one asset and one treatment, no theme swap.

```diff
-<div className="bg-primary/5 border-primary/10 rounded-2xl border p-4 dark:bg-[#E4E3FD]">
+<div className="border-primary/10 rounded-2xl border bg-[#E4E3FD] p-4">
```

**Scope, to be precise:** dark mode is byte-identical before and after, since `dark:bg-[#E4E3FD]` already resolved to the same chip. The only rendering change is in **light** mode, where the chip goes from the near-invisible `bg-primary/5` tint to the solid periwinkle. This is a consistency change, not a dark-mode fix.

Relates to PRO-132. Paired with metalbear-co/ui#33, which removes the white logo variants from the kit so a per-theme mirrord mark isn't reachable in the first place.

## Test plan

- Ran `mirrord ui` locally (`packages/ui`, `pnpm dev`) and checked the Config Wizard tab in both themes.
- Dark mode: unchanged, wordmark on the periwinkle chip.
- Light mode: same lockup as dark, chip now solid periwinkle.
- `pnpm --filter mirrord-ui typecheck` passes.
- `pnpm --filter mirrord-ui lint` passes.
- `pnpm --filter mirrord-wizard format:check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)