### PR TITLE
Capitalize "Generic" DB type in status output

### DIFF
--- a/changelog.d/+db-status-generic.changed.md
+++ b/changelog.d/+db-status-generic.changed.md
@@ -1,0 +1,1 @@
+The "Generic" DB-branching type is now capitalized in the status output, again.

--- a/mirrord/operator/src/crd/db_branching/branch_database.rs
+++ b/mirrord/operator/src/crd/db_branching/branch_database.rs
@@ -189,7 +189,7 @@ pub enum DialectConfig<'a> {
     Clickhouse(&'a ClickhouseOptions),
     #[strum_discriminants(strum(to_string = "CockroachDB"))]
     Cockroachdb(&'a CockroachdbOptions),
-    #[strum_discriminants(strum(to_string = "generic"))]
+    #[strum_discriminants(strum(to_string = "Generic"))]
     Generic(&'a GenericOptions),
 }
 


### PR DESCRIPTION
Was capitalized before, and the change to lowercase broke an E2E test on the operator.