### PR TITLE
feat(wizard): report wizard failures and crashes to telemetry

### DIFF
--- a/changelog.d/+wizard-telemetry.internal.md
+++ b/changelog.d/+wizard-telemetry.internal.md
@@ -1,0 +1,5 @@
+The config wizard now reports its failures to telemetry: a `wizard_user_blocked` event fires
+when a wizard API query settles into an error state (once per failure episode) or when the
+wizard UI crashes, with exception tracking attached, and `wizard_opened` marks wizard
+activations. Previously the wizard emitted no telemetry at all, so wizard-blocking failures
+were invisible.

--- a/packages/monitor/src/App.tsx
+++ b/packages/monitor/src/App.tsx
@@ -15,6 +15,7 @@ import OperatorSessionDetail from './components/OperatorSessionDetail'
 import type { ThemePref } from './theme'
 import {
   initAnalytics,
+  emitOpened,
   setTelemetryEnabled,
   setLicenseGroup,
   trackEvent,
@@ -136,6 +137,7 @@ export default function App({
     )
     const shouldCapture = sessionAllowsTelemetry && telemetryPref
     initAnalytics(shouldCapture)
+    emitOpened('session_monitor_opened')
     setTelemetryEnabled(shouldCapture)
   }, [sessions, telemetryPref])
 

--- a/packages/monitor/src/analytics.ts
+++ b/packages/monitor/src/analytics.ts
@@ -3,6 +3,22 @@ import posthog from 'posthog-js'
 const POSTHOG_KEY = 'phc_wIZh92nyk4vu6HidiLFUzjW6piZlZszuWZZFBS7yHHe'
 const POSTHOG_HOST = 'https://hog.metalbear.com'
 
+export const TELEMETRY_STORAGE_KEY = 'session-monitor-telemetry'
+
+/**
+ * The stored user preference for UI telemetry, shared by every surface served from the
+ * `mirrord ui` server (session monitor, config wizard). Defaults to enabled; only an explicit
+ * opt-out ('off') disables it. Lives here rather than in the pref hook so non-React code
+ * (the wizard's init path) can read it without mounting the monitor.
+ */
+export function readTelemetryPref(): boolean {
+  try {
+    return localStorage.getItem(TELEMETRY_STORAGE_KEY) !== 'off'
+  } catch {
+    return true
+  }
+}
+
 let initialized = false
 
 export function initAnalytics(telemetryEnabled: boolean) {
@@ -36,7 +52,22 @@ export function initAnalytics(telemetryEnabled: boolean) {
     },
   })
   initialized = true
-  posthog.capture('session_monitor_opened', { source: 'session-monitor' })
+}
+
+const openedEvents = new Set<string>()
+
+/**
+ * Capture a per-surface "opened" event at most once per page load. Decoupled from
+ * `initAnalytics` so each surface (monitor, wizard) marks its own first activation no matter
+ * which one happened to initialize posthog.
+ */
+export function emitOpened(
+  event: string,
+  properties?: Record<string, unknown>,
+): void {
+  if (!initialized || openedEvents.has(event)) return
+  openedEvents.add(event)
+  trackEvent(event, properties)
 }
 
 /**
@@ -84,26 +115,49 @@ export function trackEvent(
 
 export type EventKind = 'user_action' | 'health'
 
-export function emitUserBlocked(
+/**
+ * Surface-agnostic core of the `*_user_blocked` convention: one analytics event named after
+ * the surface, plus an exception-tracking capture when a throwable is attached. The monitor
+ * calls this through `emitUserBlocked`; the wizard wraps it in its own analytics module.
+ */
+export function emitBlockedEvent(
+  event: string,
+  surface: string,
   reason: string,
   kind: EventKind,
   properties: Record<string, unknown> = {},
   error?: unknown,
 ): void {
-  trackEvent('monitor_user_blocked', {
+  trackEvent(event, {
     reason,
     kind,
-    surface: 'monitor',
+    surface,
     ...properties,
   })
   if (error !== undefined && initialized) {
     posthog.captureException(error, {
       reason,
       kind,
-      surface: 'monitor',
+      surface,
       ...properties,
     })
   }
+}
+
+export function emitUserBlocked(
+  reason: string,
+  kind: EventKind,
+  properties: Record<string, unknown> = {},
+  error?: unknown,
+): void {
+  emitBlockedEvent(
+    'monitor_user_blocked',
+    'monitor',
+    reason,
+    kind,
+    properties,
+    error,
+  )
 }
 
 export function emitUserSucceeded(

--- a/packages/monitor/src/hooks/useTelemetryPref.ts
+++ b/packages/monitor/src/hooks/useTelemetryPref.ts
@@ -1,16 +1,5 @@
 import { useCallback, useEffect, useState } from 'react'
-
-const STORAGE_KEY = 'session-monitor-telemetry'
-
-function readStored(): boolean {
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY)
-    if (raw === 'off') return false
-    return true
-  } catch {
-    return true
-  }
-}
+import { TELEMETRY_STORAGE_KEY, readTelemetryPref } from '../analytics'
 
 /**
  * User-controlled toggle for sending anonymous usage analytics from the session monitor UI.
@@ -19,11 +8,11 @@ function readStored(): boolean {
  * session's opt-out.
  */
 export function useTelemetryPref(): [boolean, (next: boolean) => void] {
-  const [enabled, setEnabled] = useState<boolean>(readStored)
+  const [enabled, setEnabled] = useState<boolean>(readTelemetryPref)
 
   useEffect(() => {
     try {
-      localStorage.setItem(STORAGE_KEY, enabled ? 'on' : 'off')
+      localStorage.setItem(TELEMETRY_STORAGE_KEY, enabled ? 'on' : 'off')
     } catch {
       // localStorage can fail in private browsing; preference is per-tab only in that case.
     }

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -12,6 +12,7 @@
     "jsx": "react-jsx",
     "paths": {
       "@mirrord/monitor/theme": ["../monitor/src/theme.ts"],
+      "@mirrord/monitor/analytics": ["../monitor/src/analytics.ts"],
       "@mirrord/monitor": ["../monitor/src/index.tsx"],
       "@mirrord/wizard": ["../wizard/src/index.tsx"]
     }

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
       // not shadowed. The shell imports just the theme module (no monitor component graph) to
       // apply the shared light/dark preference on both routes.
       '@mirrord/monitor/theme': path.resolve(__dirname, '../monitor/src/theme.ts'),
+      '@mirrord/monitor/analytics': path.resolve(__dirname, '../monitor/src/analytics.ts'),
       '@mirrord/monitor': path.resolve(__dirname, '../monitor/src/index.tsx'),
       '@mirrord/wizard': path.resolve(__dirname, '../wizard/src/index.tsx'),
     },

--- a/packages/wizard/src/App.tsx
+++ b/packages/wizard/src/App.tsx
@@ -1,9 +1,19 @@
+import { useEffect } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
 import { TooltipProvider } from '@metalbear/ui'
 import { Toaster } from './components/Toaster'
 import { ConfigDataContextProvider } from './components/UserDataContext'
 import Homepage from './components/Homepage'
+import { initWizardAnalytics, observeQueryFailures } from './analytics'
 
 function App() {
+  const queryClient = useQueryClient()
+
+  useEffect(() => {
+    initWizardAnalytics()
+    return observeQueryFailures(queryClient)
+  }, [queryClient])
+
   return (
     <ConfigDataContextProvider>
       <TooltipProvider>

--- a/packages/wizard/src/analytics.test.ts
+++ b/packages/wizard/src/analytics.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { QueryClient } from '@tanstack/react-query'
+import {
+  initWizardAnalytics,
+  emitWizardBlocked,
+  observeQueryFailures,
+} from './analytics'
+import {
+  emitBlockedEvent,
+  emitOpened,
+  initAnalytics,
+  readTelemetryPref,
+} from '@mirrord/monitor/analytics'
+
+vi.mock('@mirrord/monitor/analytics', () => ({
+  emitBlockedEvent: vi.fn(),
+  emitOpened: vi.fn(),
+  initAnalytics: vi.fn(),
+  readTelemetryPref: vi.fn(() => true),
+}))
+
+const failWith = (message: string) => () =>
+  Promise.reject(new Error(message)) as Promise<string>
+
+async function fetchIgnoringError(
+  queryClient: QueryClient,
+  queryKey: string[],
+  queryFn: () => Promise<string>,
+) {
+  await queryClient
+    .fetchQuery({ queryKey, queryFn, retry: false, staleTime: 0 })
+    .catch(() => undefined)
+}
+
+describe('initWizardAnalytics', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('initializes analytics with the stored preference and marks the wizard opened', () => {
+    vi.mocked(readTelemetryPref).mockReturnValue(true)
+    initWizardAnalytics()
+    expect(initAnalytics).toHaveBeenCalledWith(true)
+    expect(emitOpened).toHaveBeenCalledWith('wizard_opened', {
+      source: 'wizard',
+    })
+  })
+
+  it('passes an opt-out through to init', () => {
+    vi.mocked(readTelemetryPref).mockReturnValue(false)
+    initWizardAnalytics()
+    expect(initAnalytics).toHaveBeenCalledWith(false)
+  })
+})
+
+describe('emitWizardBlocked', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('emits the wizard surface event with the wizard source', () => {
+    const error = new Error('boom')
+    emitWizardBlocked('ui_crashed', 'user_action', { extra: 1 }, error)
+    expect(emitBlockedEvent).toHaveBeenCalledWith(
+      'wizard_user_blocked',
+      'wizard',
+      'ui_crashed',
+      'user_action',
+      { source: 'wizard', extra: 1 },
+      error,
+    )
+  })
+})
+
+describe('observeQueryFailures', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('reports a failed query once per failure episode', async () => {
+    const queryClient = new QueryClient()
+    const unsubscribe = observeQueryFailures(queryClient)
+
+    await fetchIgnoringError(queryClient, ['kubeContexts'], failWith('down'))
+    await fetchIgnoringError(
+      queryClient,
+      ['kubeContexts'],
+      failWith('still down'),
+    )
+
+    expect(emitBlockedEvent).toHaveBeenCalledTimes(1)
+    expect(emitBlockedEvent).toHaveBeenCalledWith(
+      'wizard_user_blocked',
+      'wizard',
+      'kubeContexts_load_failed',
+      'user_action',
+      { source: 'wizard', error: 'down' },
+      expect.any(Error),
+    )
+
+    unsubscribe()
+    queryClient.clear()
+  })
+
+  it('reports again after the query recovers and fails anew', async () => {
+    const queryClient = new QueryClient()
+    const unsubscribe = observeQueryFailures(queryClient)
+
+    await fetchIgnoringError(queryClient, ['kubeNamespaces'], failWith('down'))
+    await fetchIgnoringError(queryClient, ['kubeNamespaces'], () =>
+      Promise.resolve('ok'),
+    )
+    await fetchIgnoringError(
+      queryClient,
+      ['kubeNamespaces'],
+      failWith('down again'),
+    )
+
+    expect(emitBlockedEvent).toHaveBeenCalledTimes(2)
+
+    unsubscribe()
+    queryClient.clear()
+  })
+
+  it('reports distinct queries independently', async () => {
+    const queryClient = new QueryClient()
+    const unsubscribe = observeQueryFailures(queryClient)
+
+    await fetchIgnoringError(queryClient, ['kubeContexts'], failWith('a'))
+    await fetchIgnoringError(
+      queryClient,
+      ['targetDetails', 'ctx', 'ns'],
+      failWith('b'),
+    )
+
+    expect(emitBlockedEvent).toHaveBeenCalledTimes(2)
+    expect(emitBlockedEvent).toHaveBeenLastCalledWith(
+      'wizard_user_blocked',
+      'wizard',
+      'targetDetails_load_failed',
+      'user_action',
+      { source: 'wizard', error: 'b' },
+      expect.any(Error),
+    )
+
+    unsubscribe()
+    queryClient.clear()
+  })
+})

--- a/packages/wizard/src/analytics.ts
+++ b/packages/wizard/src/analytics.ts
@@ -1,0 +1,71 @@
+import type { QueryClient } from '@tanstack/react-query'
+import {
+  emitBlockedEvent,
+  emitOpened,
+  initAnalytics,
+  readTelemetryPref,
+  type EventKind,
+} from '@mirrord/monitor/analytics'
+
+const ERROR_MESSAGE_MAX_LEN = 300
+
+/**
+ * Wizard-side entry to the shared posthog instance. The monitor initializes analytics from its
+ * session poll, but a `mirrord wizard` deep link never mounts the monitor — so the wizard has
+ * to initialize on its own or every failure it hits stays invisible. There is no session
+ * config to consult on this path; the stored user preference is the only gate.
+ */
+export function initWizardAnalytics(): void {
+  initAnalytics(readTelemetryPref())
+  emitOpened('wizard_opened', { source: 'wizard' })
+}
+
+export function emitWizardBlocked(
+  reason: string,
+  kind: EventKind,
+  properties: Record<string, unknown> = {},
+  error?: unknown,
+): void {
+  emitBlockedEvent(
+    'wizard_user_blocked',
+    'wizard',
+    reason,
+    kind,
+    { source: 'wizard', ...properties },
+    error,
+  )
+}
+
+function errorMessage(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error)
+  return message.slice(0, ERROR_MESSAGE_MAX_LEN)
+}
+
+/**
+ * Report every query that settles into an error state, once per failure episode: a query that
+ * keeps failing across refetches emits a single event until it succeeds again (the lesson from
+ * the monitor's chaos-poll alert flood). The wizard is currently the only React Query consumer
+ * in the merged UI, so subscribing to the shared cache is equivalent to subscribing to wizard
+ * queries; if the monitor ever adopts React Query, scope this by query key.
+ */
+export function observeQueryFailures(queryClient: QueryClient): () => void {
+  const failedQueries = new Set<string>()
+  return queryClient.getQueryCache().subscribe((event) => {
+    if (event.type !== 'updated') return
+    if (event.action.type === 'success') {
+      failedQueries.delete(event.query.queryHash)
+      return
+    }
+    if (event.action.type !== 'error') return
+    if (failedQueries.has(event.query.queryHash)) return
+    failedQueries.add(event.query.queryHash)
+    const [resourceKey] = event.query.queryKey as readonly unknown[]
+    const resource = typeof resourceKey === 'string' ? resourceKey : 'unknown'
+    emitWizardBlocked(
+      `${resource}_load_failed`,
+      'user_action',
+      { error: errorMessage(event.action.error) },
+      event.action.error,
+    )
+  })
+}

--- a/packages/wizard/src/components/ErrorBoundary.test.tsx
+++ b/packages/wizard/src/components/ErrorBoundary.test.tsx
@@ -1,0 +1,39 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import ErrorBoundary from './ErrorBoundary'
+import { emitWizardBlocked } from '../analytics'
+
+vi.mock('../analytics', () => ({
+  emitWizardBlocked: vi.fn(),
+}))
+
+function Thrower(): never {
+  throw new Error('component exploded')
+}
+
+describe('ErrorBoundary', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.spyOn(console, 'error').mockImplementation(() => undefined)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('reports the crash to telemetry and renders the fallback', () => {
+    render(
+      <ErrorBoundary>
+        <Thrower />
+      </ErrorBoundary>,
+    )
+
+    expect(screen.getByText('component exploded')).toBeInTheDocument()
+    expect(emitWizardBlocked).toHaveBeenCalledWith(
+      'ui_crashed',
+      'user_action',
+      expect.objectContaining({ error: 'component exploded' }),
+      expect.any(Error),
+    )
+  })
+})

--- a/packages/wizard/src/components/ErrorBoundary.tsx
+++ b/packages/wizard/src/components/ErrorBoundary.tsx
@@ -1,5 +1,8 @@
 import React from 'react'
+import { emitWizardBlocked } from '../analytics'
 import { strings } from '../strings'
+
+const STACK_TRACE_MAX_LEN = 500
 
 interface Props {
   children: React.ReactNode
@@ -23,6 +26,15 @@ class ErrorBoundary extends React.Component<Props, State> {
 
   override componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
     console.error('ErrorBoundary caught an error:', error, errorInfo)
+    emitWizardBlocked(
+      'ui_crashed',
+      'user_action',
+      {
+        error: error.message,
+        stack: errorInfo.componentStack?.slice(0, STACK_TRACE_MAX_LEN),
+      },
+      error,
+    )
   }
 
   override render() {

--- a/packages/wizard/tsconfig.json
+++ b/packages/wizard/tsconfig.json
@@ -11,7 +11,8 @@
     "jsx": "react-jsx",
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@mirrord/monitor/analytics": ["../monitor/src/analytics.ts"]
     }
   },
   "include": ["src"],

--- a/packages/wizard/vitest.config.ts
+++ b/packages/wizard/vitest.config.ts
@@ -1,8 +1,17 @@
+import path from "node:path";
 import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react-swc";
 
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      "@mirrord/monitor/analytics": path.resolve(
+        __dirname,
+        "../monitor/src/analytics.ts",
+      ),
+    },
+  },
   test: {
     globals: true,
     environment: "jsdom",


### PR DESCRIPTION
## Summary

The config wizard emits no telemetry at all today. When a user hits a broken kubeconfig, an unreachable cluster, or a wizard crash, nothing is reported anywhere: the recent wizard failure that took a customer a day to self-diagnose produced zero signal, and the same class of failure on the session monitor side is already covered by `monitor_user_blocked`. This PR gives the wizard the same visibility:

- **`wizard_user_blocked` on query failures.** A query-cache subscription (`observeQueryFailures`) reports any wizard API query that settles into an error state, with the failing resource as the reason (`kubeContexts_load_failed`, `kubeNamespaces_load_failed`, ...) and the error message attached. Events fire once per failure episode: a query that keeps failing across refetches emits a single event until it succeeds again, so a dead `mirrord ui` server cannot flood analytics the way the chaos poll once did. Because it hooks the cache rather than individual call sites, it also covers queries added later without extra wiring.
- **Crash reporting from the wizard error boundary**, matching the monitor's boundary: `wizard_user_blocked` with reason `ui_crashed` plus an exception-tracking capture with the component stack.
- **`wizard_opened`** once per page load, so blocked events have a denominator.

To support this, the monitor's analytics module is generalized rather than duplicated: `emitBlockedEvent` is the surface-agnostic core (`emitUserBlocked` now delegates to it), the `session_monitor_opened` capture moves out of `initAnalytics` into a reusable once-per-load `emitOpened`, and the telemetry preference read is hoisted from the pref hook so non-React code can use it. The wizard initializes analytics on its own mount because a `mirrord wizard` deep link never mounts the monitor; with no session config to consult on that path, the stored user preference (shared with the monitor's settings toggle) is the gate, and an explicit opt-out disables everything.

Note: on current main the target-tab queries coerce HTTP error statuses into empty successes, so today this reporter observes network-level failures (server gone, connection dropped, malformed JSON). Once #4590 lands and those queries throw, the same subscription picks up HTTP failures with the server's error detail, with no further changes.

## Test plan

- `pnpm --filter mirrord-wizard typecheck && lint && format:check`: green.
- `pnpm --filter mirrord-wizard test:run`: 138/138 (12 files), including new tests for once-per-episode query reporting (fail/fail → one event, fail/recover/fail → two, distinct queries independent), init gating, and error-boundary reporting.
- `pnpm --filter session-monitor-frontend typecheck/lint/format:check` and `pnpm --filter mirrord-ui typecheck/lint/format:check + build`: green.
- Served the built `mirrord-ui` bundle behind a stub API with PostHog network traffic intercepted and decoded, drove it with a real Chromium browser:
  - `/wizard` deep link (monitor never mounted) → `wizard_opened` captured.
  - Stub destroying every kube API socket, navigated to the Target step → exactly one `wizard_user_blocked` per failing query (4 events for 8 requests, since each query retries once) with reason/surface/error populated, plus matching `$exception` captures.
  - Healthy stub → `wizard_opened` only, no blocked events; monitor route still emits `session_monitor_opened` after the init refactor.
  - `session-monitor-telemetry=off` in localStorage → zero PostHog requests on the wizard.
- Not exercised against a live `mirrord ui` server binary (stub mirrors the v2 handler shapes read from source), and the crash path was verified in unit tests only.