### PR TITLE
Fix race in async decoder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5170,6 +5170,7 @@ version = "3.239.0"
 dependencies = [
  "bincode",
  "drain",
+ "futures",
  "log",
  "miette",
  "mirrord-intproxy-protocol",
@@ -5235,6 +5236,8 @@ name = "mirrord-intproxy-protocol"
 version = "3.239.0"
 dependencies = [
  "bincode",
+ "bytes",
+ "futures",
  "mirrord-protocol",
  "thiserror 2.0.18",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5241,6 +5241,7 @@ dependencies = [
  "mirrord-protocol",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/changelog.d/+protocol-framing-bug.fixed.md
+++ b/changelog.d/+protocol-framing-bug.fixed.md
@@ -1,0 +1,1 @@
+Fixed a `layer <-> intproxy` protocol framing bug that broke sessions where an app opened many concurrent outgoing connections.

--- a/mirrord/console/Cargo.toml
+++ b/mirrord/console/Cargo.toml
@@ -23,12 +23,13 @@ required-features = ["binary"]
 [features]
 default = []
 binary = ["dep:tracing", "dep:tracing-subscriber", "dep:tokio", "mirrord-intproxy-protocol/codec-async"]
-async-logger = ["mirrord-intproxy-protocol/codec-async", "dep:tokio", "dep:drain", "dep:tokio-util"]
+async-logger = ["mirrord-intproxy-protocol/codec-async", "dep:futures", "dep:tokio", "dep:drain", "dep:tokio-util"]
 
 [dependencies]
 mirrord-intproxy-protocol = { path = "../intproxy/protocol", features = ["codec"] }
 
 bincode.workspace = true
+futures = { workspace = true, optional = true }
 log.workspace = true
 miette.workspace = true
 thiserror.workspace = true

--- a/mirrord/console/Cargo.toml
+++ b/mirrord/console/Cargo.toml
@@ -22,7 +22,7 @@ required-features = ["binary"]
 
 [features]
 default = []
-binary = ["dep:tracing", "dep:tracing-subscriber", "dep:tokio", "mirrord-intproxy-protocol/codec-async"]
+binary = ["dep:futures", "dep:tracing", "dep:tracing-subscriber", "dep:tokio", "mirrord-intproxy-protocol/codec-async"]
 async-logger = ["mirrord-intproxy-protocol/codec-async", "dep:futures", "dep:tokio", "dep:drain", "dep:tokio-util"]
 
 [dependencies]

--- a/mirrord/console/src/async_logger.rs
+++ b/mirrord/console/src/async_logger.rs
@@ -1,4 +1,5 @@
 use drain::Watch;
+use futures::SinkExt;
 use log::LevelFilter;
 use mirrord_intproxy_protocol::codec::AsyncEncoder;
 use tokio::{
@@ -37,7 +38,7 @@ impl LoggerTask {
                 msg = self.rx.recv() => match msg {
                     None => break,
                     Some(record) => {
-                        if let Err(e) = self.encoder.send(&record).await {
+                        if let Err(e) = self.encoder.send(record).await {
                             eprintln!("Error sending log message: {e:?}");
                             break;
                         }
@@ -82,7 +83,7 @@ async fn send_hello(stream: &mut TcpStream) -> Result<()> {
     let hello = Hello::from_env();
 
     let mut encoder: AsyncEncoder<Hello, &mut TcpStream> = AsyncEncoder::new(stream);
-    encoder.send(&hello).await?;
+    encoder.send(hello).await?;
 
     Ok(())
 }

--- a/mirrord/console/src/main.rs
+++ b/mirrord/console/src/main.rs
@@ -1,4 +1,5 @@
 use bincode::Decode;
+use futures::TryStreamExt;
 use mirrord_console::protocol::{Hello, Record};
 use mirrord_intproxy_protocol::codec::AsyncDecoder;
 use tokio::{
@@ -25,7 +26,7 @@ impl ConnectionWrapper {
     {
         let mut decoder: AsyncDecoder<T, _> = AsyncDecoder::new(&mut self.conn);
         decoder
-            .receive()
+            .try_next()
             .await
             .expect("failed to receive message from client")
     }

--- a/mirrord/intproxy/protocol/Cargo.toml
+++ b/mirrord/intproxy/protocol/Cargo.toml
@@ -26,10 +26,11 @@ bytes = { workspace = true, optional = true }
 futures = { workspace = true, optional = true }
 thiserror = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }
+tokio-util = { workspace = true, optional = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["full"] }
 
 [features]
 codec = ["dep:thiserror"]
-codec-async = ["codec", "dep:bytes", "dep:futures", "dep:tokio"]
-
-[lib]
-test = false
+codec-async = ["codec", "dep:bytes", "dep:futures", "dep:tokio", "dep:tokio-util"]

--- a/mirrord/intproxy/protocol/Cargo.toml
+++ b/mirrord/intproxy/protocol/Cargo.toml
@@ -22,12 +22,14 @@ workspace = true
 mirrord-protocol = { path = "../../protocol" }
 
 bincode.workspace = true
+bytes = { workspace = true, optional = true }
+futures = { workspace = true, optional = true }
 thiserror = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }
 
 [features]
 codec = ["dep:thiserror"]
-codec-async = ["codec", "dep:tokio"]
+codec-async = ["codec", "dep:bytes", "dep:futures", "dep:tokio"]
 
 [lib]
 test = false

--- a/mirrord/intproxy/protocol/src/codec/codec_async.rs
+++ b/mirrord/intproxy/protocol/src/codec/codec_async.rs
@@ -195,24 +195,17 @@ where
 
                 DecoderState::ReadingMessage { total_len } if this.buffer.len() < *total_len => {
                     let missing = *total_len - this.buffer.len();
-                    let space = this
-                        .buffer
-                        .spare_capacity_mut()
-                        .get_mut(..missing)
-                        .expect("buffer should have been resized to fit the message");
-                    let mut read_buf = ReadBuf::uninit(space);
-                    std::task::ready!(Pin::new(&mut this.reader).poll_read(cx, &mut read_buf))?;
-                    let filled_now = read_buf.filled().len();
-                    if filled_now == 0 {
+                    let mut limited = (&mut this.buffer).limit(missing);
+                    let bytes_read = std::task::ready!(tokio_util::io::poll_read_buf(
+                        Pin::new(&mut this.reader),
+                        cx,
+                        &mut limited
+                    ))?;
+                    if bytes_read == 0 {
                         break Poll::Ready(Some(Err(CodecError::IoError(
                             io::ErrorKind::UnexpectedEof.into(),
                         ))));
                     }
-                    let new_len = this.buffer.len() + filled_now;
-                    unsafe {
-                        // SAFETY: we trust that poll_read has initialized those bytes
-                        this.buffer.set_len(new_len)
-                    };
                 }
 
                 DecoderState::ReadingMessage { .. } => {

--- a/mirrord/intproxy/protocol/src/codec/codec_async.rs
+++ b/mirrord/intproxy/protocol/src/codec/codec_async.rs
@@ -153,7 +153,7 @@ enum DecoderState {
         filled: usize,
     },
     ReadingMessage {
-        total_len: usize,
+        message_len: usize,
     },
 }
 
@@ -187,14 +187,16 @@ where
                     }
                     *filled += filled_now;
                     if *filled == buffer.len() {
-                        let total_len = usize::try_from(u32::from_be_bytes(*buffer))?;
-                        this.state = DecoderState::ReadingMessage { total_len };
-                        this.buffer.reserve(total_len);
+                        let message_len = usize::try_from(u32::from_be_bytes(*buffer))?;
+                        this.state = DecoderState::ReadingMessage { message_len };
+                        this.buffer.reserve(message_len);
                     }
                 }
 
-                DecoderState::ReadingMessage { total_len } if this.buffer.len() < *total_len => {
-                    let missing = *total_len - this.buffer.len();
+                DecoderState::ReadingMessage { message_len }
+                    if this.buffer.len() < *message_len =>
+                {
+                    let missing = *message_len - this.buffer.len();
                     let mut limited = (&mut this.buffer).limit(missing);
                     let bytes_read = std::task::ready!(tokio_util::io::poll_read_buf(
                         Pin::new(&mut this.reader),

--- a/mirrord/intproxy/protocol/src/codec/codec_async.rs
+++ b/mirrord/intproxy/protocol/src/codec/codec_async.rs
@@ -55,6 +55,9 @@ where
             let written = std::task::ready!(
                 Pin::new(&mut self.writer).poll_write(cx, self.buffer.get_ref())
             )?;
+            if written == 0 {
+                return Poll::Ready(Err(CodecError::IoError(io::ErrorKind::WriteZero.into())));
+            }
             self.buffer.get_mut().advance(written);
         }
         Poll::Ready(Ok(()))
@@ -213,13 +216,13 @@ where
                 }
 
                 DecoderState::ReadingMessage { .. } => {
-                    let (value, remaining) = bincode::decode_from_slice::<T, _>(
+                    let (value, consumed) = bincode::decode_from_slice::<T, _>(
                         this.buffer.as_ref(),
                         bincode::config::standard(),
                     )?;
-                    if remaining > 0 {
+                    if consumed > this.buffer.len() {
                         break Poll::Ready(Some(Err(CodecError::IoError(io::Error::other(
-                            format!("detected {remaining} leftover bytes"),
+                            "detected leftover bytes",
                         )))));
                     }
                     this.state = DecoderState::ReadingPrefix {

--- a/mirrord/intproxy/protocol/src/codec/codec_async.rs
+++ b/mirrord/intproxy/protocol/src/codec/codec_async.rs
@@ -1,17 +1,30 @@
-use std::io::ErrorKind;
+use std::{
+    io,
+    ops::Not,
+    pin::Pin,
+    task::{Context, Poll},
+};
 
-use bincode::{Decode, Encode};
+use bincode::{
+    Decode, Encode,
+    enc::{EncoderImpl, write::SizeWriter},
+};
+use bytes::{Buf, BufMut, BytesMut, buf::Writer};
+use futures::{Sink, Stream};
 use tokio::{
-    io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt},
+    io::{AsyncRead, AsyncWrite, ReadBuf},
     net::tcp::{OwnedReadHalf, OwnedWriteHalf},
 };
 
 use super::{BUFFER_SIZE, PREFIX_BYTES, Result};
+use crate::codec::CodecError;
 
 /// Handles sending messages of type `T` through the underlying [AsyncWrite] of type `W`.
+///
+/// Implements [`Sink`].
 #[derive(Debug)]
 pub struct AsyncEncoder<T, W> {
-    buffer: Vec<u8>,
+    buffer: Writer<BytesMut>,
     writer: W,
     _phantom: std::marker::PhantomData<fn() -> T>,
 }
@@ -20,7 +33,7 @@ impl<T, W> AsyncEncoder<T, W> {
     /// Wraps the underlying IO handler.
     pub fn new(writer: W) -> Self {
         Self {
-            buffer: Vec::with_capacity(BUFFER_SIZE),
+            buffer: BytesMut::with_capacity(BUFFER_SIZE).writer(),
             writer,
             _phantom: Default::default(),
         }
@@ -37,32 +50,75 @@ where
     T: Encode,
     W: AsyncWrite + Unpin,
 {
-    /// Encodes the given value into the inner IO handler.
-    pub async fn send(&mut self, value: &T) -> Result<()> {
-        self.buffer.resize(PREFIX_BYTES, 0);
-        let bytes: u32 =
-            bincode::encode_into_std_write(value, &mut self.buffer, bincode::config::standard())?
-                .try_into()?;
-        self.buffer
-            .get_mut(..PREFIX_BYTES)
-            .expect("buffer to short")
-            .copy_from_slice(&bytes.to_be_bytes());
+    fn poll_write(&mut self, cx: &mut Context<'_>) -> Poll<Result<()>> {
+        while self.buffer.get_ref().is_empty().not() {
+            let written = std::task::ready!(
+                Pin::new(&mut self.writer).poll_write(cx, self.buffer.get_ref())
+            )?;
+            self.buffer.get_mut().advance(written);
+        }
+        Poll::Ready(Ok(()))
+    }
+}
 
-        self.writer.write_all(&self.buffer).await?;
+impl<T, W> Sink<T> for AsyncEncoder<T, W>
+where
+    T: Encode,
+    W: AsyncWrite + Unpin,
+{
+    type Error = CodecError;
+
+    fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
+        self.get_mut().poll_write(cx)
+    }
+
+    fn start_send(self: Pin<&mut Self>, item: T) -> Result<()> {
+        let this = self.get_mut();
+        if this.buffer.get_ref().is_empty().not() {
+            return Err(CodecError::IoError(io::Error::other("codec not ready")));
+        }
+
+        let size = {
+            let mut size_writer =
+                EncoderImpl::<_, _>::new(SizeWriter::default(), bincode::config::standard());
+            item.encode(&mut size_writer)?;
+            size_writer.into_writer().bytes_written
+        };
+        let size_u32 = u32::try_from(size)?;
+        let total_size = size + PREFIX_BYTES;
+        // This reclaims freed capacity if possible.
+        this.buffer.get_mut().reserve(total_size);
+
+        this.buffer.get_mut().put_u32(size_u32);
+        bincode::encode_into_std_write(item, &mut this.buffer, bincode::config::standard())?;
 
         Ok(())
     }
 
-    /// Flushes the inner IO handler.
-    pub async fn flush(&mut self) -> Result<()> {
-        self.writer.flush().await.map_err(Into::into)
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
+        let this = self.get_mut();
+        std::task::ready!(this.poll_write(cx))?;
+        Pin::new(&mut this.writer)
+            .poll_flush(cx)
+            .map_err(CodecError::IoError)
+    }
+
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
+        let this = self.get_mut();
+        std::task::ready!(this.poll_write(cx))?;
+        Pin::new(&mut this.writer)
+            .poll_shutdown(cx)
+            .map_err(CodecError::IoError)
     }
 }
 
 /// Handles receiving messages of type `T` from the underlying [AsyncRead] of type `W`.
+///
+/// Implements [`Stream`].
 #[derive(Debug)]
 pub struct AsyncDecoder<T, R> {
-    buffer: Vec<u8>,
+    buffer: BytesMut,
+    state: DecoderState,
     reader: R,
     _phantom: std::marker::PhantomData<fn() -> T>,
 }
@@ -71,7 +127,11 @@ impl<T, R> AsyncDecoder<T, R> {
     /// Wraps the underlying IO handler.
     pub fn new(reader: R) -> Self {
         Self {
-            buffer: Vec::with_capacity(BUFFER_SIZE),
+            buffer: BytesMut::with_capacity(BUFFER_SIZE),
+            state: DecoderState::ReadingPrefix {
+                buffer: Default::default(),
+                filled: 0,
+            },
             reader,
             _phantom: Default::default(),
         }
@@ -83,28 +143,94 @@ impl<T, R> AsyncDecoder<T, R> {
     }
 }
 
-impl<T, R> AsyncDecoder<T, R>
+#[derive(Debug)]
+enum DecoderState {
+    ReadingPrefix {
+        buffer: [u8; PREFIX_BYTES],
+        filled: usize,
+    },
+    ReadingMessage {
+        total_len: usize,
+    },
+}
+
+impl<T, R> Stream for AsyncDecoder<T, R>
 where
     T: Decode<()>,
     R: AsyncRead + Unpin,
 {
-    /// Decodes the next message from the underlying IO handler.
-    /// Does not read any excessive bytes.
-    pub async fn receive(&mut self) -> Result<Option<T>> {
-        let mut len_buffer = [0; 4];
-        match self.reader.read_exact(&mut len_buffer).await {
-            Ok(..) => {}
-            Err(e) if e.kind() == ErrorKind::UnexpectedEof => return Ok(None),
-            Err(e) => Err(e)?,
+    type Item = Result<T>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+        loop {
+            match &mut this.state {
+                DecoderState::ReadingPrefix { buffer, filled } => {
+                    let missing = buffer
+                        .get_mut(*filled..)
+                        .expect("filled counter should not exceed the buffer size");
+                    let mut read_buf = ReadBuf::new(missing);
+                    std::task::ready!(Pin::new(&mut this.reader).poll_read(cx, &mut read_buf))?;
+                    let filled_now = read_buf.filled().len();
+                    if filled_now == 0 {
+                        let result = if *filled == 0 {
+                            None
+                        } else {
+                            Some(Err(CodecError::IoError(
+                                io::ErrorKind::UnexpectedEof.into(),
+                            )))
+                        };
+                        break Poll::Ready(result);
+                    }
+                    *filled += filled_now;
+                    if *filled == buffer.len() {
+                        let total_len = usize::try_from(u32::from_be_bytes(*buffer))?;
+                        this.state = DecoderState::ReadingMessage { total_len };
+                        this.buffer.reserve(total_len);
+                    }
+                }
+
+                DecoderState::ReadingMessage { total_len } if this.buffer.len() < *total_len => {
+                    let missing = *total_len - this.buffer.len();
+                    let space = this
+                        .buffer
+                        .spare_capacity_mut()
+                        .get_mut(..missing)
+                        .expect("buffer should have been resized to fit the message");
+                    let mut read_buf = ReadBuf::uninit(space);
+                    std::task::ready!(Pin::new(&mut this.reader).poll_read(cx, &mut read_buf))?;
+                    let filled_now = read_buf.filled().len();
+                    if filled_now == 0 {
+                        break Poll::Ready(Some(Err(CodecError::IoError(
+                            io::ErrorKind::UnexpectedEof.into(),
+                        ))));
+                    }
+                    let new_len = this.buffer.len() + filled_now;
+                    unsafe {
+                        // SAFETY: we trust that poll_read has initialized those bytes
+                        this.buffer.set_len(new_len)
+                    };
+                }
+
+                DecoderState::ReadingMessage { .. } => {
+                    let (value, remaining) = bincode::decode_from_slice::<T, _>(
+                        this.buffer.as_ref(),
+                        bincode::config::standard(),
+                    )?;
+                    if remaining > 0 {
+                        break Poll::Ready(Some(Err(CodecError::IoError(io::Error::other(
+                            format!("detected {remaining} leftover bytes"),
+                        )))));
+                    }
+                    this.state = DecoderState::ReadingPrefix {
+                        buffer: Default::default(),
+                        filled: 0,
+                    };
+                    this.buffer.clear();
+                    break Poll::Ready(Some(Ok(value)));
+                }
+            }
         }
-        let len = u32::from_be_bytes(len_buffer);
-
-        self.buffer.resize(len as usize, 0);
-        self.reader.read_exact(&mut self.buffer).await?;
-
-        let value = bincode::decode_from_slice(&self.buffer, bincode::config::standard())?.0;
-
-        Ok(Some(value))
     }
 }
 

--- a/mirrord/intproxy/protocol/src/codec/codec_async.rs
+++ b/mirrord/intproxy/protocol/src/codec/codec_async.rs
@@ -220,7 +220,7 @@ where
                         this.buffer.as_ref(),
                         bincode::config::standard(),
                     )?;
-                    if consumed > this.buffer.len() {
+                    if consumed < this.buffer.len() {
                         break Poll::Ready(Some(Err(CodecError::IoError(io::Error::other(
                             "detected leftover bytes",
                         )))));
@@ -251,4 +251,31 @@ pub fn make_async_framed<T1: Encode, T2: Decode<()>>(
     let receiver = AsyncDecoder::new(reader);
 
     (sender, receiver)
+}
+
+#[cfg(test)]
+mod test {
+    use futures::{SinkExt, StreamExt, TryStreamExt};
+
+    use crate::codec::{AsyncDecoder, AsyncEncoder};
+
+    #[tokio::test]
+    async fn encode_decode() {
+        let (reader, writer) = tokio::io::simplex(1);
+        let decoder = AsyncDecoder::<String, _>::new(reader);
+        let mut encoder = AsyncEncoder::<String, _>::new(writer);
+
+        let messages = ["hello", "from", "the", "other", "side", ""]
+            .into_iter()
+            .map(String::from)
+            .collect::<Vec<_>>();
+
+        let (received, ()) = tokio::join!(decoder.try_collect::<Vec<_>>(), async {
+            let mut messages = futures::stream::iter(&messages).map(Clone::clone).map(Ok);
+            encoder.send_all(&mut messages).await.unwrap();
+            encoder.close().await.unwrap();
+        },);
+
+        assert_eq!(received.unwrap(), messages,);
+    }
 }

--- a/mirrord/intproxy/protocol/src/macros.rs
+++ b/mirrord/intproxy/protocol/src/macros.rs
@@ -7,7 +7,7 @@
 ///
 /// # Example
 ///
-/// ```
+/// ```ignore
 /// use mirrord_intproxy::bind_nested;
 ///
 /// enum A {

--- a/mirrord/intproxy/src/layer_conn.rs
+++ b/mirrord/intproxy/src/layer_conn.rs
@@ -1,5 +1,6 @@
 //! Implementation of `layer <-> proxy` connection through a [`TcpStream`].
 
+use futures::{SinkExt, TryStreamExt};
 use mirrord_intproxy_protocol::{
     LayerId, LayerToProxyMessage, LocalMessage, ProxyToLayerMessage,
     codec::{self, AsyncDecoder, AsyncEncoder, CodecError},
@@ -39,10 +40,9 @@ impl LayerConnection {
     #[tracing::instrument(level = Level::TRACE, skip(self), ret, err(level = Level::TRACE))]
     async fn send_and_flush(
         &mut self,
-        msg: &LocalMessage<ProxyToLayerMessage>,
+        msg: LocalMessage<ProxyToLayerMessage>,
     ) -> Result<(), CodecError> {
-        self.layer_codec_tx.send(msg).await?;
-        self.layer_codec_tx.flush().await
+        self.layer_codec_tx.send(msg).await
     }
 }
 
@@ -59,7 +59,7 @@ impl BackgroundTask for LayerConnection {
     async fn run(&mut self, message_bus: &mut MessageBus<Self>) -> Result<(), CodecError> {
         loop {
             tokio::select! {
-                res = self.layer_codec_rx.receive() => match res {
+                res = self.layer_codec_rx.try_next() => match res {
                     Err(e) => {
                         break Err(e);
                     },
@@ -71,7 +71,7 @@ impl BackgroundTask for LayerConnection {
                 },
 
                 msg = message_bus.recv() => match msg {
-                    Some(msg) => self.send_and_flush(&msg).await?,
+                    Some(msg) => self.send_and_flush(msg).await?,
                     None => {
                         tracing::debug!("Message bus closed, exiting");
                         break Ok(());

--- a/mirrord/intproxy/src/layer_initializer.rs
+++ b/mirrord/intproxy/src/layer_initializer.rs
@@ -1,5 +1,6 @@
 use std::{io, net::SocketAddr};
 
+use futures::{SinkExt, TryStreamExt};
 use mirrord_intproxy_protocol::{
     LayerId, LayerToProxyMessage, LocalMessage, NewSessionRequest, ProxyToLayerMessage,
     codec::{AsyncDecoder, AsyncEncoder, CodecError},
@@ -52,7 +53,7 @@ impl LayerInitializer {
         let mut decoder: AsyncDecoder<LocalMessage<LayerToProxyMessage>, _> =
             AsyncDecoder::new(stream);
         let msg = decoder
-            .receive()
+            .try_next()
             .await?
             .ok_or(LayerInitializerError::NoMessage)?;
 
@@ -71,12 +72,11 @@ impl LayerInitializer {
         let mut encoder: AsyncEncoder<LocalMessage<ProxyToLayerMessage>, _> =
             AsyncEncoder::new(decoder.into_inner());
         encoder
-            .send(&LocalMessage {
+            .send(LocalMessage {
                 message_id: msg.message_id,
                 inner: ProxyToLayerMessage::NewSession(id),
             })
             .await?;
-        encoder.flush().await?;
 
         let stream = encoder.into_inner();
 

--- a/mirrord/intproxy/src/lib.rs
+++ b/mirrord/intproxy/src/lib.rs
@@ -839,6 +839,7 @@ impl IntProxy {
 mod test {
     use std::{net::SocketAddr, path::PathBuf, time::Duration};
 
+    use futures::{SinkExt, StreamExt, TryStreamExt};
     use hyper::{HeaderMap, Method, StatusCode, Uri, Version};
     use mirrord_analytics::NullReporter;
     use mirrord_config::{
@@ -936,7 +937,7 @@ mod test {
         >(conn);
         codec
             .0
-            .send(&LocalMessage {
+            .send(LocalMessage {
                 message_id: 0,
                 inner: LayerToProxyMessage::NewSession(NewSessionRequest {
                     process_info: ProcessInfo {
@@ -951,8 +952,7 @@ mod test {
             })
             .await
             .unwrap();
-        codec.0.flush().await.unwrap();
-        match codec.1.receive().await.unwrap().unwrap() {
+        match codec.1.next().await.unwrap().unwrap() {
             LocalMessage {
                 message_id: 0,
                 inner: ProxyToLayerMessage::NewSession(..),
@@ -962,7 +962,7 @@ mod test {
 
         codec
             .0
-            .send(&LocalMessage {
+            .send(LocalMessage {
                 message_id: 1,
                 inner: LayerToProxyMessage::File(FileRequest::StatFsV2(StatFsRequestV2 {
                     path: PathBuf::from("/some/path"),
@@ -970,7 +970,6 @@ mod test {
             })
             .await
             .unwrap();
-        codec.0.flush().await.unwrap();
 
         // To make sure that the proxy has a chance to do progress.
         // If the proxy was not waiting for agent protocol version,
@@ -1054,7 +1053,7 @@ mod test {
         >(conn);
 
         encoder
-            .send(&LocalMessage {
+            .send(LocalMessage {
                 message_id: 0,
                 inner: LayerToProxyMessage::NewSession(NewSessionRequest {
                     process_info: ProcessInfo {
@@ -1069,8 +1068,7 @@ mod test {
             })
             .await
             .unwrap();
-        encoder.flush().await.unwrap();
-        match decoder.receive().await.unwrap().unwrap() {
+        match decoder.next().await.unwrap().unwrap() {
             LocalMessage {
                 message_id: 0,
                 inner: ProxyToLayerMessage::NewSession(..),
@@ -1091,7 +1089,7 @@ mod test {
             .unwrap();
 
         encoder
-            .send(&LocalMessage {
+            .send(LocalMessage {
                 message_id: 1,
                 inner: LayerToProxyMessage::File(FileRequest::StatFsV2(StatFsRequestV2 {
                     path: PathBuf::from("/some/path"),
@@ -1099,9 +1097,8 @@ mod test {
             })
             .await
             .unwrap();
-        encoder.flush().await.unwrap();
 
-        match decoder.receive().await.unwrap().unwrap() {
+        match decoder.next().await.unwrap().unwrap() {
             LocalMessage {
                 message_id: 1,
                 inner: ProxyToLayerMessage::ProxyFailed { .. },
@@ -1189,7 +1186,7 @@ mod test {
         >(conn);
 
         from_layer
-            .send(&LocalMessage {
+            .send(LocalMessage {
                 message_id: 0,
                 inner: LayerToProxyMessage::NewSession(NewSessionRequest {
                     process_info: ProcessInfo {
@@ -1204,7 +1201,6 @@ mod test {
             })
             .await
             .unwrap();
-        from_layer.flush().await.unwrap();
 
         let (_, chaos_rx) = watch::channel(Default::default());
 
@@ -1225,7 +1221,7 @@ mod test {
         );
         tokio::spawn(proxy.run(Duration::from_millis(100), Duration::ZERO));
 
-        match to_layer.receive().await.unwrap().unwrap() {
+        match to_layer.next().await.unwrap().unwrap() {
             LocalMessage {
                 message_id: 0,
                 inner: ProxyToLayerMessage::NewSession(..),
@@ -1286,7 +1282,7 @@ mod test {
         // Subscribe to a port so we can later confirm that it
         // restores the subscription after the reconnect.
         from_layer
-            .send(&LocalMessage {
+            .send(LocalMessage {
                 message_id: 0,
                 inner: LayerToProxyMessage::Incoming(IncomingRequest::PortSubscribe(
                     PortSubscribe {
@@ -1340,7 +1336,7 @@ mod test {
                 .unwrap();
 
             assert!(matches!(
-                to_layer.receive().await,
+                to_layer.try_next().await,
                 Ok(Some(LocalMessage {
                     message_id: 0,
                     inner: ProxyToLayerMessage::Incoming(
@@ -1407,7 +1403,7 @@ mod test {
         });
 
         from_layer
-            .send(&LocalMessage {
+            .send(LocalMessage {
                 message_id: 0,
                 inner: LayerToProxyMessage::File(file_request.clone()),
             })
@@ -1427,7 +1423,7 @@ mod test {
         switch_protocol_version(&to_proxy, &from_proxy).await;
 
         assert!(matches!(
-            to_layer.receive().await,
+            to_layer.try_next().await,
             Ok(Some(LocalMessage {
                 message_id: 0,
                 inner: ProxyToLayerMessage::File(FileResponse::Open(Err(ResponseError::RemoteIO(
@@ -1460,7 +1456,7 @@ mod test {
         let socket_addr = SocketAddress::Ip("8.0.0.85:69".parse().unwrap());
 
         from_layer
-            .send(&LocalMessage {
+            .send(LocalMessage {
                 message_id: 0,
                 inner: LayerToProxyMessage::Outgoing(OutgoingRequest::Connect(
                     OutgoingConnectRequest {
@@ -1483,7 +1479,7 @@ mod test {
 
         // With non blocking TCP connection, intproxy responds right away.
         assert!(matches!(
-            to_layer.receive().await,
+            to_layer.try_next().await,
             Ok(Some(LocalMessage {
                 message_id: 0,
                 inner: ProxyToLayerMessage::Outgoing(OutgoingResponse::Connect(Ok(
@@ -1503,7 +1499,7 @@ mod test {
         switch_protocol_version(&to_proxy, &from_proxy).await;
 
         assert!(matches!(
-            to_layer.receive().await,
+            to_layer.try_next().await,
             Ok(Some(LocalMessage {
                 message_id: 0,
                 inner: ProxyToLayerMessage::Outgoing(OutgoingResponse::Connect(Err(
@@ -1542,7 +1538,7 @@ mod test {
         };
 
         from_layer
-            .send(&LocalMessage {
+            .send(LocalMessage {
                 message_id: 0,
                 inner: LayerToProxyMessage::GetAddrInfo(request.clone()),
             })
@@ -1560,7 +1556,7 @@ mod test {
         switch_protocol_version(&to_proxy, &from_proxy).await;
 
         assert!(matches!(
-            to_layer.receive().await,
+            to_layer.try_next().await,
             Ok(Some(LocalMessage {
                 message_id: 0,
                 inner: ProxyToLayerMessage::GetAddrInfo(GetAddrInfoResponse(Err(
@@ -1593,7 +1589,7 @@ mod test {
         switch_protocol_version(&to_proxy, &from_proxy).await;
 
         from_layer
-            .send(&LocalMessage {
+            .send(LocalMessage {
                 message_id: 0,
                 inner: LayerToProxyMessage::Incoming(IncomingRequest::PortSubscribe(
                     PortSubscribe {
@@ -1616,7 +1612,7 @@ mod test {
             .unwrap();
 
         assert!(matches!(
-            to_layer.receive().await,
+            to_layer.try_next().await,
             Ok(Some(LocalMessage {
                 message_id: 0,
                 inner: ProxyToLayerMessage::Incoming(
@@ -1738,7 +1734,7 @@ mod test {
             .unwrap();
 
         assert!(matches!(
-            to_layer.receive().await,
+            to_layer.try_next().await,
             Ok(Some(LocalMessage {
                 message_id: 0,
                 inner: ProxyToLayerMessage::Incoming(


### PR DESCRIPTION
Now `AsyncEncoder`/`AsyncDecoder` is just `Sink`/`Stream`

### Quality Checklist:

- [ ] I have documented new code sufficiently
- [ ] I have checked and updated the relevant existing docs in code, including removing outdated material
- [ ] I have written user-facing website docs for new features, or opened a (sub)issue to do so
- [ ] I have checked and updated existing website docs for changed features
- [ ] I have tested this change and know it succeeds and fails as expected
- [ ] I have written unit tests or purposefully omitted them
- [ ] I have written e2e tests or purposefully omitted them
- [ ] I have explained what this PR introduces and why, and linked to relevant context (e.g. linear issues, related PRs,
  documentation)
- [x] I have introduced a short, clear and well-formatted changelog entry

<!-- need help with the changelog? see ../CONTRIBUTING.md#submitting-a-pull-request -->
<!-- Add more details of your changes below if needed -->