### PR TITLE
Set `includeAuthors` and `disabledLabels` for Greptile

### DIFF
--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -1,0 +1,21 @@
+{
+  "includeAuthors": [
+    "0x00A5",
+    "aviramha",
+    "cristeigabriela",
+    "DmitryDodzin",
+    "eyalb181",
+    "gememma",
+    "giIuis",
+    "hank-metalbear",
+    "iniw",
+    "itsamegraf",
+    "meowjesty",
+    "MintSoup",
+    "Razz4780",
+    "skreborn",
+    "t4lz",
+    "vladrbg"
+  ],
+  "disabledLabels": ["no-greptile"]
+}

--- a/.vale/styles/config/vocabularies/Metalbear/accept.txt
+++ b/.vale/styles/config/vocabularies/Metalbear/accept.txt
@@ -172,6 +172,8 @@ jq
 jaq
 towncrier
 Bubblewrap
+greptile
+Greptile
 
 # Cloud services
 SNS

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -698,6 +698,13 @@ The xtask approach is preferred for new development as it provides better error 
 
 # Submitting a Pull Request
 
+## Greptile Reviews
+
+Greptile may review pull requests automatically. Authors and maintainers can apply the `no-greptile` label when an
+automated review is not needed, such as for a typo-only or other trivial change. Opting out of reviews that are not
+useful helps keep usage within the included monthly review quota. If Greptile's input becomes useful later, tag
+`@greptileai` in the pull request to request a review explicitly.
+
 ## Typo Checks
 
 mirrord uses [`typos`](https://github.com/crate-ci/typos) to catch typos in CI. If the pipeline fails

--- a/changelog.d/+greptile-review-policy.internal.md
+++ b/changelog.d/+greptile-review-policy.internal.md
@@ -1,0 +1,1 @@
+Configure automatic Greptile reviews and document how contributors can opt out.


### PR DESCRIPTION
## Summary

- limit automatic Greptile reviews to frequent PR authors
- allow PR authors to suppress an automatic review with the `no-greptile` label
- document the opt-out label and quota rationale in the contributor guide

## Why

Greptile consumes a monthly seat when it reviews a new author. Automatic reviews should cover frequent contributors whose regular work will use a seat anyway, while occasional contributors and trivial changes should not allocate one by default. Authors outside the allowlist can still receive a Greptile review by tagging greptile.

The opt-out label also lets authors skip Greptile on changes where an automated review is not neeed, helping keep usage within the included monthly review quota.