### PR TITLE
Enable experimental.guard_std_fds by default in OSS

### DIFF
--- a/changelog.d/+guard-std-fds-oss-default.changed.md
+++ b/changelog.d/+guard-std-fds-oss-default.changed.md
@@ -1,0 +1,2 @@
+`experimental.guard_std_fds` is now enabled by default in OSS (still off by
+default in mfT). [#4622](https://github.com/metalbear-co/mirrord/issues/4622)

--- a/mirrord-schema.json
+++ b/mirrord-schema.json
@@ -2758,7 +2758,7 @@
         },
         "guard_std_fds": {
           "title": "_experimental_ guard_std_fds {#experimental-guard_std_fds}",
-          "description": "Ensures the standard fds (0-2) are open when the layer initializes, pointing any closed\none at `/dev/null`. Protects the layer's internal fds (most importantly its connection to\nthe internal proxy) from being assigned a std fd number and reconfigured by the\napplication's runtime, e.g. `libuv` setting `O_NONBLOCK` on what it considers stdin.\n<https://github.com/metalbear-co/mirrord/issues/4622>\n\nDefaults to `false`.",
+          "description": "Ensures the standard fds (0-2) are open when the layer initializes, pointing any closed\none at `/dev/null`. Protects the layer's internal fds (most importantly its connection to\nthe internal proxy) from being assigned a std fd number and reconfigured by the\napplication's runtime, e.g. `libuv` setting `O_NONBLOCK` on what it considers stdin.\n<https://github.com/metalbear-co/mirrord/issues/4622>\n\nDefaults to `true` in OSS.\nDefaults to `false` in mfT.",
           "type": [
             "boolean",
             "null"

--- a/mirrord/cli/src/connection.rs
+++ b/mirrord/cli/src/connection.rs
@@ -450,6 +450,7 @@ fn process_config_oss<P: Progress>(config: &mut LayerConfig, progress: &mut P) -
 
     config.experimental.disable_reuseaddr = config.experimental.disable_reuseaddr.or(Some(true));
     config.experimental.go_asmcgocall = config.experimental.go_asmcgocall.or(Some(true));
+    config.experimental.guard_std_fds = config.experimental.guard_std_fds.or(Some(true));
 
     Ok(())
 }

--- a/mirrord/config/src/experimental.rs
+++ b/mirrord/config/src/experimental.rs
@@ -183,9 +183,10 @@ pub struct ExperimentalConfig {
     /// application's runtime, e.g. `libuv` setting `O_NONBLOCK` on what it considers stdin.
     /// <https://github.com/metalbear-co/mirrord/issues/4622>
     ///
-    /// Defaults to `false`.
-    #[config(default = false)]
-    pub guard_std_fds: bool,
+    /// Defaults to `true` in OSS.
+    /// Defaults to `false` in mfT.
+    #[config(default = None)]
+    pub guard_std_fds: Option<bool>,
 }
 
 impl CollectAnalytics for &ExperimentalConfig {
@@ -211,7 +212,9 @@ impl CollectAnalytics for &ExperimentalConfig {
         if let Some(go_asmcgocall) = self.go_asmcgocall {
             analytics.add("go_asmcgocall", go_asmcgocall);
         }
-        analytics.add("guard_std_fds", self.guard_std_fds);
+        if let Some(guard_std_fds) = self.guard_std_fds {
+            analytics.add("guard_std_fds", guard_std_fds);
+        }
     }
 }
 

--- a/mirrord/layer/src/lib.rs
+++ b/mirrord/layer/src/lib.rs
@@ -295,7 +295,7 @@ fn guard_std_fds() {
 /// Initialize a new session with the internal proxy and set [`PROXY_CONNECTION`]
 /// if not in trace only mode.
 fn load_only_layer_start(config: &LayerConfig) {
-    if config.experimental.guard_std_fds {
+    if config.experimental.guard_std_fds.unwrap_or_default() {
         guard_std_fds();
     }
 
@@ -379,7 +379,7 @@ fn mirrord_layer_entry_point() {
 /// 6. Fetches remote environment from the agent (if enabled with
 ///    [`EnvFileConfig::load_from_process`](mirrord_config::feature::env::EnvFileConfig::load_from_process)).
 fn layer_start(config: LayerConfig) {
-    if config.experimental.guard_std_fds {
+    if config.experimental.guard_std_fds.unwrap_or_default() {
         guard_std_fds();
     }
     init_tracing();


### PR DESCRIPTION
## Summary
- COR-1742: enable `experimental.guard_std_fds` by default for OSS users. Follows the same OSS/mfT split already used for `disable_reuseaddr` and `go_asmcgocall`: the field becomes `Option<bool>` (default `None`), and `process_config_oss` fills it to `Some(true)` when the user hasn't set it. mfT is untouched and keeps defaulting to `false` for now.
- Regenerated `mirrord-schema.json` doc/type for the field and added a towncrier changelog fragment.
- Follow-up COR-1743 tracks flipping the mfT default too, 3 weeks after this OSS rollout.

## Test plan
- [ ] CI (`cargo check`, `cargo clippy`, `cargo fmt --check`, unit + integration tests) — could not run cargo locally in this environment, no Rust toolchain available in the container.
- [ ] `issue4622` layer test (`mirrord/layer-tests/tests/issue4622.rs`) still passes with the config change.