### PR TITLE
Honor AI_NUMERICHOST in getaddrinfo instead of resolving remotely

### DIFF
--- a/changelog.d/+getaddrinfo-numerichost.fixed.md
+++ b/changelog.d/+getaddrinfo-numerichost.fixed.md
@@ -1,0 +1,1 @@
+`getaddrinfo` calls that pass `AI_NUMERICHOST` are no longer resolved remotely. That flag asks whether the given string is already a numeric address rather than for a name lookup, and must fail when it is not, so resolving it reported every hostname as a literal address.

--- a/mirrord/layer-lib/src/detour.rs
+++ b/mirrord/layer-lib/src/detour.rs
@@ -205,6 +205,9 @@ pub enum Bypass {
     /// Called `getaddrinfo` with `rawish_node` being [`None`].
     NullNode,
 
+    /// Called `getaddrinfo` with `AI_NUMERICHOST`, which asks for no name resolution at all.
+    NumericHostLookup,
+
     /// Skip patching SIP for macOS.
     #[cfg(target_os = "macos")]
     NoSipDetected(String),

--- a/mirrord/layer-lib/src/socket/dns/unix.rs
+++ b/mirrord/layer-lib/src/socket/dns/unix.rs
@@ -41,6 +41,17 @@ pub fn getaddrinfo(
     rawish_service: Option<&CStr>,
     raw_hints: Option<&libc::addrinfo>,
 ) -> Detour<*mut libc::addrinfo> {
+    // `AI_NUMERICHOST` means the caller is not asking for name resolution at all. It is asking
+    // whether `node` is already a numeric address, and POSIX requires `EAI_NONAME` when it is
+    // not. Resolving it remotely answers a question nobody asked, and callers that use this as
+    // an "is this a literal IP?" probe get a false positive for every hostname.
+    //
+    // Bypassing loses nothing: with this flag the local `getaddrinfo` does the same string
+    // parse the remote one would, and performs no DNS lookup of its own.
+    if raw_hints.is_some_and(|hints| hints.ai_flags & libc::AI_NUMERICHOST != 0) {
+        Detour::Bypass(Bypass::NumericHostLookup)?;
+    }
+
     let node: String = rawish_node
         .bypass(Bypass::NullNode)?
         .to_str()
@@ -146,4 +157,26 @@ pub fn getaddrinfo(
     trace!("getaddrinfo -> result {:#?}", result);
 
     Detour::Success(result)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    /// A caller that passes `AI_NUMERICHOST` is testing whether the string is already an
+    /// address, not asking for a lookup. Answering it from the cluster tells the caller that
+    /// every hostname is a literal address.
+    #[test]
+    fn numeric_host_lookups_are_not_resolved_remotely() {
+        let hints = libc::addrinfo {
+            ai_flags: libc::AI_NUMERICHOST,
+            ..unsafe { mem::zeroed() }
+        };
+        let node = CString::new("my-service.default.svc.cluster.local").unwrap();
+
+        assert!(matches!(
+            getaddrinfo(Some(&node), None, Some(&hints)),
+            Detour::Bypass(Bypass::NumericHostLookup),
+        ));
+    }
 }

--- a/mirrord/layer-lib/src/socket/dns/windows.rs
+++ b/mirrord/layer-lib/src/socket/dns/windows.rs
@@ -9,7 +9,7 @@ use std::{
 use socket2::SockAddr;
 use utils::{ManagedAddrInfo, ManagedAddrInfoAny, WindowsAddrInfo};
 use winapi::{
-    shared::ws2def::SOCKADDR,
+    shared::ws2def::{AI_NUMERICHOST, SOCKADDR},
     um::winsock2::{SOCKET, WSAGetLastError},
 };
 use windows_strings::PCWSTR;
@@ -37,6 +37,17 @@ pub fn getaddrinfo<T: WindowsAddrInfo>(
     raw_service: Option<String>,
     raw_hints: Option<&T>,
 ) -> Detour<ManagedAddrInfo<T>> {
+    // `AI_NUMERICHOST` means the caller is not asking for name resolution at all. It is asking
+    // whether `node` is already a numeric address, and expects `WSAHOST_NOT_FOUND` when it is
+    // not. Resolving it remotely answers a question nobody asked, and callers that use this as
+    // an "is this a literal IP?" probe get a false positive for every hostname.
+    //
+    // Bypassing loses nothing: with this flag the system `GetAddrInfo` does the same string
+    // parse the remote one would, and performs no DNS lookup of its own.
+    if raw_hints.is_some_and(|hints| hints.get_flags() & AI_NUMERICHOST != 0) {
+        Detour::Bypass(Bypass::NumericHostLookup)?;
+    }
+
     // Convert node to string
     let node = raw_node.bypass(Bypass::NullNode)?;
 

--- a/mirrord/layer-lib/src/socket/dns/windows/utils.rs
+++ b/mirrord/layer-lib/src/socket/dns/windows/utils.rs
@@ -152,6 +152,9 @@ pub trait WindowsAddrInfo: Sized {
 
     /// Extract family, socktype, and protocol from this structure (for hints processing)
     fn get_family_socktype_protocol(&self) -> (i32, i32, i32);
+
+    /// The caller's `ai_flags`, needed to honor `AI_NUMERICHOST`.
+    fn get_flags(&self) -> i32;
 }
 
 impl WindowsAddrInfo for ADDRINFOA {
@@ -197,6 +200,10 @@ impl WindowsAddrInfo for ADDRINFOA {
     fn get_family_socktype_protocol(&self) -> (i32, i32, i32) {
         (self.ai_family, self.ai_socktype, self.ai_protocol)
     }
+
+    fn get_flags(&self) -> i32 {
+        self.ai_flags
+    }
 }
 
 impl WindowsAddrInfo for ADDRINFOW {
@@ -241,6 +248,10 @@ impl WindowsAddrInfo for ADDRINFOW {
 
     fn get_family_socktype_protocol(&self) -> (i32, i32, i32) {
         (self.ai_family, self.ai_socktype, self.ai_protocol)
+    }
+
+    fn get_flags(&self) -> i32 {
+        self.ai_flags
     }
 }
 
@@ -297,6 +308,10 @@ impl WindowsAddrInfo for ADDRINFOEXW {
 
     fn get_family_socktype_protocol(&self) -> (i32, i32, i32) {
         (self.ai_family, self.ai_socktype, self.ai_protocol)
+    }
+
+    fn get_flags(&self) -> i32 {
+        self.ai_flags
     }
 }
 


### PR DESCRIPTION
## What

`getaddrinfo` hooks now bypass when the caller passes `AI_NUMERICHOST`.

## Why

`AI_NUMERICHOST` is not a request for name resolution. It asks whether the given string is *already* a numeric address, and it must fail with `EAI_NONAME` (`WSAHOST_NOT_FOUND` on Windows) when it is not. The hooks passed the flag straight through to the remote lookup and never acted on it, so any hostname came back as a successful "numeric" result. Callers that use this as a cheap "do I need to resolve this at all?" test were told yes for every hostname.

Bypassing costs nothing here. With the flag set, the local `getaddrinfo` performs the same string parse the remote one would and issues no DNS query of its own, so the answer is identical either way and no traffic escapes to the local network.

## How

- `mirrord/layer-lib/src/socket/dns/unix.rs`: bypass before any resolution when the flag is set.
- `mirrord/layer-lib/src/socket/dns/windows.rs`: same check. This needed the caller's `ai_flags` exposed, so `WindowsAddrInfo` gains `get_flags()` alongside `get_family_socktype_protocol()`, implemented for `ADDRINFOA`, `ADDRINFOW` and `ADDRINFOEXW`.
- New `Bypass::NumericHostLookup` so the reason is visible in traces.

## Testing

Unit test asserting a hostname with `AI_NUMERICHOST` bypasses rather than resolving. Verified against a live cluster that the bypass fires for a real application making these calls.

The Windows half could not be compiled locally (no Windows target on this machine) — it is a mechanical addition of one trait method and its three impls, and relies on CI for verification.

## Scope

This was found while investigating COR-1738, but **it does not fix that issue** — the affected runtime still fails to resolve with this applied, so the cause there is something else. Filing it on its own merits as a spec-compliance bug.