### PR TITLE
Add `auto_queue_splitting` for copy target

### DIFF
--- a/changelog.d/+up-replace-queue-splitting.added.md
+++ b/changelog.d/+up-replace-queue-splitting.added.md
@@ -1,0 +1,3 @@
+Added `auto_queue_splitting` option for copy target. Set to `true` by `mirrord up` command
+to inform the operator that parameters of unsupported queue kinds shall be dismissed rather than
+rejected.

--- a/mirrord/operator/src/client.rs
+++ b/mirrord/operator/src/client.rs
@@ -1356,10 +1356,16 @@ impl OperatorApi<PreparedClientCert> {
             }
 
             let (copied, reused) = {
-                let reused = self.try_reuse_copy_target(layer_config, progress).await?;
+                let reused = self
+                    .try_reuse_copy_target(layer_config, auto_queue_splitting, progress)
+                    .await?;
                 match reused {
                     Some(reused) => (reused, true),
-                    None => (self.copy_target(layer_config, progress).await?, false),
+                    None => (
+                        self.copy_target(layer_config, auto_queue_splitting, progress)
+                            .await?,
+                        false,
+                    ),
                 }
             };
             copy_subtask.success(None);
@@ -1467,7 +1473,9 @@ impl OperatorApi<PreparedClientCert> {
                 operation: OperatorOperation::WebsocketConnection,
             }) if response.code == 404 && reused_copy => {
                 connection_subtask.failure(Some("copied target is gone"));
-                let copied = self.copy_target(layer_config, progress).await?;
+                let copied = self
+                    .copy_target(layer_config, auto_queue_splitting, progress)
+                    .await?;
 
                 let connect_url = Self::copy_target_connect_url(
                     &copied,
@@ -1564,10 +1572,16 @@ impl OperatorApi<PreparedClientCert> {
             let mut copy_subtask = progress.subtask("preparing target copy");
 
             let (copied, reused) = {
-                let reused = self.try_reuse_copy_target(layer_config, progress).await?;
+                let reused = self
+                    .try_reuse_copy_target(layer_config, auto_queue_splitting, progress)
+                    .await?;
                 match reused {
                     Some(reused) => (reused, true),
-                    None => (self.copy_target(layer_config, progress).await?, false),
+                    None => (
+                        self.copy_target(layer_config, auto_queue_splitting, progress)
+                            .await?,
+                        false,
+                    ),
                 }
             };
             copy_subtask.success(None);
@@ -2049,6 +2063,7 @@ impl OperatorApi<PreparedClientCert> {
     async fn copy_target<P: Progress>(
         &self,
         layer_config: &LayerConfig,
+        auto_queue_splitting: bool,
         progress: &P,
     ) -> OperatorApiResult<CopyTargetCrd> {
         let mut subtask = progress.subtask("copying target");
@@ -2086,6 +2101,7 @@ impl OperatorApi<PreparedClientCert> {
             idle_ttl: Some(Self::COPIED_POD_IDLE_TTL),
             scale_down,
             split_queues,
+            auto_queue_splitting: auto_queue_splitting.then_some(true),
             exclude_containers,
             exclude_init_containers,
         };
@@ -2108,6 +2124,7 @@ impl OperatorApi<PreparedClientCert> {
     async fn try_reuse_copy_target<P: Progress>(
         &self,
         layer_config: &LayerConfig,
+        auto_queue_splitting: bool,
         progress: &P,
     ) -> OperatorApiResult<Option<CopyTargetCrd>> {
         let mut subtask = progress.subtask("checking for existing target copies");
@@ -2145,6 +2162,7 @@ impl OperatorApi<PreparedClientCert> {
             idle_ttl: Some(Self::COPIED_POD_IDLE_TTL),
             scale_down,
             split_queues,
+            auto_queue_splitting: auto_queue_splitting.then_some(true),
             exclude_containers,
             exclude_init_containers,
         };

--- a/mirrord/operator/src/crd/copy_target.rs
+++ b/mirrord/operator/src/crd/copy_target.rs
@@ -34,6 +34,11 @@ pub struct CopyTargetSpec {
     /// Init containers that are ignored by copy target.
     #[serde(default)]
     pub exclude_init_containers: Vec<String>,
+    /// When set to `true`, `split_queues` contains wildcard config for all queue kinds.
+    /// Resource creation handler must dismiss unsupported kinds rather than rejecting the
+    /// creation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auto_queue_splitting: Option<bool>,
 }
 
 /// This is the `status` field for [`CopyTargetCrd`].

--- a/mirrord/up/src/config.rs
+++ b/mirrord/up/src/config.rs
@@ -344,6 +344,7 @@ impl ServiceConfig {
         cfg.feature.env = self.env;
 
         cfg.feature.network.incoming.mode = IncomingMode::Steal;
+        cfg.feature.split_queues = SplitQueuesConfig::all_wildcard(&key);
 
         match self.default_mode {
             ServiceMode::Split => {
@@ -358,7 +359,6 @@ impl ServiceConfig {
                         ..Default::default()
                     }
                 };
-                cfg.feature.split_queues = SplitQueuesConfig::all_wildcard(&key);
             }
 
             ServiceMode::Replace => {
@@ -376,7 +376,6 @@ impl ServiceConfig {
                     exclude_containers: Vec::new(),
                     exclude_init_containers: Vec::new(),
                 };
-                // TODO: support auto queue splitting for `replace` mode.
             }
         }
 


### PR DESCRIPTION
<!-- Thank you for contributing to mirrord! -->
<!-- Please use the checklist below as a guide for docs, tests and admin tasks for your PR -->
<!-- Feel free to ~strikethrough~ any items that you don't think apply -->

Introduce `auto_queue_splitting` flag for copy target CRD. When set to true (by `mirrord up` only for now), operator should dismiss queue split configs of disabled queue kinds rather than denying copy target creation.

Downstream operator PR: https://github.com/metalbear-co/operator/pull/2109
Doc update: https://github.com/metalbear-co/docs/pull/292

### Quality Checklist:

- [x] I have documented new code sufficiently
- [x] I have checked and updated the relevant existing docs in code, including removing outdated material
- [x] I have written user-facing website docs for new features, or opened a (sub)issue to do so
- [x] I have checked and updated existing website docs for changed features
- [x] I have tested this change and know it succeeds and fails as expected
- [x] I have written unit tests or purposefully omitted them
- [x] I have written e2e tests or purposefully omitted them
- [x] I have explained what this PR introduces and why, and linked to relevant context (e.g. linear issues, related PRs,
  documentation)
- [x] I have introduced a short, clear and well-formatted changelog entry

<!-- need help with the changelog? see ../CONTRIBUTING.md#submitting-a-pull-request -->
<!-- Add more details of your changes below if needed -->