### PR TITLE
fix(monitor): drop operator-session polls superseded by a context change

### DIFF
--- a/changelog.d/+operator-sessions-stale-poll.fixed.md
+++ b/changelog.d/+operator-sessions-stale-poll.fixed.md
@@ -1,0 +1,1 @@
+Fixed the session monitor briefly showing cluster sessions from an unselected namespace, by dropping operator-session polls superseded by a context or namespace change.

--- a/packages/monitor/src/App.tsx
+++ b/packages/monitor/src/App.tsx
@@ -233,30 +233,45 @@ export default function App({
     }
   }, [effectiveContext])
 
-  const refreshOperatorSessions = useCallback(() => {
-    api
-      .listOperatorSessions(effectiveContext, selectedNamespace)
-      .then((resp) => {
-        setOperatorSessions(resp.sessions)
-        setWatchStatus(
-          resp.status === 'available'
-            ? { status: 'watching' }
-            : {
-                status: 'unavailable',
-                reason: resp.reason ?? 'operator not available',
-              },
-        )
-      })
-      .catch((err: unknown) => {
-        console.error(err)
-        setWatchStatus({ status: 'unavailable', reason: String(err) })
-      })
-  }, [effectiveContext, selectedNamespace])
+  const refreshOperatorSessions = useCallback(
+    (signal: AbortSignal) => {
+      api
+        .listOperatorSessions(effectiveContext, selectedNamespace, signal)
+        .then((resp) => {
+          if (signal.aborted) return
+          setOperatorSessions(resp.sessions)
+          setWatchStatus(
+            resp.status === 'available'
+              ? { status: 'watching' }
+              : {
+                  status: 'unavailable',
+                  reason: resp.reason ?? 'operator not available',
+                },
+          )
+        })
+        .catch((err: unknown) => {
+          if (signal.aborted) return
+          console.error(err)
+          setWatchStatus({ status: 'unavailable', reason: String(err) })
+        })
+    },
+    [effectiveContext, selectedNamespace],
+  )
 
+  // The context and namespace resolve after the first render, so the initial unfiltered poll is
+  // already in flight by the time the real selection arrives. Aborting it keeps a slow reply from
+  // landing on top of the selected cluster's sessions.
   useEffect(() => {
-    refreshOperatorSessions()
-    const t = setInterval(refreshOperatorSessions, OPERATOR_POLL_INTERVAL)
-    return () => clearInterval(t)
+    const controller = new AbortController()
+    refreshOperatorSessions(controller.signal)
+    const t = setInterval(
+      () => refreshOperatorSessions(controller.signal),
+      OPERATOR_POLL_INTERVAL,
+    )
+    return () => {
+      controller.abort()
+      clearInterval(t)
+    }
   }, [refreshOperatorSessions])
 
   const refreshExtensionState = useCallback(async () => {

--- a/packages/monitor/src/api.ts
+++ b/packages/monitor/src/api.ts
@@ -233,6 +233,7 @@ export const api = {
   listOperatorSessions: async (
     context: string | null,
     namespace: string | null,
+    signal: AbortSignal,
   ): Promise<OperatorSessionsResponse> => {
     const params = new URLSearchParams()
     if (context) params.set('context', context)
@@ -242,7 +243,7 @@ export const api = {
       ? `/api/v2/operator/sessions?${qs}`
       : '/api/v2/operator/sessions'
     try {
-      const r = await fetch(withToken(path), { credentials: 'include' })
+      const r = await fetch(withToken(path), { credentials: 'include', signal })
       if (!r.ok) {
         reportSessionsHealth('operator_sessions', false, r.statusText, r.status)
         throw new Error(
@@ -253,6 +254,9 @@ export const api = {
       const data = (await r.json()) as OperatorSessionsResponse
       return data
     } catch (err) {
+      // A poll abandoned because the user moved to another context or namespace says nothing
+      // about operator reachability, so it must not count as a health transition.
+      if (signal.aborted) throw err
       if (
         !(err instanceof Error) ||
         !err.message.startsWith('Failed to fetch operator sessions')


### PR DESCRIPTION
## Summary

The session monitor could show cluster sessions from a namespace the user had not selected.

The kube context and namespace resolve after the first render, so the monitor's initial
*unfiltered* operator-sessions poll is already in flight by the time the real selection
arrives. Nothing cancelled it. When that first reply was slower than the filtered one, it
landed last and overwrote the selected cluster's sessions — the list then showed another
namespace's sessions (and its `watchStatus`) until the next 5s poll. On a shared
multi-tenant cluster that is the wrong tenant's sessions on screen.

This happens on **every app open**, not only on a manual cluster switch.

Each poll is now tied to the effect's `AbortController`, so a poll superseded by a context
or namespace change is aborted and its reply ignored.

An aborted poll also must not count as a session-health transition. Adding cancellation
without that guard would make every context switch report the operator as unreachable —
a new false `sessions_unhealthy`. The guard is verified by a control build below, not
assumed.

`sessions_unhealthy` is the largest live blocking signature on the monitor surface, and
its failures are concentrated on the operator-sessions endpoint rather than the local one,
so a share of it was self-inflicted by this race.

## Test plan

All of the following was actually run, on a real Chromium against the built `mirrord ui`
bundle served by a stub API. The stub delays the unfiltered poll and answers it with a
foreign namespace's session; the filtered poll answers fast with the correct one.

**A/B against unmodified `origin/main`** (same probe, same stub, two ports):

| | requests | aborted | shows foreign namespace | shows correct session |
|---|---|---|---|---|
| `origin/main` | UNFILTERED, FILTERED | 0 | **yes** | **no** |
| this branch | UNFILTERED, FILTERED | 1 | no | yes |

So the bug reproduces on `main` and is gone here — falsified, not asserted.

**Telemetry regression check**, with analytics reaching the network (posthog requests
intercepted and their payloads decoded):

- this branch: the abort fires, `sessions_unhealthy` is **not** emitted.
- control build with only the `signal.aborted` guard removed: the same abort **does** emit
  `reason:sessions_unhealthy` followed by `sessions_healthy`. The guard is load-bearing.

**Gates:** `typecheck` (`tsc -b`), `lint` (eslint), `format:check` (prettier) all clean for
both `packages/monitor` and `packages/ui`; `pnpm --filter mirrord-ui build` succeeds.

**Not exercised:** no run against a live operator or a real cluster — the race was driven
through a stub API, so the timing is synthetic rather than observed in production.
`packages/monitor` has no unit test harness, so there is no regression test in this PR.