### PR TITLE
fix(release): embed the ui frontend in Windows release binaries (COR-1710)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -177,11 +177,22 @@ jobs:
           $version = (Select-String -Path "Cargo.toml" -Pattern '^version\s*=\s*"([^"]+)"' | Select-Object -First 1).Matches.Groups[1].Value
           echo "version=$version" >> $env:GITHUB_OUTPUT
 
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: 24
+      - name: Enable corepack (pnpm-only; leave npm alone for wizard build)
+        run: corepack enable pnpm
+
       - name: Build mirrord DLL and EXE
         run: |
           $ErrorActionPreference = "Stop"
 
-          cargo xtask build-cli --platform windows --release --no-ui
+          cargo xtask build-cli --platform windows --release
+
+          $uiIndex = "packages\ui\dist\index.html"
+          if (-not (Test-Path $uiIndex)) {
+            throw "UI frontend assets not found at $uiIndex - the release binary would serve 404s from 'mirrord ui'"
+          }
 
           $dll = "target\x86_64-pc-windows-msvc\release\mirrord_layer_win.dll"
           if (-not (Test-Path $dll)) {

--- a/changelog.d/+windows-ui-frontend-assets.fixed.md
+++ b/changelog.d/+windows-ui-frontend-assets.fixed.md
@@ -1,0 +1,1 @@
+Fixed `mirrord ui` returning 404 for every page on Windows: the Windows release build skipped the frontend build, so released binaries embedded no UI assets.


### PR DESCRIPTION
## Summary

Windows release binaries ship with zero embedded ui assets, so `mirrord ui` returns 404 for every page for every Windows user (COR-1710). The Windows release job passed `--no-ui` and had no Node toolchain; `mirrord/cli/build.rs` then creates an empty `packages/ui/dist` placeholder so rust-embed compiles, and the binary embeds nothing.

This makes the Windows job build and embed the frontend:
- installs Node 24 (matching the other workflows) and enables the repo-pinned pnpm via corepack
- drops `--no-ui`, so `cargo xtask build-cli` runs the ui build (`xtask/src/tasks/ui.rs`) before the Rust build
- adds a hard guard: the job fails if `packages/ui/dist/index.html` is missing after the build, so this class of regression can never ship silently again

## Test plan

- [x] `release.yaml` parses; Node 24 matches the check-lint workflows; corepack resolves the `packageManager`-pinned pnpm
- [x] Verified by reading `xtask/src/tasks/release.rs` + `tasks/ui.rs` that dropping `--no-ui` triggers the pnpm frontend build, and `mirrord/cli/build.rs` confirms the empty-placeholder behavior being fixed
- [ ] Not executed on a real Windows runner; the new in-job guard makes the next release build the verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Why `--no-ui` was there (so this is not Chesterton's fence)

- #4190 (2026-04-17) added `--no-wizard --no-monitor` to the Windows job during release firefighting. Correct at the time: Windows had no `mirrord ui` support and the runner had no Node toolchain.
- #4228 (2026-06-02) added Windows support for `mirrord ui`, including the `pnpm.cmd` PATHEXT handling in xtask that makes the frontend build work on Windows, but the release workflow exclusion was not revisited.
- #4503 (2026-07-08) mechanically renamed the stale flags to `--no-ui`.

Since #4228 the ui is supposed to work on Windows; the release job was the last place still assuming it should not. The Linux and macOS jobs already use exactly the setup-node + corepack + no-flag pattern this PR applies (same pinned action SHA, same step verbatim).
