### PR TITLE
fix(monitor): stop re-applying telemetry opt-in on every session poll

### DIFF
--- a/changelog.d/+monitor-opt-in-guard.internal.md
+++ b/changelog.d/+monitor-opt-in-guard.internal.md
@@ -1,0 +1,1 @@
+The session monitor no longer re-applies the telemetry opt-in on every session poll, which flooded analytics with a `$opt_in` event every two seconds per open tab.

--- a/packages/monitor/src/analytics.ts
+++ b/packages/monitor/src/analytics.ts
@@ -44,13 +44,19 @@ export function initAnalytics(telemetryEnabled: boolean) {
  * flips posthog's opt-in state and starts or stops the session recorder. If init has not
  * run yet (no active sessions, or the user opened with telemetry off), this is a no-op —
  * the `telemetryEnabled` argument passed to `initAnalytics` later will be authoritative.
+ *
+ * The caller invokes this on every session poll tick, and `posthog.opt_in_capturing()`
+ * captures a `$opt_in` event each time it is called, so this must only touch posthog when
+ * the preference actually differs from posthog's persisted opt state — otherwise every
+ * open monitor tab floods PostHog with one `$opt_in` per poll interval.
  */
 export function setTelemetryEnabled(enabled: boolean) {
   if (!initialized) return
-  if (enabled) {
+  const optedOut = posthog.has_opted_out_capturing()
+  if (enabled && optedOut) {
     posthog.opt_in_capturing()
     posthog.startSessionRecording()
-  } else {
+  } else if (!enabled && !optedOut) {
     posthog.stopSessionRecording()
     posthog.opt_out_capturing()
   }


### PR DESCRIPTION
## Summary

The session monitor applies its telemetry preference inside a React effect keyed on the polled sessions list, which produces a new array reference on every poll tick, so the effect re-runs continuously. `posthog-js` captures a `$opt_in` analytics event on every `opt_in_capturing()` call, so each open monitor tab emitted one `$opt_in` event per poll interval (every 2 seconds) for as long as it stayed open, flooding analytics and forcing an immediate network flush from the user's browser on every tick.

`setTelemetryEnabled` now reads posthog's persisted consent state via `has_opted_out_capturing()` and only opts in or out when the preference actually differs, so redundant re-applications become no-ops. Genuine transitions (toggling the preference in settings) behave exactly as before.

The fix lives entirely in `analytics.ts` to avoid overlapping the open PRs that touch the same effect in `App.tsx` (#4576, #4582).

## Test plan

All run locally on this branch:

- `pnpm --filter session-monitor-frontend run lint / format:check / typecheck` and `pnpm --filter mirrord-ui run lint / format:check / typecheck / build` (the CI gates for these packages): all green.
- Real-browser A/B against the actual UI (vite dev server + Playwright, `/api` fully route-mocked with a fake local session, `hog.metalbear.com` route-mocked and payloads gunzip-decoded, so no events reached production analytics):
  - Without the fix: a steady stream of `$opt_in` captures, one per 2-second poll tick, for the whole 30-second observation window.
  - With the fix: zero `$opt_in` captures in the same window, while `session_monitor_opened` still fires once and health events still capture normally.
  - Toggling "Anonymous usage analytics" off and back on in the settings dialog still emits exactly one `$opt_in` on the genuine re-enable transition.
- Not exercised: a previously persisted opt-out from an earlier visit being re-enabled across a full page reload (concluded from reading posthog-js consent code, not from running it).