### PR TITLE
Set TCP_NODELAY on the agent's client connection

### DIFF
--- a/changelog.d/+agent-client-connection-tcp-nodelay.changed.md
+++ b/changelog.d/+agent-client-connection-tcp-nodelay.changed.md
@@ -1,0 +1,1 @@
+Set `TCP_NODELAY` on the agent's connection to its clients, so messages sent to a session are not held back by Nagle's algorithm.

--- a/mirrord/agent/src/client_connection.rs
+++ b/mirrord/agent/src/client_connection.rs
@@ -97,6 +97,14 @@ impl ClientConnection {
         client_id: u32,
         tls: Option<AgentTlsConnector>,
     ) -> io::Result<Self> {
+        // Every message the agent sends a session travels over this one socket, including each
+        // chunk relayed from an intercepted connection, so buffering small writes here only adds
+        // latency to the session. The client sets this on its end of the same connection. Failing
+        // to set it costs latency, not correctness, so it must not fail the connection.
+        if let Err(error) = stream.set_nodelay(true) {
+            tracing::warn!(%error, "Failed to set TCP_NODELAY on a client connection");
+        }
+
         let framed = match tls {
             Some(connector) => {
                 let tls_stream = connector


### PR DESCRIPTION
## What

Disables Nagle's algorithm on the agent's side of its connection to a client.

## Why

The internal proxy already sets `TCP_NODELAY` on its end of this same connection, and the two sockets carrying intercepted outgoing traffic were given the same treatment. The agent's side of the client connection was the one remaining socket on that path without it.

Every message the agent sends a session travels over this socket, including each chunk relayed back from an intercepted connection. Those are small writes followed by a wait for the peer, which is exactly the pattern Nagle delays.

## Measurements

The original description said no improvement had been demonstrated. That was written before the measurement existed, and it was wrong — this does help under concurrency.

Agent with this change versus the same agent without it, synthetic sequential round trips through the outgoing path:

| concurrency | metric | without | with |
|---|---|---|---|
| 5 | p99 | 70.8 / 55.2 ms | **57.0 / 38.4 ms** |
| 10 | p99 | 78.4 / 65.1 ms | **57.4 / 42.0 ms** |
| 10 | throughput | 2171 / 2126 rt/s | **2717 / 2465 rt/s** |

Roughly 25-40% off the tail and ~20% more throughput at concurrency 10.

It does not remove the stalls entirely. The remaining ones are on sockets inside the API-server port-forward chain, which mirrord does not create and cannot configure — tracked separately.

Failing to set the option is logged and ignored, since it affects latency rather than correctness.