### PR TITLE
MBE-1971: Add scheduled e2e test run

### DIFF
--- a/.github/workflows/nightly-e2e.yaml
+++ b/.github/workflows/nightly-e2e.yaml
@@ -1,0 +1,68 @@
+name: Nightly E2E
+
+on:
+  schedule:
+    - cron: "0 2 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  # These jobs intentionally run concurrently. The E2E workflow builds the CLI and
+  # prepares its clusters before polling for the agent image artifact.
+  build-agent-image:
+    uses: ./.github/workflows/build-agent-image.yaml
+
+  e2e:
+    permissions:
+      contents: read
+      actions: read
+    uses: ./.github/workflows/test-e2e.yaml
+    secrets: inherit
+
+  nightly-e2e-success:
+    name: Nightly E2E
+    if: always()
+    needs: [build-agent-image, e2e]
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check required jobs passed
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          failing=$(echo "$NEEDS_JSON" | jq -r 'to_entries[] | select(.value.result != "success") | "\(.key): \(.value.result)"')
+          if [ -n "$failing" ]; then
+            echo "$failing"
+            exit 1
+          fi
+
+  notify-nightly-failure:
+    name: "Notify #ci-alerts"
+    if: ${{ always() && github.event_name == 'schedule' && needs.nightly-e2e-success.result == 'failure' }}
+    needs: [nightly-e2e-success]
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Send Slack notification
+        env:
+          SLACK_CI_ALERTS_WEBHOOK_URL: ${{ secrets.SLACK_CI_ALERTS_WEBHOOK_URL }}
+        shell: bash
+        run: |
+          if [ -z "$SLACK_CI_ALERTS_WEBHOOK_URL" ]; then
+            echo "SLACK_CI_ALERTS_WEBHOOK_URL is not set; cannot notify #ci-alerts."
+            exit 1
+          fi
+
+          run_url="https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+          text=":rotating_light: *Nightly E2E failed for \`$GITHUB_REPOSITORY\`*\n\
+          • *Branch:* \`$GITHUB_REF_NAME\`\n\
+          • *Commit:* \`$GITHUB_SHA\`\n\
+          • *Run:* <$run_url|Open GitHub Actions>"
+          payload=$(jq -Rn --arg text "$text" '{text: $text}')
+
+          curl --fail-with-body --silent --show-error \
+            -X POST \
+            -H 'Content-type: application/json' \
+            --data "$payload" \
+            "$SLACK_CI_ALERTS_WEBHOOK_URL"

--- a/changelog.d/+nightly-e2e.internal.md
+++ b/changelog.d/+nightly-e2e.internal.md
@@ -1,0 +1,1 @@
+Run the mirrord E2E suite nightly at 02:00 UTC and notify `#ci-alerts` when a scheduled run fails.


### PR DESCRIPTION
e2e tests will run everyday at 02:00 UTC, which is
- 05:00 in Israel
- 23:00 in Brazil

<!-- Thank you for contributing to mirrord! -->
<!-- Please use the checklist below as a guide for docs, tests and admin tasks for your PR -->
<!-- Feel free to ~strikethrough~ any items that you don't think apply -->

### Quality Checklist:

- [X] I have documented new code sufficiently
- [X] I have checked and updated the relevant existing docs in code, including removing outdated material
- [X] I have written user-facing website docs for new features, or opened a (sub)issue to do so
- [X]  I have checked and updated existing website docs for changed features
- [X] I have tested this change and know it succeeds and fails as expected
- [X] I have written unit tests or purposefully omitted them
- [X] I have written e2e tests or purposefully omitted them
- [X] I have explained what this PR introduces and why, and linked to relevant context (e.g. linear issues, related PRs,
  documentation)
- [X] I have introduced a short, clear and well-formatted changelog entry

<!-- need help with the changelog? see ../CONTRIBUTING.md#submitting-a-pull-request -->
<!-- Add more details of your changes below if needed -->