### PR TITLE
ci: continue lint jobs on errors

### DIFF
--- a/.github/workflows/check-lint.yaml
+++ b/.github/workflows/check-lint.yaml
@@ -125,6 +125,7 @@ jobs:
     if: ${{ inputs.run_rust }}
     timeout-minutes: 10
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: macos-latest
@@ -156,12 +157,12 @@ jobs:
       - uses: metalbear-co/setup-protoc@770e54d44679c8e1d8fdc06d1d9268fa79fbefb4
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: cargo fmt (run only on one platform)
+      - run: cargo clippy --all-targets --all-features --target ${{ matrix.target }} --keep-going --quiet -- "-Wclippy::indexing_slicing" -D warnings
+      - name: cargo fmt, operator crd check (run only on one platform)
         if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}
-        run: cargo fmt --all -- --check
-      - if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}
-        run: cargo check -p mirrord-operator --features crd --target ${{ matrix.target }}
-      - run: cargo clippy --all-targets --all-features --target ${{ matrix.target }} -- "-Wclippy::indexing_slicing" -D warnings
+        run: |
+          cargo fmt --all -- --check
+          cargo check -p mirrord-operator --features crd --target ${{ matrix.target }} --keep-going --quiet
   shear:
     if: ${{ inputs.run_rust }}
     name: 'cargo shear'

--- a/.github/workflows/check-lint.yaml
+++ b/.github/workflows/check-lint.yaml
@@ -157,12 +157,25 @@ jobs:
       - uses: metalbear-co/setup-protoc@770e54d44679c8e1d8fdc06d1d9268fa79fbefb4
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - run: cargo clippy --all-targets --all-features --target ${{ matrix.target }} --keep-going --quiet -- "-Wclippy::indexing_slicing" -D warnings
-      - name: cargo fmt, operator crd check (run only on one platform)
+      - name: cargo clippy
+        id: cargo_clippy
+        continue-on-error: true
+        run: cargo clippy --all-targets --all-features --target ${{ matrix.target }} --keep-going --quiet -- "-Wclippy::indexing_slicing" -D warnings
+      - name: cargo fmt (run only on one platform)
+        id: cargo_fmt
         if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}
+        continue-on-error: true
+        run: cargo fmt --all -- --check
+      - name: operator crd check (run only on one platform)
+        id: operator_crd_check
+        if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}
+        continue-on-error: true
+        run: cargo check -p mirrord-operator --features crd --target ${{ matrix.target }} --keep-going --quiet
+      - name: check all lint steps passed
+        if: ${{ !cancelled() && (steps.cargo_clippy.outcome == 'failure' || steps.cargo_fmt.outcome == 'failure' || steps.operator_crd_check.outcome == 'failure') }}
         run: |
-          cargo fmt --all -- --check
-          cargo check -p mirrord-operator --features crd --target ${{ matrix.target }} --keep-going --quiet
+          echo "One or more cargo lint checks failed."
+          exit 1
   shear:
     if: ${{ inputs.run_rust }}
     name: 'cargo shear'

--- a/.github/workflows/check-lint.yaml
+++ b/.github/workflows/check-lint.yaml
@@ -121,7 +121,7 @@ jobs:
         run: vale $(find . -maxdepth 1 -name '*.md' -not -name CLAUDE.md -not -name CHANGELOG.md) --output=report.tmpl
       - name: check changelog.d files
         run: vale $(git ls-files 'changelog.d/*.md') --output=report.tmpl
-  lint:
+  cargo-lint:
     if: ${{ inputs.run_rust }}
     timeout-minutes: 10
     strategy:
@@ -183,3 +183,27 @@ jobs:
         with:
           tool: cargo-shear@1.13.1
       - run: cargo shear --deny-warnings
+  lint-success:
+    if: '!cancelled()'
+    needs:
+      [
+        typos,
+        lint-markdown,
+        wizard-frontend-lint,
+        wizard-frontend-test,
+        ui-frontend-lint,
+        vale,
+        cargo-lint,
+        shear
+      ]
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check all jobs passed
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          failing=$(echo "$NEEDS_JSON" | jq -r 'to_entries[] | select(.value.result != "success" and .value.result != "skipped") | "\(.key): \(.value.result)"')
+          if [ -n "$failing" ]; then
+            echo "$failing"
+            exit 1
+          fi

--- a/changelog.d/+ci-lint-keep-going.internal.md
+++ b/changelog.d/+ci-lint-keep-going.internal.md
@@ -1,0 +1,2 @@
+Linting failures in CI now continue on error, so that as many issues are found as possible per run 
+- this should reduce re-runs of the full CI.


### PR DESCRIPTION
Linear: [issue link](https://linear.app/metalbear/issue/MBE-1973/do-not-stop-ci-lints-on-errors)

- lint jobs now continue on errors to give as much info at once as possible
- cargo clippy now uses `--quiet` which suppresses noisy logs