### PR TITLE
Set TCP_NODELAY on connections accepted by the layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2832,11 +2832,10 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]

--- a/changelog.d/+tcp-nodelay-accepted-sockets.changed.md
+++ b/changelog.d/+tcp-nodelay-accepted-sockets.changed.md
@@ -1,0 +1,1 @@
+Connections accepted on a mirrord-managed listener now have `TCP_NODELAY` set. Stolen and mirrored traffic is relayed to the local application one request at a time, so Nagle's algorithm could add a delayed-ACK stall to every request on servers that do not set the option themselves.

--- a/changelog.d/+tcp-nodelay-accepted-sockets.changed.md
+++ b/changelog.d/+tcp-nodelay-accepted-sockets.changed.md
@@ -1,1 +1,1 @@
-Connections accepted on a mirrord-managed listener now have `TCP_NODELAY` set. Stolen and mirrored traffic is relayed to the local application one request at a time, so Nagle's algorithm could add a delayed-ACK stall to every request on servers that do not set the option themselves.
+Connections accepted by the layer now have `TCP_NODELAY` set to reduce latency.

--- a/mirrord/layer/src/socket/ops.rs
+++ b/mirrord/layer/src/socket/ops.rs
@@ -666,10 +666,6 @@ pub(super) fn accept(
     let peer_address = {
         let stream = unsafe { TcpStream::from_raw_fd(new_fd) };
         let peer_address = stream.peer_addr();
-        // This connection carries traffic relayed from the cluster, one request at a time,
-        // so Nagle's algorithm can add a delayed-ACK stall to every request on it. The
-        // application has no way to know the socket is fed by mirrord, and many servers
-        // never set this themselves. Failing to set it costs latency, not correctness.
         if let Err(error) = stream.set_nodelay(true) {
             tracing::debug!(
                 ?error,

--- a/mirrord/layer/src/socket/ops.rs
+++ b/mirrord/layer/src/socket/ops.rs
@@ -666,6 +666,13 @@ pub(super) fn accept(
     let peer_address = {
         let stream = unsafe { TcpStream::from_raw_fd(new_fd) };
         let peer_address = stream.peer_addr();
+        // This connection carries traffic relayed from the cluster, one request at a time,
+        // so Nagle's algorithm can add a delayed-ACK stall to every request on it. The
+        // application has no way to know the socket is fed by mirrord, and many servers
+        // never set this themselves. Failing to set it costs latency, not correctness.
+        if let Err(error) = stream.set_nodelay(true) {
+            warn!(%error, "Failed to set TCP_NODELAY on an accepted connection");
+        }
         let _fd = stream.into_raw_fd();
         peer_address?
     };

--- a/mirrord/layer/src/socket/ops.rs
+++ b/mirrord/layer/src/socket/ops.rs
@@ -671,7 +671,10 @@ pub(super) fn accept(
         // application has no way to know the socket is fed by mirrord, and many servers
         // never set this themselves. Failing to set it costs latency, not correctness.
         if let Err(error) = stream.set_nodelay(true) {
-            warn!(%error, "Failed to set TCP_NODELAY on an accepted connection");
+            tracing::debug!(
+                ?error,
+                "Failed to set TCP_NODELAY on an accepted connection"
+            );
         }
         let _fd = stream.into_raw_fd();
         peer_address?


### PR DESCRIPTION
## What

Sets `TCP_NODELAY` on connections accepted through the layer's `accept` hook.

## Why

#4635 set `TCP_NODELAY` on mirrord's own proxying sockets. This covers the remaining socket in the path: the one the layer hands to the application.

Stolen and mirrored traffic is relayed to the local application one request at a time. On a Nagle-enabled socket that request/response pattern can incur a delayed-ACK stall (~40ms) on every request, because each small write waits for an ACK that the peer is holding back. The application has no way to know the socket is fed by mirrord rather than by a real peer, and many servers never set the option themselves — so the stall shows up as a fixed per-request cost that does not scale with anything and is not visible without mirrord.

Measured against a server that does not set the option, a request/response exchange under steal cost roughly twice as much per request as the same server with `TCP_NODELAY` set. Servers that already set it (Puma, for example, sets it on the listening socket) are unaffected.

## Scope

The hook body only runs for fds in `SocketState::Listening` — i.e. listeners mirrord manages — so sockets the application accepts for unrelated local traffic keep their own semantics.

Failing to set the option does not fail the accept: it costs latency, not correctness. It is logged at `debug`, matching the other socket-option failures in this file (`SO_REUSEADDR` / `SO_REUSEPORT` at `ops.rs:249`/`:254`), since it is not actionable by the user.

## Not verified end to end

This compiles and lints, but has not been benchmarked with a rebuilt layer. The reasoning rests on the app-side measurement above rather than a before/after with this patch in place.

## Unrelated commit

`f2fb3f54` bumps `event-listener` 5.4.1 → 5.4.2 for RUSTSEC-2026-0221, which is failing `cargo-deny` on main and therefore on every branch. Happy to split it out if preferred.

Relates to COR-1739.