### PR TITLE
docs(agents): require local verification before opening a PR

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,25 @@ cargo fmt
 cargo clippy --all-targets -- --deny warnings
 ```
 
+## Verify Locally Before Opening a PR
+
+Run the change before you propose it. A clean `cargo check`, `clippy`, or `tsc` proves the code
+compiles, not that it works: those gates pass just as happily on a feature that silently does
+nothing. Before opening a PR, exercise the actual behavior you changed.
+
+- Rust: build it (`cargo xtask build-cli` / `build-layer`) and run the relevant `cargo xtask
+  test-ut` or `test-integration` tests, not only `cargo check`.
+- Frontend (`packages/*`): `pnpm --filter <pkg> typecheck && lint && format:check`, then
+  `pnpm --filter mirrord-ui build` and load the built bundle in a browser. A stub HTTP server
+  standing in for the session API is enough to exercise most UI paths without a cluster.
+- Behavior you cannot reach locally (needs a cluster, a customer setup, a released binary): say so
+  explicitly in the PR body and describe what you did check.
+
+State in the test plan what you actually ran and what you observed. Never describe a check you
+did not perform, and never present something you reasoned about as something you verified. If you
+concluded it from reading code or docs rather than running it, write it that way. CI is a backstop
+against mistakes, not a substitute for having tried your own change.
+
 ## Simplicity and Reuse
 
 mirrord is actively maintained by dozens of people, it is not a greenfield project. When adding or changing things,


### PR DESCRIPTION
## Summary

`AGENTS.md` tells contributors how to compile, lint, and format, but never says to actually run the change before proposing it. That gap is easy to fall into: `cargo check` and `tsc` pass just as happily on a change that silently does nothing, so "it builds" reads like "it works" and CI becomes the first thing that ever exercises the code.

This adds a "Verify Locally Before Opening a PR" section with the per-language expectation (run the tests and the binary, not just the type checker; build the frontend and load it in a browser), guidance for behavior that genuinely cannot be reached locally, and one reporting rule: describe only checks you actually ran, and do not present something you reasoned about as something you verified.

Docs only, no code changes.

## Test plan

- `vale AGENTS.md` reports 0 errors on the edited file (the remaining warnings and suggestions are pre-existing, on untouched lines).
- Rendered the section to confirm the list and heading structure match the rest of the file.
- `CLAUDE.md` is a symlink to `AGENTS.md`, so it picks this up with no separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
