### PR TITLE
Make AsyncDecoder::receive cancel safe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5235,6 +5235,7 @@ name = "mirrord-intproxy-protocol"
 version = "3.239.0"
 dependencies = [
  "bincode",
+ "futures-core",
  "mirrord-protocol",
  "thiserror 2.0.18",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,6 +123,7 @@ flate2 = { version = "1", default-features = false, features = ["rust_backend"] 
 frida-gum = { version = "0.17", features = ["auto-download", "std"] }
 fs4 = { version = "0.13", features = ["tokio", "sync"], default-features = false }
 futures = "0.3"
+futures-core = "0.3"
 futures-util = "0.3"
 glob = "0.3"
 hex = "0.4"

--- a/changelog.d/+intproxy-codec-cancel-safety.fixed.md
+++ b/changelog.d/+intproxy-codec-cancel-safety.fixed.md
@@ -1,0 +1,1 @@
+Fixed a `layer <-> intproxy` protocol desynchronization that broke sessions where an application opened a large number of concurrent outgoing connections.

--- a/changelog.d/+intproxy-codec-cancel-safety.fixed.md
+++ b/changelog.d/+intproxy-codec-cancel-safety.fixed.md
@@ -1,1 +1,1 @@
-Fixed a `layer <-> intproxy` protocol desynchronization that broke sessions where an application opened a large number of concurrent outgoing connections.
+Fixed a `layer <-> intproxy` protocol framing bug that broke sessions where an app opened many concurrent outgoing connections.

--- a/mirrord/intproxy/protocol/Cargo.toml
+++ b/mirrord/intproxy/protocol/Cargo.toml
@@ -22,12 +22,13 @@ workspace = true
 mirrord-protocol = { path = "../../protocol" }
 
 bincode.workspace = true
+futures-core = { workspace = true, optional = true }
 thiserror = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }
 
 [features]
 codec = ["dep:thiserror"]
-codec-async = ["codec", "dep:tokio"]
+codec-async = ["codec", "dep:tokio", "dep:futures-core"]
 
 [lib]
 test = false

--- a/mirrord/intproxy/protocol/src/codec/codec_async.rs
+++ b/mirrord/intproxy/protocol/src/codec/codec_async.rs
@@ -1,4 +1,4 @@
-use std::io::ErrorKind;
+use std::io::{self, ErrorKind};
 
 use bincode::{Decode, Encode};
 use tokio::{
@@ -64,6 +64,16 @@ where
 pub struct AsyncDecoder<T, R> {
     buffer: Vec<u8>,
     reader: R,
+    /// Length prefix bytes read so far for the message currently being decoded.
+    ///
+    /// Retained across [`AsyncDecoder::receive`] calls to keep it cancel safe.
+    prefix: [u8; PREFIX_BYTES],
+    /// How much of [`AsyncDecoder::prefix`] is filled.
+    prefix_read: usize,
+    /// Payload length, known once the whole prefix has been read.
+    payload_len: Option<usize>,
+    /// How much of the payload was already read into [`AsyncDecoder::buffer`].
+    payload_read: usize,
     _phantom: std::marker::PhantomData<fn() -> T>,
 }
 
@@ -73,6 +83,10 @@ impl<T, R> AsyncDecoder<T, R> {
         Self {
             buffer: Vec::with_capacity(BUFFER_SIZE),
             reader,
+            prefix: [0; PREFIX_BYTES],
+            prefix_read: 0,
+            payload_len: None,
+            payload_read: 0,
             _phantom: Default::default(),
         }
     }
@@ -90,17 +104,54 @@ where
 {
     /// Decodes the next message from the underlying IO handler.
     /// Does not read any excessive bytes.
+    ///
+    /// This method is cancel safe. Callers select over it against other futures (the intproxy's
+    /// `LayerConnection` races it against outgoing messages), so the returned future gets dropped
+    /// whenever another branch wins. Progress through the current message is therefore kept in
+    /// `self` rather than on the stack: dropping the future mid-message leaves the already
+    /// consumed bytes recorded, and the next call resumes where this one stopped.
+    ///
+    /// Getting this wrong desynchronizes the stream rather than failing loudly - the bytes taken
+    /// from the socket are gone, and the next call reads the middle of a message as a length
+    /// prefix, which then either decodes into garbage or asks for an absurdly large allocation.
     pub async fn receive(&mut self) -> Result<Option<T>> {
-        let mut len_buffer = [0; 4];
-        match self.reader.read_exact(&mut len_buffer).await {
-            Ok(..) => {}
-            Err(e) if e.kind() == ErrorKind::UnexpectedEof => return Ok(None),
-            Err(e) => Err(e)?,
+        while self.prefix_read < PREFIX_BYTES {
+            match self.reader.read(&mut self.prefix[self.prefix_read..]).await {
+                // The peer is done sending. Treated as a clean end of the stream, matching what
+                // `read_exact` reported here before.
+                Ok(0) => return Ok(None),
+                Ok(read) => self.prefix_read += read,
+                Err(e) if e.kind() == ErrorKind::UnexpectedEof => return Ok(None),
+                Err(e) => Err(e)?,
+            }
         }
-        let len = u32::from_be_bytes(len_buffer);
 
-        self.buffer.resize(len as usize, 0);
-        self.reader.read_exact(&mut self.buffer).await?;
+        let len = match self.payload_len {
+            Some(len) => len,
+            None => {
+                let len = u32::from_be_bytes(self.prefix) as usize;
+                self.buffer.resize(len, 0);
+                self.payload_read = 0;
+                self.payload_len = Some(len);
+                len
+            }
+        };
+
+        while self.payload_read < len {
+            match self
+                .reader
+                .read(&mut self.buffer[self.payload_read..])
+                .await
+            {
+                Ok(0) => Err(io::Error::from(ErrorKind::UnexpectedEof))?,
+                Ok(read) => self.payload_read += read,
+                Err(e) => Err(e)?,
+            }
+        }
+
+        self.prefix_read = 0;
+        self.payload_len = None;
+        self.payload_read = 0;
 
         let value = bincode::decode_from_slice(&self.buffer, bincode::config::standard())?.0;
 

--- a/mirrord/intproxy/protocol/src/codec/codec_async.rs
+++ b/mirrord/intproxy/protocol/src/codec/codec_async.rs
@@ -1,8 +1,13 @@
-use std::io::{self, ErrorKind};
+use std::{
+    io::{self, ErrorKind},
+    pin::Pin,
+    task::{Context, Poll, ready},
+};
 
 use bincode::{Decode, Encode};
+use futures_core::Stream;
 use tokio::{
-    io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt},
+    io::{AsyncRead, AsyncWrite, AsyncWriteExt, ReadBuf},
     net::tcp::{OwnedReadHalf, OwnedWriteHalf},
 };
 
@@ -102,27 +107,28 @@ where
     T: Decode<()>,
     R: AsyncRead + Unpin,
 {
-    /// Decodes the next message from the underlying IO handler.
+    /// Polls for the next message from the underlying IO handler.
     /// Does not read any excessive bytes.
     ///
-    /// This method is cancel safe. Callers select over it against other futures (the intproxy's
-    /// `LayerConnection` races it against outgoing messages), so the returned future gets dropped
-    /// whenever another branch wins. Progress through the current message is therefore kept in
-    /// `self` rather than on the stack: dropping the future mid-message leaves the already
-    /// consumed bytes recorded, and the next call resumes where this one stopped.
+    /// Returning [`Poll::Pending`] part-way through a message is the normal case, so all progress
+    /// lives in `self`. A caller that stops polling - a `select!` branch that loses the race, and
+    /// so gets its future dropped - can resume with a later call without losing the bytes already
+    /// taken from the reader.
     ///
-    /// Getting this wrong desynchronizes the stream rather than failing loudly - the bytes taken
-    /// from the socket are gone, and the next call reads the middle of a message as a length
-    /// prefix, which then either decodes into garbage or asks for an absurdly large allocation.
-    pub async fn receive(&mut self) -> Result<Option<T>> {
+    /// Losing them does not fail loudly, it desynchronizes the stream: the next read takes the
+    /// middle of a message for a length prefix, which then either decodes into garbage or asks for
+    /// an absurdly large allocation. Keeping the state machine behind a `poll` signature is what
+    /// makes that unrepresentable, since nothing can be held across a [`Poll::Pending`] return.
+    pub fn poll_receive(&mut self, cx: &mut Context<'_>) -> Poll<Result<Option<T>>> {
         while self.prefix_read < PREFIX_BYTES {
-            match self.reader.read(&mut self.prefix[self.prefix_read..]).await {
+            let mut buf = ReadBuf::new(&mut self.prefix[self.prefix_read..]);
+            ready!(Pin::new(&mut self.reader).poll_read(cx, &mut buf))?;
+
+            match buf.filled().len() {
                 // The peer is done sending. Treated as a clean end of the stream, matching what
                 // `read_exact` reported here before.
-                Ok(0) => return Ok(None),
-                Ok(read) => self.prefix_read += read,
-                Err(e) if e.kind() == ErrorKind::UnexpectedEof => return Ok(None),
-                Err(e) => Err(e)?,
+                0 => return Poll::Ready(Ok(None)),
+                read => self.prefix_read += read,
             }
         }
 
@@ -138,14 +144,12 @@ where
         };
 
         while self.payload_read < len {
-            match self
-                .reader
-                .read(&mut self.buffer[self.payload_read..])
-                .await
-            {
-                Ok(0) => Err(io::Error::from(ErrorKind::UnexpectedEof))?,
-                Ok(read) => self.payload_read += read,
-                Err(e) => Err(e)?,
+            let mut buf = ReadBuf::new(&mut self.buffer[self.payload_read..]);
+            ready!(Pin::new(&mut self.reader).poll_read(cx, &mut buf))?;
+
+            match buf.filled().len() {
+                0 => Err(io::Error::from(ErrorKind::UnexpectedEof))?,
+                read => self.payload_read += read,
             }
         }
 
@@ -155,7 +159,31 @@ where
 
         let value = bincode::decode_from_slice(&self.buffer, bincode::config::standard())?.0;
 
-        Ok(Some(value))
+        Poll::Ready(Ok(Some(value)))
+    }
+
+    /// Decodes the next message from the underlying IO handler.
+    /// Does not read any excessive bytes.
+    ///
+    /// Cancel safe, see [`AsyncDecoder::poll_receive`].
+    pub async fn receive(&mut self) -> Result<Option<T>> {
+        std::future::poll_fn(|cx| self.poll_receive(cx)).await
+    }
+}
+
+impl<T, R> Stream for AsyncDecoder<T, R>
+where
+    T: Decode<()>,
+    R: AsyncRead + Unpin,
+{
+    type Item = Result<T>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        match ready!(self.get_mut().poll_receive(cx)) {
+            Ok(Some(value)) => Poll::Ready(Some(Ok(value))),
+            Ok(None) => Poll::Ready(None),
+            Err(error) => Poll::Ready(Some(Err(error))),
+        }
     }
 }
 

--- a/mirrord/intproxy/protocol/src/codec/codec_async.rs
+++ b/mirrord/intproxy/protocol/src/codec/codec_async.rs
@@ -121,7 +121,11 @@ where
     /// makes that unrepresentable, since nothing can be held across a [`Poll::Pending`] return.
     pub fn poll_receive(&mut self, cx: &mut Context<'_>) -> Poll<Result<Option<T>>> {
         while self.prefix_read < PREFIX_BYTES {
-            let mut buf = ReadBuf::new(&mut self.prefix[self.prefix_read..]);
+            let unfilled = self
+                .prefix
+                .get_mut(self.prefix_read..)
+                .expect("loop condition keeps `prefix_read` below the prefix length");
+            let mut buf = ReadBuf::new(unfilled);
             ready!(Pin::new(&mut self.reader).poll_read(cx, &mut buf))?;
 
             match buf.filled().len() {
@@ -151,7 +155,11 @@ where
         while self.payload_read < len {
             // Bounded by `len`, not by the buffer: the tail beyond the current message belongs to
             // whatever the peer sends next, and reading into it would swallow the following frame.
-            let mut buf = ReadBuf::new(&mut self.buffer[self.payload_read..len]);
+            let unfilled = self
+                .buffer
+                .get_mut(self.payload_read..len)
+                .expect("loop condition keeps `payload_read` below `len`, and the buffer holds at least `len`");
+            let mut buf = ReadBuf::new(unfilled);
             ready!(Pin::new(&mut self.reader).poll_read(cx, &mut buf))?;
 
             match buf.filled().len() {
@@ -164,7 +172,11 @@ where
         self.payload_len = None;
         self.payload_read = 0;
 
-        let value = bincode::decode_from_slice(&self.buffer[..len], bincode::config::standard())?.0;
+        let payload = self
+            .buffer
+            .get(..len)
+            .expect("the buffer was grown to hold at least `len`");
+        let value = bincode::decode_from_slice(payload, bincode::config::standard())?.0;
 
         Poll::Ready(Ok(Some(value)))
     }

--- a/mirrord/intproxy/protocol/src/codec/codec_async.rs
+++ b/mirrord/intproxy/protocol/src/codec/codec_async.rs
@@ -136,7 +136,12 @@ where
             Some(len) => len,
             None => {
                 let len = u32::from_be_bytes(self.prefix) as usize;
-                self.buffer.resize(len, 0);
+                // Only ever grows, settling at the largest message this connection has carried.
+                // Sizing it exactly per message would rezero the whole buffer every time, and the
+                // messages on this channel are mostly uniform, so the growth stops almost at once.
+                if self.buffer.len() < len {
+                    self.buffer.resize(len, 0);
+                }
                 self.payload_read = 0;
                 self.payload_len = Some(len);
                 len
@@ -144,7 +149,9 @@ where
         };
 
         while self.payload_read < len {
-            let mut buf = ReadBuf::new(&mut self.buffer[self.payload_read..]);
+            // Bounded by `len`, not by the buffer: the tail beyond the current message belongs to
+            // whatever the peer sends next, and reading into it would swallow the following frame.
+            let mut buf = ReadBuf::new(&mut self.buffer[self.payload_read..len]);
             ready!(Pin::new(&mut self.reader).poll_read(cx, &mut buf))?;
 
             match buf.filled().len() {
@@ -157,7 +164,7 @@ where
         self.payload_len = None;
         self.payload_read = 0;
 
-        let value = bincode::decode_from_slice(&self.buffer, bincode::config::standard())?.0;
+        let value = bincode::decode_from_slice(&self.buffer[..len], bincode::config::standard())?.0;
 
         Poll::Ready(Ok(Some(value)))
     }

--- a/mirrord/intproxy/src/layer_conn.rs
+++ b/mirrord/intproxy/src/layer_conn.rs
@@ -81,3 +81,55 @@ impl BackgroundTask for LayerConnection {
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+    use std::time::Duration;
+
+    use futures::FutureExt;
+    use mirrord_intproxy_protocol::codec::{AsyncDecoder, AsyncEncoder};
+    use tokio::io::AsyncWriteExt;
+
+    /// Length of the codec's message prefix, see [`mirrord_intproxy_protocol::codec`].
+    const PREFIX_BYTES: usize = 4;
+
+    /// [`LayerConnection::run`] selects over [`AsyncDecoder::receive`], so that future is dropped
+    /// every time the other branch wins the race. If the decoder kept its progress on the stack,
+    /// the bytes it had already taken from the socket would vanish with the dropped future, and
+    /// the next call would read the middle of a message as a length prefix.
+    ///
+    /// A layer opening many outgoing connections at once keeps both directions busy and hits this
+    /// within a few hundred messages.
+    #[tokio::test]
+    async fn receive_resumes_after_being_cancelled_mid_message() {
+        let (mut layer, proxy) = tokio::io::duplex(1024);
+        let mut decoder: AsyncDecoder<u64, _> = AsyncDecoder::new(proxy);
+
+        let mut frame = Vec::new();
+        let mut encoder: AsyncEncoder<u64, _> = AsyncEncoder::new(&mut frame);
+        encoder.send(&1234).await.unwrap();
+        encoder.flush().await.unwrap();
+
+        let (prefix, payload) = frame.split_at(PREFIX_BYTES);
+
+        // Deliver only the length prefix, then cancel a `receive` that consumed it.
+        layer.write_all(prefix).await.unwrap();
+        assert!(
+            decoder.receive().now_or_never().is_none(),
+            "receive should be pending while the payload is missing"
+        );
+
+        // The payload arrives. The next call has to resume the message in flight rather than
+        // treat these bytes as a fresh length prefix.
+        //
+        // The timeout is what makes a regression fail instead of hang: reading the payload as a
+        // prefix yields a huge length, and the decoder then waits forever for bytes that the
+        // layer is never going to send.
+        layer.write_all(payload).await.unwrap();
+        let received = tokio::time::timeout(Duration::from_secs(5), decoder.receive())
+            .await
+            .expect("decoder lost the bytes it consumed before being cancelled")
+            .unwrap();
+        assert_eq!(received, Some(1234));
+    }
+}

--- a/mirrord/intproxy/src/layer_conn.rs
+++ b/mirrord/intproxy/src/layer_conn.rs
@@ -1,5 +1,6 @@
 //! Implementation of `layer <-> proxy` connection through a [`TcpStream`].
 
+use futures::StreamExt;
 use mirrord_intproxy_protocol::{
     LayerId, LayerToProxyMessage, LocalMessage, ProxyToLayerMessage,
     codec::{self, AsyncDecoder, AsyncEncoder, CodecError},
@@ -59,15 +60,18 @@ impl BackgroundTask for LayerConnection {
     async fn run(&mut self, message_bus: &mut MessageBus<Self>) -> Result<(), CodecError> {
         loop {
             tokio::select! {
-                res = self.layer_codec_rx.receive() => match res {
-                    Err(e) => {
+                // `StreamExt::next` is cancel safe, which matters here: this branch loses the race
+                // to the one below often enough that a decoder holding partial reads on the stack
+                // would desynchronize the stream. See `AsyncDecoder::poll_receive`.
+                res = self.layer_codec_rx.next() => match res {
+                    Some(Err(e)) => {
                         break Err(e);
                     },
-                    Ok(None) => {
+                    None => {
                         tracing::debug!("Layer closed connection, exiting");
                         break Ok(());
                     }
-                    Ok(Some(msg)) => message_bus.send(FromLayer { message: msg.inner, message_id: msg.message_id, layer_id: self.layer_id }).await,
+                    Some(Ok(msg)) => message_bus.send(FromLayer { message: msg.inner, message_id: msg.message_id, layer_id: self.layer_id }).await,
                 },
 
                 msg = message_bus.recv() => match msg {
@@ -86,22 +90,25 @@ impl BackgroundTask for LayerConnection {
 mod test {
     use std::time::Duration;
 
-    use futures::FutureExt;
+    use futures::{FutureExt, StreamExt};
     use mirrord_intproxy_protocol::codec::{AsyncDecoder, AsyncEncoder};
     use tokio::io::AsyncWriteExt;
 
     /// Length of the codec's message prefix, see [`mirrord_intproxy_protocol::codec`].
     const PREFIX_BYTES: usize = 4;
 
-    /// [`LayerConnection::run`] selects over [`AsyncDecoder::receive`], so that future is dropped
-    /// every time the other branch wins the race. If the decoder kept its progress on the stack,
-    /// the bytes it had already taken from the socket would vanish with the dropped future, and
-    /// the next call would read the middle of a message as a length prefix.
+    /// [`LayerConnection::run`] selects over the decoder, so that future is dropped every time the
+    /// other branch wins the race. If the decoder kept its progress on the stack, the bytes it had
+    /// already taken from the socket would vanish with the dropped future, and the next poll would
+    /// read the middle of a message as a length prefix.
     ///
     /// A layer opening many outgoing connections at once keeps both directions busy and hits this
     /// within a few hundred messages.
+    ///
+    /// Cancelling through [`StreamExt::next`] and resuming through `receive` also pins down that
+    /// both entry points drive the same state machine, rather than each keeping its own.
     #[tokio::test]
-    async fn receive_resumes_after_being_cancelled_mid_message() {
+    async fn decoder_resumes_after_being_cancelled_mid_message() {
         let (mut layer, proxy) = tokio::io::duplex(1024);
         let mut decoder: AsyncDecoder<u64, _> = AsyncDecoder::new(proxy);
 
@@ -112,15 +119,16 @@ mod test {
 
         let (prefix, payload) = frame.split_at(PREFIX_BYTES);
 
-        // Deliver only the length prefix, then cancel a `receive` that consumed it.
+        // Deliver only the length prefix, then cancel a poll that consumed it, the way `select!`
+        // does when the outgoing branch wins.
         layer.write_all(prefix).await.unwrap();
         assert!(
-            decoder.receive().now_or_never().is_none(),
-            "receive should be pending while the payload is missing"
+            decoder.next().now_or_never().is_none(),
+            "decoder should be pending while the payload is missing"
         );
 
-        // The payload arrives. The next call has to resume the message in flight rather than
-        // treat these bytes as a fresh length prefix.
+        // The payload arrives. The next poll has to resume the message in flight rather than treat
+        // these bytes as a fresh length prefix.
         //
         // The timeout is what makes a regression fail instead of hang: reading the payload as a
         // prefix yields a huge length, and the decoder then waits forever for bytes that the

--- a/mirrord/intproxy/src/layer_conn.rs
+++ b/mirrord/intproxy/src/layer_conn.rs
@@ -140,4 +140,27 @@ mod test {
             .unwrap();
         assert_eq!(received, Some(1234));
     }
+
+    /// The decoder's buffer only grows, so it stays sized for the largest message seen so far. A
+    /// shorter message that follows a longer one has to be read and decoded against its own
+    /// length, not against whatever the buffer happens to be holding.
+    #[tokio::test]
+    async fn decoder_reuses_its_buffer_across_message_sizes() {
+        let (mut layer, proxy) = tokio::io::duplex(4096);
+        let mut decoder: AsyncDecoder<String, _> = AsyncDecoder::new(proxy);
+
+        let long = "x".repeat(512);
+        let short = "y".to_owned();
+
+        let mut frames = Vec::new();
+        let mut encoder: AsyncEncoder<String, _> = AsyncEncoder::new(&mut frames);
+        encoder.send(&long).await.unwrap();
+        encoder.send(&short).await.unwrap();
+        encoder.flush().await.unwrap();
+
+        layer.write_all(&frames).await.unwrap();
+
+        assert_eq!(decoder.receive().await.unwrap(), Some(long));
+        assert_eq!(decoder.receive().await.unwrap(), Some(short));
+    }
 }


### PR DESCRIPTION
Sessions died with `Proxy error, connectivity issue or a bug: connection closed.` when an
application opened a large number of concurrent outgoing connections. The intproxy log showed:

```
ERROR mirrord_intproxy::layer_conn: io failed: Invalid argument (os error 22)
ERROR mirrord_intproxy: Layer connection failed
```

## Cause

`AsyncDecoder::receive` was not cancel safe, and `LayerConnection::run` selects over it:

```rust
tokio::select! {
    res = self.layer_codec_rx.receive() => ...,
    msg = message_bus.recv() => self.send_and_flush(&msg).await?,
}
```

`receive` kept its progress on the stack — it read the 4-byte length prefix, then awaited the
payload. When the outgoing branch won the race, `select!` dropped the receive future and the
already-consumed prefix bytes went with it. The next call then read a message *payload* as a
length prefix.

The resulting length is garbage. It either fails to decode, or asks for a multi-gigabyte read,
which on macOS returns `EINVAL` — `read` rejects `nbyte > INT_MAX`. That is the "Invalid argument"
above. Either way the layer connection dies and takes the session with it.

This needs both directions busy at the same time, which is why it only shows up under a burst of
concurrent connections and why extra logging makes it disappear.

## Evidence

Instrumenting both sides of the codec and comparing the ledgers ruled the writer out: declared
length always matched payload length, and every frame went out in a single `write()` syscall — no
partial writes, no `EINTR`, no errors, all under the `sender` mutex. On the reader side the phase
shift is visible directly. Where a frame prefix belonged, the decoder read `a5 03 00 00`, which is
the payload head of the *previous* message, with the frames after it still well-formed:

```
76 03 00 00 00 0a ... <payload, no prefix>
00 00 00 38 | fb f6 01 03 ...    <- next frame, framed correctly
00 00 00 36 | 78 03 ...          <- and the one after
```

Bytes were being consumed and discarded, not mis-written.

## Fix

Move the read progress into `AsyncDecoder` (`prefix`, `prefix_read`, `payload_len`,
`payload_read`) and loop on cancel-safe `read` instead of `read_exact`, so a dropped future
resumes where it stopped. EOF semantics are unchanged.

## Testing

Reproduced with a Go program opening 1000 concurrent TCP connections to a cluster service through
`mirrord exec`.

- Before: failed on every run at 1000 connections; never at 300.
- After: 1000 connections pass 3/3. 2000 and 4000 no longer desynchronize either — the remaining
  failures there are the single target replica resetting connections, reported per connection with
  the session intact.
- `cargo test -p mirrord-intproxy`: 72 passed. Clippy clean with `--deny warnings`.

Added `receive_resumes_after_being_cancelled_mid_message` in `layer_conn.rs`, next to the
`select!` that motivates the requirement. Confirmed it catches the bug by reverting the fix — it
hangs on the old decoder, so the test is wrapped in a timeout to fail fast rather than hang CI.

### Quality Checklist:

- [x] I have documented new code sufficiently
- [x] I have checked and updated the relevant existing docs in code, including removing outdated material
- [ ] ~I have written user-facing website docs for new features, or opened a (sub)issue to do so~
- [ ] ~I have checked and updated existing website docs for changed features~
- [x] I have tested this change and know it succeeds and fails as expected
- [x] I have written unit tests or purposefully omitted them
- [ ] ~I have written e2e tests or purposefully omitted them~
- [x] I have explained what this PR introduces and why, and linked to relevant context
- [x] I have introduced a short, clear and well-formatted changelog entry
