### PR TITLE
Add changelog fragment to trigger a new release

### DIFF
--- a/changelog.d/+retrigger-release.internal.md
+++ b/changelog.d/+retrigger-release.internal.md
@@ -1,0 +1,3 @@
+Trigger a fresh release run after the previous attempt stopped before it
+published anything. This entry carries no functional change; it exists so the
+release workflow has a changelog fragment to build the next version from.


### PR DESCRIPTION
The previous release run stopped at the validation step and never published, so `main` has no unreleased changelog fragments to build the next version from.

This adds a single `internal` fragment so a release PR can be cut. No code changes.