### PR TITLE
ci: recognise release branches again so the IDE e2e tests run

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -185,11 +185,19 @@ jobs:
         with:
           files: |
             mirrord-schema.json
+      # `auto-release-pr` names release branches `releases/<version>`, so the
+      # bare-version pattern this used to match stopped matching anything and
+      # the IDE end-to-end jobs below have been silently skipping. Match the
+      # same prefix that `release.yaml` and `auto-release-pr.yaml` use.
+      #
+      # This is false in the merge queue, where the ref is
+      # `gh-readonly-queue/...` and carries a pull request number rather than a
+      # branch name. The pull request run is the one that matters here.
       - id: release-branch
         env:
           BRANCH: ${{ github.head_ref || github.ref_name }}
         run: |
-          echo "branch=$([[ "$BRANCH" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]  && echo "true" || echo "false" )" >> "$GITHUB_OUTPUT"
+          echo "branch=$([[ "$BRANCH" == releases/* ]] && echo "true" || echo "false")" >> "$GITHUB_OUTPUT"
       - name: output test
         run: |
           echo ${{ steps.changed-rs.outputs.any_changed }};

--- a/changelog.d/+fix-release-branch-detection.internal.md
+++ b/changelog.d/+fix-release-branch-detection.internal.md
@@ -1,0 +1,4 @@
+Run the IntelliJ and VSCode end-to-end tests on release pull requests again.
+The check that recognises a release branch still looked for a bare version
+number, so it stopped matching when those branches were renamed, and both test
+suites had been quietly skipping ever since.


### PR DESCRIPTION
## The bug

`plan.outputs.release_branch` is computed as:

```bash
[[ "$BRANCH" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
```

But `auto-release-pr` names release branches **`releases/<version>`**. `releases/3.244.0` doesn't match a bare-version pattern, so this has been evaluating `false` for every release PR.

## What that silently disabled

Three jobs gate on it:

- `build_mirrord_on_release_branch` — never ran
- `intellij_e2e_on_release_branch` — skipped, because its `needs` was skipped
- `vscode_e2e_on_release_branch` — same

Those last two exist **specifically to test the release binary against the IntelliJ and VSCode plugins before a release ships**. They've been doing nothing.

Confirmed on the 3.244.0 release PR (run `30758877977`):

```
skipped  intellij_e2e_on_release_branch
skipped  vscode_e2e_on_release_branch
```

So release PRs have been getting *less* verification than the code intends, not more.

## Fix

Match the `releases/` prefix — the same thing `release.yaml` and `auto-release-pr.yaml` already key off, so all three agree on what a release branch is.

| branch | before | after |
|---|---|---|
| `releases/3.245.0` | false | **true** |
| `aviram/some-feature` | false | false |
| `gh-readonly-queue/main/pr-4652-abc` | false | false |
| `3.245.0` | true | false |

## Why nothing else needs changing

`test_agent_image` is the other dependency of both e2e jobs. It's gated on `rs_changed`, whose file list includes `Cargo.toml` and `Cargo.lock` — which every release PR touches. So it already runs, and fixing the regex is sufficient to unblock the chain.

## Merge queue

Stays `false` there: the ref is `gh-readonly-queue/main/pr-N-<sha>`, which carries a PR number rather than a branch name. The PR run is the meaningful one, and matching in the queue would mean resolving the ref back to a PR for no real gain.

## Testing

YAML parses. Match logic verified against the four branch shapes above. The jobs themselves only exercise on a real release PR — the next release is the proof, and it's worth watching that both e2e jobs actually start.