### PR TITLE
COR-1729 — preserve Windows bind errors

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -18,5 +18,5 @@ incremental = false
 
 [target.'cfg(windows)']
 rustflags = [
-    "-C", "link-args=/STACK:8388608", # STACKSIZE=32MB
+    "-C", "link-args=/STACK:8388608", # STACKSIZE=8MB
 ]

--- a/changelog.d/+windows-bind-last-error.fixed.md
+++ b/changelog.d/+windows-bind-last-error.fixed.md
@@ -1,0 +1,1 @@
+Fixed Windows applications reporting the wrong error when a requested local port was unavailable.

--- a/mirrord/layer-win/src/hooks/socket/mod.rs
+++ b/mirrord/layer-win/src/hooks/socket/mod.rs
@@ -309,33 +309,60 @@ unsafe extern "system" fn wsa_socket_w_detour(
 }
 
 /// Windows socket hook for bind
-#[mirrord_layer_macro::instrument(level = "trace", ret)]
+///
+/// The instrumented implementation may call Windows APIs while its tracing span is being closed.
+/// Restore the original bind error only after it returns so the caller receives the correct
+/// WinSock error.
 unsafe extern "system" fn bind_detour(s: SOCKET, name: *const SOCKADDR, namelen: INT) -> INT {
+    let (result, last_error) = unsafe { bind_detour_impl(s, name, namelen) };
+    if let Some(last_error) = last_error {
+        unsafe { WSASetLastError(last_error) };
+    }
+
+    result
+}
+
+#[mirrord_layer_macro::instrument(level = "trace", ret)]
+unsafe fn bind_detour_impl(s: SOCKET, name: *const SOCKADDR, namelen: INT) -> (INT, Option<i32>) {
     tracing::trace!("bind_detour -> socket: {}, namelen: {}", s, namelen);
 
     let original = BIND_ORIGINAL.get().unwrap();
 
     // Define bind function before early returns so it can be reused
-    let bind_fn = |addr: *const SOCKADDR, addr_len: INT, reason: &str| -> INT {
+    let bind_fn = |addr: *const SOCKADDR,
+                   addr_len: INT,
+                   reason: &str,
+                   failure_is_final: bool|
+     -> (INT, Option<i32>) {
         let res = unsafe { original(s, addr, addr_len) };
+        let last_error = (res != ERROR_SUCCESS_I32).then(|| unsafe { WSAGetLastError() });
 
-        if res != ERROR_SUCCESS_I32 {
-            tracing::error!(
-                "bind_detour -> {} failed (wsa_last_error={})",
-                reason,
-                unsafe { WSAGetLastError() }
-            );
+        if let Some(last_error) = last_error {
+            if failure_is_final {
+                tracing::error!(
+                    "bind_detour -> {} failed (wsa_last_error={})",
+                    reason,
+                    last_error
+                );
+            } else {
+                tracing::debug!(
+                    "bind_detour -> {} failed, retrying on a random port \
+                        (wsa_last_error={})",
+                    reason,
+                    last_error
+                );
+            }
         } else {
             tracing::debug!("bind_detour -> {} succeeded", reason);
         }
 
-        res
+        (res, last_error)
     };
     let requested_addr = match unsafe { SocketAddr::try_from_raw(name, namelen) } {
         Some(addr) => addr,
         None => {
             tracing::error!("bind_detour -> failed to convert address");
-            return bind_fn(name, namelen, "address parse error");
+            return bind_fn(name, namelen, "address parse error", true);
         }
     };
 
@@ -351,7 +378,7 @@ unsafe extern "system" fn bind_detour(s: SOCKET, name: *const SOCKADDR, namelen:
 
         let Some(entry) = sockets.remove(&s) else {
             // fallback / early return when the socket isn’t tracked
-            return bind_fn(name, namelen, "non-managed socket");
+            return bind_fn(name, namelen, "non-managed socket", true);
         };
 
         // The user's requested address must behave as taken even though we actually bind to a
@@ -369,8 +396,7 @@ unsafe extern "system" fn bind_detour(s: SOCKET, name: *const SOCKADDR, namelen:
                 requested_addr
             );
             sockets.insert(s, entry);
-            unsafe { WSASetLastError(WSAEADDRINUSE) };
-            return SOCKET_ERROR;
+            return (SOCKET_ERROR, Some(WSAEADDRINUSE));
         }
 
         entry
@@ -380,14 +406,14 @@ unsafe extern "system" fn bind_detour(s: SOCKET, name: *const SOCKADDR, namelen:
             "bind_detour -> socket {} is not in Initialized state, using original bind",
             s
         );
-        return bind_fn(name, namelen, "invalid socket state");
+        return bind_fn(name, namelen, "invalid socket state", true);
     }
 
     // Check configuration-based early returns
     let incoming_config = setup().incoming_config();
     if incoming_config.ignore_localhost && requested_addr.ip().is_loopback() {
         tracing::debug!("bind_detour -> ignoring localhost bind");
-        return bind_fn(name, namelen, "localhost ignored");
+        return bind_fn(name, namelen, "localhost ignored", true);
     }
 
     // A configured `listen_ports` mapping pins the port; otherwise we may fall back to a
@@ -408,37 +434,32 @@ unsafe extern "system" fn bind_detour(s: SOCKET, name: *const SOCKADDR, namelen:
         Ok((storage, len)) => (storage, len),
         Err(e) => {
             tracing::error!("bind_detour -> failed to convert local address: {}", e);
-            return bind_fn(name, namelen, "address conversion error");
+            return bind_fn(name, namelen, "address conversion error", true);
         }
     };
 
     // Attempt primary bind
-    let bind_result = bind_fn(
+    let (bind_result, last_error) = bind_fn(
         &local_addr_storage as *const _ as *const SOCKADDR,
         local_addr_len,
         "primary bind",
+        can_use_random_port.not(),
     );
 
     // Handle bind failures
     if bind_result != ERROR_SUCCESS_I32 {
-        // Check for access denied error which may indicate UAC privilege issues
-        // Check if this is a privileged port that requires elevation
-        if WindowsError::wsa_last_error() == WSAEACCES && local_addr.port() < IPPORT_RESERVED as u16
-        {
-            // graceful_exit if process is not elevated.
-            require_elevation(&format!(
-                "mirrord failed to bind to privileged port {} - insufficient UAC privileges. On Windows, binding to privileged ports (< {}) requires running as Administrator or with elevated UAC privileges. Please restart your application with elevated privileges.",
-                local_addr.port(),
-                IPPORT_RESERVED
-            ));
-            // if we are not elevated, this line will not be reachable as require_elevation calls
-            // graceful_exit!()
-        }
-
         // Fall back to a random local port when the requested one is busy, mirroring the Unix
         // layer's `bind_similar_address`. The real port is recovered below via `getsockname`.
         if can_use_random_port.not() {
-            return bind_result;
+            if last_error == Some(WSAEACCES) && local_addr.port() < IPPORT_RESERVED as u16 {
+                require_elevation(&format!(
+                    "mirrord failed to bind to privileged port {} - insufficient UAC privileges. On Windows, binding to privileged ports (< {}) requires running as Administrator or with elevated UAC privileges. Please restart your application with elevated privileges.",
+                    local_addr.port(),
+                    IPPORT_RESERVED
+                ));
+            }
+
+            return (bind_result, last_error);
         }
 
         let fallback_addr = SocketAddr::new(local_addr.ip(), 0);
@@ -446,17 +467,18 @@ unsafe extern "system" fn bind_detour(s: SOCKET, name: *const SOCKADDR, namelen:
             Ok((storage, len)) => (storage, len),
             Err(e) => {
                 tracing::error!("bind_detour -> failed to convert fallback address: {}", e);
-                return bind_result;
+                return (bind_result, last_error);
             }
         };
 
-        let fallback_result = bind_fn(
+        let (fallback_result, fallback_error) = bind_fn(
             &fallback_storage as *const _ as *const SOCKADDR,
             fallback_len,
             "random port fallback",
+            true,
         );
         if fallback_result != ERROR_SUCCESS_I32 {
-            return fallback_result;
+            return (fallback_result, fallback_error);
         }
     }
 
@@ -482,7 +504,7 @@ unsafe extern "system" fn bind_detour(s: SOCKET, name: *const SOCKADDR, namelen:
         requested_addr
     );
 
-    ERROR_SUCCESS_I32
+    (ERROR_SUCCESS_I32, None)
 }
 
 /// Windows socket hook for listen


### PR DESCRIPTION
# Preserve Windows bind errors

## Linear

- https://linear.app/metalbear/issue/COR-1729

## Summary

Preserves the real WinSock error returned by the Windows `bind` hook and lets ordinary managed binds complete the existing random-local-port fallback before considering whether elevation is required.

The requested port remains the remote subscription identity. When `incoming.listen_ports` does not pin the local port, mirrord may bind the local socket to an ephemeral port without exposing that implementation detail to the application.

## Motivation

The Windows bind detour called the original `bind`, then performed tracing and managed-socket work before returning. WinSock's last error is thread-local, so intervening Windows calls could replace `WSAEADDRINUSE (10048)` with error `6`. Java consequently reported:

```text
java.net.SocketException: Unrecognized Windows Sockets error: 6: bind
```

Preserving the actual `WSAEACCES` also made an ordering bug observable in the Windows HTTP tests. An ordinary managed bind to a privileged requested port logged that it would retry on a random local port, but the UAC diagnostic terminated the process before the fallback ran.

This is a deterministic bind-path correction rather than a test-flake workaround. Host port and elevation state only determine whether the affected path is reached.

## Implementation

- keeps the exported bind detour uninstrumented;
- captures each failed `bind` immediately;
- restores the final error after the instrumented implementation and tracing span return;
- distinguishes retryable primary failures from final failures;
- allows ordinary managed binds to complete the existing random-local-port fallback;
- retains the UAC diagnostic when `incoming.listen_ports` pins a privileged local port and prevents fallback;
- keeps the requested remote subscription port and managed user-visible socket address unchanged;
- complements the random-local-port fallback from #4422;
- corrects the Windows linker comment from 32 MB to the configured 8 MB stack size.

## Verification

- `cargo fmt --all -- --check`;
- `cargo check -p mirrord-layer-win --all-targets --keep-going`;
- `cargo clippy -p mirrord-layer-win --all-targets -- --deny warnings`;
- `cargo xtask build-cli` on Windows from the independent split branch;
- Java bind-collision reproduction through a real mirrord agent: fixed local-port failures return `BindException: Address already in use`, not error `6`;
- occupied managed port: mirrord selects a free local port while the remote subscription retains the requested port and managed `getsockname` returns the user-visible address;
- focused Windows HTTP mirroring with the same bind commit: the Node application requested port 80, subscribed to `Tcp(PortSubscribe(80))`, completed GET/POST/PUT/DELETE, and passed without elevation.

### Quality Checklist:

- [x] I have documented new code sufficiently
- [x] I have tested this change and know it succeeds and fails as expected
- [x] I have written unit tests or purposefully omitted them
- [x] I have written e2e tests or purposefully omitted them
- [x] I have explained what this PR introduces and why, and linked to relevant context
- [x] I have introduced a short, clear and well-formatted changelog entry