### PR TITLE
Carry the operator-agent connection over QUIC, with per-connection data streams

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5481,8 +5481,10 @@ version = "3.244.1"
 name = "mirrord-operator"
 version = "3.244.1"
 dependencies = [
+ "actix-codec",
  "base64",
  "bincode",
+ "bytes",
  "chrono",
  "dotenvy",
  "flate2",
@@ -5499,6 +5501,7 @@ dependencies = [
  "mirrord-kube",
  "mirrord-progress",
  "mirrord-protocol",
+ "mirrord-quic",
  "rand 0.10.2",
  "rstest",
  "schemars 1.2.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5063,12 +5063,14 @@ dependencies = [
  "mirrord-agent-iptables",
  "mirrord-nightly-polyfill",
  "mirrord-protocol",
+ "mirrord-quic",
  "mirrord-tls-util",
  "nix",
  "oci-spec",
  "pem",
  "procfs",
  "prometheus",
+ "quinn",
  "rand 0.10.2",
  "rcgen",
  "reqwest 0.13.4",
@@ -5320,6 +5322,8 @@ dependencies = [
  "mirrord-agent-env",
  "mirrord-config",
  "mirrord-progress",
+ "mirrord-quic",
+ "quinn",
  "rand 0.10.2",
  "regex",
  "rstest",
@@ -5594,6 +5598,20 @@ dependencies = [
  "mirrord-protocol",
  "rand 0.10.2",
  "rstest",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "mirrord-quic"
+version = "3.244.1"
+dependencies = [
+ "mirrord-tls-util",
+ "quinn",
+ "rcgen",
+ "rustls",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -196,6 +196,10 @@ proc-macro2 = "1"
 proc-macro2-diagnostics = "0.10"
 procfs = "0.17.0"
 prometheus = { version = "0.14", features = ["process"] }
+quinn = { version = "0.11", default-features = false, features = [
+    "runtime-tokio",
+    "rustls-aws-lc-rs",
+] }
 quote = "1"
 rand = "0.10"
 rcgen = { version = "0.14", features = ["x509-parser"] }

--- a/changelog.d/+agent-quic-data-streams.added.md
+++ b/changelog.d/+agent-quic-data-streams.added.md
@@ -1,0 +1,4 @@
+Outgoing TCP connections handled for a session now travel on a QUIC stream of their own, rather than
+being framed into protocol messages alongside everything else the session is doing. Each connection
+gets its own ordering and its own flow control window, so a large or slow transfer no longer holds up
+the rest of the session between the operator and the agent.

--- a/changelog.d/+agent-quic-transport.added.md
+++ b/changelog.d/+agent-quic-transport.added.md
@@ -1,0 +1,4 @@
+The agent accepts QUIC connections from the mirrord Operator on its client port, in addition to
+TCP. A stream per logical connection removes the head-of-line blocking that a single TCP connection
+multiplexing a whole session is subject to. Operators that do not support QUIC, and clusters where
+UDP to the agent is blocked, keep using TCP.

--- a/changelog.d/+direct-operator-connection.added.md
+++ b/changelog.d/+direct-operator-connection.added.md
@@ -1,0 +1,4 @@
+The session connection to the operator can now be made directly over QUIC, instead of being proxied
+by the Kubernetes API server, when the operator installation exposes an endpoint for it. Sessions
+fall back to the API server whenever the direct connection is unavailable, and
+`direct_operator_connection` turns it off.

--- a/mirrord-schema.json
+++ b/mirrord-schema.json
@@ -61,6 +61,14 @@
         }
       ]
     },
+    "direct_operator_connection": {
+      "title": "direct_operator_connection {#root-direct_operator_connection}",
+      "description": "Whether the session connection may be made directly to the operator over QUIC, instead of\nbeing proxied by the Kubernetes API server.\n\nOnly possible when the operator installation exposes an endpoint for it; when it does not,\nthis has no effect. Set to `false` to stay on the API server path even then.\n\nDefaults to `true`.",
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
     "experimental": {
       "title": "experimental {#root-experimental}",
       "anyOf": [

--- a/mirrord/agent/Cargo.toml
+++ b/mirrord/agent/Cargo.toml
@@ -22,6 +22,7 @@ workspace = true
 mirrord-protocol = { path = "../protocol" }
 mirrord-agent-env = { path = "./env", default-features = false }
 mirrord-agent-iptables = { path = "./iptables" }
+mirrord-quic = { path = "../quic" }
 mirrord-tls-util = { path = "../tls-util" }
 mirrord-nightly-polyfill = { path = "../nightly-polyfill" }
 
@@ -70,6 +71,7 @@ semver.workspace = true
 tokio-rustls.workspace = true
 x509-parser.workspace = true
 rustls.workspace = true
+quinn.workspace = true
 socket2.workspace = true
 prometheus.workspace = true
 axum = { workspace = true, features = ["macros"] }

--- a/mirrord/agent/Dockerfile
+++ b/mirrord/agent/Dockerfile
@@ -23,6 +23,7 @@ COPY mirrord/macros /app/mirrord/macros
 COPY mirrord/nightly-polyfill /app/mirrord/nightly-polyfill
 COPY mirrord/tls-util /app/mirrord/tls-util
 COPY mirrord/protocol /app/mirrord/protocol
+COPY mirrord/quic /app/mirrord/quic
 COPY mirrord/agent /app/mirrord/agent
 COPY Cargo.toml Cargo.lock CHANGELOG.md README.md LICENSE rust-toolchain.toml /app/
 

--- a/mirrord/agent/src/client_connection.rs
+++ b/mirrord/agent/src/client_connection.rs
@@ -7,6 +7,7 @@ use std::{
 use actix_codec::Framed;
 use futures::{SinkExt, TryStreamExt};
 use mirrord_protocol::{ClientMessage, DaemonCodec, DaemonMessage};
+use mirrord_quic::{ControlStream, DATA_STREAM_VERSION};
 use mirrord_tls_util::{GetSanError, HasSubjectAlternateNames};
 use thiserror::Error;
 use tokio::net::TcpStream;
@@ -120,12 +121,40 @@ impl ClientConnection {
         Ok(Self { framed, client_id })
     }
 
+    /// Wraps a QUIC control stream into this struct.
+    ///
+    /// Unlike [`Self::new`], there is no separate TLS step: a QUIC connection is already
+    /// authenticated and encrypted by the mutual TLS handshake described in [`mirrord_quic`].
+    pub fn new_quic(stream: ControlStream, client_id: ClientId) -> Self {
+        Self {
+            framed: ConnectionFramed::Quic(Box::new(Framed::new(stream, DaemonCodec::default()))),
+            client_id,
+        }
+    }
+
+    /// The QUIC connection this client is on, if it can carry intercepted connections on their own
+    /// data streams.
+    ///
+    /// [`None`] for clients on TCP, and for QUIC clients that negotiated a transport version older
+    /// than [`DATA_STREAM_VERSION`], whose connections are relayed as mirrord-protocol messages
+    /// instead.
+    pub fn data_stream_connection(&self) -> Option<&quinn::Connection> {
+        match &self.framed {
+            ConnectionFramed::Tcp(..) | ConnectionFramed::Tls(..) => None,
+            ConnectionFramed::Quic(framed) => {
+                let control = framed.io_ref();
+                (control.version() >= DATA_STREAM_VERSION).then(|| control.connection())
+            }
+        }
+    }
+
     /// Sends a [`DaemonMessage`] to the client.
     #[tracing::instrument(level = "trace", err)]
     pub async fn send(&mut self, message: DaemonMessage) -> io::Result<()> {
         match &mut self.framed {
             ConnectionFramed::Tcp(framed) => framed.send(message).await?,
             ConnectionFramed::Tls(framed) => framed.send(message).await?,
+            ConnectionFramed::Quic(framed) => framed.send(message).await?,
         }
 
         Ok(())
@@ -137,6 +166,7 @@ impl ClientConnection {
         match &mut self.framed {
             ConnectionFramed::Tcp(framed) => framed.try_next().await,
             ConnectionFramed::Tls(framed) => framed.try_next().await,
+            ConnectionFramed::Quic(framed) => framed.try_next().await,
         }
     }
 }
@@ -147,17 +177,25 @@ impl fmt::Debug for ClientConnection {
             .field("client_id", &self.client_id)
             .field(
                 "uses_tls",
-                &matches!(self.framed, ConnectionFramed::Tls(..)),
+                &!matches!(self.framed, ConnectionFramed::Tcp(..)),
+            )
+            .field(
+                "transport",
+                &match self.framed {
+                    ConnectionFramed::Tcp(..) | ConnectionFramed::Tls(..) => "tcp",
+                    ConnectionFramed::Quic(..) => "quic",
+                },
             )
             .finish()
     }
 }
 
-/// Enum wraps whole [`Framed`] instead of just [`TcpStream`]/[`TlsStream`], so we don't have to
+/// Enum wraps whole [`Framed`] instead of just the underlying stream, so we don't have to
 /// implement [`AsyncRead`](actix_codec::AsyncRead) and [`AsyncWrite`](actix_codec::AsyncWrite).
 enum ConnectionFramed {
     Tcp(Framed<TcpStream, DaemonCodec>),
     Tls(Box<Framed<TlsStream<TcpStream>, DaemonCodec>>),
+    Quic(Box<Framed<ControlStream, DaemonCodec>>),
 }
 
 #[cfg(test)]

--- a/mirrord/agent/src/data_stream.rs
+++ b/mirrord/agent/src/data_stream.rs
@@ -1,0 +1,58 @@
+//! Routing of QUIC data streams to the feature that owns the connection each one carries.
+//!
+//! When a client is connected over QUIC and both ends negotiated
+//! [`DATA_STREAM_VERSION`](mirrord_quic::DATA_STREAM_VERSION), the bytes of an intercepted
+//! connection travel on their own stream instead of being framed into mirrord-protocol messages.
+//! Everything else about the session still goes over the control stream.
+//!
+//! Streams are opened by the operator once the control stream has told it a connection exists, so
+//! by the time one arrives here, the feature that owns the connection is already holding the socket
+//! and waiting for it.
+
+use mirrord_protocol::ConnectionId;
+use mirrord_quic::{BiStream, DataStreamKind};
+use tokio::sync::mpsc::Sender;
+use tracing::Level;
+
+/// A data stream, handed to the feature that owns the connection it carries.
+pub(crate) struct IncomingDataStream {
+    pub(crate) connection_id: ConnectionId,
+    pub(crate) stream: BiStream,
+}
+
+/// Accepts data streams for as long as the client's QUIC connection lives, handing each one to the
+/// feature named by its header.
+///
+/// Returns when the connection is gone, or when the feature that would own the streams has stopped
+/// listening for them.
+#[tracing::instrument(level = Level::TRACE, skip_all)]
+pub(crate) async fn route_data_streams(
+    connection: quinn::Connection,
+    tcp_outgoing: Sender<IncomingDataStream>,
+) {
+    loop {
+        let (header, stream) = match mirrord_quic::accept_data_stream(&connection).await {
+            Ok(accepted) => accepted,
+            Err(error) => {
+                tracing::trace!(%error, "Stopped accepting data streams");
+                break;
+            }
+        };
+
+        let sent = match header.kind {
+            DataStreamKind::TcpOutgoing => {
+                tcp_outgoing
+                    .send(IncomingDataStream {
+                        connection_id: header.connection_id,
+                        stream,
+                    })
+                    .await
+            }
+        };
+
+        if sent.is_err() {
+            tracing::trace!("Data stream consumer is gone, stopped accepting data streams");
+            break;
+        }
+    }
+}

--- a/mirrord/agent/src/entrypoint.rs
+++ b/mirrord/agent/src/entrypoint.rs
@@ -1,7 +1,6 @@
 use std::{
     collections::HashMap,
     mem,
-    net::{Ipv4Addr, Ipv6Addr, SocketAddr},
     ops::Not,
     path::PathBuf,
     sync::{
@@ -21,9 +20,7 @@ use mirrord_agent_iptables::{
     error::{IPTablesError, IPTablesResult},
 };
 use mirrord_protocol::{ClientMessage, DaemonMessage, GetEnvVarsRequest};
-use socket2::SockRef;
 use tokio::{
-    net::{TcpListener, TcpSocket, TcpStream},
     process::Command,
     select,
     signal::unix::SignalKind,
@@ -39,7 +36,9 @@ use crate::{
     cli::{self, Args},
     client_connection::{self, ClientConnection},
     container_handle::ContainerHandle,
+    data_stream,
     dns::{self, DnsApi},
+    entrypoint::listener::{ClientListener, IncomingClient},
     env,
     error::{AgentError, AgentResult},
     file::FileManager,
@@ -55,6 +54,7 @@ use crate::{
     util::{ClientId, protocol_version::ClientProtocolVersion},
 };
 
+mod listener;
 mod setup;
 
 /// [`ExitCode`](std::process::ExitCode) returned from the child agent process
@@ -258,23 +258,39 @@ impl State {
 
     pub async fn serve_client_connection(
         self,
-        stream: TcpStream,
+        client: IncomingClient,
         tasks: BackgroundTasks,
         cancellation_token: CancellationToken,
     ) -> u32 {
         let client_id = self.next_client_id.fetch_add(1, Ordering::Relaxed);
+        let tls_connector = self.tls_connector.clone();
 
-        // mirrord protocol messages are small and latency sensitive,
-        // buffering them with Nagle's algorithm only slows the session down.
-        if let Err(error) = stream.set_nodelay(true) {
-            warn!(client_id, %error, "Failed to set TCP_NODELAY on a client connection");
+        let result = async move {
+            let connection = match client {
+                IncomingClient::Tcp(stream) => {
+                    ClientConnection::new(stream, client_id, tls_connector).await?
+                }
+
+                IncomingClient::Quic(incoming) => {
+                    let connection = (*incoming).await?;
+                    let control = mirrord_quic::accept_control_stream(&connection).await?;
+
+                    trace!(
+                        client_id,
+                        transport_version = control.version(),
+                        peer = %connection.remote_address(),
+                        "serve_client_connection -> QUIC connection established",
+                    );
+
+                    ClientConnection::new_quic(control, client_id)
+                }
+            };
+
+            ClientConnectionHandler::new(client_id, connection, tasks, self)
+                .and_then(|client| client.start(cancellation_token))
+                .await
         }
-
-        let result = ClientConnection::new(stream, client_id, self.tls_connector.clone())
-            .map_err(AgentError::from)
-            .and_then(|connection| ClientConnectionHandler::new(client_id, connection, tasks, self))
-            .and_then(|client| client.start(cancellation_token))
-            .await;
+        .await;
 
         match result {
             Ok(()) => {
@@ -400,7 +416,16 @@ impl ClientConnectionHandler {
         .await?;
         let dns_api = Self::create_dns_api(bg_tasks.dns);
         let reverse_dns_api = ReverseDnsApi::new(&state.network_runtime);
-        let tcp_outgoing_api = TcpOutgoingApi::new(&state.network_runtime, file_pid);
+        // Data streams are accepted on the main runtime, where the QUIC endpoint's driver lives,
+        // and handed to the outgoing task on the network runtime, which may be in the target's
+        // network namespace. Only the sockets are namespace-bound; the streams are not.
+        let data_streams = connection.data_stream_connection().map(|quic| {
+            let (tx, rx) = tokio::sync::mpsc::channel(64);
+            tokio::spawn(data_stream::route_data_streams(quic.clone(), tx));
+            rx
+        });
+
+        let tcp_outgoing_api = TcpOutgoingApi::new(&state.network_runtime, file_pid, data_streams);
         let udp_outgoing_api = UdpOutgoingApi::new(&state.network_runtime);
         let seqpacket_api = SeqpacketApi::new(&state.network_runtime, file_pid);
 
@@ -683,8 +708,8 @@ impl ClientConnectionHandler {
 
 /// Upon first client connection, immediately sends [`DaemonMessage::Close`] to the client due to
 /// the presence of dirty IP tables.
-pub async fn notify_client_about_dirty_iptables(
-    listener: TcpListener,
+async fn notify_client_about_dirty_iptables(
+    mut listener: ClientListener,
     communication_timeout: u16,
     tls_connector: Option<AgentTlsConnector>,
 ) -> AgentResult<()> {
@@ -703,8 +728,18 @@ pub async fn notify_client_about_dirty_iptables(
     // Attempt to send [`DaemonMessage::Close`]. Otherwise, the agent will still fail (but
     // ungracefully).
     match first_connection {
-        Ok(Ok((stream, ..))) => {
-            let mut connection = ClientConnection::new(stream, 0, tls_connector).await?;
+        Ok(Ok(client)) => {
+            let mut connection = match client {
+                IncomingClient::Tcp(stream) => {
+                    ClientConnection::new(stream, 0, tls_connector).await?
+                }
+                IncomingClient::Quic(incoming) => {
+                    let connection = (*incoming).await?;
+                    let control = mirrord_quic::accept_control_stream(&connection).await?;
+                    ClientConnection::new_quic(control, 0)
+                }
+            };
+
             connection
                 .send(DaemonMessage::Close(
                     DIRTY_IPTABLES_ERROR_MESSAGE.to_owned(),
@@ -882,37 +917,8 @@ async fn check_leftover_rules(
 /// starts background tasks and listens for client connections.
 #[tracing::instrument(level = Level::TRACE, ret, err)]
 async fn start_agent(args: Args) -> AgentResult<()> {
-    let listener = {
-        // Prefer a dual-stack IPv6 socket so both IPv4 and IPv6 clients can connect.
-        // If anything in that setup fails (e.g. IPv6 is disabled in the cluster),
-        // fall back to a plain IPv4 listener.
-        let create_dual_stack = || -> AgentResult<TcpListener> {
-            let listener = TcpSocket::new_v6()?;
-            // SO_REUSEADDR is required to handle rapid agent restarts.
-            listener.set_reuseaddr(true)?;
-            // Accept IPv4 clients on this socket as well, not only IPv6 ones.
-            SockRef::from(&listener).set_only_v6(false)?;
-            listener.bind(SocketAddr::new(
-                Ipv6Addr::UNSPECIFIED.into(),
-                args.communicate_port,
-            ))?;
-            listener.listen(1024).map_err(AgentError::from)
-        };
-
-        match create_dual_stack() {
-            Ok(listener) => listener,
-            Err(error) => {
-                warn!(%error, "Failed to set up an IPv6 client listener, falling back to IPv4.");
-                let listener = TcpSocket::new_v4()?;
-                listener.set_reuseaddr(true)?;
-                listener.bind(SocketAddr::new(
-                    Ipv4Addr::UNSPECIFIED.into(),
-                    args.communicate_port,
-                ))?;
-                listener.listen(1024).map_err(AgentError::from)?
-            }
-        }
-    };
+    let mut listener =
+        ClientListener::bind(args.communicate_port, args.operator_tls_cert_pem.as_deref())?;
 
     let client_listener_address = listener.local_addr()?;
     debug!(address = %client_listener_address, "Created the client listener.");
@@ -1024,10 +1030,10 @@ async fn start_agent(args: Args) -> AgentResult<()> {
     .await;
 
     match first_connection {
-        Ok(Ok((stream, addr))) => {
-            trace!(peer = %addr, "start_agent -> First connection accepted");
+        Ok(Ok(client)) => {
+            trace!("start_agent -> First connection accepted");
             clients.spawn(state.clone().serve_client_connection(
-                stream,
+                client,
                 bg_tasks.clone(),
                 cancellation_token.clone(),
             ));
@@ -1054,12 +1060,12 @@ async fn start_agent(args: Args) -> AgentResult<()> {
             OptionFuture::from(clients.is_empty().then_some(tokio::time::sleep(idle_ttl)));
 
         select! {
-            Ok((stream, addr)) = listener.accept() => {
-                trace!(peer = %addr, "start_agent -> Connection accepted");
+            Ok(client) = listener.accept() => {
+                trace!("start_agent -> Connection accepted");
                 clients.spawn(state
                     .clone()
                     .serve_client_connection(
-                        stream,
+                        client,
                         bg_tasks.clone(),
                         cancellation_token.clone()
                     )

--- a/mirrord/agent/src/entrypoint/listener.rs
+++ b/mirrord/agent/src/entrypoint/listener.rs
@@ -1,0 +1,182 @@
+//! Accepting client connections to the agent.
+//!
+//! The agent always listens for TCP connections on its client port. When it was given an operator
+//! certificate to pin, it additionally listens for QUIC connections on the same port number, over
+//! UDP. Which transport a client uses is its own choice: an operator that predates the QUIC
+//! transport, or one that cannot reach the agent over UDP, simply connects over TCP and never
+//! sends a packet to the UDP socket. There is nothing to negotiate before the connection exists,
+//! which is what makes the fallback work without a version handshake.
+//!
+//! The QUIC socket is bound in the agent's own network namespace, like the TCP one. Only the
+//! background task runtime enters the target's namespace.
+
+use std::{
+    io,
+    net::{Ipv4Addr, Ipv6Addr, SocketAddr, UdpSocket},
+    os::fd::AsFd,
+    sync::Arc,
+};
+
+use socket2::SockRef;
+use tokio::{
+    net::{TcpListener, TcpSocket, TcpStream},
+    select,
+};
+use tracing::Level;
+
+use crate::error::{AgentError, AgentResult};
+
+/// A client connection that has arrived but has not been set up yet.
+///
+/// Handshakes are deliberately left to the per-client task: a QUIC handshake involves several
+/// round trips, and doing it on the accept path would let one slow client hold up every other
+/// client waiting to connect.
+pub(super) enum IncomingClient {
+    /// A TCP connection, which may still need a TLS handshake.
+    Tcp(TcpStream),
+    /// A QUIC connection that has not completed its handshake.
+    Quic(Box<quinn::Incoming>),
+}
+
+/// Listens for client connections on both transports the agent supports.
+pub(super) struct ClientListener {
+    tcp: TcpListener,
+    /// [`None`] when the agent has no operator certificate to pin, since without one there is no
+    /// way to tell the operator apart from any other pod that can reach this port.
+    quic: Option<quinn::Endpoint>,
+}
+
+impl ClientListener {
+    /// Binds both listeners to `port`.
+    ///
+    /// `operator_cert_pem` is the certificate the agent pins, from
+    /// [`OPERATOR_CERT`](mirrord_agent_env::envs::OPERATOR_CERT). Failing to set up QUIC is not
+    /// fatal: the agent logs it and serves TCP clients only.
+    #[tracing::instrument(level = Level::DEBUG, skip(operator_cert_pem), err)]
+    pub(super) fn bind(port: u16, operator_cert_pem: Option<&str>) -> AgentResult<Self> {
+        let tcp = bind_tcp(port)?;
+
+        let quic = operator_cert_pem.and_then(|cert| match bind_quic(port, cert) {
+            Ok(endpoint) => Some(endpoint),
+            Err(error) => {
+                tracing::warn!(
+                    %error,
+                    "Failed to set up the QUIC client listener, serving TCP clients only.",
+                );
+                None
+            }
+        });
+
+        Ok(Self { tcp, quic })
+    }
+
+    /// Address of the TCP listener.
+    ///
+    /// The QUIC listener uses the same port, so this is also where QUIC clients connect.
+    pub(super) fn local_addr(&self) -> io::Result<SocketAddr> {
+        self.tcp.local_addr()
+    }
+
+    /// Waits for the next client on either transport.
+    ///
+    /// # Cancel safety
+    ///
+    /// This function is cancel safe. If it is dropped before completing, no connection is lost:
+    /// both transports keep the pending connection queued.
+    pub(super) async fn accept(&mut self) -> io::Result<IncomingClient> {
+        loop {
+            let Some(endpoint) = self.quic.as_ref() else {
+                let (stream, _) = self.tcp.accept().await?;
+                return Ok(IncomingClient::Tcp(stream));
+            };
+
+            let quic_closed = select! {
+                accepted = self.tcp.accept() => {
+                    let (stream, _) = accepted?;
+                    return Ok(IncomingClient::Tcp(stream));
+                },
+
+                incoming = endpoint.accept() => match incoming {
+                    Some(incoming) => return Ok(IncomingClient::Quic(Box::new(incoming))),
+                    // The endpoint is closed and will never yield another connection. Forget it,
+                    // so that the next iteration does not spin on an immediately ready future.
+                    None => true,
+                },
+            };
+
+            if quic_closed {
+                tracing::debug!("QUIC client listener closed, serving TCP clients only.");
+                self.quic = None;
+            }
+        }
+    }
+}
+
+/// Prefers a dual-stack IPv6 socket so both IPv4 and IPv6 clients can connect. If anything in that
+/// setup fails (e.g. IPv6 is disabled in the cluster), falls back to a plain IPv4 socket.
+///
+/// `prepare` sets any socket options that must be applied before binding, and binds the socket to
+/// the given address.
+fn bind_dual_stack<T: AsFd>(
+    port: u16,
+    new_v6: impl Fn() -> io::Result<T>,
+    new_v4: impl Fn() -> io::Result<T>,
+    prepare: impl Fn(&T, SocketAddr) -> io::Result<()>,
+) -> io::Result<T> {
+    let dual_stack = new_v6().and_then(|socket| {
+        // Accept IPv4 clients on this socket as well, not only IPv6 ones.
+        SockRef::from(&socket).set_only_v6(false)?;
+        prepare(&socket, SocketAddr::new(Ipv6Addr::UNSPECIFIED.into(), port))?;
+        Ok(socket)
+    });
+
+    match dual_stack {
+        Ok(socket) => Ok(socket),
+        Err(error) => {
+            tracing::warn!(%error, "Failed to set up an IPv6 client listener, falling back to IPv4.");
+            let socket = new_v4()?;
+            prepare(&socket, SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), port))?;
+            Ok(socket)
+        }
+    }
+}
+
+fn bind_tcp(port: u16) -> AgentResult<TcpListener> {
+    let socket = bind_dual_stack(
+        port,
+        TcpSocket::new_v6,
+        TcpSocket::new_v4,
+        |socket, address| {
+            // SO_REUSEADDR is required to handle rapid agent restarts.
+            socket.set_reuseaddr(true)?;
+            socket.bind(address)
+        },
+    )?;
+
+    socket.listen(1024).map_err(AgentError::from)
+}
+
+fn bind_quic(port: u16, operator_cert_pem: &str) -> AgentResult<quinn::Endpoint> {
+    let socket = bind_dual_stack(
+        port,
+        || socket2::Socket::new(socket2::Domain::IPV6, socket2::Type::DGRAM, None),
+        || socket2::Socket::new(socket2::Domain::IPV4, socket2::Type::DGRAM, None),
+        |socket, address| {
+            // SO_REUSEADDR is required to handle rapid agent restarts.
+            socket.set_reuse_address(true)?;
+            socket.bind(&address.into())
+        },
+    )?;
+    socket.set_nonblocking(true)?;
+
+    let config = mirrord_quic::server_config(operator_cert_pem)
+        .map_err(|error| io::Error::other(error.to_string()))?;
+
+    quinn::Endpoint::new(
+        quinn::EndpointConfig::default(),
+        Some(config),
+        UdpSocket::from(socket),
+        Arc::new(quinn::TokioRuntime),
+    )
+    .map_err(AgentError::from)
+}

--- a/mirrord/agent/src/error.rs
+++ b/mirrord/agent/src/error.rs
@@ -37,6 +37,12 @@ pub(crate) enum AgentError {
     #[error("TLS setup failed: {0}")]
     TlsSetupError(#[from] TlsSetupError),
 
+    #[error("QUIC handshake with the client failed: {0}")]
+    QuicConnectionError(#[from] quinn::ConnectionError),
+
+    #[error("QUIC control stream setup failed: {0}")]
+    QuicControlStreamError(#[from] mirrord_quic::ControlStreamError),
+
     /// Child agent process spawned in `main` failed.
     #[error("Agent child process failed: {0}")]
     AgentFailed(ExitStatus),

--- a/mirrord/agent/src/main.rs
+++ b/mirrord/agent/src/main.rs
@@ -14,6 +14,8 @@ mod client_connection;
 #[cfg(target_os = "linux")]
 mod container_handle;
 #[cfg(target_os = "linux")]
+mod data_stream;
+#[cfg(target_os = "linux")]
 mod dns;
 #[cfg(target_os = "linux")]
 mod entrypoint;

--- a/mirrord/agent/src/outgoing.rs
+++ b/mirrord/agent/src/outgoing.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{HashMap, VecDeque},
+    collections::{HashMap, HashSet, VecDeque},
     fmt,
     pin::Pin,
     sync::Arc,
@@ -14,6 +14,7 @@ use mirrord_protocol::{
     outgoing::{tcp::*, *},
     uid::Uid,
 };
+use mirrord_quic::BiStream;
 use socket_stream::SocketStream;
 use streammap_ext::StreamMap;
 use tokio::{
@@ -23,12 +24,14 @@ use tokio::{
         OwnedSemaphorePermit, Semaphore,
         mpsc::{self, Receiver, Sender, error::SendError},
     },
+    task::JoinSet,
 };
 use tokio_stream::StreamExt;
 use tokio_util::io::ReaderStream;
 use tracing::Level;
 
 use crate::{
+    data_stream::IncomingDataStream,
     error::AgentResult,
     metrics::TCP_OUTGOING_CONNECTION,
     outgoing::throttle::ThrottledStream,
@@ -86,7 +89,16 @@ impl TcpOutgoingApi {
     ///   will be passed to an
     ///   [`InTargetPathResolver`](crate::util::path_resolver::InTargetPathResolver) to resolve unix
     ///   socket paths.
-    pub(crate) fn new(runtime: &BgTaskRuntime, pid: Option<u64>) -> Self {
+    ///
+    /// * `data_streams` - yields the QUIC stream opened for each connection this task reports to
+    ///   the client, and makes connections be spliced onto those streams rather than relayed as
+    ///   mirrord-protocol messages. Pass [`None`] when the client is not on a QUIC connection that
+    ///   negotiated [`DATA_STREAM_VERSION`](mirrord_quic::DATA_STREAM_VERSION).
+    pub(crate) fn new(
+        runtime: &BgTaskRuntime,
+        pid: Option<u64>,
+        data_streams: Option<Receiver<IncomingDataStream>>,
+    ) -> Self {
         // IMPORTANT: this makes tokio tasks spawn on `runtime`.
         // Do not remove this.
         let _rt = runtime.handle().enter();
@@ -94,8 +106,9 @@ impl TcpOutgoingApi {
         let (layer_tx, layer_rx) = mpsc::channel(1000);
         let (daemon_tx, daemon_rx) = mpsc::channel(1000);
 
-        let task_status = tokio::spawn(TcpOutgoingTask::new(pid, layer_rx, daemon_tx).run())
-            .into_status("TcpOutgoingTask");
+        let task_status =
+            tokio::spawn(TcpOutgoingTask::new(pid, layer_rx, daemon_tx, data_streams).run())
+                .into_status("TcpOutgoingTask");
 
         Self {
             task_status,
@@ -138,11 +151,32 @@ struct TcpOutgoingTask {
     connects_v1: FuturesQueue<BoxFuture<'static, RemoteResult<Connected>>>,
     connects_v2: FuturesUnordered<BoxFuture<'static, (RemoteResult<Connected>, Uid)>>,
     throttler: Arc<Semaphore>,
+    /// Data streams opened by the operator, one per connection. [`None`] when the client cannot
+    /// carry connections on their own streams, in which case their bytes are relayed as
+    /// mirrord-protocol messages through [`Self::writers`] and [`Self::readers`] instead.
+    data_streams: Option<Receiver<IncomingDataStream>>,
+    /// Connections that have been reported to the client and are waiting for their data stream.
+    ///
+    /// Nothing is read from these sockets yet, so anything the peer sends in the meantime stays in
+    /// the kernel's receive buffer and is subject to normal TCP backpressure.
+    awaiting_data_stream: HashMap<ConnectionId, SocketStream>,
+    /// Connections currently being copied between their socket and their data stream.
+    splices: JoinSet<ConnectionId>,
 }
 
 impl Drop for TcpOutgoingTask {
     fn drop(&mut self) {
-        let connections = self.readers.keys().chain(self.writers.keys()).count();
+        // A relayed connection is tracked once per io half, so its halves have to be counted as one
+        // connection to match the single increment made when it was opened. Spliced connections and
+        // ones still waiting for their stream are tracked once each.
+        let relayed = self
+            .readers
+            .keys()
+            .chain(self.writers.keys())
+            .collect::<HashSet<_>>()
+            .len();
+        let connections = relayed + self.awaiting_data_stream.len() + self.splices.len();
+
         TCP_OUTGOING_CONNECTION.fetch_sub(connections, std::sync::atomic::Ordering::Relaxed);
     }
 }
@@ -177,6 +211,7 @@ impl TcpOutgoingTask {
         pid: Option<u64>,
         layer_rx: Receiver<LayerTcpOutgoing>,
         daemon_tx: Sender<Throttled<DaemonMessage>>,
+        data_streams: Option<Receiver<IncomingDataStream>>,
     ) -> Self {
         Self {
             next_connection_id: 0,
@@ -188,7 +223,49 @@ impl TcpOutgoingTask {
             connects_v1: Default::default(),
             connects_v2: Default::default(),
             throttler: Arc::new(Semaphore::new(Self::THROTTLE_PERMITS)),
+            data_streams,
+            awaiting_data_stream: Default::default(),
+            splices: JoinSet::new(),
         }
+    }
+
+    /// Whether connections should be spliced onto their own data stream rather than relayed as
+    /// mirrord-protocol messages.
+    fn splices_connections(&self) -> bool {
+        self.data_streams.is_some()
+    }
+
+    /// Copies between an intercepted connection and the data stream carrying it, until both
+    /// directions are done.
+    ///
+    /// Finishing the sending half of the stream is how the peer's `shutdown` is passed on, and
+    /// dropping the stream without finishing it resets it, which is how the operator learns the
+    /// connection failed. [`tokio::io::copy_bidirectional`] already propagates shutdown each way,
+    /// so both fall out of its normal and error returns.
+    async fn splice(
+        connection_id: ConnectionId,
+        mut socket: SocketStream,
+        mut stream: BiStream,
+    ) -> ConnectionId {
+        match tokio::io::copy_bidirectional(&mut socket, &mut stream).await {
+            Ok((from_stream, from_socket)) => {
+                tracing::trace!(
+                    connection_id,
+                    from_stream,
+                    from_socket,
+                    "Spliced connection finished",
+                );
+            }
+            Err(error) => {
+                tracing::trace!(
+                    connection_id,
+                    %error,
+                    "Spliced connection failed, resetting its data stream",
+                );
+            }
+        }
+
+        connection_id
     }
 
     /// Runs this task as long as the channels connecting it with the [`TcpOutgoingApi`] are open.
@@ -219,6 +296,19 @@ impl TcpOutgoingTask {
                 Some((result, uid)) = self.connects_v2.next() => {
                     self.handle_connect_result(Some(uid), result).await.is_err()
                 }
+
+                Some(data_stream) = Self::next_data_stream(&mut self.data_streams) => {
+                    self.handle_data_stream(data_stream);
+                    false
+                }
+
+                Some(finished) = self.splices.join_next() => {
+                    if let Ok(connection_id) = finished {
+                        TCP_OUTGOING_CONNECTION.fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
+                        tracing::trace!(connection_id, "Spliced connection closed");
+                    }
+                    false
+                }
             };
 
             if channel_closed {
@@ -226,6 +316,38 @@ impl TcpOutgoingTask {
                 break;
             }
         }
+    }
+
+    /// Waits for the next data stream, or never resolves when connections are not spliced.
+    async fn next_data_stream(
+        data_streams: &mut Option<Receiver<IncomingDataStream>>,
+    ) -> Option<IncomingDataStream> {
+        match data_streams {
+            Some(receiver) => receiver.recv().await,
+            None => std::future::pending().await,
+        }
+    }
+
+    /// Marries a data stream with the connection it carries and starts copying between them.
+    #[tracing::instrument(level = Level::TRACE, skip(self, data_stream))]
+    fn handle_data_stream(&mut self, data_stream: IncomingDataStream) {
+        let IncomingDataStream {
+            connection_id,
+            stream,
+        } = data_stream;
+
+        let Some(socket) = self.awaiting_data_stream.remove(&connection_id) else {
+            // The client closed the connection between us reporting it and the stream arriving.
+            // Dropping the stream resets it, which is what we want to tell the operator anyway.
+            tracing::trace!(
+                connection_id,
+                "Received a data stream for an unknown connection, dropping it",
+            );
+            return;
+        };
+
+        self.splices
+            .spawn(Self::splice(connection_id, socket, stream));
     }
 
     /// Returns [`Err`] only when the client has disconnected.
@@ -362,15 +484,24 @@ impl TcpOutgoingTask {
             let connection_id = self.next_connection_id;
             self.next_connection_id += 1;
 
-            let (read_half, write_half) = io::split(connected.stream);
-            self.writers.insert(connection_id, write_half);
-            self.readers.insert(
-                connection_id,
-                ThrottledStream::new(
-                    ReaderStream::with_capacity(read_half, Self::READ_BUFFER_SIZE),
-                    self.throttler.clone(),
-                ),
-            );
+            if self.splices_connections() {
+                // The operator opens the data stream once it sees the message we are about to send,
+                // so the socket waits here until then. Not reading from it yet is deliberate: it
+                // leaves early data in the kernel's receive buffer under normal TCP backpressure,
+                // instead of buffering it in the agent.
+                self.awaiting_data_stream
+                    .insert(connection_id, connected.stream);
+            } else {
+                let (read_half, write_half) = io::split(connected.stream);
+                self.writers.insert(connection_id, write_half);
+                self.readers.insert(
+                    connection_id,
+                    ThrottledStream::new(
+                        ReaderStream::with_capacity(read_half, Self::READ_BUFFER_SIZE),
+                        self.throttler.clone(),
+                    ),
+                );
+            }
             TCP_OUTGOING_CONNECTION.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 
             DaemonConnect {
@@ -430,6 +561,18 @@ impl TcpOutgoingTask {
                 connection_id,
                 bytes,
             }) => {
+                if self.splices_connections() {
+                    // Connections are carried on their own data streams, so their bytes never
+                    // arrive as messages. An operator sending them anyway is out of step with the
+                    // negotiated transport version, and dropping them beats tearing down a
+                    // connection that is working.
+                    tracing::trace!(
+                        connection_id,
+                        "Ignoring a write message for a spliced connection",
+                    );
+                    return Ok(());
+                }
+
                 let write_result = match self.writers.get_mut(&connection_id) {
                     Some(writer) if bytes.is_empty() => {
                         tracing::trace!(
@@ -506,10 +649,19 @@ impl TcpOutgoingTask {
 
             // Layer closed a connection entirely.
             // We remove io halves and forget about it.
+            //
+            // A spliced connection is closed by resetting its data stream instead, so the only one
+            // that can be closed this way is one still waiting for its stream. The metric is only
+            // adjusted for a connection we were actually still tracking, so that a close for an
+            // already-forgotten connection cannot drive the count below the truth.
             LayerTcpOutgoing::Close(LayerClose { connection_id }) => {
-                self.writers.remove(&connection_id);
-                self.readers.remove(&connection_id);
-                TCP_OUTGOING_CONNECTION.fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
+                let was_tracked = self.awaiting_data_stream.remove(&connection_id).is_some()
+                    | self.writers.remove(&connection_id).is_some()
+                    | self.readers.remove(&connection_id).is_some();
+
+                if was_tracked {
+                    TCP_OUTGOING_CONNECTION.fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
+                }
 
                 Ok(())
             }

--- a/mirrord/config/src/lib.rs
+++ b/mirrord/config/src/lib.rs
@@ -279,6 +279,18 @@ pub struct LayerConfig {
     #[config(env = "MIRRORD_OPERATOR_ENABLE")]
     pub operator: Option<bool>,
 
+    /// ## direct_operator_connection {#root-direct_operator_connection}
+    ///
+    /// Whether the session connection may be made directly to the operator over QUIC, instead of
+    /// being proxied by the Kubernetes API server.
+    ///
+    /// Only possible when the operator installation exposes an endpoint for it; when it does not,
+    /// this has no effect. Set to `false` to stay on the API server path even then.
+    ///
+    /// Defaults to `true`.
+    #[config(default = true, env = "MIRRORD_DIRECT_OPERATOR_CONNECTION")]
+    pub direct_operator_connection: bool,
+
     /// ## multi_cluster {#root-multi_cluster}
     ///
     /// Controls multi-cluster session behavior when connecting to a multi-cluster Primary
@@ -1615,6 +1627,7 @@ mod tests {
             }),
             container: None,
             operator: None,
+            direct_operator_connection: None,
             profile: None,
             sip_binaries: None,
             kube_context: None,

--- a/mirrord/kube/Cargo.toml
+++ b/mirrord/kube/Cargo.toml
@@ -18,8 +18,11 @@ workspace = true
 
 [features]
 default = []
-# Enables connecting to the agent pod with plain TCP.
-incluster = []
+# Enables connecting to the agent pod with plain TCP or QUIC.
+incluster = [
+  "dep:mirrord-quic",
+  "dep:quinn"
+]
 # Enables connecting to the agent pod with kube's portforwarder.
 portforward = [
   "dep:tokio-retry"
@@ -29,6 +32,9 @@ portforward = [
 mirrord-agent-env = { path = "../agent/env", features = ["k8s-openapi"] }
 mirrord-config = { path = "../config"}
 mirrord-progress = { path = "../progress" }
+mirrord-quic = { path = "../quic", optional = true }
+
+quinn = { workspace = true, optional = true }
 
 async-stream.workspace = true
 futures.workspace = true

--- a/mirrord/kube/src/api/kubernetes.rs
+++ b/mirrord/kube/src/api/kubernetes.rs
@@ -173,6 +173,82 @@ impl KubernetesAPI {
         Ok(conn)
     }
 
+    /// Connects to the agent over QUIC, on the same port number the agent listens on for TCP.
+    ///
+    /// The returned connection is not yet usable: the caller must establish the control stream
+    /// with [`mirrord_quic::open_control_stream`], which is also what verifies that the agent
+    /// accepted our client certificate. An agent that predates the QUIC transport has nothing
+    /// bound on the UDP port, so this never completes and the caller is expected to time it out
+    /// and fall back to [`Self::create_connection`].
+    ///
+    /// `endpoint` is a client-side QUIC endpoint, shared across agents so that all connections
+    /// use one UDP socket and one driver task.
+    #[cfg(feature = "incluster")]
+    pub async fn create_quic_connection(
+        &self,
+        endpoint: &mirrord_quic::ClientEndpoint,
+        connect_info: &AgentKubernetesConnectInfo,
+    ) -> Result<quinn::Connection> {
+        let address = self.resolve_agent_address(connect_info).await?;
+        tracing::trace!(%address, "connecting to the agent over QUIC");
+
+        endpoint
+            .connect(address)
+            .map_err(|error| KubeApiError::AgentQuicConnectFailed(error.to_string()))?
+            .await
+            .map_err(|error| KubeApiError::AgentQuicConnectFailed(error.to_string()))
+    }
+
+    /// Resolves the address the agent can be reached at.
+    ///
+    /// Unlike [`Self::create_connection`], which can hand a hostname straight to
+    /// [`TcpStream::connect`](tokio::net::TcpStream::connect), QUIC needs a resolved
+    /// [`SocketAddr`](std::net::SocketAddr), so a pod without an IP in its status is looked up
+    /// here.
+    #[cfg(feature = "incluster")]
+    async fn resolve_agent_address(
+        &self,
+        AgentKubernetesConnectInfo {
+            pod_name,
+            pod_namespace,
+            agent_port,
+            ..
+        }: &AgentKubernetesConnectInfo,
+    ) -> Result<std::net::SocketAddr> {
+        use std::net::IpAddr;
+
+        use k8s_openapi::api::core::v1::Pod;
+
+        let pod_api: Api<Pod> = Api::namespaced(self.client.clone(), pod_namespace);
+        let pod = pod_api.get(pod_name).await?;
+
+        let pod_ip = pod
+            .status
+            .as_ref()
+            .and_then(|status| status.pod_ip.as_ref());
+
+        match pod_ip {
+            Some(pod_ip) => {
+                let ip = pod_ip
+                    .parse::<IpAddr>()
+                    .map_err(|e| KubeApiError::invalid_value(&pod, "status.podIp", e))?;
+                Ok((ip, *agent_port).into())
+            }
+
+            None => {
+                let hostname = format!("{pod_name}.{pod_namespace}");
+                tokio::net::lookup_host((hostname.as_str(), *agent_port))
+                    .await?
+                    .next()
+                    .ok_or_else(|| {
+                        KubeApiError::AgentQuicConnectFailed(format!(
+                            "{hostname} resolved to no addresses"
+                        ))
+                    })
+            }
+        }
+    }
+
     /// Connects to the agent using kube's [`kube::Api::portforward`].
     #[cfg(feature = "portforward")]
     pub async fn create_connection_portforward(

--- a/mirrord/kube/src/error.rs
+++ b/mirrord/kube/src/error.rs
@@ -24,6 +24,9 @@ pub enum KubeApiError {
     #[error("Timeout waiting for agent to be ready")]
     AgentReadyTimeout,
 
+    #[error("QUIC connection to agent failed: {0}")]
+    AgentQuicConnectFailed(String),
+
     #[error("Port not found in port forward")]
     PortForwardFailed,
 

--- a/mirrord/operator/Cargo.toml
+++ b/mirrord/operator/Cargo.toml
@@ -20,8 +20,10 @@ workspace = true
 default = []
 client = [
   "crd",
+  "dep:actix-codec",
   "dep:base64",
   "dep:bincode",
+  "dep:bytes",
   "dep:flate2",
   "dep:futures",
   "dep:http",
@@ -33,6 +35,7 @@ client = [
   "dep:mirrord-kube",
   "dep:mirrord-progress",
   "dep:mirrord-protocol",
+  "dep:mirrord-quic",
   "dep:rand",
   "dep:serde_urlencoded",
   "dep:sha2",
@@ -65,9 +68,12 @@ mirrord-config = { path = "../config", optional = true }
 mirrord-kube = { path = "../kube", optional = true }
 mirrord-progress = { path = "../progress", optional = true }
 mirrord-protocol = { path = "../protocol", optional = true }
+mirrord-quic = { path = "../quic", optional = true }
 
+actix-codec = { workspace = true, optional = true }
 base64 = { workspace = true, optional = true }
 bincode = { workspace = true, features = ["serde"], optional = true }
+bytes = { workspace = true, optional = true }
 chrono = { workspace = true, features = ["clock", "serde"] }
 dotenvy = { workspace = true, optional = true }
 flate2 = { workspace = true, optional = true }

--- a/mirrord/operator/src/client.rs
+++ b/mirrord/operator/src/client.rs
@@ -51,6 +51,7 @@ use crate::{
             ensure_branch_migrations, list_existing_branches, list_reusable_mongodb_branches,
             list_reusable_mysql_branches, list_reusable_pg_branches, wait_for_pending_branches,
         },
+        direct::DirectSession,
     },
     crd::{
         MirrordClusterOperatorUserCredential, MirrordOperatorCrd, NewOperatorFeature,
@@ -72,6 +73,7 @@ pub mod connect_params;
 pub mod connection;
 mod credentials;
 pub mod database_branches;
+mod direct;
 mod discovery;
 pub mod error;
 mod upgrade;
@@ -162,6 +164,12 @@ pub struct OperatorSession {
     /// OpenTelemetry (OTel) / W3C baggage propagator.
     /// See [OTel docs](https://opentelemetry.io/docs/specs/otel/context/env-carriers/#environment-variable-names)
     baggage: Option<String>,
+    /// How to reach the operator directly, when this session can be carried that way.
+    ///
+    /// Held here rather than derived at connect time so that a reconnect makes the same choice the
+    /// first connection did, without fetching [`MirrordOperatorCrd`] again.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    direct: Option<DirectSession>,
 }
 
 impl OperatorSession {
@@ -190,7 +198,8 @@ impl fmt::Debug for OperatorSession {
             .field("operator_version", &self.operator_version)
             .field("allow_reconnect", &self.allow_reconnect)
             .field("traceparent", &self.traceparent)
-            .field("baggage", &self.baggage);
+            .field("baggage", &self.baggage)
+            .field("direct", &self.direct);
         debug_struct.finish()
     }
 }
@@ -1414,6 +1423,7 @@ impl OperatorApi<PreparedClientCert> {
                 connect_url,
                 layer_config.traceparent.clone(),
                 layer_config.baggage.clone(),
+                layer_config.direct_operator_connection,
             )?;
 
             (session, reused)
@@ -1475,6 +1485,7 @@ impl OperatorApi<PreparedClientCert> {
                 connect_url,
                 layer_config.traceparent.clone(),
                 layer_config.baggage.clone(),
+                layer_config.direct_operator_connection,
             )?;
 
             (session, false)
@@ -1513,6 +1524,7 @@ impl OperatorApi<PreparedClientCert> {
                     connect_url,
                     layer_config.traceparent.clone(),
                     layer_config.baggage.clone(),
+                    layer_config.direct_operator_connection,
                 )?;
 
                 let mut connection_subtask = progress.subtask("connecting to the target");
@@ -1631,6 +1643,7 @@ impl OperatorApi<PreparedClientCert> {
                 connect_url,
                 layer_config.traceparent.clone(),
                 layer_config.baggage.clone(),
+                layer_config.direct_operator_connection,
             )?;
 
             let mut connection_subtask = progress.subtask("connecting to the target");
@@ -1660,6 +1673,7 @@ impl OperatorApi<PreparedClientCert> {
                 connect_url,
                 layer_config.traceparent.clone(),
                 layer_config.baggage.clone(),
+                layer_config.direct_operator_connection,
             )?;
 
             let mut connection_subtask = progress.subtask("connecting to the target");
@@ -1874,6 +1888,7 @@ impl OperatorApi<PreparedClientCert> {
         connect_url: String,
         traceparent: Option<String>,
         baggage: Option<String>,
+        allow_direct: bool,
     ) -> OperatorApiResult<OperatorSession> {
         let id = id
             .map(|id| u64::from_str_radix(id, 16))
@@ -1888,6 +1903,13 @@ impl OperatorApi<PreparedClientCert> {
         let operator_version = self.operator.spec.operator_version.clone();
         let supported_features = self.operator.spec.supported_features();
         let allow_reconnect = supported_features.contains(&NewOperatorFeature::LayerReconnect);
+
+        // Derived before the parameters are moved into a header below, because the direct path
+        // sends them as the query string the operator parses either way.
+        let direct = allow_direct
+            .then(|| self.operator.spec.session_endpoint.clone())
+            .flatten()
+            .and_then(|endpoint| DirectSession::new(endpoint, &connect_url));
 
         // Move the connect parameters out of the URL query string and into a header when the
         // operator supports it, so the websocket upgrade survives ingress proxies that reject the
@@ -1914,6 +1936,7 @@ impl OperatorApi<PreparedClientCert> {
             allow_reconnect,
             traceparent,
             baggage,
+            direct,
         })
     }
 
@@ -2319,9 +2342,39 @@ impl OperatorApi<PreparedClientCert> {
         Ok(OperatorSessionConnection { conn, session })
     }
 
-    /// Creates websocket connection to the operator target.
+    /// Creates the session connection to the operator target.
+    ///
+    /// Prefers a direct connection when the session has one available, and falls back to the
+    /// websocket through the Kubernetes API server otherwise. Falling back is not an error worth
+    /// showing anyone: the session runs identically either way, just with the API server in the
+    /// data path.
     #[tracing::instrument(level = Level::TRACE, skip(client), err)]
     async fn connect_target(
+        client: &Client,
+        session: &OperatorSession,
+    ) -> OperatorApiResult<OperatorConnection> {
+        if let Some(direct) = &session.direct {
+            match direct.connect(client, session.id).await {
+                Ok(stream) => {
+                    tracing::debug!(?stream, "Connected to the operator directly");
+
+                    return Ok(OperatorConnection::direct(stream));
+                }
+                Err(error) => {
+                    tracing::debug!(
+                        %error,
+                        "Failed to connect to the operator directly, falling back to the Kubernetes API server",
+                    );
+                }
+            }
+        }
+
+        Self::connect_target_ws(client, session).await
+    }
+
+    /// Creates websocket connection to the operator target, proxied by the Kubernetes API server.
+    #[tracing::instrument(level = Level::TRACE, skip(client), err)]
+    async fn connect_target_ws(
         client: &Client,
         session: &OperatorSession,
     ) -> OperatorApiResult<OperatorConnection> {
@@ -2354,7 +2407,7 @@ impl OperatorApi<PreparedClientCert> {
                 error,
                 operation: OperatorOperation::WebsocketConnection,
             })
-            .map(OperatorConnection)
+            .map(OperatorConnection::websocket)
     }
 
     /// Opens a websocket to the operator's no-session ping endpoint, used by
@@ -2381,7 +2434,7 @@ impl OperatorApi<PreparedClientCert> {
                 error,
                 operation: OperatorOperation::WebsocketConnection,
             })
-            .map(OperatorConnection)
+            .map(OperatorConnection::websocket)
     }
 }
 

--- a/mirrord/operator/src/client/connection.rs
+++ b/mirrord/operator/src/client/connection.rs
@@ -1,12 +1,16 @@
 use std::{
+    io,
     pin::Pin,
     task::{Context, Poll},
 };
 
+use actix_codec::{Decoder, Encoder, Framed};
+use bytes::BytesMut;
 use futures::{Sink, SinkExt, Stream, StreamExt};
 use hyper::{body::Bytes, upgrade::Upgraded};
 use hyper_util::rt::TokioIo;
 use mirrord_protocol::{ClientMessage, DaemonMessage};
+use mirrord_quic::session::SessionStream;
 use thiserror::Error;
 use tokio_tungstenite::{
     WebSocketStream,
@@ -20,102 +24,194 @@ use tokio_tungstenite::{
 /// 2. [`Sink`] of [`ClientMessage`]s
 /// 3. [`Sink`] of [`Vec<u8>`]s ([`ClientMessage`]s pre-encoded with [`bincode`]) - mostly to fit
 ///    into the existing interfaces. Encoded messages are not verified in any way.
-pub struct OperatorConnection(pub(super) WebSocketStream<TokioIo<Upgraded>>);
+///
+/// The variants carry the same message exchange over different transports. Which one a session
+/// gets is decided when it connects, and nothing downstream is meant to care.
+pub enum OperatorConnection {
+    /// Proxied by the Kubernetes API server as a websocket. Always available.
+    WebSocket(Box<WebSocketStream<TokioIo<Upgraded>>>),
+    /// Dialed directly over QUIC. Available when the installation exposes an endpoint for it.
+    Direct(Box<Framed<SessionStream, SessionCodec>>),
+}
+
+impl OperatorConnection {
+    pub(super) fn websocket(stream: WebSocketStream<TokioIo<Upgraded>>) -> Self {
+        Self::WebSocket(Box::new(stream))
+    }
+
+    pub(super) fn direct(stream: SessionStream) -> Self {
+        Self::Direct(Box::new(Framed::new(stream, SessionCodec)))
+    }
+}
+
+/// Codec for the session connection when it runs over QUIC.
+///
+/// A websocket frames messages for us; a QUIC stream is a plain byte stream, so the framing has to
+/// come from somewhere. bincode's encoding is self-delimiting - decoding consumes exactly one
+/// message's worth of bytes and no more - so messages need no length prefix of their own, and a
+/// message encoded elsewhere can be appended to the stream as it is. That is what lets one codec
+/// encode both [`ClientMessage`]s and already-encoded bytes onto the same stream.
+pub struct SessionCodec;
+
+impl Decoder for SessionCodec {
+    type Item = DaemonMessage;
+    type Error = OperatorConnectionError;
+
+    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+        match bincode::decode_from_slice(&src[..], bincode::config::standard()) {
+            Ok((message, read)) => {
+                let _ = src.split_to(read);
+                Ok(Some(message))
+            }
+            Err(bincode::error::DecodeError::UnexpectedEnd { .. }) => Ok(None),
+            Err(error) => Err(OperatorConnectionError::DecodeError(error)),
+        }
+    }
+}
+
+impl Encoder<ClientMessage> for SessionCodec {
+    type Error = OperatorConnectionError;
+
+    fn encode(&mut self, item: ClientMessage, dst: &mut BytesMut) -> Result<(), Self::Error> {
+        let encoded = bincode::encode_to_vec(&item, bincode::config::standard())?;
+        dst.extend_from_slice(&encoded);
+
+        Ok(())
+    }
+}
+
+impl Encoder<Vec<u8>> for SessionCodec {
+    type Error = OperatorConnectionError;
+
+    fn encode(&mut self, item: Vec<u8>, dst: &mut BytesMut) -> Result<(), Self::Error> {
+        dst.extend_from_slice(&item);
+
+        Ok(())
+    }
+}
+
+impl Encoder<Bytes> for SessionCodec {
+    type Error = OperatorConnectionError;
+
+    fn encode(&mut self, item: Bytes, dst: &mut BytesMut) -> Result<(), Self::Error> {
+        dst.extend_from_slice(&item);
+
+        Ok(())
+    }
+}
 
 impl Stream for OperatorConnection {
     type Item = Result<DaemonMessage, OperatorConnectionError>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        let this = self.get_mut();
+        match self.get_mut() {
+            OperatorConnection::WebSocket(stream) => {
+                let item = match std::task::ready!(stream.poll_next_unpin(cx)) {
+                    Some(Ok(Message::Binary(msg))) => {
+                        match bincode::decode_from_slice(&msg, bincode::config::standard()) {
+                            Ok((message, _)) => Some(Ok(message)),
+                            Err(error) => Some(Err(OperatorConnectionError::DecodeError(error))),
+                        }
+                    }
+                    // Operator only sends binary messages.
+                    Some(Ok(unexpected)) => Some(Err(OperatorConnectionError::InvalidMessage(
+                        Box::new(unexpected),
+                    ))),
+                    Some(Err(error)) => Some(Err(OperatorConnectionError::WsError(error.into()))),
+                    None => None,
+                };
 
-        let item = match std::task::ready!(this.0.poll_next_unpin(cx)) {
-            Some(Ok(Message::Binary(msg))) => {
-                match bincode::decode_from_slice(&msg, bincode::config::standard()) {
-                    Ok((message, _)) => Some(Ok(message)),
-                    Err(error) => Some(Err(OperatorConnectionError::DecodeError(error))),
+                Poll::Ready(item)
+            }
+            OperatorConnection::Direct(stream) => stream.poll_next_unpin(cx),
+        }
+    }
+}
+
+/// Implements [`Sink`] for one of the item types the connection accepts.
+///
+/// The websocket puts each item in a frame of its own and needs [`ClientMessage`]s encoded on the
+/// way in; the direct connection hands everything to [`SessionCodec`]. Both variants support every
+/// item type, they just do not share a type to delegate to, so each one is written out per item
+/// type rather than once.
+macro_rules! sink_impl {
+    ($item:ty, |$stream:ident, $item_name:ident| $websocket_send:expr) => {
+        impl Sink<$item> for OperatorConnection {
+            type Error = OperatorConnectionError;
+
+            fn poll_close(
+                self: Pin<&mut Self>,
+                cx: &mut Context<'_>,
+            ) -> Poll<Result<(), Self::Error>> {
+                match self.get_mut() {
+                    OperatorConnection::WebSocket(stream) => {
+                        stream.poll_close_unpin(cx).map_err(From::from)
+                    }
+                    OperatorConnection::Direct(stream) => {
+                        <Framed<_, _> as SinkExt<$item>>::poll_close_unpin(stream, cx)
+                    }
                 }
             }
-            // Operator only sends binary messages.
-            Some(Ok(unexpected)) => Some(Err(OperatorConnectionError::InvalidMessage(
-                unexpected.into(),
-            ))),
-            Some(Err(error)) => Some(Err(OperatorConnectionError::WsError(error.into()))),
-            None => None,
-        };
 
-        Poll::Ready(item)
-    }
+            fn poll_flush(
+                self: Pin<&mut Self>,
+                cx: &mut Context<'_>,
+            ) -> Poll<Result<(), Self::Error>> {
+                match self.get_mut() {
+                    OperatorConnection::WebSocket(stream) => {
+                        stream.poll_flush_unpin(cx).map_err(From::from)
+                    }
+                    OperatorConnection::Direct(stream) => {
+                        <Framed<_, _> as SinkExt<$item>>::poll_flush_unpin(stream, cx)
+                    }
+                }
+            }
+
+            fn poll_ready(
+                self: Pin<&mut Self>,
+                cx: &mut Context<'_>,
+            ) -> Poll<Result<(), Self::Error>> {
+                match self.get_mut() {
+                    OperatorConnection::WebSocket(stream) => {
+                        stream.poll_ready_unpin(cx).map_err(From::from)
+                    }
+                    OperatorConnection::Direct(stream) => {
+                        <Framed<_, _> as SinkExt<$item>>::poll_ready_unpin(stream, cx)
+                    }
+                }
+            }
+
+            fn start_send(self: Pin<&mut Self>, item: $item) -> Result<(), Self::Error> {
+                match self.get_mut() {
+                    OperatorConnection::WebSocket($stream) => {
+                        let $item_name = item;
+                        $websocket_send
+                    }
+                    OperatorConnection::Direct(stream) => stream.start_send_unpin(item),
+                }
+            }
+        }
+    };
 }
 
-impl Sink<ClientMessage> for OperatorConnection {
-    type Error = OperatorConnectionError;
+sink_impl!(ClientMessage, |stream, item| {
+    let encoded = bincode::encode_to_vec(&item, bincode::config::standard())?;
+    stream
+        .start_send_unpin(Message::Binary(encoded.into()))
+        .map_err(From::from)
+});
 
-    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.get_mut().0.poll_close_unpin(cx).map_err(From::from)
-    }
+sink_impl!(Vec<u8>, |stream, item| {
+    stream
+        .start_send_unpin(Message::Binary(item.into()))
+        .map_err(From::from)
+});
 
-    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.get_mut().0.poll_flush_unpin(cx).map_err(From::from)
-    }
-
-    fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.get_mut().0.poll_ready_unpin(cx).map_err(From::from)
-    }
-
-    fn start_send(self: Pin<&mut Self>, item: ClientMessage) -> Result<(), Self::Error> {
-        let item = bincode::encode_to_vec(&item, bincode::config::standard())?;
-        self.get_mut()
-            .0
-            .start_send_unpin(Message::Binary(item.into()))
-            .map_err(From::from)
-    }
-}
-
-impl Sink<Vec<u8>> for OperatorConnection {
-    type Error = OperatorConnectionError;
-
-    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.get_mut().0.poll_close_unpin(cx).map_err(From::from)
-    }
-
-    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.get_mut().0.poll_flush_unpin(cx).map_err(From::from)
-    }
-
-    fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.get_mut().0.poll_ready_unpin(cx).map_err(From::from)
-    }
-
-    fn start_send(self: Pin<&mut Self>, item: Vec<u8>) -> Result<(), Self::Error> {
-        self.get_mut()
-            .0
-            .start_send_unpin(Message::Binary(item.into()))
-            .map_err(From::from)
-    }
-}
-
-impl Sink<Bytes> for OperatorConnection {
-    type Error = OperatorConnectionError;
-
-    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.get_mut().0.poll_close_unpin(cx).map_err(From::from)
-    }
-
-    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.get_mut().0.poll_flush_unpin(cx).map_err(From::from)
-    }
-
-    fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.get_mut().0.poll_ready_unpin(cx).map_err(From::from)
-    }
-
-    fn start_send(self: Pin<&mut Self>, item: Bytes) -> Result<(), Self::Error> {
-        self.get_mut()
-            .0
-            .start_send_unpin(Message::Binary(item))
-            .map_err(From::from)
-    }
-}
+sink_impl!(Bytes, |stream, item| {
+    stream
+        .start_send_unpin(Message::Binary(item))
+        .map_err(From::from)
+});
 
 /// Errors that can occur when working with [`OperatorConnection`].
 #[derive(Error, Debug)]
@@ -134,10 +230,78 @@ pub enum OperatorConnectionError {
     /// Only [`Message::Binary`] messages are expected.
     #[error("unexpected message: {0:?}")]
     InvalidMessage(Box<Message>),
+    /// The direct connection to the operator failed at the transport level.
+    #[error("operator connection: {0}")]
+    Io(#[from] io::Error),
 }
 
 impl From<tungstenite::Error> for OperatorConnectionError {
     fn from(error: tungstenite::Error) -> Self {
         Self::WsError(Box::new(error))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    /// The direct connection relies on bincode framing itself: a message appended to the stream as
+    /// pre-encoded bytes has to decode back to exactly that message, leaving the bytes that follow
+    /// it untouched. That is what makes the `Vec<u8>` and [`Bytes`] sinks safe to append blindly.
+    #[test]
+    fn encoded_messages_are_self_delimiting() {
+        let mut codec = SessionCodec;
+        let mut buffer = BytesMut::new();
+
+        let version = semver::Version::new(1, 2, 3);
+
+        Encoder::<ClientMessage>::encode(&mut codec, ClientMessage::Ping, &mut buffer).unwrap();
+        let pre_encoded = bincode::encode_to_vec(
+            ClientMessage::SwitchProtocolVersion(version.clone()),
+            bincode::config::standard(),
+        )
+        .unwrap();
+        Encoder::<Vec<u8>>::encode(&mut codec, pre_encoded, &mut buffer).unwrap();
+
+        // Decoding is `DaemonMessage`-shaped, so read the messages back the way the operator's
+        // codec would rather than through this one.
+        let (first, read) = bincode::decode_from_slice::<ClientMessage, _>(
+            &buffer[..],
+            bincode::config::standard(),
+        )
+        .unwrap();
+        assert!(matches!(first, ClientMessage::Ping));
+
+        let (second, _) = bincode::decode_from_slice::<ClientMessage, _>(
+            buffer.get(read..).expect("the first message was consumed"),
+            bincode::config::standard(),
+        )
+        .unwrap();
+        assert!(
+            matches!(second, ClientMessage::SwitchProtocolVersion(decoded) if decoded == version),
+        );
+    }
+
+    /// A partial message must leave the buffer alone and ask for more bytes, rather than erroring
+    /// out and killing the session. QUIC delivers a stream, so a read landing mid-message is
+    /// normal.
+    #[test]
+    fn partial_message_is_not_an_error() {
+        let encoded =
+            bincode::encode_to_vec(DaemonMessage::Pong, bincode::config::standard()).unwrap();
+        let truncated = encoded
+            .split_last()
+            .expect("an encoded message is not empty")
+            .1;
+        let mut buffer = BytesMut::from(truncated);
+
+        let decoded = SessionCodec.decode(&mut buffer).unwrap();
+
+        assert!(decoded.is_none(), "a partial message should decode to None");
+        assert_eq!(
+            buffer.len(),
+            encoded.len() - 1,
+            "a partial message should not be consumed",
+        );
     }
 }

--- a/mirrord/operator/src/client/direct.rs
+++ b/mirrord/operator/src/client/direct.rs
@@ -1,0 +1,229 @@
+//! Dialing the operator directly for the session connection, instead of being proxied by the
+//! Kubernetes API server.
+//!
+//! The API server path is still what sets a session up, and it is what makes this one possible:
+//! the ticket and the operator certificate both come back over a request the API server has
+//! already authenticated. See [`mirrord_quic::session`] for what that buys and why it is safe.
+//!
+//! Everything here is best-effort. A failure at any point means the session runs on the websocket
+//! instead, which is why no error in this module reaches the user as a failure.
+
+use std::{net::SocketAddr, time::Duration};
+
+use base64::{Engine, engine::general_purpose};
+use http::Request;
+use kube::{Client, Resource};
+use mirrord_quic::session::{self, SessionStream};
+use thiserror::Error;
+use tracing::Level;
+
+use crate::{
+    crd::{MirrordOperatorCrd, OPERATOR_STATUS_NAME, SessionEndpoint},
+    types::{SESSION_ID_HEADER, SESSION_TICKET_SUBRESOURCE, SessionRequest, SessionTicket},
+};
+
+/// How long the whole dial is given, from the first UDP packet to the operator's verdict.
+///
+/// An operator whose advertised address is unreachable - a stale address, a firewall dropping UDP,
+/// a load balancer that never came up - gives no error, it simply never answers. Without a bound
+/// here that would stall every session start by QUIC's idle timeout before falling back, turning a
+/// misconfiguration into a permanent tax on session startup.
+const DIAL_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// A session that can be carried on a direct connection to the operator.
+///
+/// Held on the [`OperatorSession`](super::OperatorSession) so that reconnects dial the same way the
+/// first connection did.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub(super) struct DirectSession {
+    endpoint: SessionEndpoint,
+    namespace: String,
+    target: String,
+    connect_params: String,
+}
+
+impl DirectSession {
+    /// Picks apart the connect URL the API server path would have used.
+    ///
+    /// Deriving the parts from that URL rather than collecting them separately keeps the two paths
+    /// from drifting: whatever the connect URL asks for is what the direct connection asks for.
+    ///
+    /// Returns `None` for anything that is not a plain target - a copied target, most notably -
+    /// since only targets are served over the direct path. Those sessions stay on the websocket.
+    pub(super) fn new(endpoint: SessionEndpoint, connect_url: &str) -> Option<Self> {
+        let (path, connect_params) = connect_url.split_once('?')?;
+
+        let mut segments = path.rsplit('/');
+        let target = segments.next()?;
+        segments.next().filter(|it| *it == "targets")?;
+        let namespace = segments.next()?;
+        segments.next().filter(|it| *it == "namespaces")?;
+
+        Some(Self {
+            endpoint,
+            namespace: namespace.to_owned(),
+            target: target.to_owned(),
+            connect_params: connect_params.to_owned(),
+        })
+    }
+
+    /// Asks the operator for a ticket, then redeems it on a fresh QUIC connection.
+    ///
+    /// The ticket is single use, so this runs in full for every connection, including reconnects.
+    #[tracing::instrument(level = Level::TRACE, skip(client), err(level = Level::DEBUG))]
+    pub(super) async fn connect(
+        &self,
+        client: &Client,
+        session_id: u64,
+    ) -> Result<SessionStream, DirectConnectionError> {
+        let ticket = self.request_ticket(client, session_id).await?;
+
+        let certificate = general_purpose::STANDARD
+            .decode(&ticket.certificate)
+            .map_err(DirectConnectionError::MalformedCertificate)?;
+        let config = session::client_config(certificate)?;
+
+        let request = serde_json::to_vec(&SessionRequest {
+            ticket: ticket.ticket,
+            namespace: self.namespace.clone(),
+            target: self.target.clone(),
+            connect_params: self.connect_params.clone(),
+        })
+        .map_err(DirectConnectionError::EncodeRequest)?;
+
+        let address = resolve(&ticket.address).await?;
+
+        tokio::time::timeout(DIAL_TIMEOUT, session::connect(config, address, &request))
+            .await
+            .map_err(|_| DirectConnectionError::DialTimeout(address))?
+            .map_err(DirectConnectionError::from)
+    }
+
+    /// Mints a ticket over the API server, which is where the caller's identity is established.
+    async fn request_ticket(
+        &self,
+        client: &Client,
+        session_id: u64,
+    ) -> Result<SessionTicket, DirectConnectionError> {
+        let url_path = MirrordOperatorCrd::url_path(&(), None);
+        let request = Request::builder()
+            .method(http::Method::POST)
+            .uri(format!(
+                "{url_path}/{OPERATOR_STATUS_NAME}/{SESSION_TICKET_SUBRESOURCE}"
+            ))
+            .header(SESSION_ID_HEADER, session_id.to_string())
+            .body(Vec::new())
+            .map_err(DirectConnectionError::BuildTicketRequest)?;
+
+        client
+            .request::<SessionTicket>(request)
+            .await
+            .map_err(DirectConnectionError::TicketRequestFailed)
+    }
+}
+
+/// Turns the advertised address into something to send UDP to.
+///
+/// The address is whatever the installation was configured with, so it may be a name.
+async fn resolve(address: &str) -> Result<SocketAddr, DirectConnectionError> {
+    tokio::net::lookup_host(address)
+        .await
+        .map_err(|error| DirectConnectionError::ResolveAddress {
+            address: address.to_owned(),
+            error,
+        })?
+        .next()
+        .ok_or_else(|| DirectConnectionError::NoAddress(address.to_owned()))
+}
+
+/// Why a session could not be carried directly.
+///
+/// Every one of these is recoverable by falling back to the websocket, so they are logged rather
+/// than shown to the user.
+#[derive(Debug, Error)]
+pub(super) enum DirectConnectionError {
+    #[error("failed to build the session ticket request: {0}")]
+    BuildTicketRequest(http::Error),
+    #[error("the operator did not issue a session ticket: {0}")]
+    TicketRequestFailed(kube::Error),
+    #[error("the operator's certificate is not valid base64: {0}")]
+    MalformedCertificate(base64::DecodeError),
+    #[error("failed to encode the session request: {0}")]
+    EncodeRequest(serde_json::Error),
+    #[error("failed to resolve the operator address `{address}`: {error}")]
+    ResolveAddress {
+        address: String,
+        error: std::io::Error,
+    },
+    #[error("the operator address `{0}` resolved to nothing")]
+    NoAddress(String),
+    #[error("failed to set up the QUIC connection: {0}")]
+    Setup(#[from] mirrord_quic::QuicSetupError),
+    #[error("failed to establish the session stream: {0}")]
+    Stream(#[from] mirrord_quic::SessionStreamError),
+    #[error("the operator at {0} did not answer within {DIAL_TIMEOUT:?}")]
+    DialTimeout(SocketAddr),
+}
+
+#[cfg(test)]
+mod test {
+    use rstest::rstest;
+
+    use super::*;
+
+    fn endpoint() -> SessionEndpoint {
+        SessionEndpoint {
+            address: "operator.example.com:3000".to_owned(),
+        }
+    }
+
+    /// Both shapes of target connect URL - direct and through the API server's proxy verb - have to
+    /// yield the same namespace and target, since which one the CLI uses depends on the operator's
+    /// features rather than on anything about the session.
+    #[rstest]
+    #[case::url_path(
+        "/apis/operator.metalbear.co/v1/namespaces/my-ns/targets/deployment.my-app?connect=true"
+    )]
+    #[case::proxy(
+        "/apis/operator.metalbear.co/v1/proxy/namespaces/my-ns/targets/deployment.my-app?connect=true"
+    )]
+    fn parses_target_connect_urls(#[case] connect_url: &str) {
+        let direct = DirectSession::new(endpoint(), connect_url)
+            .expect("a target connect URL should be usable directly");
+
+        assert_eq!(direct.namespace, "my-ns");
+        assert_eq!(direct.target, "deployment.my-app");
+        assert_eq!(direct.connect_params, "connect=true");
+    }
+
+    /// The whole query string has to survive, because the operator parses it with the same code
+    /// that parses it off the URL on the API server path.
+    #[test]
+    fn keeps_the_whole_query_string() {
+        let direct = DirectSession::new(
+            endpoint(),
+            "/apis/operator.metalbear.co/v1/namespaces/ns/targets/pod.p?connect=true&on_concurrent_steal=abort&profile=strict",
+        )
+        .expect("a target connect URL should be usable directly");
+
+        assert_eq!(
+            direct.connect_params,
+            "connect=true&on_concurrent_steal=abort&profile=strict",
+        );
+    }
+
+    /// Only plain targets are served directly. Anything else has to fall back rather than be
+    /// mangled into a target request.
+    #[rstest]
+    #[case::copy_target(
+        "/apis/operator.metalbear.co/v1/namespaces/my-ns/copytargets/my-copy?connect=true"
+    )]
+    #[case::no_query("/apis/operator.metalbear.co/v1/namespaces/my-ns/targets/deployment.my-app")]
+    #[case::not_namespaced("/apis/operator.metalbear.co/v1/targets/deployment.my-app?connect=true")]
+    fn rejects_everything_else(#[case] connect_url: &str) {
+        assert!(
+            DirectSession::new(endpoint(), connect_url).is_none(),
+            "`{connect_url}` should not be served over a direct connection",
+        );
+    }
+}

--- a/mirrord/operator/src/crd.rs
+++ b/mirrord/operator/src/crd.rs
@@ -204,6 +204,24 @@ pub struct MirrordOperatorSpec {
     /// Used by CLI in multi-cluster management-only mode to create CRDs
     /// in the operator's namespace with a target-namespace annotation.
     pub operator_namespace: Option<String>,
+    /// Where the operator can be reached directly over QUIC, bypassing the Kubernetes API server
+    /// for the session connection.
+    ///
+    /// `None` when the installation does not expose that endpoint, which is the default. A client
+    /// that sees an address here can ask for a session ticket; one that does not stays on the API
+    /// server path.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_endpoint: Option<SessionEndpoint>,
+}
+
+/// A directly dialable address for the operator's session connection.
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionEndpoint {
+    /// Host and port the CLI should dial over UDP, as configured by whoever installed the
+    /// operator. The operator does not discover this for itself, because what a client outside the
+    /// cluster can reach is not visible from inside it.
+    pub address: String,
 }
 
 impl MirrordOperatorSpec {
@@ -214,6 +232,7 @@ impl MirrordOperatorSpec {
         license: LicenseInfoOwned,
         protocol_version: Option<String>,
         operator_namespace: Option<String>,
+        session_endpoint: Option<SessionEndpoint>,
     ) -> Self {
         let features = supported_features
             .contains(&NewOperatorFeature::ProxyApi)
@@ -230,6 +249,7 @@ impl MirrordOperatorSpec {
             features,
             copy_target_enabled,
             operator_namespace,
+            session_endpoint,
         }
     }
 

--- a/mirrord/operator/src/types.rs
+++ b/mirrord/operator/src/types.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use chrono::NaiveDate;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -76,3 +78,74 @@ pub const DEFAULT_OPERATOR_ISOLATION_MARKER: &str = "mirrord-operator";
 /// The sync controllers check for this label and skip syncing the resource to other clusters,
 /// keeping it local to the Primary.
 pub const MULTI_CLUSTER_SKIP_SYNC_LABEL: &str = "operator.metalbear.co/skip-mc-sync";
+
+/// Subresource on the operator status resource that mints a [`SessionTicket`].
+///
+/// `POST /apis/operator.metalbear.co/v1/mirrordoperators/operator/session-ticket`.
+pub const SESSION_TICKET_SUBRESOURCE: &str = "session-ticket";
+
+/// Everything the CLI needs to open one session connection directly to the operator, instead of
+/// through the Kubernetes API server.
+///
+/// Minted by the operator in response to a request the API server has already authenticated, which
+/// is what lets the QUIC connection carry no identity of its own.
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionTicket {
+    /// Proof that the bearer is the identity this was issued to.
+    ///
+    /// Single use and short lived, so a leaked ticket buys an attacker one race against the
+    /// legitimate CLI rather than a reusable credential.
+    pub ticket: String,
+    /// Host and port to dial over UDP.
+    pub address: String,
+    /// The operator's serving certificate, DER, base64 encoded.
+    ///
+    /// The CLI accepts this certificate and no other on the QUIC connection. It arrives over the
+    /// API server, which is what makes it trustworthy.
+    pub certificate: String,
+    /// How long the ticket stays redeemable, so a CLI that cannot dial in time can say so rather
+    /// than reporting a confusing rejection.
+    pub expires_in_seconds: u64,
+}
+
+impl fmt::Debug for SessionTicket {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SessionTicket")
+            .field("ticket", &"<redacted>")
+            .field("address", &self.address)
+            .field("expires_in_seconds", &self.expires_in_seconds)
+            .finish_non_exhaustive()
+    }
+}
+
+/// What the CLI sends first on the QUIC session stream, identifying the session it wants.
+///
+/// Deliberately says nothing about who the caller is: the operator takes that from the ticket, so
+/// there is nothing here worth forging. The target and parameters are not bound to the ticket
+/// either, because the operator still checks the caller's Kubernetes permissions against whatever
+/// target is asked for.
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionRequest {
+    /// The `ticket` field of a [`SessionTicket`].
+    pub ticket: String,
+    /// Namespace of the target to connect to.
+    pub namespace: String,
+    /// Target to connect to, in the same dotted form the API server path puts in the URL, e.g.
+    /// `deployment.my-app.container.web`.
+    pub target: String,
+    /// Connect parameters, as the same query string the API server path puts in the URL, so that
+    /// both paths parse them with the same code.
+    pub connect_params: String,
+}
+
+impl fmt::Debug for SessionRequest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SessionRequest")
+            .field("ticket", &"<redacted>")
+            .field("namespace", &self.namespace)
+            .field("target", &self.target)
+            .finish_non_exhaustive()
+    }
+}

--- a/mirrord/quic/Cargo.toml
+++ b/mirrord/quic/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "mirrord-quic"
+version.workspace = true
+authors.workspace = true
+description.workspace = true
+documentation.workspace = true
+readme.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+publish.workspace = true
+edition.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+mirrord-tls-util = { path = "../tls-util" }
+
+quinn = { workspace = true }
+rcgen.workspace = true
+rustls.workspace = true
+socket2.workspace = true
+thiserror.workspace = true
+tokio = { workspace = true, features = ["io-util"] }
+tracing.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt", "time"] }
+
+[lib]
+doctest = false

--- a/mirrord/quic/src/error.rs
+++ b/mirrord/quic/src/error.rs
@@ -29,6 +29,38 @@ pub enum QuicSetupError {
     /// The client verifier could not be built from the operator certificate.
     #[error("failed to build the client certificate verifier: {0}")]
     ClientVerifier(#[from] rustls::server::VerifierBuilderError),
+    /// The listener could not bind its UDP socket.
+    #[error("failed to bind the QUIC listener: {0}")]
+    Bind(io::Error),
+}
+
+/// Errors that can occur when establishing the session stream between the CLI and the operator.
+#[derive(Debug, Error)]
+pub enum SessionStreamError {
+    /// The local UDP socket could not be bound.
+    #[error("failed to bind a local socket: {0}")]
+    Bind(io::Error),
+    /// The connection could not be started, e.g. the address is malformed.
+    #[error("failed to start the connection: {0}")]
+    Connect(#[from] quinn::ConnectError),
+    /// The peer never opened the stream, or the connection was lost while establishing it.
+    #[error("failed to establish the session stream: {0}")]
+    Connection(#[from] quinn::ConnectionError),
+    /// The stream was closed or errored while the preamble was being exchanged.
+    #[error("failed to exchange the session stream preamble: {0}")]
+    Io(#[from] io::Error),
+    /// The peer's first bytes were not a session stream preamble, so it is speaking something
+    /// other than this transport.
+    #[error("the peer did not send a mirrord session stream preamble")]
+    BadMagic,
+    /// The peer announced a preamble larger than [`MAX_PREAMBLE_LEN`](super::session::
+    /// MAX_PREAMBLE_LEN), which is refused before anything is allocated for it.
+    #[error("the peer announced an oversized session stream preamble of {0} bytes")]
+    OversizedPreamble(u32),
+    /// The operator refused to start the session. Carries the reason, which is meant to be shown
+    /// to the user.
+    #[error("the operator refused the session: {0}")]
+    Refused(String),
 }
 
 /// Errors that can occur when establishing a data stream for an intercepted connection.

--- a/mirrord/quic/src/error.rs
+++ b/mirrord/quic/src/error.rs
@@ -1,0 +1,63 @@
+use std::io;
+
+use thiserror::Error;
+
+/// Errors that can occur when building the QUIC configuration for either end.
+#[derive(Debug, Error)]
+pub enum QuicSetupError {
+    /// The operator certificate PEM could not be parsed.
+    #[error("failed to parse the operator certificate: {0}")]
+    MalformedOperatorCert(rustls::pki_types::pem::Error),
+    /// The operator certificate PEM contained no certificate.
+    #[error("the operator certificate PEM contains no certificate")]
+    NoOperatorCert,
+    /// The operator private key PEM could not be parsed.
+    #[error("failed to parse the operator private key: {0}")]
+    MalformedOperatorKey(rustls::pki_types::pem::Error),
+    /// The generated agent certificate produced a key rustls cannot use.
+    #[error("failed to encode the generated agent private key: {0}")]
+    MalformedAgentKey(String),
+    /// We failed to generate the agent's ephemeral certificate.
+    #[error("failed to generate the agent certificate: {0}")]
+    CertGeneration(#[from] rcgen::Error),
+    /// rustls rejected the configuration, e.g. the certificate and key do not match.
+    #[error("failed to build the TLS configuration: {0}")]
+    Tls(#[from] rustls::Error),
+    /// The TLS configuration cannot be used with QUIC, e.g. it allows a version older than 1.3.
+    #[error("the TLS configuration is not usable with QUIC: {0}")]
+    NoQuicSupport(#[from] quinn::crypto::rustls::NoInitialCipherSuite),
+    /// The client verifier could not be built from the operator certificate.
+    #[error("failed to build the client certificate verifier: {0}")]
+    ClientVerifier(#[from] rustls::server::VerifierBuilderError),
+}
+
+/// Errors that can occur when establishing a data stream for an intercepted connection.
+#[derive(Debug, Error)]
+pub enum DataStreamError {
+    /// The connection was lost while the stream was being established.
+    #[error("failed to establish the data stream: {0}")]
+    Connection(#[from] quinn::ConnectionError),
+    /// The stream was closed or errored while the header was being exchanged.
+    #[error("failed to exchange the data stream header: {0}")]
+    Io(#[from] io::Error),
+    /// The peer opened a data stream for something this build does not know how to carry. Only
+    /// reachable if the negotiated version is wrong, since the kind is covered by version
+    /// negotiation.
+    #[error("the peer opened a data stream of unknown kind {0}")]
+    UnknownKind(u8),
+}
+
+/// Errors that can occur when establishing the control stream.
+#[derive(Debug, Error)]
+pub enum ControlStreamError {
+    /// The peer never opened the stream, or the connection was lost while establishing it.
+    #[error("failed to establish the control stream: {0}")]
+    Connection(#[from] quinn::ConnectionError),
+    /// The stream was closed or errored while the header was being exchanged.
+    #[error("failed to exchange the control stream header: {0}")]
+    Io(#[from] io::Error),
+    /// The peer's first bytes were not a control stream header, so it is speaking something other
+    /// than this transport.
+    #[error("the peer did not send a mirrord control stream header")]
+    BadMagic,
+}

--- a/mirrord/quic/src/lib.rs
+++ b/mirrord/quic/src/lib.rs
@@ -1,0 +1,772 @@
+//! QUIC transport for the connection between the mirrord Operator and mirrord-agent.
+//!
+//! # Why QUIC
+//!
+//! A single agent is shared by many sessions, and every session multiplexes all of its remote IO
+//! (outgoing connections, stolen connections, file operations) onto one connection with the agent.
+//! Over TCP, a large or slow message blocks every other message behind it, because the whole
+//! multiplex shares one byte stream and one congestion window. QUIC gives each logical connection
+//! its own stream, with independent ordering, flow control, and loss recovery.
+//!
+//! # Streams
+//!
+//! The first bidirectional stream, opened by the operator right after the handshake, is the
+//! *control stream*. It carries the mirrord-protocol message exchange
+//! ([`ClientMessage`](mirrord_protocol::ClientMessage) /
+//! [`DaemonMessage`](mirrord_protocol::DaemonMessage)) framed exactly as it is over TCP, so both
+//! ends can reuse their existing codecs.
+//!
+//! Every other stream is a *data stream*, carrying the raw bytes of one intercepted connection with
+//! no framing and no per-chunk decode. Data streams are always opened by the **operator**, after
+//! the control stream has told it that the connection exists. That ordering is what makes the
+//! rendezvous trivial: by the time the agent accepts a data stream, the socket it belongs to is
+//! already waiting, so neither end has to park a stream it cannot yet match. Until the stream
+//! arrives the agent simply does not read from the socket, and the kernel's receive buffer plus
+//! TCP backpressure hold whatever the peer sent in the meantime.
+//!
+//! A data stream also carries the connection's lifecycle, which keeps it ordered with the data
+//! rather than racing it on the control stream:
+//!
+//! * Either side finishing its sending half means "no more data this way", the equivalent of a
+//!   `shutdown(2)` on the intercepted socket.
+//! * Resetting the stream means the connection is gone.
+//!
+//! # Trust model
+//!
+//! QUIC requires the side that dials to be the TLS client, which inverts the TLS roles used over
+//! TCP: there, the agent accepts the TCP connection but acts as the TLS client, pinning the
+//! operator certificate it was given in
+//! [`OPERATOR_CERT`](mirrord_agent_env::envs::OPERATOR_CERT).
+//!
+//! The inversion is resolved with mutual TLS, which preserves the property the TCP setup relies
+//! on - that only the operator can talk to the agent:
+//!
+//! * The agent presents an ephemeral self-signed certificate generated in-process on startup. Its
+//!   private key never leaves the agent's pod, and nothing needs to provision it.
+//! * The agent requires a client certificate and verifies it against the pinned operator
+//!   certificate, so only the holder of the operator's private key can open a connection.
+//! * The operator presents that certificate as its client certificate and accepts the agent's
+//!   ephemeral certificate without verification. The agent is identified by the pod IP resolved
+//!   from the Kubernetes API, which is how the TCP transport identifies it as well.
+
+use std::{
+    fmt, io,
+    net::{Ipv4Addr, Ipv6Addr, SocketAddr},
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+    time::Duration,
+};
+
+use mirrord_tls_util::DangerousNoVerifierServer;
+use quinn::crypto::rustls::{QuicClientConfig, QuicServerConfig};
+use rustls::{
+    RootCertStore,
+    pki_types::{CertificateDer, PrivateKeyDer, pem::PemObject},
+    server::WebPkiClientVerifier,
+};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, Join, ReadBuf};
+
+mod error;
+
+pub use error::{ControlStreamError, DataStreamError, QuicSetupError};
+
+/// ALPN protocol negotiated on every operator to agent QUIC connection.
+///
+/// The suffix is the transport generation, not [`TRANSPORT_VERSION`]. It only changes if the
+/// meaning of the streams themselves changes in a way that older peers cannot detect, which
+/// [`ControlHeader`] version negotiation would be too late to catch.
+pub const ALPN: &[u8] = b"mirrord-agent/1";
+
+/// Highest version of the stream conventions this build understands.
+///
+/// Both ends exchange this in [`ControlHeader`] and continue with the lower of the two, so a newer
+/// operator keeps working against an older agent and vice versa.
+///
+/// * `1` - control stream only. All remote IO is carried as mirrord-protocol messages.
+/// * `2` - adds data streams for outgoing TCP connections.
+pub const TRANSPORT_VERSION: u16 = 2;
+
+/// First [`TRANSPORT_VERSION`] in which data streams exist.
+pub const DATA_STREAM_VERSION: u16 = 2;
+
+/// Identifies the control stream, so that a peer speaking something else on this port fails
+/// immediately and legibly instead of as a protocol decode error further down.
+const CONTROL_MAGIC: [u8; 6] = *b"mrdqic";
+
+/// Subject alternate name of the agent's ephemeral certificate, and the server name the operator
+/// passes to [`quinn::Endpoint::connect`].
+///
+/// The operator does not verify the agent's certificate, so this never has to match anything the
+/// agent is reachable at. It is only ever seen in logs and in TLS-level errors.
+pub const AGENT_SERVER_NAME: &str = "mirrord-agent";
+
+/// How long a connection may be idle before either end tears it down.
+///
+/// The operator runs its own ping-pong over the control stream at a shorter interval, so reaching
+/// this means the peer is gone rather than quiet.
+const MAX_IDLE_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// How often the operator sends QUIC-level keep-alives, well below [`MAX_IDLE_TIMEOUT`].
+const KEEP_ALIVE_INTERVAL: Duration = Duration::from_secs(10);
+
+/// Upper bound on concurrently open streams in one direction.
+///
+/// Each remote connection handled for a session gets its own stream, so this bounds how many
+/// connections a single session can have in flight.
+const MAX_CONCURRENT_STREAMS: u32 = 1 << 16;
+
+/// How much data one intercepted connection may have in flight before its sender is made to wait.
+///
+/// This is QUIC's per-stream flow control doing the job that the agent otherwise has to do by hand
+/// with a semaphore around its reads: bound how much a connection can buffer without letting a busy
+/// connection starve the others.
+const STREAM_RECEIVE_WINDOW: u32 = 512 * 1024;
+
+/// How much data all streams together may have in flight.
+///
+/// Bounds total memory per agent connection, so that many busy intercepted connections cannot add
+/// up to an unbounded amount of buffered data.
+const CONNECTION_RECEIVE_WINDOW: u32 = 16 * 1024 * 1024;
+
+/// A bidirectional QUIC stream presented as a single byte stream.
+///
+/// Framed codecs need one type that is both [`AsyncRead`](tokio::io::AsyncRead) and
+/// [`AsyncWrite`](tokio::io::AsyncWrite), while QUIC hands out the two halves separately.
+pub type BiStream = Join<quinn::RecvStream, quinn::SendStream>;
+
+/// Preamble exchanged on the control stream before any mirrord-protocol message.
+///
+/// The operator sends its header immediately after opening the stream, and the agent replies with
+/// its own. Beyond negotiating [`TRANSPORT_VERSION`], the operator's header is what makes the
+/// stream visible to the agent at all: QUIC only surfaces a newly opened stream to the peer once
+/// something has been written to it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ControlHeader {
+    /// Highest version understood by the sender.
+    pub version: u16,
+}
+
+impl ControlHeader {
+    const LEN: usize = CONTROL_MAGIC.len() + size_of::<u16>();
+
+    /// Header advertising this build's [`TRANSPORT_VERSION`].
+    pub const CURRENT: Self = Self {
+        version: TRANSPORT_VERSION,
+    };
+
+    fn encode(&self) -> [u8; Self::LEN] {
+        let mut buffer = [0_u8; Self::LEN];
+        buffer[..CONTROL_MAGIC.len()].copy_from_slice(&CONTROL_MAGIC);
+        buffer[CONTROL_MAGIC.len()..].copy_from_slice(&self.version.to_be_bytes());
+        buffer
+    }
+
+    fn decode(buffer: [u8; Self::LEN]) -> Result<Self, ControlStreamError> {
+        let (magic, version) = buffer.split_at(CONTROL_MAGIC.len());
+        if magic != CONTROL_MAGIC {
+            return Err(ControlStreamError::BadMagic);
+        }
+
+        Ok(Self {
+            version: u16::from_be_bytes(
+                version
+                    .try_into()
+                    .expect("header remainder is exactly two bytes"),
+            ),
+        })
+    }
+
+    async fn write_to(&self, stream: &mut BiStream) -> Result<(), ControlStreamError> {
+        stream.write_all(&self.encode()).await?;
+        stream.flush().await?;
+        Ok(())
+    }
+
+    async fn read_from(stream: &mut BiStream) -> Result<Self, ControlStreamError> {
+        let mut buffer = [0_u8; Self::LEN];
+        stream.read_exact(&mut buffer).await?;
+        Self::decode(buffer)
+    }
+}
+
+/// What kind of intercepted connection a data stream carries.
+///
+/// Sent on the wire as a single byte, so that a peer which learns about new kinds in a later
+/// version can reject one it does not know instead of misreading the bytes that follow.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum DataStreamKind {
+    /// A connection the intercepted process made to a remote address, which the agent established
+    /// on its behalf.
+    TcpOutgoing = 1,
+}
+
+impl DataStreamKind {
+    fn from_byte(byte: u8) -> Result<Self, DataStreamError> {
+        match byte {
+            1 => Ok(Self::TcpOutgoing),
+            other => Err(DataStreamError::UnknownKind(other)),
+        }
+    }
+}
+
+/// Identifies the intercepted connection a data stream carries.
+///
+/// Written by the operator as the first bytes of every data stream it opens.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DataStreamHeader {
+    pub kind: DataStreamKind,
+    /// The connection's id in the agent's own numbering, as the agent reported it on the control
+    /// stream.
+    pub connection_id: u64,
+}
+
+impl DataStreamHeader {
+    const LEN: usize = 1 + size_of::<u64>();
+
+    fn encode(&self) -> [u8; Self::LEN] {
+        let mut buffer = [0_u8; Self::LEN];
+        buffer[0] = self.kind as u8;
+        buffer[1..].copy_from_slice(&self.connection_id.to_be_bytes());
+        buffer
+    }
+
+    fn decode(buffer: [u8; Self::LEN]) -> Result<Self, DataStreamError> {
+        Ok(Self {
+            kind: DataStreamKind::from_byte(buffer[0])?,
+            connection_id: u64::from_be_bytes(
+                buffer[1..]
+                    .try_into()
+                    .expect("header remainder is exactly eight bytes"),
+            ),
+        })
+    }
+}
+
+/// Opens data streams on an established connection. Held by the operator.
+///
+/// Handing this out rather than the [`quinn::Connection`] keeps the QUIC types from leaking into
+/// callers that only need to carry connections.
+#[derive(Clone)]
+pub struct DataStreamOpener(quinn::Connection);
+
+impl DataStreamOpener {
+    /// Opens a data stream for an intercepted connection.
+    ///
+    /// Only valid once the negotiated version is at least [`DATA_STREAM_VERSION`], and only for a
+    /// connection the agent has already reported on the control stream.
+    pub async fn open(&self, header: DataStreamHeader) -> Result<BiStream, DataStreamError> {
+        let (mut send, recv) = self.0.open_bi().await?;
+        send.write_all(&header.encode())
+            .await
+            .map_err(io::Error::from)?;
+
+        Ok(tokio::io::join(recv, send))
+    }
+}
+
+impl fmt::Debug for DataStreamOpener {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("DataStreamOpener")
+            .field(&self.0.remote_address())
+            .finish()
+    }
+}
+
+/// Accepts the next data stream and reads the header identifying its connection. Called by the
+/// agent.
+pub async fn accept_data_stream(
+    connection: &quinn::Connection,
+) -> Result<(DataStreamHeader, BiStream), DataStreamError> {
+    let (send, mut recv) = connection.accept_bi().await?;
+
+    let mut buffer = [0_u8; DataStreamHeader::LEN];
+    recv.read_exact(&mut buffer)
+        .await
+        .map_err(|error| io::Error::other(error.to_string()))?;
+
+    Ok((
+        DataStreamHeader::decode(buffer)?,
+        tokio::io::join(recv, send),
+    ))
+}
+
+/// An established control stream, carrying the framed mirrord-protocol message exchange.
+///
+/// Owns the connection it belongs to, so that holding the control stream keeps the whole QUIC
+/// connection - and any other stream on it - alive.
+pub struct ControlStream {
+    connection: quinn::Connection,
+    stream: BiStream,
+    version: u16,
+}
+
+impl ControlStream {
+    /// The connection this stream belongs to, on which further streams can be opened.
+    pub fn connection(&self) -> &quinn::Connection {
+        &self.connection
+    }
+
+    /// A handle for opening data streams on this connection.
+    pub fn data_stream_opener(&self) -> DataStreamOpener {
+        DataStreamOpener(self.connection.clone())
+    }
+
+    /// Lower of the two peers' [`TRANSPORT_VERSION`]s, and therefore the set of stream conventions
+    /// both ends can use.
+    pub fn version(&self) -> u16 {
+        self.version
+    }
+}
+
+impl fmt::Debug for ControlStream {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ControlStream")
+            .field("peer", &self.connection.remote_address())
+            .field("version", &self.version)
+            .finish()
+    }
+}
+
+impl AsyncRead for ControlStream {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.stream).poll_read(cx, buf)
+    }
+}
+
+impl AsyncWrite for ControlStream {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        Pin::new(&mut self.stream).poll_write(cx, buf)
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.stream).poll_flush(cx)
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.stream).poll_shutdown(cx)
+    }
+}
+
+/// Builds the agent side of the QUIC connection.
+///
+/// `operator_cert_pem` is the PEM-encoded operator certificate from
+/// [`OPERATOR_CERT`](mirrord_agent_env::envs::OPERATOR_CERT). Only a peer that can prove
+/// possession of its private key is allowed to connect. The agent's own certificate is generated
+/// here and discarded when the returned config is dropped.
+pub fn server_config(operator_cert_pem: &str) -> Result<quinn::ServerConfig, QuicSetupError> {
+    let mut roots = RootCertStore::empty();
+    let mut added = 0;
+    for cert in CertificateDer::pem_slice_iter(operator_cert_pem.as_bytes()) {
+        roots.add(cert.map_err(QuicSetupError::MalformedOperatorCert)?)?;
+        added += 1;
+    }
+    if added == 0 {
+        return Err(QuicSetupError::NoOperatorCert);
+    }
+
+    let client_verifier = WebPkiClientVerifier::builder(roots.into()).build()?;
+
+    let agent_cert = mirrord_tls_util::generate_cert(AGENT_SERVER_NAME, None, false)?;
+    let agent_key = PrivateKeyDer::try_from(agent_cert.signing_key.serialize_der())
+        .map_err(|error| QuicSetupError::MalformedAgentKey(error.to_owned()))?;
+
+    let mut tls_config =
+        rustls::ServerConfig::builder_with_protocol_versions(&[&rustls::version::TLS13])
+            .with_client_cert_verifier(client_verifier)
+            .with_single_cert(vec![agent_cert.cert.der().clone()], agent_key)?;
+    tls_config.alpn_protocols = vec![ALPN.to_vec()];
+
+    let mut config =
+        quinn::ServerConfig::with_crypto(Arc::new(QuicServerConfig::try_from(tls_config)?));
+    config.transport_config(Arc::new(transport_config(None)));
+
+    Ok(config)
+}
+
+/// Builds the operator side of the QUIC connection.
+///
+/// `cert_pem` and `key_pem` are the operator's own certificate and private key. The same
+/// certificate is handed to agents so that they can pin it, and it is presented here as the client
+/// certificate that the agent checks against that pin.
+pub fn client_config(cert_pem: &str, key_pem: &str) -> Result<quinn::ClientConfig, QuicSetupError> {
+    let chain = CertificateDer::pem_slice_iter(cert_pem.as_bytes())
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(QuicSetupError::MalformedOperatorCert)?;
+    if chain.is_empty() {
+        return Err(QuicSetupError::NoOperatorCert);
+    }
+    let key = PrivateKeyDer::from_pem_slice(key_pem.as_bytes())
+        .map_err(QuicSetupError::MalformedOperatorKey)?;
+
+    let mut tls_config =
+        rustls::ClientConfig::builder_with_protocol_versions(&[&rustls::version::TLS13])
+            .dangerous()
+            .with_custom_certificate_verifier(Arc::new(DangerousNoVerifierServer))
+            .with_client_auth_cert(chain, key)?;
+    tls_config.alpn_protocols = vec![ALPN.to_vec()];
+
+    let mut config = quinn::ClientConfig::new(Arc::new(QuicClientConfig::try_from(tls_config)?));
+    config.transport_config(Arc::new(transport_config(Some(KEEP_ALIVE_INTERVAL))));
+
+    Ok(config)
+}
+
+fn transport_config(keep_alive: Option<Duration>) -> quinn::TransportConfig {
+    let mut config = quinn::TransportConfig::default();
+    config
+        .max_idle_timeout(Some(
+            MAX_IDLE_TIMEOUT
+                .try_into()
+                .expect("idle timeout is within QUIC's representable range"),
+        ))
+        .keep_alive_interval(keep_alive)
+        .max_concurrent_bidi_streams(MAX_CONCURRENT_STREAMS.into())
+        .max_concurrent_uni_streams(0_u32.into())
+        .stream_receive_window(STREAM_RECEIVE_WINDOW.into())
+        .receive_window(CONNECTION_RECEIVE_WINDOW.into());
+    config
+}
+
+/// The operator's side of the QUIC transport.
+///
+/// One endpoint, and therefore one UDP socket and one driver task, serves connections to every
+/// agent. QUIC multiplexes them by connection id rather than by socket, so there is nothing to
+/// gain from a socket per agent.
+#[derive(Clone)]
+pub struct ClientEndpoint {
+    endpoint: quinn::Endpoint,
+    /// Whether the socket is IPv6 and reaches IPv4 peers through IPv4-mapped addresses.
+    dual_stack: bool,
+}
+
+impl ClientEndpoint {
+    /// Binds the endpoint on an ephemeral port.
+    ///
+    /// Prefers a dual-stack IPv6 socket so that agents on either address family are reachable,
+    /// and falls back to IPv4 if that fails, e.g. because IPv6 is disabled in the cluster.
+    pub fn new(config: quinn::ClientConfig) -> std::io::Result<Self> {
+        let dual_stack_socket = || -> std::io::Result<std::net::UdpSocket> {
+            let socket = socket2::Socket::new(socket2::Domain::IPV6, socket2::Type::DGRAM, None)?;
+            socket.set_only_v6(false)?;
+            socket.bind(&SocketAddr::from((Ipv6Addr::UNSPECIFIED, 0)).into())?;
+            socket.set_nonblocking(true)?;
+            Ok(socket.into())
+        };
+
+        let (socket, dual_stack) = match dual_stack_socket() {
+            Ok(socket) => (socket, true),
+            Err(error) => {
+                tracing::warn!(
+                    %error,
+                    "Failed to bind a dual-stack QUIC socket, falling back to IPv4.",
+                );
+                (
+                    std::net::UdpSocket::bind(SocketAddr::from((Ipv4Addr::UNSPECIFIED, 0)))?,
+                    false,
+                )
+            }
+        };
+
+        let mut endpoint = quinn::Endpoint::new(
+            quinn::EndpointConfig::default(),
+            None,
+            socket,
+            Arc::new(quinn::TokioRuntime),
+        )?;
+        endpoint.set_default_client_config(config);
+
+        Ok(Self {
+            endpoint,
+            dual_stack,
+        })
+    }
+
+    /// Starts a connection to an agent listening at `address`.
+    pub fn connect(&self, address: SocketAddr) -> Result<quinn::Connecting, quinn::ConnectError> {
+        // A dual-stack socket can only send to an IPv4 peer through its IPv4-mapped form.
+        let address = match address {
+            SocketAddr::V4(v4) if self.dual_stack => (v4.ip().to_ipv6_mapped(), v4.port()).into(),
+            other => other,
+        };
+
+        self.endpoint.connect(address, AGENT_SERVER_NAME)
+    }
+
+    /// Waits for all connections on this endpoint to be cleanly shut down.
+    pub async fn wait_idle(&self) {
+        self.endpoint.wait_idle().await
+    }
+}
+
+impl std::fmt::Debug for ClientEndpoint {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ClientEndpoint")
+            .field("local_addr", &self.endpoint.local_addr().ok())
+            .field("dual_stack", &self.dual_stack)
+            .finish()
+    }
+}
+
+/// Opens the control stream on a freshly established connection and negotiates the transport
+/// version. Called by the operator.
+///
+/// A successful QUIC handshake does not on its own mean the peer accepted us: under TLS 1.3 the
+/// client certificate is verified only after the client considers the handshake complete, so a
+/// rejected operator sees `connect` succeed and fails here instead. Treat a connection as usable
+/// only once this call has returned.
+pub async fn open_control_stream(
+    connection: &quinn::Connection,
+) -> Result<ControlStream, ControlStreamError> {
+    let (send, recv) = connection.open_bi().await?;
+    let mut stream = tokio::io::join(recv, send);
+
+    ControlHeader::CURRENT.write_to(&mut stream).await?;
+    let peer = ControlHeader::read_from(&mut stream).await?;
+
+    Ok(ControlStream {
+        connection: connection.clone(),
+        stream,
+        version: peer.version.min(TRANSPORT_VERSION),
+    })
+}
+
+/// Accepts the control stream on a freshly established connection and negotiates the transport
+/// version. Called by the agent.
+pub async fn accept_control_stream(
+    connection: &quinn::Connection,
+) -> Result<ControlStream, ControlStreamError> {
+    let (send, recv) = connection.accept_bi().await?;
+    let mut stream = tokio::io::join(recv, send);
+
+    let peer = ControlHeader::read_from(&mut stream).await?;
+    ControlHeader::CURRENT.write_to(&mut stream).await?;
+
+    Ok(ControlStream {
+        connection: connection.clone(),
+        stream,
+        version: peer.version.min(TRANSPORT_VERSION),
+    })
+}
+
+#[cfg(test)]
+mod test {
+    use std::net::{Ipv4Addr, SocketAddr};
+
+    use mirrord_tls_util::generate_cert;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    use super::*;
+
+    fn install_crypto_provider() {
+        let _ = rustls::crypto::CryptoProvider::install_default(
+            rustls::crypto::aws_lc_rs::default_provider(),
+        );
+    }
+
+    /// Certificate and key PEM for an operator, in the shape the operator generates them.
+    fn operator_pems() -> (String, String) {
+        let cert = generate_cert("operator", None, false).unwrap();
+        (cert.cert.pem(), cert.signing_key.serialize_pem())
+    }
+
+    /// Runs an agent-side endpoint that accepts one connection and echoes the control stream back.
+    async fn spawn_agent(operator_cert_pem: String) -> SocketAddr {
+        let endpoint = quinn::Endpoint::server(
+            server_config(&operator_cert_pem).unwrap(),
+            (Ipv4Addr::LOCALHOST, 0).into(),
+        )
+        .unwrap();
+        let addr = endpoint.local_addr().unwrap();
+
+        tokio::spawn(async move {
+            let connection = endpoint.accept().await.unwrap().await.unwrap();
+            let mut control = accept_control_stream(&connection).await.unwrap();
+            assert_eq!(control.version(), TRANSPORT_VERSION);
+
+            let mut buffer = [0_u8; 5];
+            control.read_exact(&mut buffer).await.unwrap();
+            control.write_all(&buffer).await.unwrap();
+            control.flush().await.unwrap();
+
+            // Report back, on each data stream the peer opens, which connection its header claimed
+            // the stream was for.
+            while let Ok((header, mut stream)) = accept_data_stream(&connection).await {
+                tokio::spawn(async move {
+                    assert_eq!(header.kind, DataStreamKind::TcpOutgoing);
+                    stream
+                        .write_all(&header.connection_id.to_be_bytes())
+                        .await
+                        .unwrap();
+                    // Finishes the sending half, so the peer sees the bytes followed by EOF.
+                    // Dropping without this would reset the stream and discard them.
+                    stream.shutdown().await.unwrap();
+                });
+            }
+        });
+
+        addr
+    }
+
+    fn client_endpoint(config: quinn::ClientConfig) -> quinn::Endpoint {
+        let mut endpoint = quinn::Endpoint::client((Ipv4Addr::LOCALHOST, 0).into()).unwrap();
+        endpoint.set_default_client_config(config);
+        endpoint
+    }
+
+    /// The operator can establish a control stream and exchange bytes over it.
+    #[tokio::test]
+    async fn control_stream_round_trip() {
+        install_crypto_provider();
+
+        let (cert_pem, key_pem) = operator_pems();
+        let addr = spawn_agent(cert_pem.clone()).await;
+
+        let endpoint = client_endpoint(client_config(&cert_pem, &key_pem).unwrap());
+        let connection = endpoint
+            .connect(addr, AGENT_SERVER_NAME)
+            .unwrap()
+            .await
+            .unwrap();
+
+        let mut control = open_control_stream(&connection).await.unwrap();
+        assert_eq!(control.version(), TRANSPORT_VERSION);
+
+        control.write_all(b"hello").await.unwrap();
+        control.flush().await.unwrap();
+        let mut buffer = [0_u8; 5];
+        control.read_exact(&mut buffer).await.unwrap();
+        assert_eq!(&buffer, b"hello");
+    }
+
+    /// A peer holding some other key cannot use the connection, which is the property the TCP
+    /// transport gets from the agent pinning the operator certificate.
+    ///
+    /// The rejection surfaces on the control stream rather than on `connect`, for the reason
+    /// described on [`open_control_stream`].
+    #[tokio::test]
+    async fn rejects_client_with_other_certificate() {
+        install_crypto_provider();
+
+        let (cert_pem, _) = operator_pems();
+        let (other_cert_pem, other_key_pem) = operator_pems();
+        let addr = spawn_agent(cert_pem).await;
+
+        let endpoint = client_endpoint(client_config(&other_cert_pem, &other_key_pem).unwrap());
+        let Ok(connection) = endpoint.connect(addr, AGENT_SERVER_NAME).unwrap().await else {
+            return;
+        };
+
+        assert!(open_control_stream(&connection).await.is_err());
+    }
+
+    /// The endpoint the operator actually uses reaches an agent bound to an IPv4 address, which on
+    /// a dual-stack socket only works through the IPv4-mapped form.
+    #[tokio::test]
+    async fn client_endpoint_reaches_ipv4_agent() {
+        install_crypto_provider();
+
+        let (cert_pem, key_pem) = operator_pems();
+        let addr = spawn_agent(cert_pem.clone()).await;
+
+        let endpoint = ClientEndpoint::new(client_config(&cert_pem, &key_pem).unwrap()).unwrap();
+        let connection = endpoint.connect(addr).unwrap().await.unwrap();
+
+        let mut control = open_control_stream(&connection).await.unwrap();
+        control.write_all(b"hello").await.unwrap();
+        control.flush().await.unwrap();
+        let mut buffer = [0_u8; 5];
+        control.read_exact(&mut buffer).await.unwrap();
+        assert_eq!(&buffer, b"hello");
+    }
+
+    /// Data streams reach the agent carrying the connection they belong to, and stay independent
+    /// of each other.
+    #[tokio::test]
+    async fn data_streams_carry_their_connection() {
+        install_crypto_provider();
+
+        let (cert_pem, key_pem) = operator_pems();
+        let addr = spawn_agent(cert_pem.clone()).await;
+
+        let endpoint = client_endpoint(client_config(&cert_pem, &key_pem).unwrap());
+        let connection = endpoint
+            .connect(addr, AGENT_SERVER_NAME)
+            .unwrap()
+            .await
+            .unwrap();
+
+        let mut control = open_control_stream(&connection).await.unwrap();
+        control.write_all(b"hello").await.unwrap();
+        control.flush().await.unwrap();
+        let mut buffer = [0_u8; 5];
+        control.read_exact(&mut buffer).await.unwrap();
+
+        let opener = control.data_stream_opener();
+
+        // Opened out of order, to show that a stream is matched by its header rather than by the
+        // order the streams were created in.
+        for connection_id in [7_u64, 3, 900] {
+            let mut stream = opener
+                .open(DataStreamHeader {
+                    kind: DataStreamKind::TcpOutgoing,
+                    connection_id,
+                })
+                .await
+                .unwrap();
+
+            let mut reported = [0_u8; 8];
+            stream.read_exact(&mut reported).await.unwrap();
+            assert_eq!(u64::from_be_bytes(reported), connection_id);
+        }
+    }
+
+    #[test]
+    fn data_stream_header_round_trip() {
+        let header = DataStreamHeader {
+            kind: DataStreamKind::TcpOutgoing,
+            connection_id: u64::MAX,
+        };
+        assert_eq!(DataStreamHeader::decode(header.encode()).unwrap(), header);
+    }
+
+    #[test]
+    fn data_stream_header_rejects_unknown_kind() {
+        let mut buffer = DataStreamHeader {
+            kind: DataStreamKind::TcpOutgoing,
+            connection_id: 1,
+        }
+        .encode();
+        buffer[0] = 0xff;
+
+        assert!(matches!(
+            DataStreamHeader::decode(buffer),
+            Err(DataStreamError::UnknownKind(0xff))
+        ));
+    }
+
+    #[test]
+    fn control_header_round_trip() {
+        let header = ControlHeader { version: 7 };
+        assert_eq!(ControlHeader::decode(header.encode()).unwrap(), header);
+    }
+
+    #[test]
+    fn control_header_rejects_foreign_bytes() {
+        let mut buffer = ControlHeader::CURRENT.encode();
+        buffer[0] = b'x';
+        assert!(matches!(
+            ControlHeader::decode(buffer),
+            Err(ControlStreamError::BadMagic)
+        ));
+    }
+}

--- a/mirrord/quic/src/lib.rs
+++ b/mirrord/quic/src/lib.rs
@@ -1,4 +1,7 @@
-//! QUIC transport for the connection between the mirrord Operator and mirrord-agent.
+//! QUIC transport for mirrord's long-lived connections.
+//!
+//! Two hops use it, each with its own ALPN, its own preamble, and its own trust model. This module
+//! is the operator to agent hop; [`session`] is the CLI to operator hop.
 //!
 //! # Why QUIC
 //!
@@ -68,8 +71,9 @@ use rustls::{
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, Join, ReadBuf};
 
 mod error;
+pub mod session;
 
-pub use error::{ControlStreamError, DataStreamError, QuicSetupError};
+pub use error::{ControlStreamError, DataStreamError, QuicSetupError, SessionStreamError};
 
 /// ALPN protocol negotiated on every operator to agent QUIC connection.
 ///
@@ -292,25 +296,45 @@ pub async fn accept_data_stream(
     ))
 }
 
-/// An established control stream, carrying the framed mirrord-protocol message exchange.
+/// A stream that keeps its connection alive for as long as it is held.
 ///
-/// Owns the connection it belongs to, so that holding the control stream keeps the whole QUIC
-/// connection - and any other stream on it - alive.
-pub struct ControlStream {
+/// QUIC closes a connection as soon as the last handle to it is dropped, taking every stream on it
+/// with it. Holding the connection next to the stream means a caller that only keeps the stream -
+/// which is the common case, since the stream is what the codecs are built on - does not silently
+/// lose the connection underneath it.
+pub(crate) struct OwnedStream {
     connection: quinn::Connection,
     stream: BiStream,
+}
+
+impl OwnedStream {
+    pub(crate) fn new(connection: &quinn::Connection, stream: BiStream) -> Self {
+        Self {
+            connection: connection.clone(),
+            stream,
+        }
+    }
+
+    pub(crate) fn connection(&self) -> &quinn::Connection {
+        &self.connection
+    }
+}
+
+/// An established control stream, carrying the framed mirrord-protocol message exchange.
+pub struct ControlStream {
+    stream: OwnedStream,
     version: u16,
 }
 
 impl ControlStream {
     /// The connection this stream belongs to, on which further streams can be opened.
     pub fn connection(&self) -> &quinn::Connection {
-        &self.connection
+        self.stream.connection()
     }
 
     /// A handle for opening data streams on this connection.
     pub fn data_stream_opener(&self) -> DataStreamOpener {
-        DataStreamOpener(self.connection.clone())
+        DataStreamOpener(self.stream.connection().clone())
     }
 
     /// Lower of the two peers' [`TRANSPORT_VERSION`]s, and therefore the set of stream conventions
@@ -323,9 +347,37 @@ impl ControlStream {
 impl fmt::Debug for ControlStream {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ControlStream")
-            .field("peer", &self.connection.remote_address())
+            .field("peer", &self.stream.connection().remote_address())
             .field("version", &self.version)
             .finish()
+    }
+}
+
+impl AsyncRead for OwnedStream {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.stream).poll_read(cx, buf)
+    }
+}
+
+impl AsyncWrite for OwnedStream {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        Pin::new(&mut self.stream).poll_write(cx, buf)
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.stream).poll_flush(cx)
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.stream).poll_shutdown(cx)
     }
 }
 
@@ -421,7 +473,7 @@ pub fn client_config(cert_pem: &str, key_pem: &str) -> Result<quinn::ClientConfi
     Ok(config)
 }
 
-fn transport_config(keep_alive: Option<Duration>) -> quinn::TransportConfig {
+pub(crate) fn transport_config(keep_alive: Option<Duration>) -> quinn::TransportConfig {
     let mut config = quinn::TransportConfig::default();
     config
         .max_idle_timeout(Some(
@@ -437,24 +489,41 @@ fn transport_config(keep_alive: Option<Duration>) -> quinn::TransportConfig {
     config
 }
 
-/// The operator's side of the QUIC transport.
+/// The dialing side of a QUIC transport, used by the operator to reach agents and by the CLI to
+/// reach the operator.
 ///
-/// One endpoint, and therefore one UDP socket and one driver task, serves connections to every
-/// agent. QUIC multiplexes them by connection id rather than by socket, so there is nothing to
-/// gain from a socket per agent.
+/// One endpoint, and therefore one UDP socket and one driver task, serves every connection it
+/// dials. QUIC multiplexes them by connection id rather than by socket, so there is nothing to
+/// gain from a socket per peer.
 #[derive(Clone)]
 pub struct ClientEndpoint {
     endpoint: quinn::Endpoint,
     /// Whether the socket is IPv6 and reaches IPv4 peers through IPv4-mapped addresses.
     dual_stack: bool,
+    /// Server name passed to every [`connect`](Self::connect). Both hops pin their peer's
+    /// certificate rather than checking a name, so this only shows up in logs and TLS errors.
+    server_name: &'static str,
 }
 
 impl ClientEndpoint {
+    /// Binds an endpoint that dials agents.
+    pub fn new(config: quinn::ClientConfig) -> std::io::Result<Self> {
+        Self::with_server_name(config, AGENT_SERVER_NAME)
+    }
+
+    /// Binds an endpoint that dials operators.
+    pub fn new_for_session(config: quinn::ClientConfig) -> std::io::Result<Self> {
+        Self::with_server_name(config, session::OPERATOR_SERVER_NAME)
+    }
+
     /// Binds the endpoint on an ephemeral port.
     ///
-    /// Prefers a dual-stack IPv6 socket so that agents on either address family are reachable,
-    /// and falls back to IPv4 if that fails, e.g. because IPv6 is disabled in the cluster.
-    pub fn new(config: quinn::ClientConfig) -> std::io::Result<Self> {
+    /// Prefers a dual-stack IPv6 socket so that peers on either address family are reachable,
+    /// and falls back to IPv4 if that fails, e.g. because IPv6 is disabled.
+    fn with_server_name(
+        config: quinn::ClientConfig,
+        server_name: &'static str,
+    ) -> std::io::Result<Self> {
         let dual_stack_socket = || -> std::io::Result<std::net::UdpSocket> {
             let socket = socket2::Socket::new(socket2::Domain::IPV6, socket2::Type::DGRAM, None)?;
             socket.set_only_v6(false)?;
@@ -488,10 +557,11 @@ impl ClientEndpoint {
         Ok(Self {
             endpoint,
             dual_stack,
+            server_name,
         })
     }
 
-    /// Starts a connection to an agent listening at `address`.
+    /// Starts a connection to a peer listening at `address`.
     pub fn connect(&self, address: SocketAddr) -> Result<quinn::Connecting, quinn::ConnectError> {
         // A dual-stack socket can only send to an IPv4 peer through its IPv4-mapped form.
         let address = match address {
@@ -499,7 +569,7 @@ impl ClientEndpoint {
             other => other,
         };
 
-        self.endpoint.connect(address, AGENT_SERVER_NAME)
+        self.endpoint.connect(address, self.server_name)
     }
 
     /// Waits for all connections on this endpoint to be cleanly shut down.
@@ -534,8 +604,7 @@ pub async fn open_control_stream(
     let peer = ControlHeader::read_from(&mut stream).await?;
 
     Ok(ControlStream {
-        connection: connection.clone(),
-        stream,
+        stream: OwnedStream::new(connection, stream),
         version: peer.version.min(TRANSPORT_VERSION),
     })
 }
@@ -552,8 +621,7 @@ pub async fn accept_control_stream(
     ControlHeader::CURRENT.write_to(&mut stream).await?;
 
     Ok(ControlStream {
-        connection: connection.clone(),
-        stream,
+        stream: OwnedStream::new(connection, stream),
         version: peer.version.min(TRANSPORT_VERSION),
     })
 }

--- a/mirrord/quic/src/session.rs
+++ b/mirrord/quic/src/session.rs
@@ -1,0 +1,741 @@
+//! QUIC transport for the connection between the mirrord CLI and the Operator.
+//!
+//! # Why QUIC
+//!
+//! The session connection normally reaches the operator through the Kubernetes API server, which
+//! proxies it as a websocket. That path is convenient - it authenticates the user, it needs no
+//! network setup, and it works from anywhere a `kubectl` works - but every byte of the session
+//! crosses a component whose job is serving API requests, and which buffers, rate limits and
+//! disconnects accordingly. Dialing the operator directly takes the API server out of the data
+//! path.
+//!
+//! # Streams
+//!
+//! One bidirectional stream per session, opened by the CLI. After the preamble below it carries
+//! the mirrord-protocol message exchange framed exactly as the websocket carries it, so both ends
+//! reuse their existing codecs. Nothing else is opened on the connection.
+//!
+//! # Trust model
+//!
+//! Taking the API server out of the path also takes out the thing that authenticated the user, so
+//! neither end can be trusted on its own say-so. Both directions are solved by bootstrapping from
+//! the API server path, which is still used to set the session up:
+//!
+//! * **The operator trusts the CLI** because the CLI presents a ticket that the operator issued
+//!   over the API server, to a request the API server had already authenticated. The ticket is
+//!   single use, short lived, and carries the identity it was issued to, so nothing about who the
+//!   caller is travels over QUIC where it could be forged.
+//! * **The CLI trusts the operator** because it pins the exact certificate that the same API server
+//!   response handed it. The operator's certificate is usually self-signed and issued for
+//!   in-cluster service names, so neither a public root nor hostname verification would say
+//!   anything useful about it; byte equality against a certificate fetched over an authenticated
+//!   channel is a stronger statement than either.
+//!
+//! Because the certificate is pinned by value, whatever terminates the advertised address must
+//! pass UDP through rather than terminate TLS itself.
+
+use std::{fmt, io, sync::Arc};
+
+use rustls::{
+    DigitallySignedStruct, SignatureScheme,
+    client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier},
+    crypto::CryptoProvider,
+    pki_types::{CertificateDer, PrivateKeyDer, ServerName, UnixTime},
+};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, ReadBuf};
+
+use crate::{BiStream, KEEP_ALIVE_INTERVAL, OwnedStream, QuicSetupError, SessionStreamError};
+
+/// ALPN protocol negotiated on every CLI to operator QUIC connection.
+///
+/// Distinct from the operator to agent ALPN so that pointing one at the other fails during the
+/// handshake rather than as a confusing preamble mismatch afterwards.
+pub const SESSION_ALPN: &[u8] = b"mirrord-session/1";
+
+/// Highest version of the session stream conventions this build understands.
+///
+/// Both ends exchange this in the preamble and continue with the lower of the two.
+pub const SESSION_VERSION: u16 = 1;
+
+/// Identifies the session stream, so that a peer speaking something else on this port fails
+/// immediately and legibly instead of as a protocol decode error further down.
+const SESSION_MAGIC: [u8; 6] = *b"mrdses";
+
+/// Server name the CLI passes to [`connect`](quinn::Endpoint::connect).
+///
+/// The operator's certificate is pinned by value rather than checked against a name, so this never
+/// has to match anything. It is only ever seen in logs and in TLS-level errors.
+pub const OPERATOR_SERVER_NAME: &str = "mirrord-operator";
+
+/// Largest preamble either end will read.
+///
+/// The preamble length arrives before the preamble itself, so a peer could otherwise ask either
+/// end to allocate an arbitrary amount before it has proven anything at all. The request carries a
+/// ticket, a target and the connect parameters, all of which are far below this.
+pub const MAX_PREAMBLE_LEN: u32 = 64 * 1024;
+
+/// Whether the operator accepted the session, sent as a single byte so an older CLI reading a
+/// status it does not know still knows the session did not start.
+const STATUS_ACCEPTED: u8 = 0;
+
+/// Whether the operator refused the session. Any status other than [`STATUS_ACCEPTED`] means
+/// refused, so a CLI that meets a status a later operator invented still fails closed.
+const STATUS_REFUSED: u8 = 1;
+
+/// An established session stream, carrying the framed mirrord-protocol message exchange.
+pub struct SessionStream {
+    stream: OwnedStream,
+    version: u16,
+}
+
+impl SessionStream {
+    /// Lower of the two peers' [`SESSION_VERSION`]s, and therefore the set of conventions both
+    /// ends can use.
+    pub fn version(&self) -> u16 {
+        self.version
+    }
+}
+
+impl fmt::Debug for SessionStream {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SessionStream")
+            .field("peer", &self.stream.connection().remote_address())
+            .field("version", &self.version)
+            .finish()
+    }
+}
+
+impl AsyncRead for SessionStream {
+    fn poll_read(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> std::task::Poll<io::Result<()>> {
+        std::pin::Pin::new(&mut self.stream).poll_read(cx, buf)
+    }
+}
+
+impl AsyncWrite for SessionStream {
+    fn poll_write(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &[u8],
+    ) -> std::task::Poll<io::Result<usize>> {
+        std::pin::Pin::new(&mut self.stream).poll_write(cx, buf)
+    }
+
+    fn poll_flush(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<io::Result<()>> {
+        std::pin::Pin::new(&mut self.stream).poll_flush(cx)
+    }
+
+    fn poll_shutdown(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<io::Result<()>> {
+        std::pin::Pin::new(&mut self.stream).poll_shutdown(cx)
+    }
+}
+
+/// Reads the magic and returns the version the peer announced.
+async fn read_magic(stream: &mut BiStream) -> Result<u16, SessionStreamError> {
+    let mut head = [0_u8; SESSION_MAGIC.len() + size_of::<u16>()];
+    stream.read_exact(&mut head).await?;
+
+    let (magic, version) = head.split_at(SESSION_MAGIC.len());
+    if magic != SESSION_MAGIC {
+        return Err(SessionStreamError::BadMagic);
+    }
+
+    Ok(u16::from_be_bytes(
+        version.try_into().expect("split at the version offset"),
+    ))
+}
+
+/// Writes the magic and this build's [`SESSION_VERSION`].
+async fn write_magic(stream: &mut BiStream) -> Result<(), SessionStreamError> {
+    stream.write_all(&SESSION_MAGIC).await?;
+    stream.write_all(&SESSION_VERSION.to_be_bytes()).await?;
+
+    Ok(())
+}
+
+/// Reads a length-prefixed payload, refusing an oversized one before allocating for it.
+async fn read_payload(stream: &mut BiStream) -> Result<Vec<u8>, SessionStreamError> {
+    let length = stream.read_u32().await?;
+    if length > MAX_PREAMBLE_LEN {
+        return Err(SessionStreamError::OversizedPreamble(length));
+    }
+
+    let mut payload = vec![0_u8; length as usize];
+    stream.read_exact(&mut payload).await?;
+
+    Ok(payload)
+}
+
+/// Writes a length-prefixed payload and flushes, which is also what makes a freshly opened stream
+/// visible to the peer.
+async fn write_payload(stream: &mut BiStream, payload: &[u8]) -> Result<(), SessionStreamError> {
+    let length = u32::try_from(payload.len())
+        .map_err(|_| SessionStreamError::OversizedPreamble(u32::MAX))?;
+    if length > MAX_PREAMBLE_LEN {
+        return Err(SessionStreamError::OversizedPreamble(length));
+    }
+
+    stream.write_all(&length.to_be_bytes()).await?;
+    stream.write_all(payload).await?;
+    stream.flush().await?;
+
+    Ok(())
+}
+
+/// Opens the session stream on a freshly established connection, sends `request`, and waits for
+/// the operator's verdict. Called by the CLI.
+///
+/// `request` is opaque here: this crate carries it, and the CLI and operator agree on what is in
+/// it. Returning [`SessionStreamError::Refused`] means the operator understood the request and
+/// declined it, and carries a reason meant for the user; every other error means the session never
+/// got that far.
+pub async fn open_session_stream(
+    connection: &quinn::Connection,
+    request: &[u8],
+) -> Result<SessionStream, SessionStreamError> {
+    let (send, recv) = connection.open_bi().await?;
+    let mut stream = tokio::io::join(recv, send);
+
+    write_magic(&mut stream).await?;
+    write_payload(&mut stream, request).await?;
+
+    let peer_version = read_magic(&mut stream).await?;
+    let status = stream.read_u8().await?;
+    let message = read_payload(&mut stream).await?;
+
+    if status != STATUS_ACCEPTED {
+        return Err(SessionStreamError::Refused(
+            String::from_utf8_lossy(&message).into_owned(),
+        ));
+    }
+
+    Ok(SessionStream {
+        stream: OwnedStream::new(connection, stream),
+        version: peer_version.min(SESSION_VERSION),
+    })
+}
+
+/// Binds a local socket, dials the operator at `address`, and opens the session stream on it.
+///
+/// The whole dial in one call so that callers need nothing from `quinn` itself. The endpoint is
+/// dropped on the way out; quinn keeps its driver alive while the connection is, so the returned
+/// stream is all there is to hold onto.
+pub async fn connect(
+    config: quinn::ClientConfig,
+    address: std::net::SocketAddr,
+    request: &[u8],
+) -> Result<SessionStream, SessionStreamError> {
+    let endpoint =
+        crate::ClientEndpoint::new_for_session(config).map_err(SessionStreamError::Bind)?;
+    let connection = endpoint.connect(address)?.await?;
+
+    open_session_stream(&connection, request).await
+}
+
+/// A session the CLI has asked for, which the operator has not yet accepted or refused.
+///
+/// Deciding takes the whole connect flow - license, policy, Kubernetes permissions, acquiring the
+/// session, starting an agent - so the request is read and answered as two separate steps, and the
+/// stream is held in between.
+pub struct PendingSession {
+    connection: quinn::Connection,
+    stream: BiStream,
+    version: u16,
+}
+
+impl PendingSession {
+    /// Lower of the two peers' [`SESSION_VERSION`]s.
+    pub fn version(&self) -> u16 {
+        self.version
+    }
+
+    /// The address the request came from, for logging.
+    pub fn peer(&self) -> std::net::SocketAddr {
+        self.connection.remote_address()
+    }
+
+    /// A handle to the underlying connection, which survives this session being accepted.
+    pub fn connection(&self) -> SessionConnection {
+        SessionConnection(self.connection.clone())
+    }
+
+    /// Tells the CLI the session is starting, and hands back the stream it will run on.
+    pub async fn accept(mut self) -> Result<SessionStream, SessionStreamError> {
+        write_magic(&mut self.stream).await?;
+        self.stream.write_u8(STATUS_ACCEPTED).await?;
+        write_payload(&mut self.stream, &[]).await?;
+
+        Ok(SessionStream {
+            stream: OwnedStream::new(&self.connection, self.stream),
+            version: self.version,
+        })
+    }
+
+    /// Tells the CLI why the session is not starting.
+    ///
+    /// Sent on the stream rather than as a connection close so that the reason survives as text
+    /// the CLI can show, instead of becoming a QUIC error code.
+    pub async fn refuse(mut self, reason: &str) -> Result<(), SessionStreamError> {
+        // Any status other than STATUS_ACCEPTED means refused; the reason is the useful part.
+        write_magic(&mut self.stream).await?;
+        self.stream.write_u8(STATUS_REFUSED).await?;
+        write_payload(&mut self.stream, reason.as_bytes()).await?;
+        self.stream.shutdown().await?;
+
+        Ok(())
+    }
+}
+
+impl fmt::Debug for PendingSession {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PendingSession")
+            .field("peer", &self.connection.remote_address())
+            .field("version", &self.version)
+            .finish()
+    }
+}
+
+/// Accepts the session stream on a freshly established connection and reads the CLI's request.
+/// Called by the operator.
+pub async fn accept_session_stream(
+    connection: &quinn::Connection,
+) -> Result<(Vec<u8>, PendingSession), SessionStreamError> {
+    let (send, recv) = connection.accept_bi().await?;
+    let mut stream = tokio::io::join(recv, send);
+
+    let peer_version = read_magic(&mut stream).await?;
+    let request = read_payload(&mut stream).await?;
+
+    Ok((
+        request,
+        PendingSession {
+            connection: connection.clone(),
+            stream,
+            version: peer_version.min(SESSION_VERSION),
+        },
+    ))
+}
+
+/// Builds the operator side of the QUIC configuration.
+///
+/// `chain` and `key` are the operator's own serving certificate and private key - the same ones it
+/// serves its API with, so that the certificate a CLI pins from the API response is the one it
+/// meets here. Clients are not asked for a certificate; the ticket in the request is what
+/// authenticates them.
+pub fn server_config(
+    chain: Vec<CertificateDer<'static>>,
+    key: PrivateKeyDer<'static>,
+) -> Result<quinn::ServerConfig, QuicSetupError> {
+    if chain.is_empty() {
+        return Err(QuicSetupError::NoOperatorCert);
+    }
+
+    let mut tls_config =
+        rustls::ServerConfig::builder_with_protocol_versions(&[&rustls::version::TLS13])
+            .with_no_client_auth()
+            .with_single_cert(chain, key)?;
+    tls_config.alpn_protocols = vec![SESSION_ALPN.to_vec()];
+
+    let mut config = quinn::ServerConfig::with_crypto(Arc::new(
+        quinn::crypto::rustls::QuicServerConfig::try_from(tls_config)?,
+    ));
+    config.transport_config(Arc::new(crate::transport_config(None)));
+
+    Ok(config)
+}
+
+/// The operator's side of the QUIC transport: one UDP socket accepting session connections.
+///
+/// Wraps quinn rather than exposing it so that the operator, which otherwise has no QUIC in it,
+/// does not take on the dependency for the sake of four calls.
+pub struct SessionListener(quinn::Endpoint);
+
+impl SessionListener {
+    /// Binds the listener, serving `chain` as the operator's certificate.
+    pub fn bind(
+        address: std::net::SocketAddr,
+        chain: Vec<CertificateDer<'static>>,
+        key: PrivateKeyDer<'static>,
+    ) -> Result<Self, QuicSetupError> {
+        let config = server_config(chain, key)?;
+
+        quinn::Endpoint::server(config, address)
+            .map(Self)
+            .map_err(QuicSetupError::Bind)
+    }
+
+    pub fn local_addr(&self) -> Option<std::net::SocketAddr> {
+        self.0.local_addr().ok()
+    }
+
+    /// Waits for the next connection. `None` once the listener has been closed.
+    pub async fn accept(&self) -> Option<IncomingSession> {
+        self.0.accept().await.map(IncomingSession)
+    }
+
+    /// Refuses further connections and tells current peers why, rather than leaving them to time
+    /// out.
+    pub fn close(&self, reason: &[u8]) {
+        self.0.close(0_u32.into(), reason);
+    }
+}
+
+/// A connection that has arrived but whose handshake has not completed.
+pub struct IncomingSession(quinn::Incoming);
+
+impl IncomingSession {
+    pub fn peer(&self) -> std::net::SocketAddr {
+        self.0.remote_address()
+    }
+
+    /// Completes the handshake and reads the request the client opened with.
+    pub async fn accept(self) -> Result<(Vec<u8>, PendingSession), SessionStreamError> {
+        let connection = self.0.await?;
+
+        accept_session_stream(&connection).await
+    }
+}
+
+/// A handle to the connection a session arrived on, which outlives the stream itself.
+///
+/// Needed because a session can be refused after its stream has already been handed off, at which
+/// point the only way left to say so is to close the connection.
+#[derive(Clone)]
+pub struct SessionConnection(quinn::Connection);
+
+impl SessionConnection {
+    pub fn peer(&self) -> std::net::SocketAddr {
+        self.0.remote_address()
+    }
+
+    /// Closes the connection, carrying a code and a reason the peer can read.
+    pub fn close(&self, code: u32, reason: &[u8]) {
+        self.0.close(code.into(), reason);
+    }
+}
+
+impl fmt::Debug for SessionConnection {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("SessionConnection")
+            .field(&self.0.remote_address())
+            .finish()
+    }
+}
+
+/// Builds the CLI side of the QUIC connection.
+///
+/// `operator_cert_der` is the operator's certificate exactly as it came back over the Kubernetes
+/// API server, and is the only certificate this connection will accept. Taken as raw DER so that
+/// callers need nothing from `rustls` either.
+pub fn client_config(operator_cert_der: Vec<u8>) -> Result<quinn::ClientConfig, QuicSetupError> {
+    let operator_cert = CertificateDer::from(operator_cert_der);
+
+    let builder = rustls::ClientConfig::builder_with_protocol_versions(&[&rustls::version::TLS13]);
+    // Taken from the builder rather than from `CryptoProvider::get_default`, which is only set
+    // once something has installed a process-wide default. The builder falls back to the one the
+    // crate features selected, so this works in a process that never installed one.
+    let provider = builder.crypto_provider().clone();
+
+    let mut tls_config = builder
+        .dangerous()
+        .with_custom_certificate_verifier(Arc::new(PinnedServerCert {
+            expected: operator_cert,
+            provider,
+        }))
+        .with_no_client_auth();
+    tls_config.alpn_protocols = vec![SESSION_ALPN.to_vec()];
+
+    let mut config = quinn::ClientConfig::new(Arc::new(
+        quinn::crypto::rustls::QuicClientConfig::try_from(tls_config)?,
+    ));
+    config.transport_config(Arc::new(crate::transport_config(Some(KEEP_ALIVE_INTERVAL))));
+
+    Ok(config)
+}
+
+/// Accepts one specific certificate, by value, and nothing else.
+///
+/// Neither the name nor the validity period is checked. Both exist to answer "is this the peer I
+/// meant, and is this certificate still one it should be using", and a certificate fetched from
+/// that same peer over an authenticated channel moments earlier answers both more directly.
+#[derive(Debug)]
+struct PinnedServerCert {
+    expected: CertificateDer<'static>,
+    provider: Arc<CryptoProvider>,
+}
+
+impl ServerCertVerifier for PinnedServerCert {
+    fn verify_server_cert(
+        &self,
+        end_entity: &CertificateDer<'_>,
+        _intermediates: &[CertificateDer<'_>],
+        _server_name: &ServerName<'_>,
+        _ocsp_response: &[u8],
+        _now: UnixTime,
+    ) -> Result<ServerCertVerified, rustls::Error> {
+        if *end_entity == self.expected {
+            Ok(ServerCertVerified::assertion())
+        } else {
+            Err(rustls::Error::InvalidCertificate(
+                rustls::CertificateError::ApplicationVerificationFailure,
+            ))
+        }
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer<'_>,
+        _dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        // QUIC is TLS 1.3 only, so reaching this means the configuration was built wrong.
+        Err(rustls::Error::PeerIncompatible(
+            rustls::PeerIncompatible::Tls12NotOffered,
+        ))
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        rustls::crypto::verify_tls13_signature(
+            message,
+            cert,
+            dss,
+            &self.provider.signature_verification_algorithms,
+        )
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        self.provider
+            .signature_verification_algorithms
+            .supported_schemes()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::net::{Ipv4Addr, SocketAddr};
+
+    use mirrord_tls_util::generate_cert;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    use super::*;
+    use crate::ClientEndpoint;
+
+    fn install_crypto_provider() {
+        let _ = CryptoProvider::install_default(rustls::crypto::aws_lc_rs::default_provider());
+    }
+
+    /// A serving certificate in the shape the operator makes one: self-signed, for in-cluster
+    /// service names that a CLI dialing an external address could never match.
+    fn operator_cert() -> (CertificateDer<'static>, PrivateKeyDer<'static>) {
+        let cert = generate_cert("mirrord-operator.mirrord.svc", None, false).unwrap();
+        let key = PrivateKeyDer::try_from(cert.signing_key.serialize_der()).unwrap();
+        (cert.cert.der().clone(), key)
+    }
+
+    /// Runs an operator-side endpoint that accepts one session and either serves or refuses it.
+    ///
+    /// When it serves, it echoes the stream back so a test can prove the session bytes flow. The
+    /// request comes back over a channel rather than as the task's result, because the task has to
+    /// outlive the client: dropping the connection closes it and discards anything the client has
+    /// not read yet.
+    async fn spawn_operator(
+        chain: Vec<CertificateDer<'static>>,
+        key: PrivateKeyDer<'static>,
+        refuse_with: Option<&'static str>,
+    ) -> (SocketAddr, tokio::sync::oneshot::Receiver<Vec<u8>>) {
+        let endpoint = quinn::Endpoint::server(
+            server_config(chain, key).unwrap(),
+            (Ipv4Addr::LOCALHOST, 0).into(),
+        )
+        .unwrap();
+        let address = endpoint.local_addr().unwrap();
+        let (request_tx, request_rx) = tokio::sync::oneshot::channel();
+
+        tokio::spawn(async move {
+            let connection = endpoint.accept().await.unwrap().await.unwrap();
+            let (request, pending) = accept_session_stream(&connection).await.unwrap();
+            let _ = request_tx.send(request);
+
+            match refuse_with {
+                Some(reason) => {
+                    pending.refuse(reason).await.unwrap();
+                }
+                None => {
+                    let mut stream = pending.accept().await.unwrap();
+                    let mut echoed = [0_u8; 5];
+                    stream.read_exact(&mut echoed).await.unwrap();
+                    stream.write_all(&echoed).await.unwrap();
+                    stream.flush().await.unwrap();
+                }
+            }
+
+            connection.closed().await;
+        });
+
+        (address, request_rx)
+    }
+
+    /// The happy path: the CLI pins the certificate it was handed, the operator accepts, and the
+    /// request arrives intact along with a stream that carries bytes both ways.
+    #[tokio::test]
+    async fn session_stream_round_trip() {
+        install_crypto_provider();
+
+        let (cert, key) = operator_cert();
+        let (address, request) = spawn_operator(vec![cert.clone()], key, None).await;
+
+        let endpoint =
+            ClientEndpoint::new_for_session(client_config(cert.to_vec()).unwrap()).unwrap();
+        let connection = endpoint.connect(address).unwrap().await.unwrap();
+        let mut stream = open_session_stream(&connection, b"ticket-and-target")
+            .await
+            .unwrap();
+
+        assert_eq!(stream.version(), SESSION_VERSION);
+
+        stream.write_all(b"hello").await.unwrap();
+        stream.flush().await.unwrap();
+        let mut echoed = [0_u8; 5];
+        stream.read_exact(&mut echoed).await.unwrap();
+        assert_eq!(&echoed, b"hello");
+
+        assert_eq!(request.await.unwrap(), b"ticket-and-target");
+    }
+
+    /// A refusal has to reach the user as text. The CLI must be able to tell "the operator said
+    /// no, and here is why" apart from "the connection broke".
+    #[tokio::test]
+    async fn refusal_carries_its_reason() {
+        install_crypto_provider();
+
+        let (cert, key) = operator_cert();
+        let (address, _request) =
+            spawn_operator(vec![cert.clone()], key, Some("ticket expired")).await;
+
+        let endpoint =
+            ClientEndpoint::new_for_session(client_config(cert.to_vec()).unwrap()).unwrap();
+        let connection = endpoint.connect(address).unwrap().await.unwrap();
+
+        let error = open_session_stream(&connection, b"ticket-and-target")
+            .await
+            .expect_err("the operator refused this session");
+
+        assert!(
+            matches!(&error, SessionStreamError::Refused(reason) if reason == "ticket expired"),
+            "expected a refusal carrying its reason, got {error:?}",
+        );
+    }
+
+    /// An operator presenting any other certificate must be rejected, even though that certificate
+    /// is perfectly valid and self-signed the exact same way. This is the whole point of pinning:
+    /// there is no CA in the picture that could vouch for a substitute.
+    #[tokio::test]
+    async fn rejects_operator_with_other_certificate() {
+        install_crypto_provider();
+
+        let (served_cert, served_key) = operator_cert();
+        let (pinned_cert, _) = operator_cert();
+        let (address, _request) = spawn_operator(vec![served_cert], served_key, None).await;
+
+        let endpoint =
+            ClientEndpoint::new_for_session(client_config(pinned_cert.to_vec()).unwrap()).unwrap();
+        let result = endpoint.connect(address).unwrap().await;
+
+        assert!(
+            result.is_err(),
+            "connecting to an operator serving an unpinned certificate should fail",
+        );
+    }
+
+    /// A peer that announces a huge preamble must be refused before anything is allocated for it,
+    /// since the length arrives before any ticket has been checked.
+    #[tokio::test]
+    async fn rejects_oversized_preamble() {
+        install_crypto_provider();
+
+        let (cert, key) = operator_cert();
+        let endpoint = quinn::Endpoint::server(
+            server_config(vec![cert.clone()], key).unwrap(),
+            (Ipv4Addr::LOCALHOST, 0).into(),
+        )
+        .unwrap();
+        let address = endpoint.local_addr().unwrap();
+
+        let operator = tokio::spawn(async move {
+            let connection = endpoint.accept().await.unwrap().await.unwrap();
+            accept_session_stream(&connection).await
+        });
+
+        let client =
+            ClientEndpoint::new_for_session(client_config(cert.to_vec()).unwrap()).unwrap();
+        let connection = client.connect(address).unwrap().await.unwrap();
+        let (mut send, _recv) = connection.open_bi().await.unwrap();
+        send.write_all(&SESSION_MAGIC).await.unwrap();
+        send.write_all(&SESSION_VERSION.to_be_bytes())
+            .await
+            .unwrap();
+        send.write_all(&(MAX_PREAMBLE_LEN + 1).to_be_bytes())
+            .await
+            .unwrap();
+        send.flush().await.unwrap();
+
+        let error = operator
+            .await
+            .unwrap()
+            .expect_err("an oversized preamble should be refused");
+        assert!(
+            matches!(error, SessionStreamError::OversizedPreamble(..)),
+            "expected an oversized preamble error, got {error:?}",
+        );
+    }
+
+    /// Something that is not this transport at all must fail as a legible magic mismatch rather
+    /// than as a decode error further down.
+    #[tokio::test]
+    async fn rejects_foreign_preamble() {
+        install_crypto_provider();
+
+        let (cert, key) = operator_cert();
+        let endpoint = quinn::Endpoint::server(
+            server_config(vec![cert.clone()], key).unwrap(),
+            (Ipv4Addr::LOCALHOST, 0).into(),
+        )
+        .unwrap();
+        let address = endpoint.local_addr().unwrap();
+
+        let operator = tokio::spawn(async move {
+            let connection = endpoint.accept().await.unwrap().await.unwrap();
+            accept_session_stream(&connection).await
+        });
+
+        let client =
+            ClientEndpoint::new_for_session(client_config(cert.to_vec()).unwrap()).unwrap();
+        let connection = client.connect(address).unwrap().await.unwrap();
+        let (mut send, _recv) = connection.open_bi().await.unwrap();
+        send.write_all(b"GET / HTTP/1.1\r\n").await.unwrap();
+        send.flush().await.unwrap();
+
+        let error = operator
+            .await
+            .unwrap()
+            .expect_err("a foreign preamble should be refused");
+        assert!(
+            matches!(error, SessionStreamError::BadMagic),
+            "expected a magic mismatch, got {error:?}",
+        );
+    }
+}


### PR DESCRIPTION
Draft. The operator-side counterpart is a separate PR and pins this branch; neither merges alone.

## What

The agent accepts QUIC on its client port alongside TCP. A control stream carries the existing framed protocol unchanged. Each **outgoing TCP** connection then gets its own bidirectional stream carrying raw bytes, so it has its own ordering and its own flow-control window.

## Why

A session multiplexes every connection onto one operator-agent link. A large or slow outgoing transfer holds up everything else behind it. Per-stream flow control also replaces the shared throttling semaphore for spliced connections, and applies per connection rather than across all of them.

## Design notes

- **The operator opens data streams, never the agent.** A connection is reported on the control stream before its stream exists, so the agent's lookup cannot miss and neither side parks a stream it cannot match.
- **Backpressure stays in the kernel.** Until a stream arrives the agent leaves the socket unread, so early data waits in the receive buffer rather than being buffered in the agent.
- **Lifecycle rides on the stream** rather than racing it on the control stream: finishing a sending half is a shutdown, resetting is a close. That keeps a close ordered behind the writes before it — a real hazard if closes had stayed on the control stream while data moved to another.
- **Negotiation:** transport version 2 enables splicing; both ends take the lower version, so a new operator against an old agent degrades to version 1 (QUIC, everything relayed as messages) rather than breaking.

## Scope

Outgoing TCP only. Stolen incoming traffic is untouched. HTTP-filtered steal can never use this, since the agent parses HTTP and sends request objects rather than raw bytes. UDP outgoing and unix seqpacket are message-oriented and stay on the control stream.

QUIC requires the agent to have an operator certificate to pin, which is only provisioned when `agent.tls` is enabled.

## Measurements

Local cluster, operator path, one large outgoing transfer concurrent with five small outgoing request streams. Transport verified per arm from operator logs. Three interleaved rounds; TCP arm forced with the operator's kill switch.

Small-request latency while the transfer runs:

| round | arm | p50 | p90 | throughput | transferred |
|---|---|---|---|---|---|
| 1 | QUIC | 1.85 ms | **3.18 ms** | 968 rt/s | 516 MB |
| 1 | TCP | 2.08 ms | **80.0 ms** | 270 rt/s | 206 MB |
| 2 | QUIC | 1.93 ms | **20.4 ms** | 972 rt/s | 523 MB |
| 2 | TCP | 2.04 ms | **78.5 ms** | 447 rt/s | 312 MB |
| 3 | QUIC | 1.91 ms | **8.08 ms** | 986 rt/s | 529 MB |
| 3 | TCP | 2.06 ms | **73.3 ms** | 453 rt/s | 319 MB |

Small-request throughput is ~2.2x higher and the large transfer moves ~1.7x more data, so the tail improvement is not bought by starving the transfer. Worst observed small-request latency was 5,792 ms on TCP against 57-83 ms across every QUIC run.

**Cost:** operator CPU peaked at 82/169/69m on QUIC against 53/13/14m on TCP, roughly 2-3x for the same work. Userspace packet handling. Worth watching before this reaches a busy cluster.

## Also in here

`TcpOutgoingTask::drop` counted readers and writers separately, double-counting every relayed connection against a single increment when it opened. That line had to change to count spliced connections, so it now de-duplicates — a behaviour change to an existing metric.

## Testing

`mirrord-quic` has unit tests including data streams opened out of order, to prove they are matched by header rather than creation order. Clippy clean with `--deny warnings`. The agent is checked in a Linux container.

Verified end to end against a local cluster with `transport_version=2` confirmed on the operator side each run. Not yet exercised against a shared or remote cluster, and outgoing-connection semantics (half-close, error propagation) are rebuilt on stream lifecycle rather than messages, so that is where a regression would most likely hide.