### PR TITLE
ci: merge approved release PRs as the release bot, and lock manual merges

### DIFF
--- a/.github/workflows/merge-release-pr.yaml
+++ b/.github/workflows/merge-release-pr.yaml
@@ -23,8 +23,29 @@ permissions:
 
 jobs:
   merge:
+    # `pull_request_review` runs in the context of the base repository, with
+    # access to secrets, even when the pull request comes from a fork. On a
+    # public repository anyone can open a pull request from a fork with any head
+    # branch name they like — including `releases/1.2.3` — and anyone can submit
+    # an approving review on it. Both of those are attacker-controlled, so
+    # neither the branch name nor the approval is worth anything on its own.
+    #
+    # Two conditions make this safe:
+    #
+    #   - the pull request must come from this repository, not a fork. Only the
+    #     release bot can create a `releases/*` branch here, because the
+    #     release-branches-bot-only ruleset blocks creation by anyone else, so a
+    #     same-repository release branch is necessarily one the bot generated.
+    #   - the approval must come from someone with write access. Reviews from
+    #     outside collaborators do not count towards the review requirement, and
+    #     must not count here either.
+    #
+    # Without the first condition an outsider could open `releases/9.9.9` from a
+    # fork, approve it themselves, and have this job mint a bot token for it.
     if: >-
       github.event.review.state == 'approved'
+      && github.event.pull_request.head.repo.full_name == github.repository
+      && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association)
       && startsWith(github.event.pull_request.head.ref, 'releases/')
       && github.event.pull_request.state == 'open'
       && github.event.pull_request.draft == false

--- a/.github/workflows/merge-release-pr.yaml
+++ b/.github/workflows/merge-release-pr.yaml
@@ -1,0 +1,60 @@
+# Merges an approved release pull request as the release bot.
+#
+# The `main-merge-method` ruleset restricts everyone to squash merges on main
+# and exempts the release bot, so the bot is the only identity that can produce
+# a merge commit. That matters because the release workflow pins every published
+# artifact to the release branch tip, and the tip is only reachable from main —
+# and so only taggable — if the pull request lands as a merge commit.
+#
+# Approval therefore replaces merging as the human gate on a release: a reviewer
+# approves, and this merges.
+#
+# The bot does NOT bypass `main-protection`, so required checks and the review
+# requirement still apply to it exactly as they do to everyone else. This cannot
+# push out a release with red CI.
+name: Merge Release PR
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  contents: read
+
+jobs:
+  merge:
+    if: >-
+      github.event.review.state == 'approved'
+      && startsWith(github.event.pull_request.head.ref, 'releases/')
+      && github.event.pull_request.state == 'open'
+      && github.event.pull_request.draft == false
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Create release bot token
+        id: app-token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        with:
+          app-id: ${{ secrets.CUBBY_CLIENT_ID }}
+          private-key: ${{ secrets.CUBBY_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+
+      - name: Merge as a merge commit
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          # Merge outright if the required checks are already green. If they are
+          # not, fall back to auto-merge so GitHub completes it as the bot once
+          # they pass, rather than failing here because approval arrived first.
+          #
+          # `--merge` is not a preference: a squash would orphan the commit the
+          # release is pinned to.
+          if gh pr merge "${PR}" --merge; then
+            echo "Merged release PR #${PR}."
+          else
+            echo "Required checks are not green yet, enabling auto-merge."
+            gh pr merge "${PR}" --merge --auto
+          fi

--- a/.github/workflows/release-merge-lock.yaml
+++ b/.github/workflows/release-merge-lock.yaml
@@ -1,0 +1,59 @@
+# Keeps release pull requests from being merged by hand.
+#
+# Everyone except the release bot is restricted to squash merges on main by the
+# `main-merge-method` ruleset. A squashed release PR orphans the release branch
+# tip, so the release workflow refuses to tag it and the release aborts with the
+# version already bumped on main. That is a safe failure but an annoying one, so
+# this blocks the merge button rather than catching it afterwards.
+#
+# It works by reporting a `release-merge-lock` commit status that is required by
+# `main-merge-method`: success on ordinary pull requests, and permanently
+# pending on release ones. Pending blocks the merge exactly like a failure would
+# but is not red, and it carries a description explaining what to do instead.
+#
+# The release bot bypasses `main-merge-method`, so the pending status does not
+# stand in its way.
+#
+# This deliberately posts a status through the API rather than reporting a job
+# result. A skipped job is treated as passing for required checks in several
+# configurations, which would silently unlock the very thing this exists to
+# lock.
+name: Release Merge Lock
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, reopened, synchronize]
+  merge_group:
+
+permissions:
+  statuses: write
+
+jobs:
+  lock:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Report release-merge-lock
+        env:
+          GH_TOKEN: ${{ github.token }}
+          # Empty on merge_group, where nothing is a release PR: release PRs are
+          # merged directly by the bot and never enter the queue.
+          HEAD_REF: ${{ github.head_ref }}
+          SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
+        run: |
+          set -euo pipefail
+
+          if [[ "${HEAD_REF}" == releases/* ]]; then
+            state=pending
+            description="Release PRs are merged by automation. Approve instead of merging."
+          else
+            state=success
+            description="Not a release pull request."
+          fi
+
+          echo "Reporting release-merge-lock=${state} on ${SHA}"
+
+          gh api "repos/${GITHUB_REPOSITORY}/statuses/${SHA}" \
+            -f state="${state}" \
+            -f context=release-merge-lock \
+            -f description="${description}" > /dev/null

--- a/.github/workflows/release-merge-lock.yaml
+++ b/.github/workflows/release-merge-lock.yaml
@@ -20,8 +20,19 @@
 # lock.
 name: Release Merge Lock
 
+# `pull_request_target` rather than `pull_request`, because a pull request from
+# a fork gets a read-only token and could not post the status at all — leaving
+# the required check unreported and every outside contribution permanently
+# unmergeable.
+#
+# The usual danger of `pull_request_target` is that it runs in the base
+# repository's context, with secrets, against code the pull request author
+# controls. That does not apply here: this workflow never checks the pull
+# request out and never executes anything from it. It reads the head branch
+# name, which is untrusted and is only ever compared, never interpolated into a
+# shell command, and posts a status. Do not add a checkout step to this file.
 on:
-  pull_request:
+  pull_request_target:
     branches: [main]
     types: [opened, reopened, synchronize]
   merge_group:

--- a/changelog.d/+release-pr-merge-automation.internal.md
+++ b/changelog.d/+release-pr-merge-automation.internal.md
@@ -1,0 +1,4 @@
+Merge approved release pull requests automatically as the release bot, and block
+merging them by hand. Only the bot can create the merge commit that keeps the
+released commit reachable from the main branch, so approval now stands in for
+pressing the merge button.


### PR DESCRIPTION
## What this adds

Two workflows, in both `mirrord` and `operator`.

### `merge-release-pr`

Merges an **approved** release PR as the release bot. The `main-merge-method` ruleset restricts everyone to squash and exempts the bot, so the bot is the only identity that can produce a merge commit — and the release only stays taggable if the PR lands as one.

So **approval replaces merging as the human gate on a release.** Same judgment, different button.

It merges outright when required checks are already green, and falls back to auto-merge when approval arrives first. The bot does **not** bypass `main-protection`, so required checks and the review requirement still bind it — this cannot ship a release with red CI.

### `release-merge-lock`

Stops the mistake happening at all. Reports a `release-merge-lock` commit status that `main-merge-method` requires:

| | status | effect |
|---|---|---|
| ordinary PR | success | merges as usual |
| release PR | **pending** | merge button disabled, reason shown |
| release bot | — | bypasses the ruleset, merges through |

Pending rather than failure: it blocks just as hard without painting every release PR red, and carries a description — *"Release PRs are merged by automation. Approve instead of merging."*

## Why a commit status and not a job result

A skipped job is treated as **passing** for required checks in several configurations. Reporting via the API is deterministic — the status is exactly what we set, with no skipped-job semantics involved. Given this is the thing standing between a human and a broken release, that mattered.

## Context

mirrord 3.244.0 failed exactly this way: release PR squash-merged by hand, branch tip orphaned, `validate_release_request` aborted. Nothing shipped — the guard worked — but main is bumped to 3.244.0 with no release, and every future release would repeat it.

Requires the infra PR adding `release-merge-lock` to `main-merge-method`. Order: land these two first so the status is being reported, then the infra one — otherwise the required check has nothing reporting it and blocks every PR.

## Testing

Both workflows parse. Not exercised end to end — that needs a real release PR, which is the next scheduled run.