### PR TITLE
fix(wizard): surface kubeconfig errors when listing contexts fails

### DIFF
--- a/changelog.d/+wizard-kubeconfig-error.fixed.md
+++ b/changelog.d/+wizard-kubeconfig-error.fixed.md
@@ -1,0 +1,1 @@
+The mirrord ui wizard now shows an actionable error when Kubernetes contexts cannot be loaded (for example an unreadable kubeconfig), instead of silently rendering empty pickers.

--- a/packages/wizard/src/components/steps/TargetTab.test.tsx
+++ b/packages/wizard/src/components/steps/TargetTab.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen } from '../../test/test-utils'
+import TargetTab from './TargetTab'
+import { strings } from '../../strings'
+
+const jsonResponse = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+
+const mockKubeRoutes = (contexts: () => Response) => {
+  vi.mocked(fetch).mockImplementation((input) => {
+    const url = String(input)
+    if (url.includes('/api/v2/kube/contexts')) {
+      return Promise.resolve(contexts())
+    }
+    if (url.includes('/api/v2/kube/namespaces')) {
+      return Promise.resolve(jsonResponse({ namespaces: [] }))
+    }
+    if (url.includes('/api/v2/kube/target-types')) {
+      return Promise.resolve(jsonResponse({ targetTypes: [] }))
+    }
+    return Promise.resolve(jsonResponse([]))
+  })
+}
+
+describe('TargetTab', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('shows an actionable error when contexts cannot be loaded', async () => {
+    mockKubeRoutes(() =>
+      jsonResponse(
+        { error: 'failed to read kubeconfig: no such file or directory' },
+        500,
+      ),
+    )
+
+    render(<TargetTab setTargetPorts={vi.fn()} />)
+
+    expect(
+      await screen.findByText(strings.targetTab.kubeContextsError, undefined, {
+        timeout: 4000,
+      }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText('failed to read kubeconfig: no such file or directory'),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(strings.targetTab.kubeContextsErrorHint),
+    ).toBeInTheDocument()
+  })
+
+  it('falls back to the response status when the error body is not JSON', async () => {
+    mockKubeRoutes(() => new Response('boom', { status: 500 }))
+
+    render(<TargetTab setTargetPorts={vi.fn()} />)
+
+    expect(
+      await screen.findByText(strings.targetTab.kubeContextsError, undefined, {
+        timeout: 4000,
+      }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText('request failed with status 500'),
+    ).toBeInTheDocument()
+  })
+
+  it('shows the context picker without an error when contexts load', async () => {
+    mockKubeRoutes(() =>
+      jsonResponse({
+        contexts: [{ name: 'minikube', namespace: null }],
+        current: 'minikube',
+      }),
+    )
+
+    render(<TargetTab setTargetPorts={vi.fn()} />)
+
+    expect(
+      await screen.findByText(strings.targetTab.kubeContext),
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByText(strings.targetTab.kubeContextsError),
+    ).not.toBeInTheDocument()
+  })
+})

--- a/packages/wizard/src/components/steps/TargetTab.tsx
+++ b/packages/wizard/src/components/steps/TargetTab.tsx
@@ -24,6 +24,16 @@ import { strings } from '../../strings'
 const QUERY_STALE_TIME_MS = 30000
 const CLICK_OUTSIDE_DELAY_MS = 10
 
+const readApiError = async (res: Response): Promise<string> => {
+  const fallback = `request failed with status ${String(res.status)}`
+  try {
+    const body = (await res.json()) as { error?: string }
+    return body.error ?? fallback
+  } catch {
+    return fallback
+  }
+}
+
 interface Target {
   target_path: string
   target_namespace: string
@@ -113,14 +123,13 @@ const TargetTab = ({
 
   const contextsQuery = useQuery<ContextsResponse>({
     staleTime: QUERY_STALE_TIME_MS,
+    retry: 1,
     queryKey: ['kubeContexts'],
-    queryFn: () =>
-      fetch(window.location.origin + ALL_API_ROUTES.contexts).then(
-        async (res) =>
-          res.ok
-            ? ((await res.json()) as ContextsResponse)
-            : { contexts: [], current: null },
-      ),
+    queryFn: async () => {
+      const res = await fetch(window.location.origin + ALL_API_ROUTES.contexts)
+      if (!res.ok) throw new Error(await readApiError(res))
+      return (await res.json()) as ContextsResponse
+    },
   })
   const availableContexts =
     contextsQuery.data?.contexts.map((c) => c.name) ?? []
@@ -247,6 +256,20 @@ const TargetTab = ({
         </div>
       </div>
       <div className="space-y-5">
+        {contextsQuery.isError && (
+          <div className="text-destructive bg-destructive/10 border-l-destructive border-destructive/10 flex items-start gap-2 rounded-lg border border-l-2 p-3 text-sm">
+            <AlertCircle className="mt-0.5 h-4 w-4 flex-shrink-0" />
+            <div className="space-y-1">
+              <p className="font-medium">
+                {strings.targetTab.kubeContextsError}
+              </p>
+              <p>{contextsQuery.error.message}</p>
+              <p className="text-muted-foreground">
+                {strings.targetTab.kubeContextsErrorHint}
+              </p>
+            </div>
+          </div>
+        )}
         {availableContexts.length > 0 && (
           <div className="space-y-2">
             <Label htmlFor="kube-context" className="text-sm font-medium">

--- a/packages/wizard/src/strings.ts
+++ b/packages/wizard/src/strings.ts
@@ -120,6 +120,9 @@ export const strings = {
     title: 'Target Selection',
     subtitle: 'Choose the Kubernetes resource to connect to',
     kubeContext: 'Kube Context',
+    kubeContextsError: "Couldn't load your Kubernetes contexts",
+    kubeContextsErrorHint:
+      'Make sure your kubeconfig is reachable: set KUBECONFIG or MIRRORD_KUBECONFIG to its path, then run "mirrord ui stop" and open the wizard again.',
     namespace: 'Namespace',
     noNamespaces: 'No namespaces available',
     resourceType: 'Resource Type',


### PR DESCRIPTION
## Summary

When the `mirrord ui` wizard could not list Kubernetes contexts (for example an unreadable kubeconfig, which a user can hit on their very first run if their kubeconfig lives at a non-standard path), the Target step swallowed the failed response into an empty success. The result was a silently broken wizard: no context picker, "No namespaces available", an empty target list, and no indication anywhere of what went wrong.

This PR makes that failure visible and actionable:

- The contexts query now surfaces the server's error (the `/api/v2/kube` handlers already return a useful `{ "error": ... }` body, e.g. `failed to read kubeconfig: ...`) instead of coercing it to an empty list, with one retry for transient blips.
- The Target step shows an error callout (matching the existing destructive callout style) with the server detail and a hint: set `KUBECONFIG` or `MIRRORD_KUBECONFIG` to the kubeconfig path, then run `mirrord ui stop` and reopen the wizard. The restart matters because the ui server captures its environment at startup, so a stale server keeps the old env.

Pairs with #4584, which makes `MIRRORD_KUBECONFIG` actually honoured by the ui server; this change tells the user that is the knob to reach for.

## Test plan

- [x] `pnpm --filter mirrord-wizard typecheck`, `lint`, `format:check` all green
- [x] `pnpm --filter mirrord-wizard test:run`: 134/134 passing, including 3 new `TargetTab` tests (error body with `error` field, non-JSON error body fallback, happy path with no banner)
- [x] Built the merged `mirrord-ui` bundle and served it against a stub API in a real browser:
  - contexts endpoint returning the real 500 `{ "error": "failed to read kubeconfig: ..." }` shape: the callout renders with title, server detail, and hint, and the request stops after the bounded retry
  - contexts endpoint returning a context list: picker renders with the current context selected, no callout
- [ ] Not exercised against a live `mirrord ui` server binary in this change (the stub reproduces the exact handler error shape from `mirrord/cli/src/ui/error.rs`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)