### PR TITLE
chaos cli: fix chaos edit command returning 422

### DIFF
--- a/.vale/styles/config/vocabularies/Metalbear/accept.txt
+++ b/.vale/styles/config/vocabularies/Metalbear/accept.txt
@@ -140,6 +140,7 @@ VPN
 URI
 loopback
 hostnames?
+[uU]nprocessable
 
 # File formats
 YAML

--- a/changelog.d/+chaos-edit-422.fixed.md
+++ b/changelog.d/+chaos-edit-422.fixed.md
@@ -1,0 +1,1 @@
+The `chaos edit` command no longer returns a "422 Unprocessable Entity" error.

--- a/mirrord/cli/src/ui.rs
+++ b/mirrord/cli/src/ui.rs
@@ -726,7 +726,11 @@ pub async fn chaos_command(args: ChaosArgs) -> Result<(), UiCliError> {
                 ChaosSubcommand::Edit { .. } => {
                     let new_rule =
                         new_rules.expect("args.expects_rule() requires rule(s) before match");
-                    if new_rule.len() > 1 {
+                    if new_rule.len() == 1
+                        && let Some(rule) = new_rule.first()
+                    {
+                        client.put(router_path).json(&rule)
+                    } else {
                         return Err(ChaosApiError::BadRequest {
                             reason: format!(
                                 "'chaos edit' command only accepts a single rule, found {} rules",
@@ -735,7 +739,6 @@ pub async fn chaos_command(args: ChaosArgs) -> Result<(), UiCliError> {
                         }
                         .into());
                     }
-                    client.put(router_path).json(&new_rule)
                 }
                 ChaosSubcommand::Delete { .. } => client.delete(router_path),
                 _ => unreachable!(),
@@ -752,12 +755,6 @@ pub async fn chaos_command(args: ChaosArgs) -> Result<(), UiCliError> {
         .await
         .into_iter()
         .collect::<Result<Vec<Response>, SessionError>>()?;
-
-    // handle status
-    // match VecOrSingle::from(responses) {
-    //     VecOrSingle::Single(response) => todo!(),
-    //     VecOrSingle::Multiple(responses) => todo!(),
-    // };
 
     match (args.format, args.returns_json()) {
         (ChaosFormat::Pretty, returns_json) => {


### PR DESCRIPTION
Linear Issue: https://linear.app/metalbear/issue/COR-1762/fix-mirrord-chaos-edit-failing-with-422

- `mirrord edit` was returning "422 Unprocessable Entity"
- even thought it only accepted a single rule definition, it still wrapped the rule in `[ ]`
- the `SessionClient` doesn't expect a `Vec`, so it failed
- also removed a leftover comment