### PR TITLE
fix(monitor): contain pane crashes instead of blanking the session monitor

### DIFF
--- a/changelog.d/+monitor-pane-crash-containment.fixed.md
+++ b/changelog.d/+monitor-pane-crash-containment.fixed.md
@@ -1,0 +1,1 @@
+A crash in the session monitor's session list or session detail panel no longer blanks the whole monitor; the failing panel is isolated and recovers when another session is selected.

--- a/packages/monitor/src/App.tsx
+++ b/packages/monitor/src/App.tsx
@@ -12,6 +12,7 @@ import EmptySessionState from './components/EmptySessionState'
 import FunnelHero from './components/FunnelHero'
 import ConnectOperatorModal from './components/ConnectOperatorModal'
 import OperatorSessionDetail from './components/OperatorSessionDetail'
+import { ErrorBoundary, PaneCrashNotice } from './components/ErrorBoundary'
 import type { ThemePref } from './theme'
 import {
   initAnalytics,
@@ -413,45 +414,56 @@ export default function App({
         namespacesError={namespacesError}
       />
       <div className="flex flex-1 overflow-hidden">
-        <SessionSidebar
-          sessions={sessions}
-          selectedId={selectedKind === 'local' ? selectedId : null}
-          loading={loading}
-          onSelect={handleSelectLocal}
-          onKill={(id) => void handleKill(id)}
-          onKillAll={() => void handleKillAll()}
-          operatorSessions={teamSessions}
-          yoursOperatorSessions={yoursOperatorSessions}
-          allOperatorSessions={operatorSessions}
-          watchStatus={watchStatus}
-          selectedOperatorId={selectedKind === 'operator' ? selectedId : null}
-          onSelectOperator={handleSelectOperator}
-          onConnectOperator={() => setConnectModalOpen(true)}
-          joinedKey={extensionState.joinedKey ?? null}
-          query={searchQuery}
-          onQueryChange={setSearchQuery}
-        />
+        <ErrorBoundary
+          component="session_sidebar"
+          fallback={<PaneCrashNotice className="w-72 shrink-0 border-r" />}
+        >
+          <SessionSidebar
+            sessions={sessions}
+            selectedId={selectedKind === 'local' ? selectedId : null}
+            loading={loading}
+            onSelect={handleSelectLocal}
+            onKill={(id) => void handleKill(id)}
+            onKillAll={() => void handleKillAll()}
+            operatorSessions={teamSessions}
+            yoursOperatorSessions={yoursOperatorSessions}
+            allOperatorSessions={operatorSessions}
+            watchStatus={watchStatus}
+            selectedOperatorId={selectedKind === 'operator' ? selectedId : null}
+            onSelectOperator={handleSelectOperator}
+            onConnectOperator={() => setConnectModalOpen(true)}
+            joinedKey={extensionState.joinedKey ?? null}
+            query={searchQuery}
+            onQueryChange={setSearchQuery}
+          />
+        </ErrorBoundary>
         <div className="flex-1 overflow-hidden">
-          {selectedLocal ? (
-            <SessionDetail
-              session={selectedLocal}
-              onKill={() => void handleKill(selectedLocal.session_id)}
-              extensionState={extensionState}
-              onJoin={() => handleJoinViaExtension(selectedLocal.key ?? '')}
-              onLeave={handleLeaveViaExtension}
-            />
-          ) : selectedOperator ? (
-            <OperatorSessionDetail
-              session={selectedOperator}
-              extensionState={extensionState}
-              onJoin={() => handleJoinViaExtension(selectedOperator.key)}
-              onLeave={handleLeaveViaExtension}
-            />
-          ) : showFunnelHero ? (
-            <FunnelHero onConnect={() => setConnectModalOpen(true)} />
-          ) : (
-            <EmptySessionState />
-          )}
+          <ErrorBoundary
+            component="session_detail"
+            resetKey={`${selectedKind ?? ''}:${selectedId ?? ''}`}
+            fallback={<PaneCrashNotice />}
+          >
+            {selectedLocal ? (
+              <SessionDetail
+                session={selectedLocal}
+                onKill={() => void handleKill(selectedLocal.session_id)}
+                extensionState={extensionState}
+                onJoin={() => handleJoinViaExtension(selectedLocal.key ?? '')}
+                onLeave={handleLeaveViaExtension}
+              />
+            ) : selectedOperator ? (
+              <OperatorSessionDetail
+                session={selectedOperator}
+                extensionState={extensionState}
+                onJoin={() => handleJoinViaExtension(selectedOperator.key)}
+                onLeave={handleLeaveViaExtension}
+              />
+            ) : showFunnelHero ? (
+              <FunnelHero onConnect={() => setConnectModalOpen(true)} />
+            ) : (
+              <EmptySessionState />
+            )}
+          </ErrorBoundary>
         </div>
       </div>
       <ConnectOperatorModal

--- a/packages/monitor/src/components/ErrorBoundary.tsx
+++ b/packages/monitor/src/components/ErrorBoundary.tsx
@@ -1,5 +1,7 @@
 import type { ErrorInfo, ReactNode } from 'react'
 import { Component } from 'react'
+import { cn } from '@metalbear/ui'
+import { TriangleAlert } from 'lucide-react'
 import { emitUserBlocked } from '../analytics'
 import { strings } from '../strings'
 
@@ -7,6 +9,8 @@ const STACK_TRACE_MAX_LEN = 500
 
 interface Props {
   component: string
+  resetKey?: string | null
+  fallback?: ReactNode
   children: ReactNode
 }
 
@@ -19,6 +23,12 @@ export class ErrorBoundary extends Component<Props, State> {
 
   static getDerivedStateFromError(): State {
     return { crashed: true }
+  }
+
+  override componentDidUpdate(prev: Props): void {
+    if (this.state.crashed && prev.resetKey !== this.props.resetKey) {
+      this.setState({ crashed: false })
+    }
   }
 
   override componentDidCatch(error: Error, info: ErrorInfo): void {
@@ -37,12 +47,31 @@ export class ErrorBoundary extends Component<Props, State> {
   override render(): ReactNode {
     if (this.state.crashed) {
       return (
-        <div style={{ padding: 24, fontFamily: 'system-ui' }}>
-          <h2>{strings.errorBoundary.title}</h2>
-          <p>{strings.errorBoundary.body}</p>
-        </div>
+        this.props.fallback ?? (
+          <div style={{ padding: 24, fontFamily: 'system-ui' }}>
+            <h2>{strings.errorBoundary.title}</h2>
+            <p>{strings.errorBoundary.body}</p>
+          </div>
+        )
       )
     }
     return this.props.children
   }
+}
+
+export function PaneCrashNotice({ className }: { className?: string }) {
+  return (
+    <div
+      className={cn(
+        'text-muted-foreground flex h-full flex-col items-center justify-center gap-1 p-6 text-center',
+        className,
+      )}
+    >
+      <TriangleAlert className="text-muted-foreground/70 h-5 w-5" />
+      <p className="text-body font-semibold">
+        {strings.errorBoundary.paneTitle}
+      </p>
+      <p className="text-meta">{strings.errorBoundary.paneBody}</p>
+    </div>
+  )
 }

--- a/packages/monitor/src/strings.ts
+++ b/packages/monitor/src/strings.ts
@@ -113,6 +113,8 @@ export const strings = {
   errorBoundary: {
     title: 'Session Monitor crashed.',
     body: 'Please reload the page.',
+    paneTitle: 'This panel stopped responding.',
+    paneBody: 'The rest of the session monitor is still running.',
   },
   funnel: {
     badge: 'mirrord for Teams',


### PR DESCRIPTION
## Summary

The session monitor has a single error boundary, at the root. Any render error anywhere in the tree therefore replaces the **entire** tool with "Session Monitor crashed. Please reload the page." The session list, the cluster and namespace pickers, the connection status and the detail pane all disappear together, and the only way out is reloading.

Two consequences show up in the crash telemetry:

- A defect confined to one panel costs the user the whole tool, and users hit it repeatedly in a short window rather than once.
- Every `ui_crashed` report is attributed to `component: "App"`, because that is the only boundary there is. The report cannot say which panel failed, so triage starts by decoding a minified component stack.

This wraps the session list and the session detail pane in their own boundaries. A failing panel now shows a compact inline notice while the rest of the monitor keeps working, and the report carries the panel that actually failed.

React error boundaries stay in the error state until something resets them, so a crashed detail pane would otherwise stay dead for the rest of the process even after the user selects a different session. The detail boundary is keyed on the current selection and clears when it changes.

This does not change any of the code that throws. It changes how far a throw propagates.

## Test plan

Built `mirrord-ui` and drove the built bundle in a real browser (Chrome) against a stub local API, comparing against a control build of unmodified `origin/main` served side by side.

**Blast radius, with a malformed operator-session payload** (a session row with no `owner` object, which the session list reads unguarded):

| | result |
|---|---|
| `origin/main` | whole monitor replaced by the reload prompt; header, pickers, connection status and detail pane all gone |
| this branch | session list shows the inline notice; header, context/namespace pickers, connection status and the detail pane for the healthy session all still render |

Console on the control build confirms the throw is `Cannot read properties of undefined (reading 'username')` from `Array.every`, i.e. a genuine data-shape crash rather than an injected one.

**Recovery**, exercised with a fault injected into the detail pane in a scratch build (not part of this diff), with two operator sessions listed:

- select the faulting session, detail pane shows the notice, session list stays interactive
- select the healthy session, notice clears and the detail pane renders fully
- control build with the reset key removed and nothing else changed: notice persists and the detail pane never renders again

Also ran `pnpm --filter session-monitor-frontend typecheck`, `lint` and `format:check`, and `pnpm --filter mirrord-ui build`, all pass.

Not observed, established by reading source instead: that the `component` value on the emitted `ui_crashed` event is the new panel name. The stub environment never flushes a telemetry request, so there was no payload to decode; what the browser does show is that the panel-level boundary, not the root one, is the one that caught the error. Confirmation on the wire will come from production data once this ships.