### PR TITLE
COR-1708 — kill Windows pitm child trees with a Job Object

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -267,6 +267,7 @@ winapi = { version = "0.3.9", features = [
     "sysinfoapi",
     "synchapi",
     "handleapi",
+    "jobapi2",
     "processenv",
     "winioctl",
     "memoryapi",

--- a/changelog.d/+windows-pitm-kill-children.fixed.md
+++ b/changelog.d/+windows-pitm-kill-children.fixed.md
@@ -1,0 +1,1 @@
+Fixed Windows-native runs (IntelliJ `pitm` and `mirrord exec`) leaking the injected target process when the parent was killed abruptly — e.g. IntelliJ/Gradle stopping a run. The child is now bound to a job object and torn down with the parent, so the layer disconnects and the agent cleans up instead of leaving "dirty iptables" that break the next session.

--- a/mirrord/cli/src/main.rs
+++ b/mirrord/cli/src/main.rs
@@ -620,6 +620,9 @@ where
         // current_directory (inherit from parent)
         None,
         env_vars,
+        // `mirrord exec` runs-and-waits; bind the child tree to this process so an
+        // abrupt kill can't leave the layer-loaded child (and thus the agent) alive.
+        true,
         Some(progress),
     )
     .and_then(|managed_process| managed_process.wait_until_exit())

--- a/mirrord/cli/src/pitm.rs
+++ b/mirrord/cli/src/pitm.rs
@@ -150,6 +150,10 @@ pub(crate) fn pitm_command(args: PitmArgs) -> CliResult<()> {
         command_line,
         None,
         env_vars,
+        // Bind the child JVM's lifetime to this pitm process via a kill-on-close job,
+        // so IntelliJ/Gradle abruptly stopping the run can't orphan it (an orphaned,
+        // still-connected layer keeps the agent alive → "dirty iptables" next session).
+        true,
         None::<NullProgress>,
     )
     .map_err(|e| CliError::PitmExecuteFailed(exe.to_owned(), e.to_string()))?;

--- a/mirrord/layer-lib/src/process/windows/execution/mod.rs
+++ b/mirrord/layer-lib/src/process/windows/execution/mod.rs
@@ -13,6 +13,7 @@ use winapi::{
     },
     um::{
         handleapi::{CloseHandle, SetHandleInformation},
+        jobapi2::{AssignProcessToJobObject, CreateJobObjectW, SetInformationJobObject},
         minwinbase::LPSECURITY_ATTRIBUTES,
         processenv::GetStdHandle,
         processthreadsapi::{
@@ -25,7 +26,10 @@ use winapi::{
             STARTF_USESTDHANDLES, STD_ERROR_HANDLE, STD_INPUT_HANDLE, STD_OUTPUT_HANDLE,
             WAIT_OBJECT_0,
         },
-        winnt::PHANDLE,
+        winnt::{
+            JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE, JOBOBJECT_EXTENDED_LIMIT_INFORMATION,
+            JobObjectExtendedLimitInformation, PHANDLE,
+        },
     },
 };
 
@@ -86,6 +90,18 @@ pub struct LayerManagedProcess {
     process_info: PROCESS_INFORMATION,
     released: bool,
     terminate_on_drop: bool,
+    /// Job object the child is bound to when the caller asked to kill children on
+    /// exit (`kill_children_on_exit`). `None` otherwise.
+    ///
+    /// Holding this handle open ties the child's lifetime to ours: when this process
+    /// dies for *any* reason — clean exit, `TerminateProcess`, or a crash — the OS
+    /// closes our handles, and the job's `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` limit
+    /// then kills the whole child tree. `terminate_on_drop` alone can't guarantee
+    /// this: it fires from `Drop`, which never runs when the OS kills us abruptly
+    /// (exactly how IntelliJ/Gradle stop a run), leaving the layer-loaded child
+    /// orphaned — and an orphaned child keeps the agent alive, which surfaces later
+    /// as "dirty iptables".
+    job: Option<HANDLE>,
 }
 
 impl LayerManagedProcess {
@@ -231,12 +247,53 @@ impl LayerManagedProcess {
         }
     }
 
+    /// Creates an anonymous job object with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` and
+    /// assigns `process` to it, returning the job handle.
+    ///
+    /// While the returned handle is held open the job's processes run; when the last
+    /// handle to the job closes — including when *this* process dies and the OS
+    /// reclaims its handles — the OS terminates every process still in the job. Assign
+    /// the child while it is suspended so it is bound before it can spawn descendants.
+    fn assign_to_kill_on_close_job(process: HANDLE) -> LayerResult<HANDLE> {
+        unsafe {
+            let job = CreateJobObjectW(ptr::null_mut(), ptr::null());
+            if job.is_null() {
+                return Err(LayerError::WindowsProcessCreation(
+                    WindowsError::last_error(),
+                ));
+            }
+
+            let mut info: JOBOBJECT_EXTENDED_LIMIT_INFORMATION = std::mem::zeroed();
+            info.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+            if SetInformationJobObject(
+                job,
+                JobObjectExtendedLimitInformation,
+                &mut info as *mut _ as LPVOID,
+                std::mem::size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as DWORD,
+            ) == 0
+            {
+                let error = WindowsError::last_error();
+                CloseHandle(job);
+                return Err(LayerError::WindowsProcessCreation(error));
+            }
+
+            if AssignProcessToJobObject(job, process) == 0 {
+                let error = WindowsError::last_error();
+                CloseHandle(job);
+                return Err(LayerError::WindowsProcessCreation(error));
+            }
+
+            Ok(job)
+        }
+    }
+
     /// Execute process with layer injection for CLI context, returning managed process
     pub fn execute<P>(
         application_name: Option<String>,
         command_line: String,
         current_directory: Option<String>,
         env_vars: HashMap<String, String>,
+        kill_children_on_exit: bool,
         progress: Option<P>,
     ) -> LayerResult<Self>
     where
@@ -301,6 +358,7 @@ impl LayerManagedProcess {
             default_creation_flags,
             &mut default_startup_info,
             create_process_fn,
+            kill_children_on_exit,
             progress,
         )
     }
@@ -312,6 +370,7 @@ impl LayerManagedProcess {
         caller_creation_flags: DWORD,
         caller_startup_info: &mut STARTUPINFOW,
         create_process_fn: F,
+        kill_children_on_exit: bool,
         progress: Option<P>,
     ) -> LayerResult<Self>
     where
@@ -363,14 +422,27 @@ impl LayerManagedProcess {
         // Call the original function with processed parameters
         let process_info = create_process_fn(creation_flags, environment_ptr, caller_startup_info)?;
 
-        // The child is suspended, so we can create the PID-based event before injection.
-        let parent_event = LayerInitEvent::for_parent(process_info.dwProcessId)?;
-
-        let managed_process = Self {
+        // Take ownership immediately so every later error path terminates the suspended process
+        // and closes both process handles.
+        let mut managed_process = Self {
             process_info,
             released: false,
             terminate_on_drop: true,
+            job: None,
         };
+
+        // Bind the child's lifetime to ours while it is still suspended, so an abrupt
+        // kill of this process can't orphan it (see [`LayerManagedProcess::job`]). Done
+        // before the child resumes, so it is captured before it can spawn its own
+        // children (which the job then also owns).
+        if kill_children_on_exit {
+            managed_process.job = Some(Self::assign_to_kill_on_close_job(
+                managed_process.process_info.hProcess,
+            )?);
+        }
+
+        // The child is suspended, so we can create the PID-based event before injection.
+        let parent_event = LayerInitEvent::for_parent(managed_process.process_info.dwProcessId)?;
 
         // The process is already created and suspended by the original call
         // Now we just need to inject the DLL and resume
@@ -477,6 +549,14 @@ impl Drop for LayerManagedProcess {
             unsafe {
                 CloseHandle(self.process_info.hProcess);
                 CloseHandle(self.process_info.hThread);
+            }
+        }
+        // Closing the last job handle reaps any child still in the job (KILL_ON_JOB_CLOSE).
+        // A job is only ever set for callers that own the child's lifetime and never
+        // `release()` it, so this is always the right thing when present.
+        if let Some(job) = self.job.take() {
+            unsafe {
+                CloseHandle(job);
             }
         }
     }

--- a/mirrord/layer-win/src/hooks/process/mod.rs
+++ b/mirrord/layer-win/src/hooks/process/mod.rs
@@ -114,6 +114,9 @@ unsafe extern "system" fn create_process_internal_w_hook(
         creation_flags,
         unsafe { &mut *startup_info },
         create_process_fn,
+        // Hooked child processes are released to run independently; the root
+        // pitm/exec job already owns the whole descendant tree via inheritance.
+        false,
         None::<mirrord_progress::NullProgress>, // No progress in hook context
     )
     .map(|managed_process| managed_process.release())


### PR DESCRIPTION
# Bind the Windows `pitm` child lifetime to mirrord

## Linear

https://linear.app/metalbear/issue/COR-1708/windows-pitm-bind-the-child-jvms-lifetime-via-a-job-object-orphan-on

## Stack

2 of 4 in the Windows `pitm` and bind-fix stack. Based on #4614; review only the Job Object commit in this PR.

## Summary

Places Windows processes launched by `mirrord pitm` and `mirrord exec` in a Job Object configured with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`.

The child is assigned while still suspended, before it can create descendants, and the owning handle is kept alive for the managed process lifetime. If the mirrord wrapper exits normally, crashes, or is terminated by the IDE, Windows tears down the full child tree.

## Motivation

IntelliJ stops the `mirrord pitm` wrapper with `TerminateProcess`. That bypasses Rust destructors, so the previous `terminate_on_drop` cleanup never ran. The injected JVM could remain orphaned and keep its layer connection alive; that kept the intproxy and agent alive as well, leaving agent iptables behind for the next session.

The failure was intermittent because it depended on how the IDE stopped the process tree. The next run then surfaced the secondary symptom: `Detected dirty iptables.`

## Implementation

`LayerManagedProcess::execute` receives an explicit `kill_children_on_exit` policy. On Windows, enabled callers create and configure a Job Object, assign the suspended child to it, and retain the handle in the managed process.

`pitm` and `mirrord exec` enable the policy. The layer's child-process hook disables it because that process is already covered by job inheritance and is intentionally released from the local process wrapper.

The Windows API feature set is updated only for the Job Object calls required by this path.

## Verification

- `cargo fmt --check`
- `cargo check -p mirrord-layer-win --all-targets --keep-going`
- `cargo xtask build-cli`
- Windows IntelliJ Gradle Run/Debug stop behavior exercised with the combined stack

### Quality Checklist

- [x] I have documented why the Job Object is required
- [x] I have tested this change and know it succeeds and fails as expected
- [x] Unit-test coverage is purposefully omitted for the OS-owned process-tree lifetime behavior
- [x] The behavior was exercised through the Windows IDE integration path
- [x] I have linked the relevant Linear issue and preceding stack PR
- [x] I have introduced a short, clear changelog entry
