### PR TITLE
COR-1718 Fix chaos UI updating changed rule

### DIFF
--- a/changelog.d/+chaos-ui.fixed.md
+++ b/changelog.d/+chaos-ui.fixed.md
@@ -1,0 +1,2 @@
+Fixed an issue where chaos UI not refreshing existing rule definition if
+the rule isn't updated by using the UI.

--- a/packages/monitor/src/hooks/useChaosRules.ts
+++ b/packages/monitor/src/hooks/useChaosRules.ts
@@ -159,14 +159,25 @@ export function useChaosRules(sessionId: string): UseChaosRules {
         }
         const server = byServerId.get(rule.serverId)
         if (!server) continue
+        // Re-derive the definition from the server every poll: a rule edited via
+        // PUT (from outside this UI) keeps its id but gets a fresh definition and
+        // a hit_count reset, so keying only on the id and preserving the local
+        // definition would leave the card showing the stale, original rule.
+        const mapped = fromServer(server)
+        if (!mapped) {
+          next.push(rule)
+          continue
+        }
         const delta = Math.max(0, server.hit_count - rule.serverHits)
         next.push({
-          ...rule,
+          ...mapped,
+          key: rule.key,
           hits: rule.hits + delta,
           serverHits: server.hit_count,
           spark: [...rule.spark, { id: nextBucketId++, value: delta }].slice(
             -SPARK_BUCKETS,
           ),
+          flash: rule.flash,
         })
       }
       for (const server of serverRules) {


### PR DESCRIPTION
Fixed the issue where chaos UI won't update existing rule definition if the rule is updated outside of the UI, for example, using CLI or raw HTTP requests.

<!-- Thank you for contributing to mirrord! -->
<!-- Please use the checklist below as a guide for docs, tests and admin tasks for your PR -->
<!-- Feel free to ~strikethrough~ any items that you don't think apply -->

### Quality Checklist:

- [x] I have documented new code sufficiently
- [x] I have checked and updated the relevant existing docs in code, including removing outdated material
- [x] I have written user-facing website docs for new features, or opened a (sub)issue to do so
- [x] I have checked and updated existing website docs for changed features
- [x] I have tested this change and know it succeeds and fails as expected
- [x] I have written unit tests or purposefully omitted them
- [x] I have written e2e tests or purposefully omitted them
- [x] I have explained what this PR introduces and why, and linked to relevant context (e.g. linear issues, related PRs,
  documentation)
- [x] I have introduced a short, clear and well-formatted changelog entry

<!-- need help with the changelog? see ../CONTRIBUTING.md#submitting-a-pull-request -->
<!-- Add more details of your changes below if needed -->