### PR TITLE
honour MIRRORD_KUBECONFIG in mirrord ui and wizard

### DIFF
--- a/changelog.d/+ui-mirrord-kubeconfig.fixed.md
+++ b/changelog.d/+ui-mirrord-kubeconfig.fixed.md
@@ -1,0 +1,1 @@
+`mirrord ui` and `mirrord wizard` now honour the `MIRRORD_KUBECONFIG` environment variable when reading the kubeconfig, matching the rest of the CLI. Users with a kubeconfig outside the default chain can now point the wizard at it the same way they do for `mirrord exec`.

--- a/mirrord/cli/src/ui/error.rs
+++ b/mirrord/cli/src/ui/error.rs
@@ -4,7 +4,6 @@ use axum::{
     http::StatusCode,
     response::{IntoResponse, Response},
 };
-use kube::config::KubeconfigError;
 use mirrord_kube::error::KubeApiError;
 use thiserror::Error;
 
@@ -15,16 +14,16 @@ use thiserror::Error;
 /// to the cluster's API server is `502`.
 #[derive(Debug, Error)]
 pub(super) enum ApiError {
-    /// Reading the merged kubeconfig (honouring `KUBECONFIG`) failed.
+    /// Reading the merged kubeconfig (honouring `MIRRORD_KUBECONFIG` and `KUBECONFIG`) failed.
     #[error("failed to read kubeconfig: {0}")]
-    ReadKubeconfig(#[source] KubeconfigError),
+    ReadKubeconfig(#[source] KubeApiError),
 
     /// Loading the requested context from the kubeconfig failed, e.g. the context does not exist.
     #[error("failed to load context {context:?}: {source}")]
     LoadContext {
         context: String,
         #[source]
-        source: KubeconfigError,
+        source: Box<KubeApiError>,
     },
 
     /// Building the kube client from the resolved config failed.

--- a/mirrord/cli/src/ui/server.rs
+++ b/mirrord/cli/src/ui/server.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use std::{
     collections::{BTreeMap, HashMap, hash_map::Entry},
     convert::Infallible,
+    ffi::OsString,
     str::FromStr,
     sync::Arc,
     time::{Duration, SystemTime, UNIX_EPOCH},
@@ -28,9 +29,13 @@ use k8s_openapi::{
 use kube::{
     Api, Client,
     api::{ListParams, PostParams},
-    config::{Config, KubeConfigOptions, Kubeconfig},
+    config::Kubeconfig,
 };
 use mirrord_config::target::{Target, TargetDisplay};
+use mirrord_kube::{
+    api::kubernetes::{create_kube_config, merge_kubeconfig_paths},
+    error::KubeApiError,
+};
 use mirrord_operator::crd::{MirrordOperatorCrd, OPERATOR_STATUS_NAME, Session, SessionHttpFilter};
 use mirrord_session_monitor_client::{
     SESSION_SENTINEL_EXTENSION, SessionClient, SessionEndpoint, connect_to_session,
@@ -569,7 +574,7 @@ async fn auth_token(State(state): State<AppState>) -> axum::Json<TokenResponse> 
 }
 
 async fn current_user() -> axum::Json<CurrentUserResponse> {
-    let client = match Client::try_default().await {
+    let client = match client_for_context(None).await {
         Ok(c) => c,
         Err(err) => {
             return axum::Json(CurrentUserResponse {
@@ -608,10 +613,10 @@ struct ContextsResponse {
 }
 
 /// Lists the kube contexts available in the user's kubeconfig, along with the one currently
-/// selected. Read straight from the merged kubeconfig files (honouring `KUBECONFIG`) — this touches
-/// no cluster, so it works even when no cluster is reachable.
+/// selected. Read straight from the merged kubeconfig files (honouring `MIRRORD_KUBECONFIG` and
+/// `KUBECONFIG`) — this touches no cluster, so it works even when no cluster is reachable.
 async fn list_contexts() -> UiResult<axum::Json<ContextsResponse>> {
-    let kubeconfig = Kubeconfig::read().map_err(ApiError::ReadKubeconfig)?;
+    let kubeconfig = read_kubeconfig()?;
     Ok(axum::Json(ContextsResponse {
         contexts: kubeconfig
             .contexts
@@ -635,25 +640,38 @@ struct NamespacesResponse {
     context: Option<String>,
 }
 
-/// Builds a kube client for the given context, or for the kubeconfig's current context when
-/// `context` is `None`.
-pub(super) async fn client_for_context(context: Option<&str>) -> UiResult<Client> {
-    match context {
-        Some(context) => {
-            let options = KubeConfigOptions {
-                context: Some(context.to_owned()),
-                ..Default::default()
-            };
-            let config = Config::from_kubeconfig(&options).await.map_err(|source| {
-                ApiError::LoadContext {
-                    context: context.to_owned(),
-                    source,
-                }
-            })?;
-            Ok(Client::try_from(config)?)
-        }
-        None => Ok(Client::try_default().await?),
+/// The kubeconfig path override from `MIRRORD_KUBECONFIG`, the env var the rest of the CLI honours
+/// via the `kubeconfig` config option. The `mirrord ui` server takes no config file, so the env
+/// var is the only way to point it at a kubeconfig outside the default chain.
+fn kubeconfig_override() -> Option<OsString> {
+    std::env::var_os("MIRRORD_KUBECONFIG").filter(|path| !path.is_empty())
+}
+
+/// Reads the merged kubeconfig: the `MIRRORD_KUBECONFIG` paths when set, the default chain
+/// (`KUBECONFIG`, `~/.kube/config`) otherwise.
+pub(super) fn read_kubeconfig() -> Result<Kubeconfig, ApiError> {
+    match merge_kubeconfig_paths(kubeconfig_override()).map_err(ApiError::ReadKubeconfig)? {
+        Some(kubeconfig) => Ok(kubeconfig),
+        None => Kubeconfig::read()
+            .map_err(KubeApiError::from)
+            .map_err(ApiError::ReadKubeconfig),
     }
+}
+
+/// Builds a kube client for the given context, or for the kubeconfig's current context when
+/// `context` is `None`. The kubeconfig is resolved like in every other mirrord command:
+/// `MIRRORD_KUBECONFIG` when set, the default chain otherwise.
+pub(super) async fn client_for_context(context: Option<&str>) -> UiResult<Client> {
+    let config = create_kube_config(None, kubeconfig_override(), context.map(str::to_owned))
+        .await
+        .map_err(|source| match context {
+            Some(context) => ApiError::LoadContext {
+                context: context.to_owned(),
+                source: Box::new(source),
+            },
+            None => ApiError::ReadKubeconfig(source),
+        })?;
+    Ok(Client::try_from(config)?)
 }
 
 /// Lists the namespaces visible to the user in the requested context (or the current context when
@@ -893,7 +911,7 @@ pub(crate) fn start_filesystem_watcher(
 
 pub(crate) fn start_operator_watcher(state: AppState) {
     tokio::spawn(async move {
-        let client = match Client::try_default().await {
+        let client = match client_for_context(None).await {
             Ok(client) => client,
             Err(err) => {
                 let reason = format!("kube client init failed: {err}");

--- a/mirrord/cli/src/ui/server/v2.rs
+++ b/mirrord/cli/src/ui/server/v2.rs
@@ -28,7 +28,6 @@ use k8s_openapi::api::{authentication::v1::SelfSubjectReview, core::v1::Namespac
 use kube::{
     Api, Client,
     api::{ListParams, PostParams},
-    config::Kubeconfig,
 };
 use mirrord_operator::crd::{MirrordOperatorCrd, OPERATOR_STATUS_NAME, SessionHttpFilter};
 use serde::{Deserialize, Serialize};
@@ -37,7 +36,7 @@ use tracing::warn;
 use super::{
     AppState, OperatorLicense, OperatorLockedPort, OperatorQueueSplits, OperatorSessionOwner,
     OperatorSessionSummary, OperatorSessionTarget, UiResult, client_for_context, get_session,
-    kill_session, list_sessions, session_events_sse,
+    kill_session, list_sessions, read_kubeconfig, session_events_sse,
 };
 use crate::ui::error::ApiError;
 
@@ -266,10 +265,11 @@ struct ContextEntry {
     namespace: Option<String>,
 }
 
-/// Lists kube contexts and each one's default namespace, straight from the merged kubeconfig — no
-/// cluster access, so it works even when no cluster is reachable.
+/// Lists kube contexts and each one's default namespace, straight from the merged kubeconfig
+/// (honouring `MIRRORD_KUBECONFIG` and `KUBECONFIG`) — no cluster access, so it works even when no
+/// cluster is reachable.
 async fn kube_contexts() -> UiResult<axum::Json<ContextsResponse>> {
-    let kubeconfig = Kubeconfig::read().map_err(ApiError::ReadKubeconfig)?;
+    let kubeconfig = read_kubeconfig()?;
     let contexts = kubeconfig
         .contexts
         .iter()

--- a/mirrord/kube/src/api/kubernetes.rs
+++ b/mirrord/kube/src/api/kubernetes.rs
@@ -370,29 +370,7 @@ where
         ..Default::default()
     };
 
-    // parse kubeconfig the same way as KUBECONFIG is parsed by `kube-client`, supporting
-    // colon-separated lists of paths. Borrowed affectionately & with love from
-    // https://docs.rs/kube/latest/kube/config/struct.Kubeconfig.html#method.from_env
-    let mut config = if let Some(kubeconfig) = kubeconfig
-        && let paths = std::env::split_paths(&kubeconfig)
-            .filter_map(|p| {
-                let path_str = p.as_os_str().to_string_lossy().into_owned();
-                path_str.is_empty().not().then_some(path_str)
-            })
-            .collect::<Vec<_>>()
-        && paths.is_empty().not()
-    {
-        let parsed_kube_config =
-            paths
-                .iter()
-                .try_fold(Kubeconfig::default(), |merged_kubeconfig, path_str| {
-                    let expanded = shellexpand::full(&path_str)
-                        .map_err(|e| KubeApiError::ConfigPathExpansionError(e.to_string()))?;
-
-                    Kubeconfig::read_from(expanded.deref())
-                        .and_then(|config| merged_kubeconfig.merge(config))
-                        .map_err(KubeApiError::from)
-                })?;
+    let mut config = if let Some(parsed_kube_config) = merge_kubeconfig_paths(kubeconfig)? {
         Config::from_custom_kubeconfig(parsed_kube_config, &kube_config_opts).await?
     } else if kube_config_opts.context.is_some() {
         // if context is set, it's not in cluster so it has to be a kubeconfig.
@@ -410,6 +388,45 @@ where
     Ok(config)
 }
 
+/// Reads and merges the kubeconfig files at the given path, which is parsed the same way as
+/// `KUBECONFIG` is parsed by `kube-client`, supporting colon-separated lists of paths. Borrowed
+/// affectionately & with love from
+/// https://docs.rs/kube/latest/kube/config/struct.Kubeconfig.html#method.from_env
+///
+/// Returns [`None`] when no path is given (or the given path is empty), letting callers fall back
+/// to the default kubeconfig chain (`KUBECONFIG`, `~/.kube/config`, in-cluster).
+pub fn merge_kubeconfig_paths<P>(kubeconfig: Option<P>) -> Result<Option<Kubeconfig>>
+where
+    P: AsRef<OsStr>,
+{
+    let Some(kubeconfig) = kubeconfig else {
+        return Ok(None);
+    };
+
+    let paths = std::env::split_paths(&kubeconfig)
+        .filter_map(|p| {
+            let path_str = p.as_os_str().to_string_lossy().into_owned();
+            path_str.is_empty().not().then_some(path_str)
+        })
+        .collect::<Vec<_>>();
+
+    if paths.is_empty() {
+        return Ok(None);
+    }
+
+    paths
+        .iter()
+        .try_fold(Kubeconfig::default(), |merged_kubeconfig, path_str| {
+            let expanded = shellexpand::full(path_str)
+                .map_err(|e| KubeApiError::ConfigPathExpansionError(e.to_string()))?;
+
+            Kubeconfig::read_from(expanded.deref())
+                .and_then(|config| merged_kubeconfig.merge(config))
+                .map_err(KubeApiError::from)
+        })
+        .map(Some)
+}
+
 #[tracing::instrument(level = "trace", skip(client))]
 pub fn get_k8s_resource_api<K>(client: &Client, namespace: Option<&str>) -> Api<K>
 where
@@ -420,5 +437,79 @@ where
         Api::namespaced(client.clone(), namespace)
     } else {
         Api::default_namespaced(client.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{fs, path::PathBuf};
+
+    use super::*;
+
+    fn write_kubeconfig(name: &str, context: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("mirrord-kube-test-{}", std::process::id()));
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join(name);
+        fs::write(
+            &path,
+            format!(
+                r#"apiVersion: v1
+kind: Config
+clusters:
+- name: {context}
+  cluster:
+    server: https://{context}.example
+contexts:
+- name: {context}
+  context:
+    cluster: {context}
+    user: {context}
+users:
+- name: {context}
+  user: {{}}
+current-context: {context}
+"#
+            ),
+        )
+        .unwrap();
+        path
+    }
+
+    #[test]
+    fn no_path_returns_none() {
+        assert!(merge_kubeconfig_paths::<&OsStr>(None).unwrap().is_none());
+    }
+
+    #[test]
+    fn empty_path_returns_none() {
+        assert!(merge_kubeconfig_paths(Some("")).unwrap().is_none());
+    }
+
+    #[test]
+    fn single_path_is_read() {
+        let path = write_kubeconfig("single.yaml", "ctx-single");
+        let kubeconfig = merge_kubeconfig_paths(Some(&path)).unwrap().unwrap();
+        assert_eq!(kubeconfig.current_context.as_deref(), Some("ctx-single"));
+        assert_eq!(kubeconfig.contexts.len(), 1);
+    }
+
+    #[test]
+    fn colon_separated_paths_are_merged() {
+        let first = write_kubeconfig("merged-first.yaml", "ctx-first");
+        let second = write_kubeconfig("merged-second.yaml", "ctx-second");
+        let joined = std::env::join_paths([&first, &second]).unwrap();
+        let kubeconfig = merge_kubeconfig_paths(Some(&joined)).unwrap().unwrap();
+        let names = kubeconfig
+            .contexts
+            .iter()
+            .map(|context| context.name.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(names, ["ctx-first", "ctx-second"]);
+        assert_eq!(kubeconfig.current_context.as_deref(), Some("ctx-first"));
+    }
+
+    #[test]
+    fn missing_path_errors() {
+        assert!(merge_kubeconfig_paths(Some("/nonexistent/mirrord-kubeconfig.yaml")).is_err());
     }
 }


### PR DESCRIPTION
## Summary

`mirrord ui` (and therefore `mirrord wizard`) resolved the kubeconfig only through the kube-rs default chain (`KUBECONFIG` env var, `~/.kube/config`, in-cluster). mirrord's own `kubeconfig` config option and its `MIRRORD_KUBECONFIG` env var, which every other command honours through `create_kube_config`, were silently ignored. A user whose kubeconfig lives outside the default chain gets a wizard that cannot see any contexts on first run, even though `MIRRORD_KUBECONFIG` is the documented way to point mirrord at such a kubeconfig (and `mirrord exec` etc. respect it).

Changes:
- extracted the KUBECONFIG-style path merging (colon-separated lists, shellexpand) from `create_kube_config` into a reusable `merge_kubeconfig_paths` in `mirrord-kube` (behaviour unchanged)
- the ui server's kubeconfig reads (context listing in v1 and v2) and kube client building (`client_for_context`, current-user, operator watcher) now resolve the kubeconfig the same way as the rest of the CLI: `MIRRORD_KUBECONFIG` when set, the default chain otherwise
- `ApiError` kubeconfig variants now wrap `KubeApiError` (boxed where clippy's `result_large_err` requires)

## Test plan

All of the below was run locally on this branch:

- `cargo fmt`, `cargo check -p mirrord-kube -p mirrord`, `cargo clippy -p mirrord-kube -p mirrord --all-targets -- --deny warnings`: clean
- new unit tests for `merge_kubeconfig_paths` (none/empty path, single file, colon-separated merge, missing file): 5/5 pass
- existing ui server tests (`cargo test -p mirrord ui::`): 28/28 pass
- end-to-end against the built debug binary with a sandboxed `$HOME` (no `~/.kube/config`) and a kubeconfig at a non-standard path:
  - without the fix conditions (no env vars set): `GET /api/v2/kube/contexts` returns `failed to read kubeconfig` (reproduces the first-run failure)
  - `MIRRORD_KUBECONFIG=<path> mirrord ui`: both `/api/contexts` and `/api/v2/kube/contexts` list the contexts from that file
  - `KUBECONFIG=<path>` (default chain): still works, unchanged
  - `GET /api/v2/kube/namespaces` (with and without `?context=`) attempts to connect to the server named in the override kubeconfig, confirming client building honours it too
- not exercised: a live cluster behind the override kubeconfig (the namespaces check used an unreachable test server, so it verifies resolution, not a full cluster round-trip)