### PR TITLE
fix(monitor): treat a 404 when stopping a session as already stopped

### DIFF
--- a/changelog.d/+session-monitor-stop-ended-session.fixed.md
+++ b/changelog.d/+session-monitor-stop-ended-session.fixed.md
@@ -1,0 +1,1 @@
+Stopping a session in the session monitor no longer reports a "Not Found" failure when the session has already ended.

--- a/packages/monitor/src/api.ts
+++ b/packages/monitor/src/api.ts
@@ -137,7 +137,10 @@ export const api = {
       })
       return
     }
-    if (!r.ok) {
+    // A 404 means the session ended between the last poll and the click, so the caller already has
+    // what it asked for. Reporting it as a failure alerts on a session that is gone either way, and
+    // "kill all" walks a list that is stale by definition.
+    if (!r.ok && r.status !== HTTP_NOT_FOUND) {
       emitUserBlocked('session_kill_failed', 'user_action', {
         session_id: sessionId,
         status: r.status,


### PR DESCRIPTION
## Summary

Stopping a session in the session monitor reports a "Not Found" failure when the session has
already ended.

`killSession` issues `DELETE /api/v2/local/sessions/{id}`. If the session ended between the last
poll and the click, that returns 404 and the monitor emits `session_kill_failed`, which is a
user-blocked signal and raises a frontend alert. Nothing is actually blocked: the session is gone,
which is exactly what the user asked for. "Stop all" makes it routine, since it walks a session
list that is stale by definition.

This mirrors the handling already used elsewhere in the same file: `getSession` treats 404 as
"session ended" via the existing `HTTP_NOT_FOUND` constant, and `listChaosRules` was given the same
treatment for the same reason. A 404 now records `session_killed` instead; every other non-OK
status still reports `session_kill_failed` unchanged.

## Test plan

Gates on `session-monitor-frontend`: `typecheck`, `lint`, `format:check`, plus
`pnpm --filter mirrord-ui build`. All pass.

Behaviour checked in a real browser (headless Chromium driving the built `mirrord-ui` bundle
against a stub API, with the telemetry endpoint intercepted so the emitted events could be read
off the wire). Built two bundles from this branch, one with the change and one with it reverted,
and drove the same flow against both: load the monitor, select the session, click "Stop session"
where the stub answers `DELETE` with 404.

| Bundle | DELETE responds | `session_kill_failed` | `session_killed` |
| --- | --- | --- | --- |
| change reverted | 404 | emitted | not emitted |
| this change | 404 | not emitted | emitted |
| this change | 500 | emitted | not emitted |

The 500 row is the one that matters for scope: genuine stop failures still report as before.

Not verified locally: the change against a real `mirrord ui` server with an operator-backed
session. The 404 path was exercised through a stub, not a real session that ended mid-flight.
