### PR TITLE
ci: decouple auto release PR from release tags

### DIFF
--- a/.github/workflows/auto-release-pr.yaml
+++ b/.github/workflows/auto-release-pr.yaml
@@ -50,11 +50,19 @@ jobs:
           set -euo pipefail
           shopt -s nullglob
 
+          # `towncrier build` consumes the fragments when a release PR is prepared, so anything
+          # left in `changelog.d` is by definition unreleased. Deliberately not comparing against
+          # `tags/${current_version}`: that tag is only created by the `release_gh` job, so a
+          # single failed release would wedge this workflow until someone tagged by hand.
+          fragments=(changelog.d/*.md)
+          if [ "${#fragments[@]}" -eq 0 ]; then
+            echo "No unreleased changelog fragments, nothing to release."
+            echo "should_release=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
           current_version=$(cargo get workspace.package.version)
 
-          uv run towncrier check --compare-with "tags/${current_version}"
-
-          fragments=(changelog.d/*.md)
           bump_level=patch
           for fragment in "${fragments[@]}"; do
             category=$(basename "${fragment}")
@@ -80,24 +88,30 @@ jobs:
           fi
 
           {
+            echo "should_release=true"
             echo "bump_level=${bump_level}"
             echo "new_version=${new_version}"
           } >> "${GITHUB_OUTPUT}"
 
       - name: Bump version in Cargo.toml
+        if: steps.version.outputs.should_release == 'true'
         run: cargo set workspace.package.version "${{ steps.version.outputs.new_version }}"
 
       - name: Update Cargo.lock
+        if: steps.version.outputs.should_release == 'true'
         run: cargo update -w -q
 
       - name: Generate draft release notes
+        if: steps.version.outputs.should_release == 'true'
         run: uv run towncrier build --draft --version "${{ steps.version.outputs.new_version }}" > /tmp/release-notes.md
 
       - name: Generate changelog
+        if: steps.version.outputs.should_release == 'true'
         run: uv run towncrier build --yes --version "${{ steps.version.outputs.new_version }}"
 
       - name: Create app token for release PR updates
         id: app_token
+        if: steps.version.outputs.should_release == 'true'
         uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
         with:
           app-id: ${{ secrets.CUBBY_CLIENT_ID }}
@@ -106,6 +120,7 @@ jobs:
           permission-pull-requests: write
 
       - name: Create or update release pull request
+        if: steps.version.outputs.should_release == 'true'
         env:
           APP_TOKEN: ${{ steps.app_token.outputs.token }}
           GH_TOKEN: ${{ steps.app_token.outputs.token }}

--- a/changelog.d/+auto-release-pr-tag-dependency.internal.md
+++ b/changelog.d/+auto-release-pr-tag-dependency.internal.md
@@ -1,0 +1,1 @@
+Decouple the auto release PR workflow from release tags, so a failed release no longer blocks the next release PR.


### PR DESCRIPTION
## Problem

The `Determine next release version` step compares changelog fragments against a git tag derived from the version in `Cargo.toml`:

```bash
current_version=$(cargo get workspace.package.version)
uv run towncrier check --compare-with "tags/${current_version}"
```

That tag is only created by the `release_gh` job in `release.yaml`. When a release build fails, `main` is already bumped to the new version but no matching tag exists, so the step dies with:

```
fatal: ambiguous argument 'tags/3.239.0...': unknown revision or path not in the working tree.
subprocess.CalledProcessError: Command '['git', 'diff', '--name-only', 'tags/3.239.0...']' returned non-zero exit status 128.
```

The daily run then stays red until someone creates the tag by hand. Making the workflow depend on an artifact of a downstream, failure-prone job means any failed release wedges every subsequent release PR.

## Fix

Drop the tag dependency. `towncrier build --yes` consumes the fragments in this same workflow, so anything left in `changelog.d/` is by definition unreleased — the fragment list alone answers the question `towncrier check` was asking, without touching git history.

The step now exits early with `should_release=false` when there are no fragments, and the release PR steps are gated on that output.

This also fixes a second issue: `towncrier check` exits 1 when it finds no fragments, so a day with no changes turned the scheduled run red instead of no-op'ing.

## Verified

Ran the rewritten shell logic against the current `main` tree:

- 5 fragments, one `.added.md` → `bump_level=minor`, `new_version=3.240.0`
- empty `changelog.d/` → `should_release=false`, exit 0

Workflow YAML parses.