### PR TITLE
build(ui): keep component names in the built bundle for crash stacks

### DIFF
--- a/changelog.d/+monitor-crash-component-names.internal.md
+++ b/changelog.d/+monitor-crash-component-names.internal.md
@@ -1,0 +1,1 @@
+Crash reports from the `mirrord ui` error boundary now name the React components in the stack instead of minified identifiers, so a reported crash can be traced to the component that raised it.

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -8,6 +8,12 @@ import path from 'path'
 // needs, so each feature's (conflicting) CSS tokens only ever load on its own page.
 export default defineConfig({
   plugins: [react()],
+  // React derives the component names in `componentStack` from `Function.name`, which the minifier
+  // otherwise rewrites to a one- or two-character identifier. Crash reports from the error boundary
+  // are the only view we get into a failure on a user's machine, and a stack of mangled names is
+  // not attributable to a component. Keeping names costs a little bundle size and buys a readable
+  // stack; the site is served from the local `mirrord ui` binary, so that size is not a download.
+  esbuild: { keepNames: true },
   resolve: {
     alias: {
       // Order matters: the more specific `/theme` subpath must precede the package root so it is


### PR DESCRIPTION
## Summary

The session monitor reports render crashes through its root error boundary, and that report is the only view we get into a failure on a user's machine. React builds `componentStack` from `Function.name`, which the minifier rewrites to one- and two-character identifiers, so a recurring crash signature currently arrives looking like this:

```
    at Tf (assets/index-<hash>.js:182:108291)
    at div
    at $f
    at Ff
```

That stack cannot be traced to a component. The boundary's other attribution field, `component`, is a literal passed at the single mount point, so it is the same value on every crash and adds nothing. No source maps are emitted, so there is nothing to symbolicate against either. The result is a crash signature that has been recurring for a month with no way to locate the code that raises it.

Setting esbuild's `keepNames` preserves the original function and class names through minification, which is what React reads for the stack. The same build serves the config wizard, so its crash reports get readable stacks too.

Cost is bundle size: the largest chunk goes from 466.99 kB to 490.57 kB raw (148.91 kB to 158.42 kB gzip), about 6% gzip. The site is served by the local `mirrord ui` binary rather than downloaded, so this is disk rather than transfer.

This is deliberately an observability change, not a fix. It does not change what crashes; it makes the next report say where.

## Test plan

Verified against the real production build, not a typecheck:

- Built `mirrord-ui` before and after the change. Confirmed component identifiers (`JsonHighlight`, `ConfigTab`, `SidePane`, `SessionSidebar`, `EventStream`, `SessionDetail`) are absent from the baseline bundle and present after.
- To capture a real `componentStack` end to end, temporarily added a nested component that throws inside the existing root error boundary, plus a temporary `console.error` of `info.componentStack`. Built both variants with the real vite config and served each `dist/` over HTTP, loading them in Chromium via playwright-cli.
  - Baseline printed `at Tf / at $f / at Ff / at Pf / at Lf / at UE / at GE / at d8` — the same mangled shape as the signature seen in reports.
  - With `keepNames` the identical tree printed `at DeepChild / at MiddleWrapper / at CrashProbe / at ErrorBoundary / at Monitor / at App / at QueryClientProvider`.
  - Both temporary files were removed before committing; the diff is the vite config plus a changelog fragment.
- `pnpm --filter mirrord-ui typecheck`, `lint`, `format:check` all pass, and `prettier --check vite.config.ts` is clean.

Not exercised: no live operator session was driven, since the change affects only how names survive the build and is independent of runtime data.