### PR TITLE
Send session analytics at session end instead of relying on runtime teardown

### DIFF
--- a/changelog.d/+intproxy-session-analytics.fixed.md
+++ b/changelog.d/+intproxy-session-analytics.fixed.md
@@ -1,0 +1,1 @@
+Fixed successful sessions not being reported to mirrord telemetry: the session monitor API server kept the analytics reporter alive past runtime shutdown, which also stalled internal proxy exit for the 10-second drain timeout.

--- a/mirrord/cli/src/internal_proxy.rs
+++ b/mirrord/cli/src/internal_proxy.rs
@@ -23,7 +23,7 @@ use std::{
 };
 
 use mirrord_analytics::{
-    AnalyticsReporter, CollectAnalytics, Reporter, read_correlation_id_from_env,
+    AnalyticsError, AnalyticsReporter, CollectAnalytics, Reporter, read_correlation_id_from_env,
     read_kube_version_from_env,
 };
 use mirrord_config::{
@@ -33,6 +33,7 @@ use mirrord_config::{
 use mirrord_intproxy::{
     IntProxy, IntProxyIntervals,
     agent_conn::{AgentConnectInfo, AgentConnection},
+    error::ProxyStartupError,
     session_monitor::{
         MonitorTx,
         api::SessionAnalytics,
@@ -129,16 +130,24 @@ struct SessionMonitorHandle {
 }
 
 impl SessionMonitorHandle {
-    async fn shutdown(self) {
+    /// `error` is attached to the session report before it is sent, since the reporter is out
+    /// of the intproxy's reach for the whole session.
+    async fn shutdown(self, error: Option<AnalyticsError>) {
         self.shutdown.cancel();
-        if let Some(server) = self.server
-            && tokio::time::timeout(Duration::from_secs(5), server)
-                .await
-                .is_err()
-        {
-            tracing::warn!("Session monitor API server did not shut down in time");
+        if let Some(server) = self.server {
+            match tokio::time::timeout(Duration::from_secs(5), server).await {
+                Ok(Ok(())) => {}
+                Ok(Err(join_error)) => {
+                    tracing::warn!(%join_error, "Session monitor API server task failed")
+                }
+                Err(_) => tracing::warn!("Session monitor API server did not shut down in time"),
+            }
         }
-        drop(self.analytics.take_reporter().await);
+        if let Some(mut reporter) = self.analytics.take_reporter().await
+            && let Some(error) = error
+        {
+            reporter.set_error(error);
+        }
     }
 }
 
@@ -405,7 +414,10 @@ pub(crate) async fn proxy(
     .run(first_connection_timeout, consecutive_connection_timeout)
     .await;
 
-    session_monitor.shutdown().await;
+    let analytics_error = result.as_ref().err().map(|error| match error {
+        ProxyStartupError::ConnectionAcceptTimeout => AnalyticsError::IntProxyFirstConnection,
+    });
+    session_monitor.shutdown(analytics_error).await;
 
     result.map_err(From::from)
 }

--- a/mirrord/cli/src/internal_proxy.rs
+++ b/mirrord/cli/src/internal_proxy.rs
@@ -35,6 +35,7 @@ use mirrord_intproxy::{
     agent_conn::{AgentConnectInfo, AgentConnection},
     session_monitor::{
         MonitorTx,
+        api::SessionAnalytics,
         chaos::{ChaosWatcherRx, ChaosWatcherTx},
     },
 };
@@ -114,21 +115,62 @@ fn print_addr(listener: &TcpListener) -> io::Result<()> {
     Ok(())
 }
 
+/// Handle for tearing down the session monitor API server when the session ends.
+///
+/// The session's [`AnalyticsReporter`] sends the session report from its `Drop`, which spawns
+/// onto the runtime, so [`SessionMonitorHandle::shutdown`] must run at session end, while the
+/// runtime is still live. Otherwise the reporter is dropped during runtime teardown, the
+/// report is lost, and the held [`drain::Watch`] stalls process exit until the drain timeout
+/// expires.
+struct SessionMonitorHandle {
+    shutdown: CancellationToken,
+    server: Option<tokio::task::JoinHandle<()>>,
+    analytics: SessionAnalytics,
+}
+
+impl SessionMonitorHandle {
+    async fn shutdown(self) {
+        self.shutdown.cancel();
+        if let Some(server) = self.server
+            && tokio::time::timeout(Duration::from_secs(5), server)
+                .await
+                .is_err()
+        {
+            tracing::warn!("Session monitor API server did not shut down in time");
+        }
+        drop(self.analytics.take_reporter().await);
+    }
+}
+
 /// Starts the session monitor API server if enabled.
 ///
 /// `@analytics`: optionally, pass a reporter in to be used by the chaos router for chaos metrics
 /// reporting. If `None`, the chaos router will work as normal but will not report metrics.
+///
+/// The reporter is shared with the API server through [`SessionAnalytics`]; the returned
+/// [`SessionMonitorHandle`] must be shut down at session end for the session report to be sent.
 async fn start_session_monitor(
     config: &LayerConfig,
     is_operator: bool,
     analytics: Option<AnalyticsReporter>,
-) -> (MonitorTx, ChaosWatcherRx) {
+) -> (MonitorTx, ChaosWatcherRx, SessionMonitorHandle) {
     use tokio::sync::watch;
 
     let (chaos_tx, chaos_rx) = watch::channel(Default::default());
 
+    let shutdown = CancellationToken::new();
+    let analytics = SessionAnalytics::new(analytics);
+
     if !config.api {
-        return (MonitorTx::disabled(), ChaosWatcherRx::new(chaos_rx));
+        return (
+            MonitorTx::disabled(),
+            ChaosWatcherRx::new(chaos_rx),
+            SessionMonitorHandle {
+                shutdown,
+                server: None,
+                analytics,
+            },
+        );
     }
 
     let (tx, _rx) =
@@ -183,25 +225,31 @@ async fn start_session_monitor(
         config: config_value,
     };
 
-    let shutdown = CancellationToken::new();
+    let Some(sessions_dir) = home_dir().map(|home_dir| home_dir.join(".mirrord").join("sessions"))
+    else {
+        tracing::warn!("Could not determine home directory; skipping session monitor API server");
+        return (
+            proxy_monitor_tx,
+            ChaosWatcherRx::new(chaos_rx),
+            SessionMonitorHandle {
+                shutdown,
+                server: None,
+                analytics,
+            },
+        );
+    };
 
-    let sessions_dir = home_dir().map(|home_dir| home_dir.join(".mirrord").join("sessions"));
-
-    tokio::spawn(async move {
-        let Some(sessions_dir) = sessions_dir else {
-            tracing::warn!(
-                "Could not determine home directory; skipping session monitor API server"
-            );
-            return;
-        };
+    let server_shutdown = shutdown.clone();
+    let server_analytics = analytics.clone();
+    let server = tokio::spawn(async move {
         if let Err(error) = mirrord_intproxy::session_monitor::api::start_api_server(
             sessions_dir,
             session_info,
             api_monitor_tx,
             api_monitor_rx,
-            shutdown,
+            server_shutdown,
             ChaosWatcherTx::new(chaos_tx),
-            analytics,
+            server_analytics,
         )
         .await
         {
@@ -209,7 +257,15 @@ async fn start_session_monitor(
         }
     });
 
-    (proxy_monitor_tx, ChaosWatcherRx::new(chaos_rx))
+    (
+        proxy_monitor_tx,
+        ChaosWatcherRx::new(chaos_rx),
+        SessionMonitorHandle {
+            shutdown,
+            server: Some(server),
+            analytics,
+        },
+    )
 }
 
 /// Main entry point for the internal proxy.
@@ -324,9 +380,10 @@ pub(crate) async fn proxy(
     let process_logging_interval =
         Duration::from_secs(config.internal_proxy.process_logging_interval);
 
-    let (monitor_tx, chaos_rx) = start_session_monitor(&config, is_operator, Some(analytics)).await;
+    let (monitor_tx, chaos_rx, session_monitor) =
+        start_session_monitor(&config, is_operator, Some(analytics)).await;
 
-    IntProxy::new_with_connection(
+    let result = IntProxy::new_with_connection(
         agent_conn,
         listener,
         config.feature.fs.readonly_file_buffer,
@@ -346,8 +403,11 @@ pub(crate) async fn proxy(
         chaos_rx,
     )
     .run(first_connection_timeout, consecutive_connection_timeout)
-    .await
-    .map_err(From::from)
+    .await;
+
+    session_monitor.shutdown().await;
+
+    result.map_err(From::from)
 }
 
 /// Creates a connection with the agent and handles one round of ping pong.

--- a/mirrord/intproxy/src/session_monitor/api.rs
+++ b/mirrord/intproxy/src/session_monitor/api.rs
@@ -53,6 +53,30 @@ mod win_security;
 
 use transport::bind_session_transport;
 
+/// Shared ownership of the session's [`AnalyticsReporter`].
+///
+/// Clones are held by the API server ([`AppState`]) and by the intproxy itself. axum spawns a
+/// task per connection, and a consumer holding `/events` open (e.g. `mirrord ui`) keeps its
+/// connection task (and with it [`AppState`]) alive arbitrarily long, so the reporter cannot
+/// be released by reference counting alone. [`Self::take_reporter`] hands the reporter back at
+/// session end; dropping it then sends the session report while the runtime is still live.
+#[derive(Clone)]
+pub struct SessionAnalytics(Arc<RwLock<ChaosAnalyticsReporter>>);
+
+impl SessionAnalytics {
+    pub fn new(analytics: Option<AnalyticsReporter>) -> Self {
+        Self(Arc::new(RwLock::new(ChaosAnalyticsReporter::new(
+            analytics,
+        ))))
+    }
+
+    /// Takes the session's [`AnalyticsReporter`] with all chaos rule analytics folded in.
+    /// Returns `None` if there is no reporter or it was already taken.
+    pub async fn take_reporter(&self) -> Option<AnalyticsReporter> {
+        self.0.write().await.take_inner()
+    }
+}
+
 /// Per-session API state. Access control is provided by the OS-level permissions on the
 /// transport (`0o600` on the unix socket; restrictive DACL on the named pipe), so the HTTP
 /// layer itself is unauthenticated.
@@ -108,12 +132,19 @@ async fn kill(State(state): State<AppState>) -> impl IntoResponse {
     Json(serde_json::json!({"status": "shutting_down"}))
 }
 
+/// Exits on `state.shutdown` so its [`AppState`] clone (holding a monitor sender and the
+/// analytics reporter) is released; `rx` alone never closes because `state.monitor_tx` keeps
+/// the broadcast channel open.
 async fn update_session_info_from_events(
     state: AppState,
     mut rx: tokio::sync::broadcast::Receiver<MonitorEvent>,
 ) {
     loop {
-        match rx.recv().await {
+        let event = tokio::select! {
+            _ = state.shutdown.cancelled() => break,
+            event = rx.recv() => event,
+        };
+        match event {
             Ok(MonitorEvent::LayerConnected {
                 pid,
                 parent_pid,
@@ -178,7 +209,7 @@ pub async fn start_api_server(
     monitor_rx: tokio::sync::broadcast::Receiver<MonitorEvent>,
     shutdown: CancellationToken,
     chaos_tx: ChaosWatcherTx,
-    analytics: Option<AnalyticsReporter>,
+    analytics: SessionAnalytics,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let session_id = session_info.session_id.clone();
 
@@ -199,7 +230,7 @@ pub async fn start_api_server(
         monitor_tx,
         shutdown: shutdown.clone(),
         chaos_tx,
-        reporter: Arc::new(RwLock::new(ChaosAnalyticsReporter::new(analytics))),
+        reporter: analytics.0,
     };
 
     tokio::spawn(update_session_info_from_events(state.clone(), monitor_rx));
@@ -216,6 +247,12 @@ pub async fn start_api_server(
     serve_session(&sessions_dir, &session_id, app, shutdown).await
 }
 
+/// How long open connections get to drain after `shutdown` is cancelled before the server is
+/// dropped outright. Consumers like `mirrord ui` hold `/events` SSE streams open for the whole
+/// session, so a purely graceful shutdown would never finish while one is attached, leaving the
+/// server task (and the socket cleanup guard) alive past session end.
+const SHUTDOWN_CONNECTION_GRACE: Duration = Duration::from_secs(1);
+
 async fn serve_session(
     sessions_dir: &Path,
     session_id: &str,
@@ -226,9 +263,15 @@ async fn serve_session(
 
     tracing::info!(session_id, "Session monitor API server starting");
 
-    axum::serve(listener, app)
-        .with_graceful_shutdown(shutdown.cancelled_owned())
-        .await?;
+    let serve =
+        axum::serve(listener, app).with_graceful_shutdown(shutdown.clone().cancelled_owned());
+    tokio::select! {
+        result = serve => result?,
+        _ = async {
+            shutdown.cancelled().await;
+            tokio::time::sleep(SHUTDOWN_CONNECTION_GRACE).await;
+        } => {}
+    }
 
     tracing::info!("Session monitor API server stopped");
 

--- a/mirrord/intproxy/src/session_monitor/chaos/analytics.rs
+++ b/mirrord/intproxy/src/session_monitor/chaos/analytics.rs
@@ -68,6 +68,20 @@ impl ChaosAnalyticsReporter {
             self.dead_rules.insert((&rule, start_time).into());
         });
     }
+
+    /// Takes the inner [`AnalyticsReporter`] after folding all chaos rule analytics into it,
+    /// exactly as `Drop` does. Lets the session end path drop the reporter (which sends the
+    /// session report) without waiting for every holder of this reporter to be released.
+    /// `Drop` is a no-op afterwards.
+    pub fn take_inner(&mut self) -> Option<AnalyticsReporter> {
+        self.clear_session_rules();
+        let rules_info: Vec<_> = self.dead_rules.drain().map(AnalyticValue::from).collect();
+        let mut inner = self.inner.take();
+        if let Some(reporter) = inner.as_mut() {
+            reporter.get_mut().add("rules", rules_info);
+        }
+        inner
+    }
 }
 
 impl Drop for ChaosAnalyticsReporter {

--- a/mirrord/intproxy/tests/session_monitor_round_trip.rs
+++ b/mirrord/intproxy/tests/session_monitor_round_trip.rs
@@ -25,7 +25,9 @@ use std::{path::PathBuf, time::Duration};
 
 use futures::StreamExt;
 use mirrord_intproxy::session_monitor::{
-    MonitorEvent, MonitorTx, api::start_api_server, chaos::ChaosWatcherTx,
+    MonitorEvent, MonitorTx,
+    api::{SessionAnalytics, start_api_server},
+    chaos::ChaosWatcherTx,
 };
 use mirrord_session_monitor_client::{
     SESSION_SENTINEL_EXTENSION, SessionClient, SessionConnection, SessionEndpoint,
@@ -87,6 +89,7 @@ struct StartedServer {
     sessions_dir: PathBuf,
     sentinel_path: PathBuf,
     monitor_tx: MonitorTx,
+    shutdown: CancellationToken,
     server: tokio::task::JoinHandle<Result<(), Box<dyn std::error::Error + Send + Sync>>>,
 }
 
@@ -108,6 +111,7 @@ impl StartedServer {
         let server = tokio::spawn({
             let monitor_tx = monitor_tx.clone();
             let sessions_dir = sessions_dir.clone();
+            let shutdown = shutdown.clone();
             async move {
                 start_api_server(
                     sessions_dir,
@@ -116,7 +120,7 @@ impl StartedServer {
                     rx,
                     shutdown,
                     ChaosWatcherTx::new(chaos_tx),
-                    None,
+                    SessionAnalytics::new(None),
                 )
                 .await
             }
@@ -128,6 +132,7 @@ impl StartedServer {
             sessions_dir,
             sentinel_path,
             monitor_tx,
+            shutdown,
             server,
         }
     }
@@ -155,6 +160,33 @@ impl StartedServer {
             "sentinel file should be removed on shutdown"
         );
     }
+}
+
+/// Consumers like `mirrord ui` keep an `/events` SSE stream open for the whole session, so the
+/// server cannot rely on connection draining to finish shutting down. Cancelling the shutdown
+/// token from outside (the intproxy's session-end path) must stop the server within the
+/// connection grace period even while such a stream is attached.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn external_cancel_stops_server_despite_open_events_stream() {
+    let server = StartedServer::start("external-cancel").await;
+    let conn = server.connect().await;
+
+    let _sse_stream = conn
+        .client
+        .open_event_stream()
+        .await
+        .expect("events stream");
+
+    server.shutdown.cancel();
+    tokio::time::timeout(Duration::from_secs(5), server.server)
+        .await
+        .expect("server did not stop despite external cancel with an open SSE consumer")
+        .expect("server task panicked")
+        .expect("server returned error");
+    assert!(
+        !server.sentinel_path.exists(),
+        "sentinel file should be removed on shutdown"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -391,7 +423,7 @@ async fn invalid_session_id_with_path_traversal_returns_error() {
         rx,
         shutdown,
         ChaosWatcherTx::new(chaos_tx),
-        None,
+        SessionAnalytics::new(None),
     )
     .await;
 


### PR DESCRIPTION
## Summary

Since 3.222.0 (#4391), the internal proxy's `AnalyticsReporter` is moved into the session monitor API server task. Nothing stops that task when the session ends, so the reporter is only dropped during tokio runtime teardown, where the send task it spawns from `Drop` never runs. Two user-visible effects:

- Successful `mirrord exec` sessions are never reported to telemetry (the CLI-side reporter is error-only, so the intproxy report was the only success signal). Error reports still go out, which heavily skews any error-rate reading of `client_session_v1`.
- Every intproxy exit stalls for the full 10-second drain timeout (`Failed to drain in a timely manner, ongoing tasks dropped.`), because the reporter's `drain::Watch` is never released.

Reference counting alone cannot release the reporter: axum spawns a task per connection, and a consumer holding `/events` open (e.g. `mirrord ui`) keeps its connection task, and with it the app state, alive indefinitely.

Changes:

- `SessionAnalytics`: shared handle around the chaos analytics reporter; the intproxy takes the reporter back at session end (`take_reporter`, folding chaos rule analytics in exactly like `Drop`) and drops it while the runtime is live, so the report is sent regardless of API server state.
- `proxy()` shuts the session monitor down after `IntProxy::run` returns: cancels the server's token, joins the server task with a bounded wait, then drops the reporter.
- `serve_session` hard-stops the server one second after cancellation if graceful drain is still blocked by open SSE streams; the session info updater task also exits on cancellation. This also makes the socket cleanup guard actually run at session end.
- With the API server disabled (`api: false`), the reporter is now held until session end instead of being dropped (and reporting) at session start.

## Test plan

- `cargo clippy -p mirrord -p mirrord-intproxy --all-targets --all-features -- --deny warnings` clean, `cargo fmt`.
- `session_monitor_round_trip` tests pass, including a new regression test: external cancellation stops the server within the grace period while a consumer holds an open `/events` SSE stream.
- Live A/B against minikube (real `mirrord exec` with a pod target, `mirrord ui` running so an SSE consumer is attached), observing outbound requests through a local logging proxy:
  - Released 3.221.1: analytics request sent at intproxy shutdown, no drain warning.
  - Released 3.222.0: session succeeds, no analytics request ever, intproxy's last log line is the drain-timeout warning 15s after the session.
  - This branch: analytics request sent immediately after "Session monitor API server stopped", no drain warning, intproxy exits ~6s after the session (5s idle timeout + 1s connection grace) instead of 16s.

## Follow-up (second commit)

An independent adversarial review flagged that an `IntProxy::run` startup error (first-connection timeout) would be reported as a successful session, a quirk carried over from the pre-3.222.0 behavior. The second commit maps `ProxyStartupError::ConnectionAcceptTimeout` to the previously unused `AnalyticsError::IntProxyFirstConnection` before the report is sent, and logs session monitor server task join failures instead of ignoring them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)