### PR TITLE
COR-1709 — use a per-build Windows pitm layer path

### DIFF
--- a/changelog.d/+windows-layer-extract-stale.fixed.md
+++ b/changelog.d/+windows-layer-extract-stale.fixed.md
@@ -1,0 +1,1 @@
+Fixed Windows `pitm` reusing a stale layer DLL after the mirrord binary was upgraded by giving its extracted layer the existing per-build unique filename.

--- a/mirrord/cli/src/pitm.rs
+++ b/mirrord/cli/src/pitm.rs
@@ -137,7 +137,9 @@ pub(crate) fn pitm_command(args: PitmArgs) -> CliResult<()> {
     // `LayerManagedProcess::execute` reads `MIRRORD_LAYER_FILE` from the
     // supplied env_vars map, so we embed it there rather than mutating
     // the current process's environment.
-    let lib_path = extract_library(None, &NullProgress, false)?;
+    // A build-specific file name prevents a newer CLI from reusing a stale layer left by an
+    // older `pitm` invocation.
+    let lib_path = extract_library(None, &NullProgress, true)?;
     env_vars.insert(
         MIRRORD_LAYER_FILE_ENV.to_owned(),
         lib_path.to_string_lossy().into_owned(),


### PR DESCRIPTION
# Prevent `pitm` from reusing a stale Windows layer

## Linear

https://linear.app/metalbear/issue/COR-1709/windows-pitm-extracted-layer-dll-cached-by-fixed-name-stale-after

## Stack

3 of 4 in the Windows `pitm` and bind-fix stack. Based on #4615; this PR contains only the layer-cache fix.

## Summary

Changes Windows `pitm` extraction to use the build-specific layer filename that the regular CLI path already uses, instead of the fixed `%TEMP%/mirrord/libmirrord_layer.dll` path.

The same build still gets a cache hit, while a different mirrord build gets its own extracted DLL.

## Motivation

The extraction helper writes a layer only when the destination does not exist. `pitm` requested the non-prefixed filename, so installing a new mirrord binary could leave it loading an older DLL from the temp directory indefinitely.

That mixed a new CLI and resolved configuration with an old layer. In the reported reproduction, the stale layer failed while decoding the newer config with:

```text
Decoding resolved config failed: invalid type: null, expected a boolean
```

Deleting the cached DLL hid the problem, but the next binary upgrade could recreate it.

## Implementation

`pitm` now requests the prefixed extraction path. The prefix is derived from the embedded build metadata already used elsewhere by the CLI, so this reuses the established extraction and cache behavior without adding another invalidation mechanism or hashing the DLL on every run.

## Verification

- `cargo fmt --check`
- `cargo check -p mirrord-layer-win --all-targets --keep-going`
- `cargo xtask build-cli`
- Combined Windows IntelliJ Gradle Run/Debug regression validation used a freshly built CLI and extracted layer

### Quality Checklist

- [x] I have documented why the build-specific path is required
- [x] I have tested this change and know it succeeds and fails as expected
- [x] Unit-test coverage is purposefully omitted for the one-line selection of the existing extraction path
- [x] The behavior was exercised in the combined IDE regression flow
- [x] I have linked the relevant Linear issue and preceding stack PR
- [x] I have introduced a short, clear changelog entry
