### PR TITLE
mirrord chaos CLI command

### DIFF
--- a/.vale/styles/config/vocabularies/Metalbear/accept.txt
+++ b/.vale/styles/config/vocabularies/Metalbear/accept.txt
@@ -75,6 +75,7 @@ fd
 fds
 syscalls
 subcommand
+subcommands
 ASCII
 crypto
 runtime

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5206,6 +5206,7 @@ dependencies = [
  "mirrord-session-monitor-protocol",
  "mirrord-tls-util",
  "nix",
+ "prettytable-rs",
  "rand 0.10.2",
  "rcgen",
  "rstest",

--- a/changelog.d/+chaos-subcommand-cli.added.md
+++ b/changelog.d/+chaos-subcommand-cli.added.md
@@ -1,0 +1,3 @@
+Added the `mirrord chaos` command for managing chaos rules. The available subcommands are `list`,
+`add`, `edit` and `delete`. Silently starts the local UI if needed. New rules can be provided as a
+file or to `stdin`, and output can be JSON format or pretty printed.

--- a/mirrord/cli/src/config.rs
+++ b/mirrord/cli/src/config.rs
@@ -1651,6 +1651,17 @@ pub struct ChaosArgs {
     pub command: ChaosSubcommand,
 }
 
+impl ChaosArgs {
+    pub fn session_id(&self) -> &str {
+        match &self.command {
+            ChaosSubcommand::List { session_id, .. }
+            | ChaosSubcommand::Add { session_id, .. }
+            | ChaosSubcommand::Edit { session_id, .. }
+            | ChaosSubcommand::Delete { session_id, .. } => session_id,
+        }
+    }
+}
+
 /// `mirrord chaos` subcommands.
 #[derive(Subcommand, Debug)]
 pub enum ChaosSubcommand {

--- a/mirrord/cli/src/config.rs
+++ b/mirrord/cli/src/config.rs
@@ -271,8 +271,11 @@ pub(super) enum Commands {
         no_telemetry: bool,
 
         #[clap(flatten)]
-        args: Box<UiCommonArgs>,
+        args: UiCommonArgs,
     },
+
+    /// Manage per-session chaos rules for local chaos testing.
+    Chaos(ChaosArgs),
 
     /// Manage local mirrord sessions.
     #[command(visible_alias = "sessions")]
@@ -1638,6 +1641,70 @@ pub enum UiSubcommand {
     /// Stop the currently running `mirrord ui` server background task.
     #[command(visible_alias = "kill")]
     Stop,
+}
+
+/// Arguments for the `mirrord chaos` command.
+#[derive(Args, Debug)]
+pub struct ChaosArgs {
+    /// Subcommand to use with `mirrord chaos`.
+    #[command(subcommand)]
+    pub command: ChaosSubcommand,
+}
+
+/// `mirrord chaos` subcommands.
+#[derive(Subcommand, Debug)]
+pub enum ChaosSubcommand {
+    /// List existing rules or a specific rule for this session.
+    #[command(visible_alias = "get", visible_alias = "ls")]
+    List {
+        /// Session on which to list rules.
+        #[arg(short = 's', long)]
+        session_id: String,
+
+        /// Specific rule to show. If absent, all rules for this session are listed.
+        #[arg(short = 'r', long)]
+        rule_id: Option<String>,
+    },
+
+    /// Add a new rule to this session.
+    #[command(visible_alias = "post")]
+    Add {
+        /// Session on which to add rules.
+        #[arg(short = 's', long)]
+        session_id: String,
+
+        /// JSON file containing the chaos rule definition.
+        #[arg(short = 'f', long)]
+        file_path: PathBuf,
+    },
+
+    /// Edit an existing rule for this session
+    #[command(visible_alias = "put")]
+    Edit {
+        /// Session on which to edit rule.
+        #[arg(short = 's', long)]
+        session_id: String,
+
+        /// Rule to edit.
+        #[arg(short = 'r', long)]
+        rule_id: String,
+
+        /// JSON file containing the chaos rule definition.
+        #[arg(short = 'f', long)]
+        file_path: PathBuf,
+    },
+
+    /// Delete existing rules or a specific rule for this session.
+    #[command(visible_alias = "remove", visible_alias = "rm")]
+    Delete {
+        /// Session on which to delete rules.
+        #[arg(short = 's', long)]
+        session_id: String,
+
+        /// Specific rule to delete. If absent, all rules for this session are cleared.
+        #[arg(short = 'r', long)]
+        rule_id: Option<String>,
+    },
 }
 
 /// Arguments for the `mirrord session` command.

--- a/mirrord/cli/src/config.rs
+++ b/mirrord/cli/src/config.rs
@@ -1662,6 +1662,16 @@ impl ChaosArgs {
         }
     }
 
+    /// Retrieve the `file_path` that this command specifies
+    pub fn file_path(&self) -> Option<&PathBuf> {
+        match &self.command {
+            ChaosSubcommand::List { .. } | ChaosSubcommand::Delete { .. } => None,
+            ChaosSubcommand::Add { file_path, .. } | ChaosSubcommand::Edit { file_path, .. } => {
+                Some(file_path)
+            }
+        }
+    }
+
     /// Returns `true` if this command expects a JSON repsonse body
     pub fn returns_json(&self) -> bool {
         match &self.command {

--- a/mirrord/cli/src/config.rs
+++ b/mirrord/cli/src/config.rs
@@ -1667,13 +1667,24 @@ impl ChaosArgs {
         }
     }
 
-    /// Retrieve the `file_path` that this command specifies.
+    /// Retrieve the `file_path` that this command specifies. Returns `None` if not specified.
     pub fn file_path(&self) -> Option<&PathBuf> {
         match &self.command {
             ChaosSubcommand::List { .. } | ChaosSubcommand::Delete { .. } => None,
             ChaosSubcommand::Add { file_path, .. } | ChaosSubcommand::Edit { file_path, .. } => {
                 file_path.as_ref()
             }
+        }
+    }
+
+    /// Retrieve the `rule_id` that this command specifies. Returns `None` if not specified.
+    pub fn rule_id(&self) -> Option<&str> {
+        match &self.command {
+            ChaosSubcommand::List { rule_id, .. } | ChaosSubcommand::Delete { rule_id, .. } => {
+                rule_id.as_deref()
+            }
+            ChaosSubcommand::Edit { rule_id, .. } => Some(rule_id),
+            ChaosSubcommand::Add { .. } => None,
         }
     }
 
@@ -1712,15 +1723,15 @@ pub enum ChaosSubcommand {
         rule_id: Option<String>,
     },
 
-    /// Add a new rule to this session from `stdin`. If --file_path is provided, reads from the file
-    /// instead.
+    /// Add a new rule or rules to this session from `stdin`. If --file_path is provided, reads from
+    /// the file instead.
     #[command(visible_alias = "post")]
     Add {
         /// Session on which to add rules.
         #[arg(short = 's', long)]
         session_id: String,
 
-        /// JSON file containing the chaos rule definition.
+        /// JSON file containing the chaos rule definition or definitions.
         #[arg(short = 'f', long)]
         file_path: Option<PathBuf>,
     },

--- a/mirrord/cli/src/config.rs
+++ b/mirrord/cli/src/config.rs
@@ -26,6 +26,7 @@ use mirrord_config::{
     target::TargetType,
 };
 use mirrord_up::ServiceMode;
+use strum_macros::Display;
 use thiserror::Error;
 
 use crate::config::ci::CiArgs;
@@ -1649,6 +1650,10 @@ pub struct ChaosArgs {
     /// Subcommand to use with `mirrord chaos`.
     #[command(subcommand)]
     pub command: ChaosSubcommand,
+
+    /// Format to print output in.
+    #[arg(long, default_value_t, global = true)]
+    pub format: ChaosFormat,
 }
 
 impl ChaosArgs {
@@ -1738,6 +1743,20 @@ pub enum ChaosSubcommand {
         #[arg(short = 'r', long)]
         rule_id: Option<String>,
     },
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum, Default, Display)]
+#[strum(serialize_all = "lowercase")]
+pub(crate) enum ChaosFormat {
+    /// Pretty-print output. For output that can be used in scripting, use `json` instead.
+    #[default]
+    Pretty,
+
+    /// Print output in JSON.
+    Json,
+
+    /// Don't print anything to `stdout` (still prints errors to `stderr`).
+    Silent,
 }
 
 /// Arguments for the `mirrord session` command.

--- a/mirrord/cli/src/config.rs
+++ b/mirrord/cli/src/config.rs
@@ -1652,12 +1652,24 @@ pub struct ChaosArgs {
 }
 
 impl ChaosArgs {
+    /// Retrieve the `session_id` that this command targets
     pub fn session_id(&self) -> &str {
         match &self.command {
             ChaosSubcommand::List { session_id, .. }
             | ChaosSubcommand::Add { session_id, .. }
             | ChaosSubcommand::Edit { session_id, .. }
             | ChaosSubcommand::Delete { session_id, .. } => session_id,
+        }
+    }
+
+    /// Returns `true` if this command expects a JSON repsonse body
+    pub fn returns_json(&self) -> bool {
+        match &self.command {
+            ChaosSubcommand::Delete { rule_id: None, .. } => false,
+            ChaosSubcommand::List { .. }
+            | ChaosSubcommand::Add { .. }
+            | ChaosSubcommand::Edit { .. }
+            | ChaosSubcommand::Delete { .. } => true,
         }
     }
 }

--- a/mirrord/cli/src/config.rs
+++ b/mirrord/cli/src/config.rs
@@ -1657,7 +1657,7 @@ pub struct ChaosArgs {
 }
 
 impl ChaosArgs {
-    /// Retrieve the `session_id` that this command targets
+    /// Retrieve the `session_id` that this command targets.
     pub fn session_id(&self) -> &str {
         match &self.command {
             ChaosSubcommand::List { session_id, .. }
@@ -1667,17 +1667,17 @@ impl ChaosArgs {
         }
     }
 
-    /// Retrieve the `file_path` that this command specifies
+    /// Retrieve the `file_path` that this command specifies.
     pub fn file_path(&self) -> Option<&PathBuf> {
         match &self.command {
             ChaosSubcommand::List { .. } | ChaosSubcommand::Delete { .. } => None,
             ChaosSubcommand::Add { file_path, .. } | ChaosSubcommand::Edit { file_path, .. } => {
-                Some(file_path)
+                file_path.as_ref()
             }
         }
     }
 
-    /// Returns `true` if this command expects a JSON repsonse body
+    /// Returns `true` if this command expects a JSON repsonse body.
     pub fn returns_json(&self) -> bool {
         match &self.command {
             ChaosSubcommand::Delete { rule_id: None, .. } => false,
@@ -1685,6 +1685,14 @@ impl ChaosArgs {
             | ChaosSubcommand::Add { .. }
             | ChaosSubcommand::Edit { .. }
             | ChaosSubcommand::Delete { .. } => true,
+        }
+    }
+
+    /// Returns `true` if this command expects a chaos rule as input.
+    pub fn expects_rule(&self) -> bool {
+        match &self.command {
+            ChaosSubcommand::Add { .. } | ChaosSubcommand::Edit { .. } => true,
+            ChaosSubcommand::List { .. } | ChaosSubcommand::Delete { .. } => false,
         }
     }
 }
@@ -1704,7 +1712,8 @@ pub enum ChaosSubcommand {
         rule_id: Option<String>,
     },
 
-    /// Add a new rule to this session.
+    /// Add a new rule to this session from `stdin`. If --file_path is provided, reads from the file
+    /// instead.
     #[command(visible_alias = "post")]
     Add {
         /// Session on which to add rules.
@@ -1713,10 +1722,11 @@ pub enum ChaosSubcommand {
 
         /// JSON file containing the chaos rule definition.
         #[arg(short = 'f', long)]
-        file_path: PathBuf,
+        file_path: Option<PathBuf>,
     },
 
-    /// Edit an existing rule for this session
+    /// Edit an existing rule for this session from `stdin`. If --file_path is provided, reads from
+    /// the file instead.
     #[command(visible_alias = "put")]
     Edit {
         /// Session on which to edit rule.
@@ -1729,7 +1739,7 @@ pub enum ChaosSubcommand {
 
         /// JSON file containing the chaos rule definition.
         #[arg(short = 'f', long)]
-        file_path: PathBuf,
+        file_path: Option<PathBuf>,
     },
 
     /// Delete existing rules or a specific rule for this session.

--- a/mirrord/cli/src/config.rs
+++ b/mirrord/cli/src/config.rs
@@ -1688,7 +1688,7 @@ impl ChaosArgs {
         }
     }
 
-    /// Returns `true` if this command expects a JSON repsonse body.
+    /// Returns `true` if this command expects a JSON response body.
     pub fn returns_json(&self) -> bool {
         match &self.command {
             ChaosSubcommand::Delete { rule_id: None, .. } => false,

--- a/mirrord/cli/src/error.rs
+++ b/mirrord/cli/src/error.rs
@@ -677,7 +677,7 @@ pub(crate) enum CliError {
     #[diagnostic(transparent)]
     Up(#[from] UpCliError),
 
-    /// Errors produced by the `mirrord ui` command.
+    /// Errors produced by the `mirrord ui` and `mirrord chaos` commands.
     #[error(transparent)]
     #[diagnostic(transparent)]
     Ui(#[from] UiCliError),

--- a/mirrord/cli/src/main.rs
+++ b/mirrord/cli/src/main.rs
@@ -1209,8 +1209,9 @@ fn main() -> miette::Result<()> {
             Commands::Pitm(args) => pitm::pitm_command(args)?,
             Commands::Ui { args, command } => ui::ui_command(*args, command, "/").await?,
             Commands::Wizard { args, no_telemetry } => {
-                ui::wizard_command(*args, no_telemetry, watch, &user_data).await?
+                ui::wizard_command(args, no_telemetry, watch, &user_data).await?
             }
+            Commands::Chaos(args) => println!("{args:?}"),
             Commands::Session(args) => session::session_command(*args).await?,
             Commands::Kill(args) => session::kill_command(*args).await?,
             #[cfg(unix)]

--- a/mirrord/cli/src/main.rs
+++ b/mirrord/cli/src/main.rs
@@ -1211,7 +1211,7 @@ fn main() -> miette::Result<()> {
             Commands::Wizard { args, no_telemetry } => {
                 ui::wizard_command(args, no_telemetry, watch, &user_data).await?
             }
-            Commands::Chaos(args) => println!("{args:?}"),
+            Commands::Chaos(args) => ui::chaos_command(args).await?,
             Commands::Session(args) => session::session_command(*args).await?,
             Commands::Kill(args) => session::kill_command(*args).await?,
             #[cfg(unix)]

--- a/mirrord/cli/src/ui.rs
+++ b/mirrord/cli/src/ui.rs
@@ -36,7 +36,7 @@ use fs4::fs_std::FileExt;
 use miette::Diagnostic;
 use mirrord_analytics::{AnalyticsReporter, ExecutionKind};
 use mirrord_progress::MIRRORD_PROGRESS_ENV;
-use mirrord_session_monitor_client::sessions_dir;
+use mirrord_session_monitor_client::{session_endpoints, sessions_dir};
 #[cfg(unix)]
 use nix::{
     errno::Errno,
@@ -50,11 +50,11 @@ use tokio::{
     io::{AsyncBufReadExt, BufReader},
     sync::{Mutex, broadcast},
 };
-use tracing::{debug, error, warn};
+use tracing::{debug, error, info, warn};
 
 use crate::{
     CliError,
-    config::{UI_DEFAULT_PORT, UiCommonArgs, UiSubcommand},
+    config::{ChaosArgs, ChaosSubcommand, UI_DEFAULT_PORT, UiCommonArgs, UiSubcommand},
     error::CliResult,
     ui::{self, server::*},
     user_data::UserData,
@@ -140,6 +140,10 @@ pub enum UiCliError {
         then `kill $PID` in a terminal."
     ))]
     MissingPidFile,
+
+    /// Errors from making requests to the session monitor in `mirrord chaos`
+    #[error(transparent)]
+    Chaos(#[from] ChaosApiError),
 }
 
 #[derive(Debug, Error, Diagnostic)]
@@ -435,6 +439,7 @@ async fn ui_start(
 }
 
 /// Details of the server process that was started or already running
+#[derive(Debug)]
 struct ServerDetails {
     already_running: bool,
     url: String,
@@ -452,6 +457,7 @@ fn ui_start_printout(
         token,
         server_pid,
         std_err_file,
+        ..
     }: &ServerDetails,
 ) {
     let mut lines = String::new();
@@ -616,9 +622,49 @@ pub async fn wizard_command(
         None,
     );
 
-    ui::ui_command(args, Some(UiSubcommand::Start), "/wizard")
+    ui_command(args, Some(UiSubcommand::Start), "/wizard")
         .await
         .map_err(CliError::Ui)
+}
+
+/// The entrypoint for the `chaos` command. Starts the shared `mirrord ui` server (if needed) and
+/// displays or edits active chaos rules.
+pub async fn chaos_command(args: ChaosArgs) -> Result<(), UiCliError> {
+    let details = ui_start(UI_DEFAULT_PORT, true, "").await?;
+    info!(?details, "ran mirrord ui start");
+
+    // TODO: remove unwrap
+    let sessions_dir = sessions_dir().unwrap();
+    let Some((id, endpoint)) = session_endpoints(&sessions_dir)
+        .iter()
+        .find(|(id, _)| id == args.session_id())
+    else {
+        // return ChaosApiError::SessionNotFound(session_id)
+        panic!()
+    };
+
+    match args.command {
+        ChaosSubcommand::List {
+            session_id,
+            rule_id,
+        } => todo!(),
+        // ChaosSubcommand::Add {
+        //     session_id,
+        //     file_path,
+        // } => todo!(),
+        // ChaosSubcommand::Edit {
+        //     session_id,
+        //     rule_id,
+        //     file_path,
+        // } => todo!(),
+        // ChaosSubcommand::Delete {
+        //     session_id,
+        //     rule_id,
+        // } => todo!(),
+        _ => (),
+    };
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/mirrord/cli/src/ui.rs
+++ b/mirrord/cli/src/ui.rs
@@ -24,6 +24,7 @@ use std::{
     collections::HashMap,
     env::{self, temp_dir, vars},
     fs::File,
+    io::Read,
     net::{Ipv4Addr, SocketAddr},
     path::PathBuf,
     process::Stdio,
@@ -655,17 +656,24 @@ pub async fn chaos_command(args: ChaosArgs) -> Result<(), UiCliError> {
         return Err(ChaosApiError::SessionNotFound(args.session_id().to_owned()))?;
     };
 
-    let new_rule: Option<ChaosRuleRequest> = args
-        .file_path()
-        .map(|path| {
-            let rule = std::fs::read_to_string(path)?;
-            Ok::<_, UiCliError>(
-                serde_json::from_str(&rule)
-                    .map_err(SessionError::Json)
-                    .map_err(ChaosApiError::SessionMonitor)?,
-            )
-        })
-        .transpose()?;
+    let new_rule: Option<ChaosRuleRequest> = if args.expects_rule() {
+        let string_input = if let Some(file_path) = args.file_path() {
+            std::fs::read_to_string(file_path)?
+        } else {
+            let mut buffer = String::new();
+            let stdin = std::io::stdin();
+            let mut handle = stdin.lock();
+            handle.read_to_string(&mut buffer)?;
+            buffer
+        };
+        Some(
+            serde_json::from_str(&string_input)
+                .map_err(SessionError::Json)
+                .map_err(ChaosApiError::SessionMonitor)?,
+        )
+    } else {
+        None
+    };
 
     let response = match &args.command {
         ChaosSubcommand::List { rule_id, .. } => client.get(format!(

--- a/mirrord/cli/src/ui.rs
+++ b/mirrord/cli/src/ui.rs
@@ -34,13 +34,14 @@ use std::{
 };
 
 use fs4::fs_std::FileExt;
+use futures::future::join_all;
 use miette::Diagnostic;
 use mirrord_analytics::{AnalyticsReporter, ExecutionKind};
 use mirrord_config::util::VecOrSingle;
 use mirrord_intproxy::session_monitor::chaos::rules::{ChaosRule, ChaosRuleRequest};
 use mirrord_progress::MIRRORD_PROGRESS_ENV;
 use mirrord_session_monitor_client::{
-    RequestBuilder, SessionClient, SessionError, session_endpoints, sessions_dir,
+    Response, SessionClient, SessionError, session_endpoints, sessions_dir,
 };
 #[cfg(unix)]
 use nix::{
@@ -49,7 +50,7 @@ use nix::{
     unistd::Pid,
 };
 use rand::RngExt;
-use serde_json::Value;
+use serde_json::{Value, json};
 use thiserror::Error;
 use tokio::{
     fs::create_dir_all,
@@ -155,6 +156,18 @@ pub enum UiCliError {
     /// Errors from making requests to the session monitor in `mirrord chaos`
     #[error(transparent)]
     Chaos(#[from] ChaosApiError),
+}
+
+impl From<SessionError> for UiCliError {
+    fn from(value: SessionError) -> Self {
+        ChaosApiError::SessionMonitor(value).into()
+    }
+}
+
+impl From<serde_json::Error> for UiCliError {
+    fn from(value: serde_json::Error) -> Self {
+        SessionError::Json(value).into()
+    }
 }
 
 #[derive(Debug, Error, Diagnostic)]
@@ -657,7 +670,7 @@ pub async fn chaos_command(args: ChaosArgs) -> Result<(), UiCliError> {
         return Err(ChaosApiError::SessionNotFound(args.session_id().to_owned()))?;
     };
 
-    let new_rules: Option<VecOrSingle<ChaosRuleRequest>> = if args.expects_rule() {
+    let new_rules: Option<Vec<ChaosRuleRequest>> = if args.expects_rule() {
         let string_input = if let Some(file_path) = args.file_path() {
             std::fs::read_to_string(file_path)?
         } else {
@@ -672,9 +685,7 @@ pub async fn chaos_command(args: ChaosArgs) -> Result<(), UiCliError> {
         // but the error printed to the user is extremely unhelpful. To avoid this, deserialize the
         // rules one by one and stop on the first error.
 
-        let outermost_value: Value = serde_json::from_str(&string_input)
-            .map_err(SessionError::Json)
-            .map_err(ChaosApiError::SessionMonitor)?;
+        let outermost_value: Value = serde_json::from_str(&string_input)?;
 
         let rules: Vec<ChaosRuleRequest> = match outermost_value {
             Value::Array(values) => values
@@ -691,11 +702,9 @@ pub async fn chaos_command(args: ChaosArgs) -> Result<(), UiCliError> {
                 }
                 .into());
             }
-        }
-        .map_err(SessionError::Json)
-        .map_err(ChaosApiError::SessionMonitor)?;
+        }?;
 
-        Some(rules.into())
+        Some(rules)
     } else {
         None
     };
@@ -735,52 +744,69 @@ pub async fn chaos_command(args: ChaosArgs) -> Result<(), UiCliError> {
         }
     };
 
-    for request in requests {
-        send_single_internal_chaos_request(request, args.format, args.returns_json()).await?;
-    }
-
-    Ok(())
-}
-
-/// Sends a chaos request to the internal session monitor and prints the response, if any.
-///
-/// Some commands can actually contain multiple requests, for example: `chaos add` can add multiple
-/// new rules at once. In that case, this function is called once on each request.
-async fn send_single_internal_chaos_request(
-    request: RequestBuilder,
-    format: ChaosFormat,
-    returns_json: bool,
-) -> Result<(), UiCliError> {
-    let response = request
-        .send()
+    let responses: Vec<_> = requests
+        .into_iter()
+        .map(|request| async { request.send().await })
+        .collect::<Vec<_>>();
+    let responses: Vec<Response> = join_all(responses)
         .await
-        .map_err(ChaosApiError::SessionMonitor)?;
+        .into_iter()
+        .collect::<Result<Vec<Response>, SessionError>>()?;
 
-    let status = response.status();
-    if !status.is_success() {
-        let _: () = response
-            .json()
-            .await
-            .map_err(ChaosApiError::SessionMonitor)?;
-    } else {
-        match (format, returns_json) {
-            (ChaosFormat::Pretty, true) => {
-                response
-                    .json::<VecOrSingle<ChaosRule>>()
-                    .await
-                    .unwrap()
-                    .iter()
-                    .for_each(ChaosRule::pretty_print);
+    // handle status
+    // match VecOrSingle::from(responses) {
+    //     VecOrSingle::Single(response) => todo!(),
+    //     VecOrSingle::Multiple(responses) => todo!(),
+    // };
+
+    match (args.format, args.returns_json()) {
+        (ChaosFormat::Pretty, returns_json) => {
+            for response in responses.into_iter() {
+                if response.status().is_success() {
+                    if returns_json {
+                        response
+                            .json::<VecOrSingle<ChaosRule>>()
+                            .await?
+                            .iter()
+                            .for_each(ChaosRule::pretty_print);
+                    } else {
+                        println!("Request sucess: status code {}", response.status())
+                    }
+                } else {
+                    println!(
+                        "Request failed: {}",
+                        response
+                            .bytes()
+                            .await
+                            .expect_err("response status is success")
+                    )
+                }
             }
-            (ChaosFormat::Pretty, false) => {
-                println!("Command sucess: status code {status}")
-            }
-            (ChaosFormat::Json, true) => {
-                let thing = response.bytes().await.unwrap();
-                println!("{}", str::from_utf8(&thing).unwrap());
-            }
-            (ChaosFormat::Json, false) | (ChaosFormat::Silent, _) => (),
         }
+        (ChaosFormat::Json, true) => {
+            let mut objects: Vec<Value> = vec![];
+            for response in responses {
+                let status = response.status();
+                let value = match response.bytes().await {
+                    Ok(bytes) => serde_json::from_slice(&bytes)?,
+                    Err(error) => json!({
+                        "error":
+                            {
+                                "status_code": status.as_u16(),
+                                "body": error.to_string()
+                            }
+                    }),
+                };
+                objects.push(value);
+            }
+            match objects.as_array() {
+                Some([single]) => {
+                    println!("{single}")
+                }
+                _ => println!("{}", Value::from(objects)),
+            }
+        }
+        (ChaosFormat::Json, false) | (ChaosFormat::Silent, _) => (),
     }
 
     Ok(())

--- a/mirrord/cli/src/ui.rs
+++ b/mirrord/cli/src/ui.rs
@@ -40,7 +40,7 @@ use mirrord_config::util::VecOrSingle;
 use mirrord_intproxy::session_monitor::chaos::rules::{ChaosRule, ChaosRuleRequest};
 use mirrord_progress::MIRRORD_PROGRESS_ENV;
 use mirrord_session_monitor_client::{
-    SessionClient, SessionError, session_endpoints, sessions_dir,
+    RequestBuilder, SessionClient, SessionError, session_endpoints, sessions_dir,
 };
 #[cfg(unix)]
 use nix::{
@@ -675,46 +675,61 @@ pub async fn chaos_command(args: ChaosArgs) -> Result<(), UiCliError> {
         None
     };
 
-    let req_path = format!(
+    let router_path = format!(
         "{BASE_INTPROXY_CHAOS_ROUTE}/{}",
-        args.rule_id().as_deref().unwrap_or("")
+        args.rule_id().unwrap_or("")
     );
 
-    let response = match &args.command {
-        ChaosSubcommand::List { .. } => client.get(req_path),
-        // ChaosSubcommand::Add { .. } => client
-        //     .post(req_path)
-        //     .json(&new_rules.expect("file_path is a required argument")),
-        ChaosSubcommand::Add { .. } => {
-            for new_rule in new_rules.expect("file_path is a required argument") {
-                return Err(ChaosApiError::BadRequest {
-                    reason: format!(
-                        "'chaos edit' command only accepts a single rule, found {} rules",
-                        new_rule.len()
-                    ),
+    let requests = match &args.command {
+        ChaosSubcommand::Add { .. } => new_rules
+            .expect("args.expects_rule() requires rule(s) before match")
+            .iter()
+            .map(|new_rule| client.post(&router_path).json(&new_rule))
+            .collect(),
+        _ => {
+            let request = match &args.command {
+                ChaosSubcommand::List { .. } => client.get(router_path),
+                ChaosSubcommand::Edit { .. } => {
+                    let new_rule =
+                        new_rules.expect("args.expects_rule() requires rule(s) before match");
+                    if new_rule.len() > 1 {
+                        return Err(ChaosApiError::BadRequest {
+                            reason: format!(
+                                "'chaos edit' command only accepts a single rule, found {} rules",
+                                new_rule.len()
+                            ),
+                        }
+                        .into());
+                    }
+                    client.put(router_path).json(&new_rule)
                 }
-                .into());
-            }
-            client.put(req_path).json(&new_rule)
+                ChaosSubcommand::Delete { .. } => client.delete(router_path),
+                _ => unreachable!(),
+            };
+            vec![request]
         }
-        ChaosSubcommand::Edit { .. } => {
-            let new_rule = new_rules.expect("file_path is a required argument");
-            if new_rule.len() > 1 {
-                return Err(ChaosApiError::BadRequest {
-                    reason: format!(
-                        "'chaos edit' command only accepts a single rule, found {} rules",
-                        new_rule.len()
-                    ),
-                }
-                .into());
-            }
-            client.put(req_path).json(&new_rule)
-        }
-        ChaosSubcommand::Delete { .. } => client.delete(req_path),
+    };
+
+    for request in requests {
+        send_single_internal_chaos_request(request, args.format, args.returns_json()).await?;
     }
-    .send()
-    .await
-    .map_err(ChaosApiError::SessionMonitor)?;
+
+    Ok(())
+}
+
+/// Sends a chaos request to the internal session monitor and prints the response, if any.
+///
+/// Some commands can actually contain multiple requests, for example: `chaos add` can add multiple
+/// new rules at once. In that case, this function is called once on each request.
+async fn send_single_internal_chaos_request(
+    request: RequestBuilder,
+    format: ChaosFormat,
+    returns_json: bool,
+) -> Result<(), UiCliError> {
+    let response = request
+        .send()
+        .await
+        .map_err(ChaosApiError::SessionMonitor)?;
 
     let status = response.status();
     if !status.is_success() {
@@ -723,7 +738,7 @@ pub async fn chaos_command(args: ChaosArgs) -> Result<(), UiCliError> {
             .await
             .map_err(ChaosApiError::SessionMonitor)?;
     } else {
-        match (args.format, args.returns_json()) {
+        match (format, returns_json) {
             (ChaosFormat::Pretty, true) => {
                 response
                     .json::<VecOrSingle<ChaosRule>>()

--- a/mirrord/cli/src/ui.rs
+++ b/mirrord/cli/src/ui.rs
@@ -49,6 +49,7 @@ use nix::{
     unistd::Pid,
 };
 use rand::RngExt;
+use serde_json::Value;
 use thiserror::Error;
 use tokio::{
     fs::create_dir_all,
@@ -666,11 +667,35 @@ pub async fn chaos_command(args: ChaosArgs) -> Result<(), UiCliError> {
             handle.read_to_string(&mut buffer)?;
             buffer
         };
-        Some(
-            serde_json::from_str(&string_input)
-                .map_err(SessionError::Json)
-                .map_err(ChaosApiError::SessionMonitor)?,
-        )
+
+        // `VecOrSingle` can be created directly from `string_input` with `serde_json::from_str`,
+        // but the error printed to the user is extremely unhelpful. To avoid this, deserialize the
+        // rules one by one and stop on the first error.
+
+        let outermost_value: Value = serde_json::from_str(&string_input)
+            .map_err(SessionError::Json)
+            .map_err(ChaosApiError::SessionMonitor)?;
+
+        let rules: Vec<ChaosRuleRequest> = match outermost_value {
+            Value::Array(values) => values
+                .into_iter()
+                .map(serde_json::from_value)
+                .collect::<Result<Vec<ChaosRuleRequest>, _>>(),
+            rule @ Value::Object(..) => serde_json::from_value(rule).map(|rule| vec![rule]),
+            other => {
+                return Err(ChaosApiError::BadRequest {
+                    reason: format!(
+                        "expected a chaos rule or list of rules in JSON format, found {}",
+                        other
+                    ),
+                }
+                .into());
+            }
+        }
+        .map_err(SessionError::Json)
+        .map_err(ChaosApiError::SessionMonitor)?;
+
+        Some(rules.into())
     } else {
         None
     };

--- a/mirrord/cli/src/ui.rs
+++ b/mirrord/cli/src/ui.rs
@@ -58,7 +58,9 @@ use tracing::{debug, error, info, warn};
 
 use crate::{
     CliError,
-    config::{ChaosArgs, ChaosSubcommand, UI_DEFAULT_PORT, UiCommonArgs, UiSubcommand},
+    config::{
+        ChaosArgs, ChaosFormat, ChaosSubcommand, UI_DEFAULT_PORT, UiCommonArgs, UiSubcommand,
+    },
     error::CliResult,
     ui::{
         chaos::{api::BASE_INTPROXY_CHAOS_ROUTE, error::ChaosApiError},
@@ -685,18 +687,31 @@ pub async fn chaos_command(args: ChaosArgs) -> Result<(), UiCliError> {
     .await
     .map_err(ChaosApiError::SessionMonitor)?;
 
-    if args.returns_json() {
-        let rules_body: VecOrSingle<ChaosRule> = response
+    let status = response.status();
+    if !status.is_success() {
+        let _: () = response
             .json()
             .await
             .map_err(ChaosApiError::SessionMonitor)?;
-        println!("{rules_body:?}");
     } else {
-        println!(
-            "{:?}, {}",
-            response.status(),
-            response.status().is_success()
-        );
+        match (args.format, args.returns_json()) {
+            (ChaosFormat::Pretty, true) => {
+                response
+                    .json::<VecOrSingle<ChaosRule>>()
+                    .await
+                    .unwrap()
+                    .iter()
+                    .for_each(ChaosRule::pretty_print);
+            }
+            (ChaosFormat::Pretty, false) => {
+                println!("Command sucess: status code {status}")
+            }
+            (ChaosFormat::Json, true) => {
+                let thing = response.bytes().await.unwrap();
+                println!("{}", str::from_utf8(&thing).unwrap());
+            }
+            (ChaosFormat::Json, false) | (ChaosFormat::Silent, _) => (),
+        }
     }
 
     Ok(())

--- a/mirrord/cli/src/ui.rs
+++ b/mirrord/cli/src/ui.rs
@@ -35,8 +35,10 @@ use std::{
 use fs4::fs_std::FileExt;
 use miette::Diagnostic;
 use mirrord_analytics::{AnalyticsReporter, ExecutionKind};
+use mirrord_config::util::VecOrSingle;
+use mirrord_intproxy::session_monitor::chaos::rules::ChaosRule;
 use mirrord_progress::MIRRORD_PROGRESS_ENV;
-use mirrord_session_monitor_client::{session_endpoints, sessions_dir};
+use mirrord_session_monitor_client::{SessionClient, session_endpoints, sessions_dir};
 #[cfg(unix)]
 use nix::{
     errno::Errno,
@@ -56,7 +58,10 @@ use crate::{
     CliError,
     config::{ChaosArgs, ChaosSubcommand, UI_DEFAULT_PORT, UiCommonArgs, UiSubcommand},
     error::CliResult,
-    ui::{self, server::*},
+    ui::{
+        chaos::{api::BASE_INTPROXY_CHAOS_ROUTE, error::ChaosApiError},
+        server::*,
+    },
     user_data::UserData,
     util::mirrord_dir::{self, get_path_and_create_with_fallback},
 };
@@ -431,7 +436,6 @@ async fn ui_start(
     Ok(ServerDetails {
         already_running,
         url,
-        port,
         token,
         server_pid,
         std_err_file,
@@ -443,7 +447,6 @@ async fn ui_start(
 struct ServerDetails {
     already_running: bool,
     url: String,
-    port: u16,
     token: String,
     server_pid: String,
     std_err_file: PathBuf,
@@ -457,7 +460,6 @@ fn ui_start_printout(
         token,
         server_pid,
         std_err_file,
-        ..
     }: &ServerDetails,
 ) {
     let mut lines = String::new();
@@ -633,21 +635,27 @@ pub async fn chaos_command(args: ChaosArgs) -> Result<(), UiCliError> {
     let details = ui_start(UI_DEFAULT_PORT, true, "").await?;
     info!(?details, "ran mirrord ui start");
 
-    // TODO: remove unwrap
-    let sessions_dir = sessions_dir().unwrap();
-    let Some((id, endpoint)) = session_endpoints(&sessions_dir)
+    let sessions_dir = sessions_dir().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "failed to find home directory",
+        )
+    })?;
+
+    let client = if let Some((_id, endpoint)) = session_endpoints(&sessions_dir)
         .iter()
         .find(|(id, _)| id == args.session_id())
-    else {
-        // return ChaosApiError::SessionNotFound(session_id)
-        panic!()
+    {
+        SessionClient::new(endpoint.clone())
+    } else {
+        return Err(ChaosApiError::SessionNotFound(args.session_id().to_owned()))?;
     };
 
-    match args.command {
-        ChaosSubcommand::List {
-            session_id,
-            rule_id,
-        } => todo!(),
+    let response = match &args.command {
+        ChaosSubcommand::List { rule_id, .. } => client.get(format!(
+            "{BASE_INTPROXY_CHAOS_ROUTE}/{}",
+            rule_id.as_deref().unwrap_or("")
+        )),
         // ChaosSubcommand::Add {
         //     session_id,
         //     file_path,
@@ -657,12 +665,29 @@ pub async fn chaos_command(args: ChaosArgs) -> Result<(), UiCliError> {
         //     rule_id,
         //     file_path,
         // } => todo!(),
-        // ChaosSubcommand::Delete {
-        //     session_id,
-        //     rule_id,
-        // } => todo!(),
-        _ => (),
-    };
+        ChaosSubcommand::Delete { rule_id, .. } => client.delete(format!(
+            "{BASE_INTPROXY_CHAOS_ROUTE}/{}",
+            rule_id.as_deref().unwrap_or("")
+        )),
+        _ => client.get(""),
+    }
+    .send()
+    .await
+    .map_err(ChaosApiError::SessionMonitor)?;
+
+    if args.returns_json() {
+        let rules_body: VecOrSingle<ChaosRule> = response
+            .json()
+            .await
+            .map_err(ChaosApiError::SessionMonitor)?;
+        println!("{rules_body:?}");
+    } else {
+        println!(
+            "{:?}, {}",
+            response.status(),
+            response.status().is_success()
+        );
+    }
 
     Ok(())
 }

--- a/mirrord/cli/src/ui.rs
+++ b/mirrord/cli/src/ui.rs
@@ -36,9 +36,11 @@ use fs4::fs_std::FileExt;
 use miette::Diagnostic;
 use mirrord_analytics::{AnalyticsReporter, ExecutionKind};
 use mirrord_config::util::VecOrSingle;
-use mirrord_intproxy::session_monitor::chaos::rules::ChaosRule;
+use mirrord_intproxy::session_monitor::chaos::rules::{ChaosRule, ChaosRuleRequest};
 use mirrord_progress::MIRRORD_PROGRESS_ENV;
-use mirrord_session_monitor_client::{SessionClient, session_endpoints, sessions_dir};
+use mirrord_session_monitor_client::{
+    SessionClient, SessionError, session_endpoints, sessions_dir,
+};
 #[cfg(unix)]
 use nix::{
     errno::Errno,
@@ -651,25 +653,33 @@ pub async fn chaos_command(args: ChaosArgs) -> Result<(), UiCliError> {
         return Err(ChaosApiError::SessionNotFound(args.session_id().to_owned()))?;
     };
 
+    let new_rule: Option<ChaosRuleRequest> = args
+        .file_path()
+        .map(|path| {
+            let rule = std::fs::read_to_string(path)?;
+            Ok::<_, UiCliError>(
+                serde_json::from_str(&rule)
+                    .map_err(SessionError::Json)
+                    .map_err(ChaosApiError::SessionMonitor)?,
+            )
+        })
+        .transpose()?;
+
     let response = match &args.command {
         ChaosSubcommand::List { rule_id, .. } => client.get(format!(
             "{BASE_INTPROXY_CHAOS_ROUTE}/{}",
             rule_id.as_deref().unwrap_or("")
         )),
-        // ChaosSubcommand::Add {
-        //     session_id,
-        //     file_path,
-        // } => todo!(),
-        // ChaosSubcommand::Edit {
-        //     session_id,
-        //     rule_id,
-        //     file_path,
-        // } => todo!(),
+        ChaosSubcommand::Add { .. } => client
+            .post(format!("{BASE_INTPROXY_CHAOS_ROUTE}/"))
+            .json(&new_rule.expect("file_path is a required argument")),
+        ChaosSubcommand::Edit { rule_id, .. } => client
+            .put(format!("{BASE_INTPROXY_CHAOS_ROUTE}/{rule_id}"))
+            .json(&new_rule.expect("file_path is a required argument")),
         ChaosSubcommand::Delete { rule_id, .. } => client.delete(format!(
             "{BASE_INTPROXY_CHAOS_ROUTE}/{}",
             rule_id.as_deref().unwrap_or("")
         )),
-        _ => client.get(""),
     }
     .send()
     .await

--- a/mirrord/cli/src/ui.rs
+++ b/mirrord/cli/src/ui.rs
@@ -656,7 +656,7 @@ pub async fn chaos_command(args: ChaosArgs) -> Result<(), UiCliError> {
         return Err(ChaosApiError::SessionNotFound(args.session_id().to_owned()))?;
     };
 
-    let new_rule: Option<ChaosRuleRequest> = if args.expects_rule() {
+    let new_rules: Option<VecOrSingle<ChaosRuleRequest>> = if args.expects_rule() {
         let string_input = if let Some(file_path) = args.file_path() {
             std::fs::read_to_string(file_path)?
         } else {
@@ -675,21 +675,42 @@ pub async fn chaos_command(args: ChaosArgs) -> Result<(), UiCliError> {
         None
     };
 
+    let req_path = format!(
+        "{BASE_INTPROXY_CHAOS_ROUTE}/{}",
+        args.rule_id().as_deref().unwrap_or("")
+    );
+
     let response = match &args.command {
-        ChaosSubcommand::List { rule_id, .. } => client.get(format!(
-            "{BASE_INTPROXY_CHAOS_ROUTE}/{}",
-            rule_id.as_deref().unwrap_or("")
-        )),
-        ChaosSubcommand::Add { .. } => client
-            .post(format!("{BASE_INTPROXY_CHAOS_ROUTE}/"))
-            .json(&new_rule.expect("file_path is a required argument")),
-        ChaosSubcommand::Edit { rule_id, .. } => client
-            .put(format!("{BASE_INTPROXY_CHAOS_ROUTE}/{rule_id}"))
-            .json(&new_rule.expect("file_path is a required argument")),
-        ChaosSubcommand::Delete { rule_id, .. } => client.delete(format!(
-            "{BASE_INTPROXY_CHAOS_ROUTE}/{}",
-            rule_id.as_deref().unwrap_or("")
-        )),
+        ChaosSubcommand::List { .. } => client.get(req_path),
+        // ChaosSubcommand::Add { .. } => client
+        //     .post(req_path)
+        //     .json(&new_rules.expect("file_path is a required argument")),
+        ChaosSubcommand::Add { .. } => {
+            for new_rule in new_rules.expect("file_path is a required argument") {
+                return Err(ChaosApiError::BadRequest {
+                    reason: format!(
+                        "'chaos edit' command only accepts a single rule, found {} rules",
+                        new_rule.len()
+                    ),
+                }
+                .into());
+            }
+            client.put(req_path).json(&new_rule)
+        }
+        ChaosSubcommand::Edit { .. } => {
+            let new_rule = new_rules.expect("file_path is a required argument");
+            if new_rule.len() > 1 {
+                return Err(ChaosApiError::BadRequest {
+                    reason: format!(
+                        "'chaos edit' command only accepts a single rule, found {} rules",
+                        new_rule.len()
+                    ),
+                }
+                .into());
+            }
+            client.put(req_path).json(&new_rule)
+        }
+        ChaosSubcommand::Delete { .. } => client.delete(req_path),
     }
     .send()
     .await

--- a/mirrord/cli/src/ui.rs
+++ b/mirrord/cli/src/ui.rs
@@ -313,7 +313,11 @@ async fn ui_run_server(port: u16) -> Result<(), UiServerError> {
 ///
 /// `open_path` is the path the browser is pointed at (e.g. `/` for the session monitor, `/wizard`
 /// for the config wizard), appended to the server URL before the `?token=` query.
-pub async fn ui_start(port: u16, no_browser: bool, open_path: &str) -> Result<(), UiCliError> {
+async fn ui_start(
+    port: u16,
+    no_browser: bool,
+    open_path: &str,
+) -> Result<ServerDetails, UiCliError> {
     let mirrord_binary = env::current_exe()?;
 
     let std_err_dir = temp_dir()
@@ -350,7 +354,7 @@ pub async fn ui_start(port: u16, no_browser: bool, open_path: &str) -> Result<()
     let mut stdout = BufReader::new(child.stdout.take().expect("was piped")).lines();
 
     let first_line = tokio::time::timeout(Duration::from_secs(30), stdout.next_line()).await;
-    let server_already_running = match first_line {
+    let already_running = match first_line {
         Err(..) => {
             return Err(UiCliError::SpawnBackgroundTask(
                 "timed out waiting for the server process to confirm setup complete".to_owned(),
@@ -380,7 +384,7 @@ pub async fn ui_start(port: u16, no_browser: bool, open_path: &str) -> Result<()
     };
 
     let pid_file = mirrord_dir::get_path_or_fallback().join(PID_FILE_NAME);
-    let child_pid = if server_already_running {
+    let server_pid = if already_running {
         // read pid from file, and dont overwrite it
         std::fs::read_to_string(&pid_file).unwrap_or("unknown".to_owned())
     } else {
@@ -404,7 +408,7 @@ pub async fn ui_start(port: u16, no_browser: bool, open_path: &str) -> Result<()
 
     let token_path = mirrord_dir::get_path_or_fallback().join(TOKEN_FILE_NAME);
     let token = std::fs::read_to_string(&token_path)?;
-    let token = token.trim();
+    let token = token.trim().to_owned();
 
     // Open the `/auth` entry point (the only route that accepts the token in the query string); it
     // sets the cookie and redirects to `open_path` (`/` for the monitor, `/wizard` for the wizard).
@@ -414,34 +418,46 @@ pub async fn ui_start(port: u16, no_browser: bool, open_path: &str) -> Result<()
     );
 
     // open browser and print details to user
-    if !(server_already_running || no_browser) {
+    if !(already_running || no_browser) {
         let _ = opener::open_browser(&url).map_err(|err| {
             warn!(?err, "Failed to open browser");
         });
     }
-    ui_start_printout(
-        server_already_running,
-        &url,
-        token,
-        &child_pid,
-        &std_err_file.to_string_lossy(),
-    );
 
-    Ok(())
+    Ok(ServerDetails {
+        already_running,
+        url,
+        port,
+        token,
+        server_pid,
+        std_err_file,
+    })
+}
+
+/// Details of the server process that was started or already running
+struct ServerDetails {
+    already_running: bool,
+    url: String,
+    port: u16,
+    token: String,
+    server_pid: String,
+    std_err_file: PathBuf,
 }
 
 /// Prints the details of the server to the user (foreground task `stdout`)
 fn ui_start_printout(
-    already_running: bool,
-    url: &str,
-    token: &str,
-    server_pid: &str,
-    std_err_file: &str,
+    ServerDetails {
+        already_running,
+        url,
+        token,
+        server_pid,
+        std_err_file,
+    }: &ServerDetails,
 ) {
     let mut lines = String::new();
 
     lines.push('\n');
-    if already_running {
+    if *already_running {
         lines.push_str("* Another session monitor is already running\n");
     } else {
         lines.push_str("* New mirrord session monitor started\n");
@@ -456,11 +472,13 @@ fn ui_start_printout(
     lines.push_str(format!(" -> {TOKEN_HEADER_NAME}: {token}\n").as_str());
 
     lines.push('\n');
-    if already_running {
+    if *already_running {
         lines.push_str("* mirrord session monitor unchanged\n");
     } else {
         lines.push_str("* mirrord session monitor ready!\n");
-        lines.push_str(format!(" -> server log file: {std_err_file}\n").as_str());
+        lines.push_str(
+            format!(" -> server log file: {}\n", std_err_file.to_string_lossy()).as_str(),
+        );
     }
 
     println!("{lines}")
@@ -560,12 +578,19 @@ pub async fn ui_command(
                 ui_run_server(u16::from_str(&port).unwrap_or(UI_DEFAULT_PORT)).await?;
                 Ok(())
             } else {
-                let res = ui_start(port, no_browser, open_path).await;
-                if res.is_err() {
-                    error!("`mirrord ui` failed to start the server, running `mirrord ui stop`");
-                    let _ = ui_stop(false).await;
+                match ui_start(port, no_browser, open_path).await {
+                    Ok(details) => {
+                        ui_start_printout(&details);
+                        Ok(())
+                    }
+                    Err(error) => {
+                        error!(
+                            "`mirrord ui` failed to start the server, running `mirrord ui stop`"
+                        );
+                        let _ = ui_stop(false).await;
+                        Err(error)
+                    }
                 }
-                res
             }
         }
         UiSubcommand::Stop => ui_stop(true).await,

--- a/mirrord/cli/src/ui/chaos.rs
+++ b/mirrord/cli/src/ui/chaos.rs
@@ -9,8 +9,8 @@ use axum::{
 
 use crate::ui::{chaos::error::ChaosApiError, server::AppState};
 
-mod api;
-mod error;
+pub(super) mod api;
+pub(super) mod error;
 
 /// Alias for the return type of the chaos route handlers.
 type ChaosResult<T> = Result<T, ChaosApiError>;

--- a/mirrord/cli/src/ui/chaos/api.rs
+++ b/mirrord/cli/src/ui/chaos/api.rs
@@ -17,7 +17,7 @@ use super::ChaosResult;
 use crate::ui::{chaos::error::ChaosApiError, server::AppState};
 
 /// The route for the internal proxy session monitor server chaos rules.
-const BASE_INTPROXY_CHAOS_ROUTE: &str = "/chaos/rules";
+pub const BASE_INTPROXY_CHAOS_ROUTE: &str = "/chaos/rules";
 
 /// axum [`Path`] helper for the middleware.
 ///

--- a/mirrord/cli/src/ui/chaos/error.rs
+++ b/mirrord/cli/src/ui/chaos/error.rs
@@ -7,7 +7,7 @@ use mirrord_session_monitor_client::SessionError;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
-pub(super) enum ChaosApiError {
+pub enum ChaosApiError {
     #[error("session `{0}` not found")]
     SessionNotFound(String),
 

--- a/mirrord/cli/src/ui/chaos/error.rs
+++ b/mirrord/cli/src/ui/chaos/error.rs
@@ -11,6 +11,10 @@ pub enum ChaosApiError {
     #[error("session `{0}` not found")]
     SessionNotFound(String),
 
+    /// Something was wrong with the request, but it wasn't handled elsewhere (for example by clap).
+    #[error("bad request: `{reason}`")]
+    BadRequest { reason: String },
+
     /// We got a response error from the session monitor chaos api (intproxy), e.g. we made a
     /// request with `rule_id={some-uid}`, and it returned `404`, so we use this to upstream the
     /// error.
@@ -37,6 +41,11 @@ impl IntoResponse for ChaosApiError {
             Self::SessionNotFound(_) => (
                 StatusCode::NOT_FOUND,
                 format!("Could not find session: {self}"),
+            )
+                .into_response(),
+            Self::BadRequest { reason } => (
+                StatusCode::BAD_REQUEST,
+                format!("Could not make request: {reason}"),
             )
                 .into_response(),
             Self::Upstream { status, body } => (status, body).into_response(),

--- a/mirrord/config/src/util.rs
+++ b/mirrord/config/src/util.rs
@@ -155,6 +155,16 @@ pub enum VecOrSingle<T> {
     Multiple(Vec<T>),
 }
 
+impl<T> VecOrSingle<T> {
+    pub fn is_single(&self) -> bool {
+        matches!(self, VecOrSingle::Single(_))
+    }
+
+    pub fn is_multiple(&self) -> bool {
+        matches!(self, VecOrSingle::Multiple(_))
+    }
+}
+
 impl<T> Deref for VecOrSingle<T> {
     type Target = [T];
 

--- a/mirrord/intproxy/Cargo.toml
+++ b/mirrord/intproxy/Cargo.toml
@@ -51,6 +51,7 @@ tokio-rustls.workspace = true
 tokio-util = { workspace = true, features = ["rt"] }
 uuid.workspace = true
 anyhow.workspace = true
+prettytable-rs.workspace = true
 
 axum.workspace = true
 serde_json.workspace = true

--- a/mirrord/intproxy/src/session_monitor/chaos/rules.rs
+++ b/mirrord/intproxy/src/session_monitor/chaos/rules.rs
@@ -14,6 +14,11 @@ use mirrord_intproxy_protocol::NetProtocol;
 use mirrord_protocol::{
     ErrorKindInternal, RemoteIOError, outgoing::SocketAddress, tcp::HttpFilter,
 };
+use prettytable::{
+    Table,
+    format::{FormatBuilder, LinePosition, LineSeparator},
+    row,
+};
 use rand::{random_bool, random_range};
 use serde::{Deserialize, Serialize};
 use serde_with::{DisplayFromStr, serde_as, skip_serializing_none};
@@ -136,6 +141,52 @@ impl ChaosRule {
     /// Convenience method to get the chaos `effect` type for the rule `self`.
     pub fn effect_type(&self) -> Option<ChaosEffectType> {
         self.selector.effect_type()
+    }
+
+    /// Print the details of a rule to be human readable - not intended to be machine readable so
+    /// may be unstable. Associated with `config::ChaosFormat::Pretty`.
+    pub fn pretty_print(&self) {
+        let mut table = Table::new();
+        let format = FormatBuilder::new()
+            .column_separator('│')
+            .borders('│')
+            .separators(&[LinePosition::Top], LineSeparator::new('─', '┬', '┌', '┐'))
+            .separators(
+                &[LinePosition::Title],
+                LineSeparator::new('─', '┼', '├', '┤'),
+            )
+            .separators(
+                &[LinePosition::Bottom],
+                LineSeparator::new('─', '┴', '└', '┘'),
+            )
+            .padding(1, 1)
+            .build();
+        table.set_format(format);
+
+        table.set_titles(row!["id", self.id]);
+
+        self.name
+            .as_ref()
+            .map(|name| table.add_row(row!["name", name]));
+
+        let cell = if self.priority == 0 {
+            "default (0)"
+        } else {
+            &self.priority.to_string()
+        };
+        table.add_row(row!["priority", cell]);
+
+        table.add_row(row!["selector type", self.selector_type()]);
+
+        let cell = self
+            .effect_type()
+            .map(|x| x.to_string())
+            .unwrap_or("none".to_owned());
+        table.add_row(row!["effect", cell]);
+
+        table.add_row(row!["hit count", self.hit_count.load(Ordering::Acquire)]);
+
+        table.printstd();
     }
 }
 
@@ -356,7 +407,7 @@ pub struct ChaosRuleRequest {
 #[derive(Debug, Serialize, Deserialize, PartialEq, EnumDiscriminants)]
 #[serde(rename_all = "snake_case")]
 #[strum_discriminants(name(ChaosEffectType))]
-#[strum_discriminants(derive(EnumString))]
+#[strum_discriminants(derive(EnumString, Display))]
 #[repr(u8)]
 pub enum ChaosEffectRequest {
     Latency {


### PR DESCRIPTION
Adds the `mirrord chaos` set of commands, as an alternative way to manage chaos rules without manually curling the chaos endpoints exposed by the local UI server.

Linear: [COR-1537](https://linear.app/metalbear/issue/COR-1537/chaos-cli)

### Quality Checklist:

- [X] I have documented new code sufficiently
- [X] I have checked and updated the relevant existing docs in code, including removing outdated material
- [X] I have written user-facing website docs for new features, or opened a (sub)issue to do so
- [X] I have checked and updated existing website docs for changed features
- [X] I have tested this change and know it succeeds and fails as expected
- [X] I have explained what this PR introduces and why, and linked to relevant context (e.g. linear issues, related PRs,<br>documentation)
- [X] I have introduced a short, clear and well-formatted changelog entry