### PR TITLE
INT-564 Copy-target sessions don't propagate session_key to the split session

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3355,16 +3355,6 @@ dependencies = [
 
 [[package]]
 name = "granit-parser"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50ba32164f9e098d5da618776a32afbb32270adcbe3d3d006107dae11e37c91"
-dependencies = [
- "arraydeque",
- "smallvec",
-]
-
-[[package]]
-name = "granit-parser"
 version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d03f81ad4732830d85cfd417a9f62cde6dadda4354d37d078a6084a19560aa2d"
@@ -4499,8 +4489,8 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "4.0.0"
-source = "git+https://github.com/metalbear-co/kube.git?rev=ae49cce192b85db3d734d290a6031aa2d9ac60e0#ae49cce192b85db3d734d290a6031aa2d9ac60e0"
+version = "4.2.0"
+source = "git+https://github.com/metalbear-co/kube.git?rev=6cbb2e8bef0b905edcecc7e0cf8e1804f7b02c67#6cbb2e8bef0b905edcecc7e0cf8e1804f7b02c67"
 dependencies = [
  "k8s-openapi",
  "kube-client",
@@ -4511,8 +4501,8 @@ dependencies = [
 
 [[package]]
 name = "kube-client"
-version = "4.0.0"
-source = "git+https://github.com/metalbear-co/kube.git?rev=ae49cce192b85db3d734d290a6031aa2d9ac60e0#ae49cce192b85db3d734d290a6031aa2d9ac60e0"
+version = "4.2.0"
+source = "git+https://github.com/metalbear-co/kube.git?rev=6cbb2e8bef0b905edcecc7e0cf8e1804f7b02c67#6cbb2e8bef0b905edcecc7e0cf8e1804f7b02c67"
 dependencies = [
  "base64",
  "bytes",
@@ -4535,7 +4525,7 @@ dependencies = [
  "rustls-platform-verifier",
  "secrecy",
  "serde",
- "serde-saphyr 0.0.27",
+ "serde-saphyr",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
@@ -4548,8 +4538,8 @@ dependencies = [
 
 [[package]]
 name = "kube-core"
-version = "4.0.0"
-source = "git+https://github.com/metalbear-co/kube.git?rev=ae49cce192b85db3d734d290a6031aa2d9ac60e0#ae49cce192b85db3d734d290a6031aa2d9ac60e0"
+version = "4.2.0"
+source = "git+https://github.com/metalbear-co/kube.git?rev=6cbb2e8bef0b905edcecc7e0cf8e1804f7b02c67#6cbb2e8bef0b905edcecc7e0cf8e1804f7b02c67"
 dependencies = [
  "derive_more",
  "form_urlencoded",
@@ -4566,8 +4556,8 @@ dependencies = [
 
 [[package]]
 name = "kube-derive"
-version = "4.0.0"
-source = "git+https://github.com/metalbear-co/kube.git?rev=ae49cce192b85db3d734d290a6031aa2d9ac60e0#ae49cce192b85db3d734d290a6031aa2d9ac60e0"
+version = "4.2.0"
+source = "git+https://github.com/metalbear-co/kube.git?rev=6cbb2e8bef0b905edcecc7e0cf8e1804f7b02c67#6cbb2e8bef0b905edcecc7e0cf8e1804f7b02c67"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -4579,8 +4569,8 @@ dependencies = [
 
 [[package]]
 name = "kube-runtime"
-version = "4.0.0"
-source = "git+https://github.com/metalbear-co/kube.git?rev=ae49cce192b85db3d734d290a6031aa2d9ac60e0#ae49cce192b85db3d734d290a6031aa2d9ac60e0"
+version = "4.2.0"
+source = "git+https://github.com/metalbear-co/kube.git?rev=6cbb2e8bef0b905edcecc7e0cf8e1804f7b02c67#6cbb2e8bef0b905edcecc7e0cf8e1804f7b02c67"
 dependencies = [
  "ahash",
  "async-broadcast",
@@ -5167,7 +5157,7 @@ dependencies = [
  "pem",
  "reqwest 0.13.4",
  "serde",
- "serde-saphyr 0.0.29",
+ "serde-saphyr",
  "thiserror 2.0.18",
  "tokio",
  "tower-test",
@@ -5200,7 +5190,7 @@ dependencies = [
  "schemars 1.2.1",
  "semver 1.0.28",
  "serde",
- "serde-saphyr 0.0.29",
+ "serde-saphyr",
  "serde_json",
  "sha2 0.10.9",
  "str-win",
@@ -5522,7 +5512,7 @@ dependencies = [
  "schemars 1.2.1",
  "semver 1.0.28",
  "serde",
- "serde-saphyr 0.0.29",
+ "serde-saphyr",
  "serde_json",
  "serde_urlencoded",
  "sha2 0.10.9",
@@ -7981,25 +7971,6 @@ dependencies = [
 
 [[package]]
 name = "serde-saphyr"
-version = "0.0.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5897b4c3faadadd35fdb6689f015641f3bc481d5adaaac56231ea15aeb243db3"
-dependencies = [
- "ahash",
- "annotate-snippets",
- "base64",
- "encoding_rs_io",
- "getrandom 0.3.4",
- "granit-parser 0.0.3",
- "nohash-hasher",
- "num-traits",
- "serde",
- "smallvec",
- "zmij",
-]
-
-[[package]]
-name = "serde-saphyr"
 version = "0.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bd22781911de0ca6debda95f073c8f18bec65d1a94f1fa9573f3102e514cea4"
@@ -8009,7 +7980,7 @@ dependencies = [
  "base64",
  "encoding_rs_io",
  "getrandom 0.3.4",
- "granit-parser 0.0.7",
+ "granit-parser",
  "nohash-hasher",
  "num-traits",
  "serde_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,7 +156,7 @@ jaq-json = "1.1.3"
 jaq-std = "2.1.2"
 k8s-cri = "0.11"
 k8s-openapi = { version = "0.28", features = ["v1_32"] }
-kube = { git = "https://github.com/metalbear-co/kube.git", rev = "ae49cce192b85db3d734d290a6031aa2d9ac60e0", default-features = false, features = [
+kube = { git = "https://github.com/metalbear-co/kube.git", rev = "6cbb2e8bef0b905edcecc7e0cf8e1804f7b02c67", default-features = false, features = [
     "runtime",
     "derive",
     "client",

--- a/changelog.d/+copy-target-session-key.fixed.md
+++ b/changelog.d/+copy-target-session-key.fixed.md
@@ -1,0 +1,1 @@
+Send the user-provided session key when creating a copy target.

--- a/mirrord/operator/src/client.rs
+++ b/mirrord/operator/src/client.rs
@@ -2064,6 +2064,45 @@ impl OperatorApi<PreparedClientCert> {
         general_purpose::STANDARD_NO_PAD.encode(self.client_cert.cert.public_key_data())
     }
 
+    /// Builds the [`CopyTargetSpec`] describing this config's copy.
+    ///
+    /// [`Self::copy_target`] and [`Self::try_reuse_copy_target`] must build identical specs:
+    /// reuse matches on spec equality, so any drift between them silently disables copy reuse.
+    ///
+    /// Only a user-provided session key goes into the spec. An auto-generated key differs on
+    /// every run, and a per-run value in the spec would defeat the same equality check.
+    fn copy_target_spec(layer_config: &LayerConfig, auto_queue_splitting: bool) -> CopyTargetSpec {
+        // We do not validate the `target` here, it's up to the operator.
+        let target = layer_config
+            .target
+            .path
+            .clone()
+            .unwrap_or(Target::Targetless);
+        let split_queues = layer_config
+            .feature
+            .split_queues
+            .is_set()
+            .then(|| layer_config.feature.split_queues.clone());
+
+        CopyTargetSpec {
+            target,
+            idle_ttl: Some(Self::COPIED_POD_IDLE_TTL),
+            scale_down: layer_config.feature.copy_target.scale_down,
+            split_queues,
+            auto_queue_splitting: auto_queue_splitting.then_some(true),
+            exclude_containers: layer_config.feature.copy_target.exclude_containers.clone(),
+            exclude_init_containers: layer_config
+                .feature
+                .copy_target
+                .exclude_init_containers
+                .clone(),
+            session_key: layer_config
+                .key
+                .is_provided()
+                .then(|| layer_config.key.as_str().to_owned()),
+        }
+    }
+
     /// Creates a new [`CopyTargetCrd`] resource using the operator.
     ///
     /// This should create a new dummy pod out of the [`Target`] specified in the given
@@ -2086,43 +2125,16 @@ impl OperatorApi<PreparedClientCert> {
     ) -> OperatorApiResult<CopyTargetCrd> {
         let mut subtask = progress.subtask("copying target");
 
-        // We do not validate the `target` here, it's up to the operator.
-        let target = layer_config
-            .target
-            .path
-            .clone()
-            .unwrap_or(Target::Targetless);
-        let scale_down = layer_config.feature.copy_target.scale_down;
         let namespace = layer_config
             .target
             .namespace
             .as_deref()
             .unwrap_or(self.client.default_namespace());
-        let split_queues = layer_config
-            .feature
-            .split_queues
-            .is_set()
-            .then(|| layer_config.feature.split_queues.clone());
-
-        let exclude_containers = layer_config.feature.copy_target.exclude_containers.clone();
-        let exclude_init_containers = layer_config
-            .feature
-            .copy_target
-            .exclude_init_containers
-            .clone();
 
         let copy_target_api: Api<CopyTargetCrd> = Api::namespaced(self.client.clone(), namespace);
 
-        let copy_target_name = TargetCrd::urlfied_name(&target);
-        let copy_target_spec = CopyTargetSpec {
-            target,
-            idle_ttl: Some(Self::COPIED_POD_IDLE_TTL),
-            scale_down,
-            split_queues,
-            auto_queue_splitting: auto_queue_splitting.then_some(true),
-            exclude_containers,
-            exclude_init_containers,
-        };
+        let copy_target_spec = Self::copy_target_spec(layer_config, auto_queue_splitting);
+        let copy_target_name = TargetCrd::urlfied_name(&copy_target_spec.target);
 
         let copied = copy_target_api
             .create(
@@ -2147,43 +2159,16 @@ impl OperatorApi<PreparedClientCert> {
     ) -> OperatorApiResult<Option<CopyTargetCrd>> {
         let mut subtask = progress.subtask("checking for existing target copies");
 
-        // We do not validate the `target` here, it's up to the operator.
-        let target = layer_config
-            .target
-            .path
-            .clone()
-            .unwrap_or(Target::Targetless);
-        let scale_down = layer_config.feature.copy_target.scale_down;
         let namespace = layer_config
             .target
             .namespace
             .as_deref()
             .unwrap_or(self.client.default_namespace());
-        let split_queues = layer_config
-            .feature
-            .split_queues
-            .is_set()
-            .then(|| layer_config.feature.split_queues.clone());
-
-        let exclude_containers = layer_config.feature.copy_target.exclude_containers.clone();
-        let exclude_init_containers = layer_config
-            .feature
-            .copy_target
-            .exclude_init_containers
-            .clone();
 
         let user_id = self.get_user_id_str();
 
         let copy_target_api: Api<CopyTargetCrd> = Api::namespaced(self.client.clone(), namespace);
-        let copy_target_spec = CopyTargetSpec {
-            target,
-            idle_ttl: Some(Self::COPIED_POD_IDLE_TTL),
-            scale_down,
-            split_queues,
-            auto_queue_splitting: auto_queue_splitting.then_some(true),
-            exclude_containers,
-            exclude_init_containers,
-        };
+        let copy_target_spec = Self::copy_target_spec(layer_config, auto_queue_splitting);
 
         let existing = copy_target_api
             .list(&ListParams::default())
@@ -2391,7 +2376,12 @@ mod test {
 
     use k8s_openapi::api::apps::v1::Deployment;
     use kube::api::ObjectMeta;
-    use mirrord_config::feature::network::incoming::ConcurrentSteal;
+    use mirrord_config::{
+        LayerFileConfig,
+        config::{ConfigContext, MirrordConfig},
+        env_key::EnvKey,
+        feature::network::incoming::ConcurrentSteal,
+    };
     use mirrord_kube::resolved::{ResolvedResource, ResolvedTarget};
     use rstest::rstest;
 
@@ -2860,5 +2850,29 @@ mod test {
         let produced =
             OperatorApi::target_connect_url_from_config(use_proxy, &target, namespace, &params);
         assert_eq!(produced, expected)
+    }
+
+    /// Verifies which session keys make it into the [`CopyTargetSpec`]: user-provided keys are
+    /// stamped into the spec, auto-generated ones are left out so a fresh run (with a fresh
+    /// generated key) can still reuse an existing copy - reuse matches on spec equality.
+    ///
+    /// [`CopyTargetSpec`]: crate::crd::copy_target::CopyTargetSpec
+    #[test]
+    fn copy_target_spec_session_key_policy() {
+        let mut ctx = ConfigContext::default().strict_env(true);
+        let mut layer_config = LayerFileConfig::default()
+            .generate_config(&mut ctx)
+            .expect("default config generates");
+
+        layer_config.key = EnvKey::Generated("run-specific-key".to_owned());
+        let spec = OperatorApi::copy_target_spec(&layer_config, false);
+        assert_eq!(spec.session_key, None);
+
+        layer_config.key = EnvKey::Provided("user-key".to_owned());
+        let spec = OperatorApi::copy_target_spec(&layer_config, false);
+        assert_eq!(spec.session_key.as_deref(), Some("user-key"));
+
+        // The invariant `try_reuse_copy_target` relies on: same config, same spec.
+        assert_eq!(spec, OperatorApi::copy_target_spec(&layer_config, false));
     }
 }

--- a/mirrord/operator/src/crd/copy_target.rs
+++ b/mirrord/operator/src/crd/copy_target.rs
@@ -39,6 +39,16 @@ pub struct CopyTargetSpec {
     /// creation.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub auto_queue_splitting: Option<bool>,
+    /// Session key stamped onto messages matched by this copy's split session, and used for the
+    /// session's message events.
+    ///
+    /// The operator creates the split session while handling this resource's creation, before any
+    /// client connects with its `ConnectParams`, so the key has to ride in the spec. Only
+    /// user-provided keys belong here: auto-generated keys differ on every run, and a per-run
+    /// value in the spec would defeat the spec-equality check that lets clients reuse an existing
+    /// copy.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_key: Option<String>,
 }
 
 /// This is the `status` field for [`CopyTargetCrd`].


### PR DESCRIPTION
<!-- Thank you for contributing to mirrord! -->
<!-- Please use the checklist below as a guide for docs, tests and admin tasks for your PR -->
<!-- Feel free to ~strikethrough~ any items that you don't think apply -->

### Quality Checklist:

- [ ] I have documented new code sufficiently
- [ ] I have checked and updated the relevant existing docs in code, including removing outdated material
- [ ] I have written user-facing website docs for new features, or opened a (sub)issue to do so
- [ ] I have checked and updated existing website docs for changed features
- [ ] I have tested this change and know it succeeds and fails as expected
- [ ] I have written unit tests or purposefully omitted them
- [ ] I have written e2e tests or purposefully omitted them
- [ ] I have explained what this PR introduces and why, and linked to relevant context (e.g. linear issues, related PRs,
  documentation)
- [ ] I have introduced a short, clear and well-formatted changelog entry

<!-- need help with the changelog? see ../CONTRIBUTING.md#submitting-a-pull-request -->
<!-- Add more details of your changes below if needed -->