### PR TITLE
Read /etc/ssl/certs from the remote target by default

### DIFF
--- a/changelog.d/+remote-ssl-certs.changed.md
+++ b/changelog.d/+remote-ssl-certs.changed.md
@@ -1,0 +1,3 @@
+`/etc/ssl/certs` is now read from the remote target by default, so the local process trusts the same
+certificate authorities as the target when talking to services in the cluster. Add the path to
+`feature.fs.local` to restore the previous behaviour.

--- a/mirrord/layer-lib/src/file/unix/read_remote_by_default.rs
+++ b/mirrord/layer-lib/src/file/unix/read_remote_by_default.rs
@@ -1,8 +1,11 @@
 /// These paths will be read remotely by default when `fs.feature.mode` is set to
 /// `localwithoverrides`.
-pub const PATHS: [&str; 3] = [
+pub const PATHS: [&str; 4] = [
     // for dns resolving
     r"^/etc/resolv.conf$",
     r"^/etc/hosts$",
     r"^/etc/hostname$",
+    // CA bundle, so that the local process trusts the same authorities as the remote target when
+    // talking to services in the cluster.
+    r"^/etc/ssl/certs(/|$)",
 ];

--- a/mirrord/layer/src/file/ops.rs
+++ b/mirrord/layer/src/file/ops.rs
@@ -1201,6 +1201,31 @@ mod test {
         false,
         DetourKind::Success
     )]
+    #[case(
+        FsModeConfig::Read,
+        "/etc/ssl/certs/ca-certificates.crt",
+        false,
+        DetourKind::Success
+    )]
+    #[case(
+        FsModeConfig::Write,
+        "/etc/ssl/certs/ca-certificates.crt",
+        false,
+        DetourKind::Success
+    )]
+    #[case(
+        FsModeConfig::LocalWithOverrides,
+        "/etc/ssl/certs/ca-certificates.crt",
+        false,
+        DetourKind::Success
+    )]
+    #[case(FsModeConfig::Read, "/etc/ssl/certs", false, DetourKind::Success)]
+    #[case(
+        FsModeConfig::Write,
+        "/etc/ssl/certs/ca-certificates.crt",
+        true,
+        DetourKind::Bypass
+    )]
     fn remote_read_only_set(
         #[case] mode: FsModeConfig,
         #[case] path: &str,

--- a/mirrord/layer/src/file/ops.rs
+++ b/mirrord/layer/src/file/ops.rs
@@ -1201,31 +1201,6 @@ mod test {
         false,
         DetourKind::Success
     )]
-    #[case(
-        FsModeConfig::Read,
-        "/etc/ssl/certs/ca-certificates.crt",
-        false,
-        DetourKind::Success
-    )]
-    #[case(
-        FsModeConfig::Write,
-        "/etc/ssl/certs/ca-certificates.crt",
-        false,
-        DetourKind::Success
-    )]
-    #[case(
-        FsModeConfig::LocalWithOverrides,
-        "/etc/ssl/certs/ca-certificates.crt",
-        false,
-        DetourKind::Success
-    )]
-    #[case(FsModeConfig::Read, "/etc/ssl/certs", false, DetourKind::Success)]
-    #[case(
-        FsModeConfig::Write,
-        "/etc/ssl/certs/ca-certificates.crt",
-        true,
-        DetourKind::Bypass
-    )]
     fn remote_read_only_set(
         #[case] mode: FsModeConfig,
         #[case] path: &str,


### PR DESCRIPTION
## Problem

`/etc/ssl/certs` is covered by the `^/etc(/|$)` pattern in the read-local-by-default set, so a local process doing TLS against services in the cluster validates certificates against the local machine's trust store rather than the target's. Clusters that issue certificates from a private CA present in the target image (service meshes, internal registries, self-hosted services) fail to verify unless the user adds a `feature.fs.read_only` override by hand.

## Change

Add `^/etc/ssl/certs(/|$)` to the unix read-remote-by-default set, so the CA bundle and the hashed symlink directory come from the target. The set is consulted before the local defaults in both `FileFilter::check` and `ensure_remote`, and only for reads — writes still bypass to the local filesystem.

Users who want the previous behaviour can put the path in `feature.fs.local`.

No Windows equivalent — that set stays empty.