### PR TITLE
chore(xtask): run CLI unit tests through nextest for flake retries

### DIFF
--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -142,7 +142,7 @@ jobs:
       - name: mirrord operator UT
         run: cargo nextest run --target x86_64-unknown-linux-gnu -p mirrord-operator --features "crd, client" --profile ci
       - name: mirrord cli UT
-        run: cargo xtask test-ut -- --target x86_64-unknown-linux-gnu
+        run: cargo xtask test-ut -- --target x86_64-unknown-linux-gnu --profile ci
       - name: mirrord protocol-io UT
         run: cargo nextest run --target x86_64-unknown-linux-gnu -p mirrord-protocol-io --profile ci
       - name: mirrord jaq UT

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ cargo xtask test-integration
 # filtered integration tests
 cargo xtask test-integration -- outgoing_udp --nocapture
 
-# unit tests (cargo test)
+# unit tests (cargo nextest when installed, else cargo test)
 cargo xtask test-ut
 
 # filtered unit tests

--- a/changelog.d/+nextest-cli-unit-tests.internal.md
+++ b/changelog.d/+nextest-cli-unit-tests.internal.md
@@ -1,0 +1,3 @@
+`cargo xtask test-ut` now runs the CLI unit tests through `cargo nextest` when it
+is installed, falling back to `cargo test` otherwise, so those tests get the same
+flake retries as every other suite.

--- a/xtask/src/tasks/test.rs
+++ b/xtask/src/tasks/test.rs
@@ -160,7 +160,14 @@ pub fn run_unit(cargo_args: Vec<String>) -> Result<()> {
     let assets = create_dummy_cli_artifacts()?;
 
     let mut cmd = Command::new("cargo");
-    cmd.args(["test", "-p", "mirrord"]);
+
+    if cargo_nextest_available() {
+        cmd.args(["nextest", "run"]);
+    } else {
+        cmd.arg("test");
+    }
+
+    cmd.args(["-p", "mirrord"]);
     cmd.args(cargo_args);
     cmd.env("MIRRORD_LAYER_FILE", &assets.layer);
     cmd.env("MIRRORD_LAYER_FILE_MACOS_ARM64", &assets.arm64_layer);


### PR DESCRIPTION
## Summary

Every suite in `test-integration.yaml` runs under `cargo nextest ... --profile ci`, which retries flakes twice (`.config/nextest.toml`). The `mirrord cli UT` step was the exception: `cargo xtask test-ut` called `cargo test` directly, so those tests had no retries and a single flake failed the whole job.

`run_unit` now reuses the `cargo_nextest_available()` check the other suites already use, so behaviour is unchanged when nextest is not installed, and the workflow passes `--profile ci` so the retries actually apply.

- `xtask/src/tasks/test.rs`: `run_unit` picks `cargo nextest run` when available, else `cargo test`.
- `.github/workflows/test-integration.yaml`: `mirrord cli UT` passes `--profile ci`.
- `AGENTS.md`: the `test-ut` comment said "(cargo test)".

## Test plan

- `cargo run -p xtask -- test-ut -- --profile ci` → **95 tests run, 95 passed** through nextest locally (cargo-nextest 0.9.140).
- Confirmed the branch actually flips: with the change stashed, `cargo xtask test-ut -- --help` prints `cargo test` help; with it applied, it prints `cargo-nextest` help.
- Confirmed the fallback: before installing nextest locally, the same command ran `cargo test`, so machines without nextest are unaffected.
- `cargo fmt --check` clean, `cargo clippy -p xtask --all-targets -- --deny warnings` clean.

Not exercised: the retry path itself. `.config/nextest.toml` sets `retries = 2` for the `ci` profile and the profile is now passed, but I did not force a flake to watch a retry happen.

Refs COR-1569