### PR TITLE
feat(cli): end mirrord exec output with a rotating command tip

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4907,6 +4907,7 @@ dependencies = [
  "ci_info",
  "clap",
  "clap_complete",
+ "console 0.16.4",
  "const-random",
  "dll-syringe",
  "dotenvy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,6 +135,7 @@ httparse = "1"
 humantime = "2"
 hyper = { version = "1.10", features = ["full"] }
 hyper-util = { version = "0.1" }
+console = "0.16"
 indicatif = "0.18"
 inquire = "0.9.4"
 ipnet = { version = "2.8", features = ["serde"] }

--- a/changelog.d/+exec-command-tips.added.md
+++ b/changelog.d/+exec-command-tips.added.md
@@ -1,0 +1,1 @@
+`mirrord exec` now ends its output with a rotating tip pointing at other mirrord commands (`mirrord ui`, `mirrord wizard`, `mirrord dump`, and more), shown in orange right before the process starts.

--- a/mirrord/cli/Cargo.toml
+++ b/mirrord/cli/Cargo.toml
@@ -36,6 +36,7 @@ mirrord-auth = { path = "../auth" }
 
 actix-codec.workspace = true
 clap.workspace = true
+console.workspace = true
 dotenvy.workspace = true
 tracing.workspace = true
 serde_json.workspace = true

--- a/mirrord/cli/src/main.rs
+++ b/mirrord/cli/src/main.rs
@@ -345,6 +345,7 @@ mod queue_splitting;
 mod queues;
 mod subscribe;
 mod teams;
+mod tips;
 mod up;
 mod user_data;
 mod util;
@@ -376,6 +377,7 @@ use crate::{
     config::ci::{CiArgs, CiCommand, CiCommonArgs, CiStartArgs},
     newsletter::suggest_newsletter_signup,
     queue_splitting::suggest_queue_splitting,
+    tips::suggest_command_tip,
     user_data::UserData,
     util::{apply_test_env_overrides, get_user_git_branch},
 };
@@ -494,6 +496,12 @@ where
         execution_info.uses_operator,
         &mut sub_progress,
     )?;
+
+    // Surface another mirrord command as the last line before the process starts; skipped for
+    // CI runs, where nobody is reading interactively.
+    if mirrord_for_ci.is_none() {
+        suggest_command_tip(user_data, &mut sub_progress);
+    }
 
     run_process_with_mirrord(
         binary,

--- a/mirrord/cli/src/tips.rs
+++ b/mirrord/cli/src/tips.rs
@@ -1,0 +1,75 @@
+//! A rotating tip printed at the end of `mirrord exec` output, pointing users at other
+//! mirrord commands they may not know about.
+//!
+//! `mirrord exec` replaces the CLI process with the user's binary, so the tip is added to the
+//! print buffer of the final progress task and flushes right after the "Ready!" line, making it
+//! the last thing mirrord prints before the user's application takes over.
+
+use console::Style;
+use mirrord_progress::Progress;
+
+use crate::user_data::UserData;
+
+/// Commands advertised at the end of a `mirrord exec` run, as `(command, what it does)`.
+const COMMAND_TIPS: &[(&str, &str)] = &[
+    (
+        "mirrord ui",
+        "watch your mirrord sessions live in the browser",
+    ),
+    (
+        "mirrord wizard",
+        "build a mirrord config interactively instead of by hand",
+    ),
+    (
+        "mirrord dump",
+        "print a target's incoming traffic without running any app",
+    ),
+    (
+        "mirrord port-forward",
+        "reach hosts inside the cluster from local ports",
+    ),
+    (
+        "mirrord diagnose latency",
+        "measure the latency between your machine and the cluster",
+    ),
+];
+
+/// ANSI 256-color for the tip line: an orange that stands out from the rest of the output,
+/// in the style of tips printed by other developer CLIs.
+const TIP_COLOR: u8 = 209;
+
+/// Picks the tip for this run, rotating through [`COMMAND_TIPS`] with the session count so
+/// consecutive runs surface different commands.
+fn tip_for_session(session_count: u32) -> (&'static str, &'static str) {
+    COMMAND_TIPS[session_count as usize % COMMAND_TIPS.len()]
+}
+
+/// Adds a one-line command tip to the progress print buffer, so it is printed as the last
+/// mirrord line before the user's process starts.
+///
+/// [`Progress::add_to_print_buffer`] is a no-op outside of the interactive spinner mode, so
+/// IDE (json) and simple progress outputs are unaffected. [`Style::for_stdout`] strips the
+/// color when stdout is not a terminal.
+pub fn suggest_command_tip<P: Progress>(user_data: &UserData, progress: &mut P) {
+    let (command, description) = tip_for_session(user_data.session_count());
+    let line = format!(">> Try `{command}`: {description}");
+    let styled = Style::new().color256(TIP_COLOR).for_stdout().apply_to(line);
+    progress.add_to_print_buffer(&format!("\n{styled}"));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rotates_through_every_tip() {
+        let count = COMMAND_TIPS.len() as u32;
+        let mut seen = (0..count)
+            .map(|session| tip_for_session(session).0)
+            .collect::<Vec<_>>();
+        seen.sort_unstable();
+        seen.dedup();
+        assert_eq!(seen.len(), COMMAND_TIPS.len());
+        assert_eq!(tip_for_session(0), tip_for_session(count));
+    }
+}

--- a/mirrord/cli/src/user_data.rs
+++ b/mirrord/cli/src/user_data.rs
@@ -143,6 +143,11 @@ impl UserData {
         self.is_returning_wizard
     }
 
+    /// The number of mirrord runs recorded for this user so far.
+    pub(crate) fn session_count(&self) -> u32 {
+        self.session_count
+    }
+
     pub(crate) fn machine_id(&self) -> Uuid {
         self.machine_id
     }


### PR DESCRIPTION
## Summary

mirrord has grown a lot of commands users never discover. `mirrord exec` now prints one orange tip line as the very last mirrord output, right after `Ready!` and immediately before the user's process takes over:

```
✓ Ready!
>> Try `mirrord ui`: watch your mirrord sessions live in the browser
```

- Rotates through five commands (`mirrord ui`, `mirrord wizard`, `mirrord dump`, `mirrord port-forward`, `mirrord diagnose latency`) using the stored session count, so consecutive runs surface different commands instead of repeating one.
- Rendered via `console::Style::color256(209).for_stdout()`, so the color is stripped automatically when stdout is not a terminal.
- Delivered through `Progress::add_to_print_buffer`, which only the interactive `SpinnerProgress` implements: IDE (json) and simple progress output are untouched, so extension output parsing cannot break. CI runs (`mirrord_for_ci`) are skipped explicitly.
- `mirrord exec` replaces the CLI process with the user's binary, so "the end of the run" for the CLI is the moment before `execve`; the tip is the last line mirrord ever prints.

New `console` workspace dependency resolves to 0.16.4, which was already in the tree via indicatif, so no new transitive code is pulled in.

## Test plan

- `cargo check -p mirrord`, `cargo clippy -p mirrord --all-targets -- --deny warnings`, `cargo fmt` all clean.
- New unit test covers the rotation (every tip is reachable, wraps around).
- Built with `cargo xtask build-cli` and ran a full `mirrord exec --target targetless` session against a local docker-desktop cluster (agent pod created, layer injected, app ran):
  - The tip prints in orange (`38;5;209`) after `✓ Ready!` and before the app's stdout.
  - A second run printed the next tip in the rotation, confirming the session-count rotation end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)