### PR TITLE
deps: update kube fork to 4.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,7 +307,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -318,7 +318,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2516,7 +2516,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2825,7 +2825,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3347,16 +3347,6 @@ dependencies = [
 
 [[package]]
 name = "granit-parser"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50ba32164f9e098d5da618776a32afbb32270adcbe3d3d006107dae11e37c91"
-dependencies = [
- "arraydeque",
- "smallvec",
-]
-
-[[package]]
-name = "granit-parser"
 version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d03f81ad4732830d85cfd417a9f62cde6dadda4354d37d078a6084a19560aa2d"
@@ -3787,7 +3777,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -3820,7 +3810,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -4106,7 +4096,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4121,7 +4111,7 @@ version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82cb6a9f675da968c63b6208c641b9dca58fc0133ae53375736b1767b0cab8bd"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4491,8 +4481,8 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "4.0.0"
-source = "git+https://github.com/metalbear-co/kube.git?rev=ae49cce192b85db3d734d290a6031aa2d9ac60e0#ae49cce192b85db3d734d290a6031aa2d9ac60e0"
+version = "4.2.0"
+source = "git+https://github.com/metalbear-co/kube.git?rev=6cbb2e8bef0b905edcecc7e0cf8e1804f7b02c67#6cbb2e8bef0b905edcecc7e0cf8e1804f7b02c67"
 dependencies = [
  "k8s-openapi",
  "kube-client",
@@ -4503,8 +4493,8 @@ dependencies = [
 
 [[package]]
 name = "kube-client"
-version = "4.0.0"
-source = "git+https://github.com/metalbear-co/kube.git?rev=ae49cce192b85db3d734d290a6031aa2d9ac60e0#ae49cce192b85db3d734d290a6031aa2d9ac60e0"
+version = "4.2.0"
+source = "git+https://github.com/metalbear-co/kube.git?rev=6cbb2e8bef0b905edcecc7e0cf8e1804f7b02c67#6cbb2e8bef0b905edcecc7e0cf8e1804f7b02c67"
 dependencies = [
  "base64",
  "bytes",
@@ -4527,7 +4517,7 @@ dependencies = [
  "rustls-platform-verifier",
  "secrecy",
  "serde",
- "serde-saphyr 0.0.27",
+ "serde-saphyr",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
@@ -4540,8 +4530,8 @@ dependencies = [
 
 [[package]]
 name = "kube-core"
-version = "4.0.0"
-source = "git+https://github.com/metalbear-co/kube.git?rev=ae49cce192b85db3d734d290a6031aa2d9ac60e0#ae49cce192b85db3d734d290a6031aa2d9ac60e0"
+version = "4.2.0"
+source = "git+https://github.com/metalbear-co/kube.git?rev=6cbb2e8bef0b905edcecc7e0cf8e1804f7b02c67#6cbb2e8bef0b905edcecc7e0cf8e1804f7b02c67"
 dependencies = [
  "derive_more",
  "form_urlencoded",
@@ -4558,8 +4548,8 @@ dependencies = [
 
 [[package]]
 name = "kube-derive"
-version = "4.0.0"
-source = "git+https://github.com/metalbear-co/kube.git?rev=ae49cce192b85db3d734d290a6031aa2d9ac60e0#ae49cce192b85db3d734d290a6031aa2d9ac60e0"
+version = "4.2.0"
+source = "git+https://github.com/metalbear-co/kube.git?rev=6cbb2e8bef0b905edcecc7e0cf8e1804f7b02c67#6cbb2e8bef0b905edcecc7e0cf8e1804f7b02c67"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -4571,8 +4561,8 @@ dependencies = [
 
 [[package]]
 name = "kube-runtime"
-version = "4.0.0"
-source = "git+https://github.com/metalbear-co/kube.git?rev=ae49cce192b85db3d734d290a6031aa2d9ac60e0#ae49cce192b85db3d734d290a6031aa2d9ac60e0"
+version = "4.2.0"
+source = "git+https://github.com/metalbear-co/kube.git?rev=6cbb2e8bef0b905edcecc7e0cf8e1804f7b02c67#6cbb2e8bef0b905edcecc7e0cf8e1804f7b02c67"
 dependencies = [
  "ahash",
  "async-broadcast",
@@ -5158,7 +5148,7 @@ dependencies = [
  "pem",
  "reqwest 0.13.4",
  "serde",
- "serde-saphyr 0.0.29",
+ "serde-saphyr",
  "thiserror 2.0.18",
  "tokio",
  "tower-test",
@@ -5191,7 +5181,7 @@ dependencies = [
  "schemars 1.2.1",
  "semver 1.0.28",
  "serde",
- "serde-saphyr 0.0.29",
+ "serde-saphyr",
  "serde_json",
  "sha2 0.10.9",
  "str-win",
@@ -5500,7 +5490,7 @@ dependencies = [
  "schemars 1.2.1",
  "semver 1.0.28",
  "serde",
- "serde-saphyr 0.0.29",
+ "serde-saphyr",
  "serde_json",
  "serde_urlencoded",
  "sha2 0.10.9",
@@ -5938,7 +5928,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6959,7 +6949,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6998,9 +6988,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7623,7 +7613,7 @@ dependencies = [
  "errno 0.3.14",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7704,7 +7694,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7959,25 +7949,6 @@ dependencies = [
 
 [[package]]
 name = "serde-saphyr"
-version = "0.0.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5897b4c3faadadd35fdb6689f015641f3bc481d5adaaac56231ea15aeb243db3"
-dependencies = [
- "ahash",
- "annotate-snippets",
- "base64",
- "encoding_rs_io",
- "getrandom 0.3.4",
- "granit-parser 0.0.3",
- "nohash-hasher",
- "num-traits",
- "serde",
- "smallvec",
- "zmij",
-]
-
-[[package]]
-name = "serde-saphyr"
 version = "0.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bd22781911de0ca6debda95f073c8f18bec65d1a94f1fa9573f3102e514cea4"
@@ -7987,7 +7958,7 @@ dependencies = [
  "base64",
  "encoding_rs_io",
  "getrandom 0.3.4",
- "granit-parser 0.0.7",
+ "granit-parser",
  "nohash-hasher",
  "num-traits",
  "serde_core",
@@ -8329,7 +8300,7 @@ version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
- "errno 0.3.14",
+ "errno 0.2.8",
  "libc",
 ]
 
@@ -8437,7 +8408,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8693,7 +8664,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8736,7 +8707,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9844,7 +9815,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -9860,7 +9831,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
  "windows-collections",
- "windows-core 0.61.2",
+ "windows-core",
  "windows-future",
  "windows-link 0.1.3",
  "windows-numerics",
@@ -9872,7 +9843,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -9889,25 +9860,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
-]
-
-[[package]]
 name = "windows-future"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
  "windows-link 0.1.3",
  "windows-threading",
 ]
@@ -9952,7 +9910,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
  "windows-link 0.1.3",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,7 +156,7 @@ jaq-json = "1.1.3"
 jaq-std = "2.1.2"
 k8s-cri = "0.11"
 k8s-openapi = { version = "0.28", features = ["v1_32"] }
-kube = { git = "https://github.com/metalbear-co/kube.git", rev = "ae49cce192b85db3d734d290a6031aa2d9ac60e0", default-features = false, features = [
+kube = { git = "https://github.com/metalbear-co/kube.git", rev = "6cbb2e8bef0b905edcecc7e0cf8e1804f7b02c67", default-features = false, features = [
     "runtime",
     "derive",
     "client",

--- a/changelog.d/+kube-4-2.changed.md
+++ b/changelog.d/+kube-4-2.changed.md
@@ -1,0 +1,2 @@
+Updated the `kube` fork to 4.2.0. `TCP_NODELAY` is now set on connections to the Kubernetes API
+server, so requests are not held back by Nagle's algorithm.


### PR DESCRIPTION
Moves the `kube` fork pin from `ae49cce` to `6cbb2e8` (the fork's current `main`), taking it from 4.0.0 to 4.2.0.

## What this brings in

- `TCP_NODELAY` is set on the default connector, so requests to the Kubernetes API server are not held back by Nagle's algorithm.
- Ordering derives on label selector expressions.
- Upstream `kube` 4.0.0 → 4.2.0.

`k8s-openapi` stays on 0.28, so no API surface change there. The fork's MSRV moves to 1.89, which is well under the pinned toolchain.

## Verification

- `cargo check --workspace --all-targets` passes (CLI checked separately with a built layer via `MIRRORD_LAYER_FILE`).
- `cargo clippy` clean on every kube-dependent crate: `mirrord-kube`, `mirrord-operator`, `mirrord-auth`, `mirrord-vpn`, `mirrord-up`, `mirrord-intproxy`, `mirrord`.

No code changes were needed — the bump is source-compatible.

## Note for the operator

The operator pins `kube` to the same rev as the one used by its mirrord dependencies, so its bump also has to move its mirrord pin to this commit. That PR is up and blocked on this one merging.