### PR TITLE
COR-1729 — preserve WinSock bind errors and complete random-port fallback

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -18,5 +18,5 @@ incremental = false
 
 [target.'cfg(windows)']
 rustflags = [
-    "-C", "link-args=/STACK:8388608", # STACKSIZE=32MB
+    "-C", "link-args=/STACK:8388608", # STACKSIZE=8MB
 ]

--- a/changelog.d/+windows-bind-last-error.fixed.md
+++ b/changelog.d/+windows-bind-last-error.fixed.md
@@ -1,0 +1,1 @@
+Fixed Windows socket hooks replacing a failed `bind` call's WinSock error while closing the tracing span, which made applications receive an unrelated error code.

--- a/mirrord/layer-win/src/hooks/socket/mod.rs
+++ b/mirrord/layer-win/src/hooks/socket/mod.rs
@@ -309,33 +309,60 @@ unsafe extern "system" fn wsa_socket_w_detour(
 }
 
 /// Windows socket hook for bind
-#[mirrord_layer_macro::instrument(level = "trace", ret)]
+///
+/// The instrumented implementation may call Windows APIs while its tracing span is being closed.
+/// Restore the original bind error only after it returns so the caller receives the correct
+/// WinSock error.
 unsafe extern "system" fn bind_detour(s: SOCKET, name: *const SOCKADDR, namelen: INT) -> INT {
+    let (result, last_error) = unsafe { bind_detour_impl(s, name, namelen) };
+    if let Some(last_error) = last_error {
+        unsafe { WSASetLastError(last_error) };
+    }
+
+    result
+}
+
+#[mirrord_layer_macro::instrument(level = "trace", ret)]
+unsafe fn bind_detour_impl(s: SOCKET, name: *const SOCKADDR, namelen: INT) -> (INT, Option<i32>) {
     tracing::trace!("bind_detour -> socket: {}, namelen: {}", s, namelen);
 
     let original = BIND_ORIGINAL.get().unwrap();
 
     // Define bind function before early returns so it can be reused
-    let bind_fn = |addr: *const SOCKADDR, addr_len: INT, reason: &str| -> INT {
+    let bind_fn = |addr: *const SOCKADDR,
+                   addr_len: INT,
+                   reason: &str,
+                   failure_is_final: bool|
+     -> (INT, Option<i32>) {
         let res = unsafe { original(s, addr, addr_len) };
+        let last_error = (res != ERROR_SUCCESS_I32).then(|| unsafe { WSAGetLastError() });
 
-        if res != ERROR_SUCCESS_I32 {
-            tracing::error!(
-                "bind_detour -> {} failed (wsa_last_error={})",
-                reason,
-                unsafe { WSAGetLastError() }
-            );
+        if let Some(last_error) = last_error {
+            if failure_is_final {
+                tracing::error!(
+                    "bind_detour -> {} failed (wsa_last_error={})",
+                    reason,
+                    last_error
+                );
+            } else {
+                tracing::debug!(
+                    "bind_detour -> {} failed, retrying on a random port \
+                        (wsa_last_error={})",
+                    reason,
+                    last_error
+                );
+            }
         } else {
             tracing::debug!("bind_detour -> {} succeeded", reason);
         }
 
-        res
+        (res, last_error)
     };
     let requested_addr = match unsafe { SocketAddr::try_from_raw(name, namelen) } {
         Some(addr) => addr,
         None => {
             tracing::error!("bind_detour -> failed to convert address");
-            return bind_fn(name, namelen, "address parse error");
+            return bind_fn(name, namelen, "address parse error", true);
         }
     };
 
@@ -351,7 +378,7 @@ unsafe extern "system" fn bind_detour(s: SOCKET, name: *const SOCKADDR, namelen:
 
         let Some(entry) = sockets.remove(&s) else {
             // fallback / early return when the socket isn’t tracked
-            return bind_fn(name, namelen, "non-managed socket");
+            return bind_fn(name, namelen, "non-managed socket", true);
         };
 
         // The user's requested address must behave as taken even though we actually bind to a
@@ -369,8 +396,7 @@ unsafe extern "system" fn bind_detour(s: SOCKET, name: *const SOCKADDR, namelen:
                 requested_addr
             );
             sockets.insert(s, entry);
-            unsafe { WSASetLastError(WSAEADDRINUSE) };
-            return SOCKET_ERROR;
+            return (SOCKET_ERROR, Some(WSAEADDRINUSE));
         }
 
         entry
@@ -380,14 +406,14 @@ unsafe extern "system" fn bind_detour(s: SOCKET, name: *const SOCKADDR, namelen:
             "bind_detour -> socket {} is not in Initialized state, using original bind",
             s
         );
-        return bind_fn(name, namelen, "invalid socket state");
+        return bind_fn(name, namelen, "invalid socket state", true);
     }
 
     // Check configuration-based early returns
     let incoming_config = setup().incoming_config();
     if incoming_config.ignore_localhost && requested_addr.ip().is_loopback() {
         tracing::debug!("bind_detour -> ignoring localhost bind");
-        return bind_fn(name, namelen, "localhost ignored");
+        return bind_fn(name, namelen, "localhost ignored", true);
     }
 
     // A configured `listen_ports` mapping pins the port; otherwise we may fall back to a
@@ -408,23 +434,23 @@ unsafe extern "system" fn bind_detour(s: SOCKET, name: *const SOCKADDR, namelen:
         Ok((storage, len)) => (storage, len),
         Err(e) => {
             tracing::error!("bind_detour -> failed to convert local address: {}", e);
-            return bind_fn(name, namelen, "address conversion error");
+            return bind_fn(name, namelen, "address conversion error", true);
         }
     };
 
     // Attempt primary bind
-    let bind_result = bind_fn(
+    let (bind_result, last_error) = bind_fn(
         &local_addr_storage as *const _ as *const SOCKADDR,
         local_addr_len,
         "primary bind",
+        can_use_random_port.not(),
     );
 
     // Handle bind failures
     if bind_result != ERROR_SUCCESS_I32 {
         // Check for access denied error which may indicate UAC privilege issues
         // Check if this is a privileged port that requires elevation
-        if WindowsError::wsa_last_error() == WSAEACCES && local_addr.port() < IPPORT_RESERVED as u16
-        {
+        if last_error == Some(WSAEACCES) && local_addr.port() < IPPORT_RESERVED as u16 {
             // graceful_exit if process is not elevated.
             require_elevation(&format!(
                 "mirrord failed to bind to privileged port {} - insufficient UAC privileges. On Windows, binding to privileged ports (< {}) requires running as Administrator or with elevated UAC privileges. Please restart your application with elevated privileges.",
@@ -438,7 +464,7 @@ unsafe extern "system" fn bind_detour(s: SOCKET, name: *const SOCKADDR, namelen:
         // Fall back to a random local port when the requested one is busy, mirroring the Unix
         // layer's `bind_similar_address`. The real port is recovered below via `getsockname`.
         if can_use_random_port.not() {
-            return bind_result;
+            return (bind_result, last_error);
         }
 
         let fallback_addr = SocketAddr::new(local_addr.ip(), 0);
@@ -446,17 +472,18 @@ unsafe extern "system" fn bind_detour(s: SOCKET, name: *const SOCKADDR, namelen:
             Ok((storage, len)) => (storage, len),
             Err(e) => {
                 tracing::error!("bind_detour -> failed to convert fallback address: {}", e);
-                return bind_result;
+                return (bind_result, last_error);
             }
         };
 
-        let fallback_result = bind_fn(
+        let (fallback_result, fallback_error) = bind_fn(
             &fallback_storage as *const _ as *const SOCKADDR,
             fallback_len,
             "random port fallback",
+            true,
         );
         if fallback_result != ERROR_SUCCESS_I32 {
-            return fallback_result;
+            return (fallback_result, fallback_error);
         }
     }
 
@@ -482,7 +509,7 @@ unsafe extern "system" fn bind_detour(s: SOCKET, name: *const SOCKADDR, namelen:
         requested_addr
     );
 
-    ERROR_SUCCESS_I32
+    (ERROR_SUCCESS_I32, None)
 }
 
 /// Windows socket hook for listen


### PR DESCRIPTION
# Windows managed-bind collision handling

## Linear

https://linear.app/metalbear/issue/COR-1729/preserve-wsagetlasterror-across-the-windows-bind-hook

Follow-up to COR-1496 and https://github.com/metalbear-co/mirrord/pull/4422.

## Stack

4 of 4 in the Windows `pitm` and bind-fix stack. Based on #4616; this PR contains only the Windows bind changes and the corrected stack-size comment.

## Summary

Completes the Windows managed-bind collision behavior and preserves the original WinSock failure that must be returned to the application.

For an unpinned incoming port, a collision on the local requested port now retries on port `0`, mirroring Unix `bind_similar_address`: the remote/requested port remains unchanged while mirrord privately uses an available local port. An explicit `incoming.listen_ports` mapping remains pinned and fails instead of silently changing the configured local port.

The hook also captures `WSAGetLastError` immediately after every failed original `bind` and restores the final error only after the instrumented implementation and its tracing span have returned.

## Root cause

The Windows layer previously had two related problems:

1. A managed socket could fail outright when its local port was occupied, even though the local port is an implementation detail and the remote subscription must continue using the application's requested port.
2. After a real bind failure, tracing and managed-socket bookkeeping ran before control returned to the application. WinSock's last-error value is thread-local, so an intervening Windows call could replace `WSAEADDRINUSE (10048)`. The customer JVM then received the unrelated error `6` and reported `Unrecognized Windows Sockets error: 6: bind`.

## Behavior

- No explicit local-port mapping: retry the local bind with port `0`, record the actual local address from `getsockname`, and retain the user's requested address in managed socket state.
- Explicit `listen_ports` mapping: do not fall back; return the original collision.
- Two mirrord-managed sockets requesting the same address: preserve user-visible bind semantics and return `WSAEADDRINUSE`.
- Any final original-bind failure: restore its captured WinSock error as the last uninstrumented action in the detour.

The exported detour is intentionally uninstrumented. Its inner implementation owns tracing and returns both the result and captured error; only after that span is fully closed does the outer detour call `WSASetLastError` and return.

The same commit corrects the nearby Windows linker comment: `8388608` bytes is an 8 MiB stack, not 32 MiB.

## Verification

A Java `BindCollision` Gradle reproduction was run through a real mirrord agent against fresh BusyBox pods in the `gabriela-debug` namespace.

Validated cases:

- occupied default local port: bind succeeds through an opaque random-local-port fallback while the requested/remote port remains unchanged;
- occupied explicitly mapped local port: bind fails with Java `BindException: Address already in use` and WinSock error `10048`, not error `6`;
- managed socket state continues to expose the user's requested address separately from mirrord's private local binding.

Also passed:

- `cargo fmt --check`
- `cargo check -p mirrord-layer-win --all-targets --keep-going`
- `cargo xtask build-cli`

### Quality Checklist

- [x] I have documented the requested-address versus private-local-address behavior
- [x] I have tested success and failure paths against a real agent
- [x] The Java bind-collision reproduction covers the regression end to end
- [x] I have explained the root cause and linked the related issue and PR
- [x] I have introduced a short, clear changelog entry
