### PR TITLE
COR-1690 Fix credential store save

### DIFF
--- a/changelog.d/+cred-wipe.fixed.md
+++ b/changelog.d/+cred-wipe.fixed.md
@@ -1,0 +1,2 @@
+Fixed a bug in `mirrord-auth` causing seat counting client key pair being re-generated when running
+a burst of mirrord sessions concurrently.

--- a/mirrord/auth/src/credential_store.rs
+++ b/mirrord/auth/src/credential_store.rs
@@ -90,6 +90,13 @@ impl CredentialStore {
             .write_all(buffer.as_bytes())
             .await
             .map_err(CredentialStoreError::FileAccess)?;
+        // `write_all` returns once all bytes are **queued** for writing, not once they reach the
+        // file. Flush before returning, so the write lands before the caller unlocks and another
+        // process can read the file.
+        writer
+            .flush()
+            .await
+            .map_err(CredentialStoreError::FileAccess)?;
 
         Ok(())
     }


### PR DESCRIPTION
<!-- Thank you for contributing to mirrord! -->
<!-- Please use the checklist below as a guide for docs, tests and admin tasks for your PR -->
<!-- Feel free to ~strikethrough~ any items that you don't think apply -->

In [`CredentialStoreSync::get_client_certificate`](https://github.com/metalbear-co/mirrord/blob/main/mirrord/auth/src/credential_store.rs#L299-L316), we lock the `~/.mirorrd/credentials` file, call [`CredentialStoreSync::access_credential`](https://github.com/metalbear-co/mirrord/blob/main/mirrord/auth/src/credential_store.rs#L235), and then unlock the file.

**Every call** to `CredentialStoreSync::access_credential` will load, wipe out, and then completely rewrite the `~/.mirrord/credentials` content.

The [`‎CredentialStore::save‎`](https://github.com/metalbear-co/mirrord/blob/main/mirrord/auth/src/credential_store.rs#L84), however, calls `write_all` only. Note that `write_all` returns immediately after all bytes are **queued** for writing. This opens a window where bytes are partially written, but the file is already unlocked, allowing another process starting a mirrord session in parallel to view a malformed `~/.mirrord/credentials` file, thus, triggering a re-generation of the client key pair.

This issue can cause unexpected seat count creep for users who runs many mirrord session in parallel, such as using a coding agent to run test suite.

The fix is just adding a flush after write_all, so we make sure all bytes land in the file before unlocking it.

### Quality Checklist:

- [x] I have documented new code sufficiently
- [x] I have checked and updated the relevant existing docs in code, including removing outdated material
- [ ] I have written user-facing website docs for new features, or opened a (sub)issue to do so
- [ ] I have checked and updated existing website docs for changed features
- [x] I have tested this change and know it succeeds and fails as expected
- [ ] I have written unit tests or purposefully omitted them
- [ ] I have written e2e tests or purposefully omitted them
- [x] I have explained what this PR introduces and why, and linked to relevant context (e.g. linear issues, related PRs,
  documentation)
- [x] I have introduced a short, clear and well-formatted changelog entry

<!-- need help with the changelog? see ../CONTRIBUTING.md#submitting-a-pull-request -->
<!-- Add more details of your changes below if needed -->