### PR TITLE
mirrord up: support context selection per run or per service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5726,6 +5726,7 @@ dependencies = [
  "mirrord-config",
  "mirrord-kube",
  "mirrord-progress",
+ "rstest",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/changelog.d/+up-kube-context.added.md
+++ b/changelog.d/+up-kube-context.added.md
@@ -1,0 +1,7 @@
+Added support for specifying a kube context in `mirrord up`. In order of precedence, it can be set:
+
+1. with the `--context` argument when running `mirrord up` (highest precedence)
+2. with the `context` field under a service in the configuration file
+3. with the `common.context` field in the configuration file
+
+If none of these are set, the default behaviour remains the same.

--- a/mirrord/cli/src/config.rs
+++ b/mirrord/cli/src/config.rs
@@ -9,6 +9,7 @@ use std::{
     net::{IpAddr, Ipv4Addr, SocketAddr},
     path::PathBuf,
     str::FromStr,
+    sync::Arc,
 };
 
 use clap::{ArgGroup, Args, Parser, Subcommand, ValueEnum, ValueHint};
@@ -1582,6 +1583,10 @@ pub(super) struct UpArgs {
     /// service explicitly overrides its `skip` flag.
     #[arg(value_name = "SERVICE")]
     pub services: Vec<String>,
+
+    /// Kube context to use from Kubeconfig
+    #[arg(long)]
+    pub context: Option<Arc<str>>,
 
     /// Subcommand. When absent, `mirrord up` runs the sessions defined in
     /// the config file. With a subcommand, the flags above are ignored.

--- a/mirrord/cli/src/up.rs
+++ b/mirrord/cli/src/up.rs
@@ -1,6 +1,6 @@
 //! The `mirrord up` command - runs multiple mirrord sessions from a `mirrord-up.yaml` file.
 
-use std::{io::ErrorKind, process::Stdio};
+use std::io::ErrorKind;
 
 use miette::Diagnostic;
 use mirrord_analytics::{Analytics, AnalyticsReporter, CollectAnalytics, Reporter};
@@ -11,7 +11,8 @@ use thiserror::Error;
 use uuid::Uuid;
 
 use crate::{
-    config::{UpArgs, UpSubcommand},
+    config::{UI_DEFAULT_PORT, UiCommonArgs, UpArgs, UpSubcommand},
+    ui::ui_command,
     user_data::UserData,
 };
 
@@ -126,33 +127,32 @@ async fn run_up(args: UpArgs, analytics: &mut AnalyticsReporter) -> Result<(), U
 
     // Run UI
     analytics.get_mut().add("ui_enabled", args.ui);
-
-    if let Ok(mirrord_binary) = std::env::current_exe()
-        && args.ui
-    {
-        match tokio::process::Command::new(mirrord_binary)
-            .args(vec!["ui", "--no-browser"])
-            .stdin(Stdio::null())
-            .stdout(Stdio::inherit())
-            .stderr(Stdio::inherit())
-            .kill_on_drop(false)
-            .spawn()
-        {
-            Ok(child) => {
-                tracing::info!(
-                    child_pid = ?child.id(),
-                    "spawned `mirrord ui` command",
-                );
+    if args.ui {
+        tokio::spawn(async move {
+            match ui_command(
+                UiCommonArgs {
+                    port: UI_DEFAULT_PORT,
+                    no_browser: true,
+                },
+                None,
+                "/",
+            )
+            .await
+            {
+                Ok(_) => {
+                    tracing::info!("spawned `mirrord ui` command");
+                }
+                Err(err) => {
+                    tracing::warn!(?err, "failed to start local UI");
+                }
             }
-            Err(err) => {
-                tracing::warn!(?err, "failed to start local UI");
-            }
-        }
+        });
     }
 
     let result = mirrord_up::run(
         up_config,
         &args.config_file,
+        args.context,
         key,
         correlation_id,
         ready.clone(),

--- a/mirrord/up/Cargo.toml
+++ b/mirrord/up/Cargo.toml
@@ -41,6 +41,7 @@ tera.workspace = true
 [dev-dependencies]
 serde_json.workspace = true
 assert-json-diff.workspace = true
+rstest.workspace = true
 
 [lints]
 workspace = true

--- a/mirrord/up/src/config.rs
+++ b/mirrord/up/src/config.rs
@@ -27,6 +27,8 @@ use strum::VariantArray;
 use strum_macros::{Display, IntoStaticStr, VariantArray};
 use thiserror::Error;
 
+use crate::kube_context::UpKubeContext;
+
 /// Incoming traffic mode for a service.
 #[derive(
     Clone,
@@ -105,6 +107,7 @@ pub struct CommonConfig {
     pub(crate) accept_invalid_certificates: Option<bool>,
     pub(crate) operator: Option<bool>,
     pub(crate) telemetry: Option<bool>,
+    pub(crate) context: Option<Arc<str>>,
 }
 
 /// A specified target for the non-targetless case.
@@ -213,13 +216,13 @@ impl TargetConfig {
         }
     }
 
-    /// Return a [`mirrord_config::target::TargetConfig`] when we have
-    /// a path or are explicitly targetless, OR an
-    /// [`UnresolvedTarget`] otherwise, when we need to resolve the
-    /// target workload by querying the cluster against `name`.
+    /// Return a [`mirrord_config::target::TargetConfig`] when we have a path or are explicitly
+    /// targetless, OR an [`UnresolvedTarget`] otherwise, when we need to resolve the target
+    /// workload by querying the cluster against `name` using `kube_context`.
     fn as_resolved(
         &self,
         name: &Arc<str>,
+        kube_context: Option<Arc<str>>,
     ) -> Result<mirrord_config::target::TargetConfig, UnresolvedTarget> {
         match self {
             Self::Targetless => Ok(mirrord_config::target::TargetConfig {
@@ -233,6 +236,7 @@ impl TargetConfig {
             }) => Err(UnresolvedTarget {
                 workload_name: Arc::clone(name),
                 namespace: namespace.clone(),
+                kube_context,
             }),
 
             Self::Specified(SpecifiedTarget {
@@ -289,6 +293,9 @@ pub struct ServiceConfig {
     #[serde(default)]
     pub(crate) skip: bool,
 
+    #[serde(default)]
+    pub(crate) context: Option<Arc<str>>,
+
     pub(crate) run: RunConfig,
 }
 
@@ -311,6 +318,7 @@ impl ServiceConfig {
         defaults: &CommonConfig,
         key: EnvKey,
         resolved_targets: &mut HashMap<UnresolvedTarget, ResolvedTarget>,
+        up_context: UpKubeContext,
     ) -> (LayerConfig, RunConfig) {
         let mut cfg = LayerFileConfig {
             accept_invalid_certificates: defaults.accept_invalid_certificates,
@@ -321,7 +329,10 @@ impl ServiceConfig {
         .generate_config(&mut ConfigContext::default())
         .unwrap();
 
-        cfg.target = match self.target.as_resolved(service_name) {
+        let kube_context = up_context.get_context(self.context);
+        cfg.kube_context = kube_context.as_deref().map(Into::into);
+
+        cfg.target = match self.target.as_resolved(service_name, kube_context) {
             Ok(resolved) => resolved,
             Err(unresolved) => match resolved_targets.remove(&unresolved) {
                 Some(target) => {
@@ -383,6 +394,15 @@ impl ServiceConfig {
         cfg.key = key;
 
         (cfg, self.run)
+    }
+
+    fn resolve_target(
+        &self,
+        name: &Arc<str>,
+        up_context: UpKubeContext,
+    ) -> Result<mirrord_config::target::TargetConfig, UnresolvedTarget> {
+        self.target
+            .as_resolved(name, up_context.get_context(self.context.clone()))
     }
 }
 
@@ -527,6 +547,7 @@ impl UpConfig {
         self,
         key: &'a EnvKey,
         resolved_targets: &'a mut HashMap<UnresolvedTarget, ResolvedTarget>,
+        up_context: UpKubeContext,
     ) -> impl Iterator<Item = SubprocessCfg> + use<'a> {
         let Self {
             common: defaults,
@@ -535,8 +556,13 @@ impl UpConfig {
 
         services.into_iter().map(move |(service_name, svc)| {
             let mode = svc.default_mode;
-            let (config, run) =
-                svc.assemble(&service_name, &defaults, key.clone(), resolved_targets);
+            let (config, run) = svc.assemble(
+                &service_name,
+                &defaults,
+                key.clone(),
+                resolved_targets,
+                up_context.clone(),
+            );
             SubprocessCfg {
                 config,
                 service_name,
@@ -549,10 +575,13 @@ impl UpConfig {
     /// Produces an iterator of [`UnresolvedTarget`]s that yields an
     /// item for each service entry that requires querying the cluster
     /// to resolve the workload.
-    pub(crate) fn unresolved_targets(&self) -> impl Iterator<Item = UnresolvedTarget> {
+    pub(crate) fn unresolved_targets(
+        &self,
+        up_context: UpKubeContext,
+    ) -> impl Iterator<Item = UnresolvedTarget> {
         self.services
             .iter()
-            .filter_map(|(name, svc)| svc.target.as_resolved(name).err())
+            .filter_map(move |(name, svc)| svc.resolve_target(name, up_context.clone()).err())
     }
 }
 
@@ -580,6 +609,7 @@ pub enum SelectError {
 pub(crate) struct UnresolvedTarget {
     pub(crate) workload_name: Arc<str>,
     pub(crate) namespace: Option<Arc<str>>,
+    pub(crate) kube_context: Option<Arc<str>>,
 }
 
 #[derive(Clone, PartialEq, Debug)]
@@ -593,6 +623,7 @@ impl CollectAnalytics for &CommonConfig {
             accept_invalid_certificates,
             operator,
             telemetry,
+            context,
         } = self;
 
         analytics.add(
@@ -601,6 +632,7 @@ impl CollectAnalytics for &CommonConfig {
         );
         analytics.add("operator", operator.is_some());
         analytics.add("telemetry", telemetry.is_some());
+        analytics.add("context", context.is_some());
     }
 }
 
@@ -615,6 +647,7 @@ impl CollectAnalytics for &UpConfig {
         let mut count_http_filter: u32 = 0;
         let mut count_ignore_ports: u32 = 0;
         let mut count_skip: u32 = 0;
+        let mut count_context: u32 = 0;
 
         let mut count_exec: u32 = 0;
         let mut count_container: u32 = 0;
@@ -631,6 +664,7 @@ impl CollectAnalytics for &UpConfig {
                 ignore_ports,
                 skip,
                 run,
+                context,
             } = svc;
 
             if *target != TargetConfig::UNSPECIFIED {
@@ -655,6 +689,9 @@ impl CollectAnalytics for &UpConfig {
             if *skip {
                 count_skip += 1;
             }
+            if context.is_some() {
+                count_context += 1;
+            }
 
             match run.r#type {
                 RunType::Exec => count_exec += 1,
@@ -669,6 +706,7 @@ impl CollectAnalytics for &UpConfig {
         config_fields_used.add("http_filter", count_http_filter);
         config_fields_used.add("ignore_ports", count_ignore_ports);
         config_fields_used.add("skip", count_skip);
+        config_fields_used.add("context", count_context);
         analytics.add("config_fields_used", config_fields_used);
 
         let mut run_types = Analytics::default();
@@ -687,6 +725,8 @@ impl CollectAnalytics for &UpConfig {
 #[allow(clippy::indexing_slicing)]
 mod tests {
     use std::{collections::HashSet, str::FromStr};
+
+    use rstest::rstest;
 
     use super::*;
 
@@ -716,6 +756,7 @@ mod tests {
               accept_invalid_certificates: true
               operator: false
               telemetry: false
+              context: "minikube"
             services:
               my-svc:
                 run:
@@ -728,6 +769,7 @@ mod tests {
                 accept_invalid_certificates: Some(true),
                 operator: Some(false),
                 telemetry: Some(false),
+                context: Some("minikube".into())
             }
         );
     }
@@ -845,6 +887,7 @@ mod tests {
             .service_configs(
                 &EnvKey::Provided("sqs-session".to_owned()),
                 &mut HashMap::new(),
+                UpKubeContext::default(),
             )
             .collect::<Vec<_>>();
         assert_eq!(services.len(), 1);
@@ -918,6 +961,7 @@ mod tests {
         .service_configs(
             &EnvKey::Provided("a-session".to_owned()),
             &mut HashMap::new(),
+            UpKubeContext::default(),
         )
         .collect::<Vec<_>>();
         assert_eq!(services.len(), 1);
@@ -956,6 +1000,7 @@ mod tests {
         .service_configs(
             &EnvKey::Provided("a-session".to_owned()),
             &mut HashMap::new(),
+            UpKubeContext::default(),
         )
         .collect::<Vec<_>>();
         assert_eq!(services.len(), 1);
@@ -1026,6 +1071,7 @@ mod tests {
             .service_configs(
                 &EnvKey::Provided("a-session".to_owned()),
                 &mut HashMap::new(),
+                UpKubeContext::default(),
             )
             .collect::<Vec<_>>();
 
@@ -1060,6 +1106,7 @@ mod tests {
         .service_configs(
             &EnvKey::Provided("a-session".to_owned()),
             &mut HashMap::new(),
+            UpKubeContext::default(),
         )
         .collect::<Vec<_>>();
 
@@ -1150,16 +1197,67 @@ mod tests {
         assert_eq!(config.services["svc"].target, TargetConfig::Targetless);
     }
 
+    // -- Context resolution --
+
+    #[rstest]
+    #[case("cli-arg-set", Some("cli-context"), Some("cli-context"))]
+    #[case("per-service-set", None, Some("service-context"))]
+    #[case("common-set", None, Some("common-context"))]
+    fn unresolved_target_chooses_correct_context(
+        #[case] service_name: &str,
+        #[case] cli_context_arg: Option<&str>,
+        #[case] expected_kube_context: Option<&str>,
+    ) {
+        let config = parse(
+            r#"
+            common:
+              context: common-context
+            services:
+              cli-arg-set:
+                context: service-context
+                run:
+                  command: ["echo"]
+              per-service-set:
+                context: service-context
+                run:
+                  command: ["echo"]
+              common-set:
+                run:
+                  command: ["echo"]
+            "#,
+        );
+
+        let up_context = UpKubeContext {
+            command_arg: cli_context_arg.map(Into::into),
+            common_context: config.common.context.clone(),
+        };
+
+        assert_eq!(
+            config
+                .unresolved_targets(up_context)
+                .find(|target| target.workload_name.as_ref() == service_name)
+                .unwrap()
+                .kube_context
+                .as_deref(),
+            expected_kube_context
+        );
+    }
+
     // -- Target resolution --
 
     fn env_key() -> EnvKey {
         EnvKey::Provided("test-key".to_owned())
     }
 
-    fn unresolved_target(workload_name: &str, namespace: Option<&str>) -> UnresolvedTarget {
+    fn unresolved_target(
+        workload_name: &str,
+        namespace: Option<&str>,
+        kube_context: Option<&str>,
+    ) -> UnresolvedTarget {
         UnresolvedTarget {
             workload_name: workload_name.into(),
             namespace: namespace.map(Into::into),
+            kube_context: kube_context.map(Into::into),
         }
     }
 
@@ -1209,10 +1307,12 @@ mod tests {
         let config = resolution_fixture();
 
         assert_eq!(
-            config.unresolved_targets().collect::<HashSet<_>>(),
+            config
+                .unresolved_targets(UpKubeContext::default())
+                .collect::<HashSet<_>>(),
             HashSet::from([
-                unresolved_target("inferred", None),
-                unresolved_target("inferred-ns", Some("staging")),
+                unresolved_target("inferred", None, None),
+                unresolved_target("inferred-ns", Some("staging"), None),
             ]),
         );
     }
@@ -1234,7 +1334,10 @@ mod tests {
             "#,
         );
 
-        assert_eq!(config.unresolved_targets().count(), 0);
+        assert_eq!(
+            config.unresolved_targets(UpKubeContext::default()).count(),
+            0
+        );
     }
 
     /// Explicit and `none` targets pass through as-is, inferred ones
@@ -1246,22 +1349,22 @@ mod tests {
         let key = env_key();
         let mut resolved_targets = HashMap::from([
             (
-                unresolved_target("inferred", None),
+                unresolved_target("inferred", None, None),
                 resolved_target("deployment/inferred", Some("default")),
             ),
             (
-                unresolved_target("inferred-ns", Some("staging")),
+                unresolved_target("inferred-ns", Some("staging"), None),
                 resolved_target("pod/inferred-ns-7f9d8c7df8", Some("staging")),
             ),
             // Not requested by any service; must survive the drain.
             (
-                unresolved_target("unrelated", None),
+                unresolved_target("unrelated", None, None),
                 resolved_target("deployment/unrelated", None),
             ),
         ]);
 
         let subprocesses: HashMap<String, SubprocessCfg> = config
-            .service_configs(&key, &mut resolved_targets)
+            .service_configs(&key, &mut resolved_targets, UpKubeContext::default())
             .map(|cfg| (cfg.service_name.to_string(), cfg))
             .collect();
 
@@ -1301,7 +1404,7 @@ mod tests {
 
         assert_eq!(
             resolved_targets.into_keys().collect::<Vec<_>>(),
-            vec![unresolved_target("unrelated", None)],
+            vec![unresolved_target("unrelated", None, None)],
         );
     }
 
@@ -1320,7 +1423,7 @@ mod tests {
         let mut resolved_targets = HashMap::new();
 
         config
-            .service_configs(&key, &mut resolved_targets)
+            .service_configs(&key, &mut resolved_targets, UpKubeContext::default())
             .for_each(drop);
     }
 
@@ -1342,12 +1445,12 @@ mod tests {
         );
         let key = env_key();
         let mut resolved_targets = HashMap::from([(
-            unresolved_target("inferred-ns", None),
+            unresolved_target("inferred-ns", None, None),
             resolved_target("deployment/inferred-ns", Some("staging")),
         )]);
 
         config
-            .service_configs(&key, &mut resolved_targets)
+            .service_configs(&key, &mut resolved_targets, UpKubeContext::default())
             .for_each(drop);
     }
 
@@ -1364,7 +1467,7 @@ mod tests {
         );
         let key = env_key();
         let mut resolved_targets = HashMap::from([(
-            unresolved_target("inferred", None),
+            unresolved_target("inferred", None, None),
             ResolvedTarget {
                 resolved: SpecifiedTarget {
                     path: None,
@@ -1374,7 +1477,7 @@ mod tests {
         )]);
 
         config
-            .service_configs(&key, &mut resolved_targets)
+            .service_configs(&key, &mut resolved_targets, UpKubeContext::default())
             .for_each(drop);
     }
 
@@ -1518,6 +1621,7 @@ mod tests {
                     "accept_invalid_certificates": false,
                     "operator": false,
                     "telemetry": false,
+                    "context": false,
                 },
                 "config_fields_used": {
                     "target": 0,
@@ -1526,6 +1630,7 @@ mod tests {
                     "http_filter": 0,
                     "ignore_ports": 0,
                     "skip": 0,
+                    "context": 0
                 },
                 "run_types": {
                     "exec": 1,
@@ -1577,6 +1682,7 @@ mod tests {
                 run:
                   command: ["echo"]
               svc-b:
+                context: "magical-mystery-cluster"
                 env:
                   override:
                     KEY: "value"
@@ -1600,6 +1706,7 @@ mod tests {
         assert_eq!(result["config_fields_used"]["http_filter"], 1);
         assert_eq!(result["config_fields_used"]["ignore_ports"], 1);
         assert_eq!(result["config_fields_used"]["default_mode"], 0);
+        assert_eq!(result["config_fields_used"]["context"], 1);
         assert_eq!(result["run_types"]["exec"], 2);
         assert_eq!(result["run_types"]["container"], 1);
     }

--- a/mirrord/up/src/init.rs
+++ b/mirrord/up/src/init.rs
@@ -131,6 +131,7 @@ fn prompt_common() -> Result<CommonConfig, InitError> {
         operator: (!use_operator).then_some(false),
         accept_invalid_certificates: accept_invalid_certs.then_some(true),
         telemetry: (!telemetry).then_some(false),
+        context: None,
     })
 }
 
@@ -174,6 +175,7 @@ fn prompt_service(
             ignore_ports,
             skip: false,
             run,
+            context: None,
         },
     ))
 }
@@ -470,6 +472,7 @@ mod tests {
                 r#type: RunType::Exec,
                 command: vec!["go".to_owned(), "run".to_owned(), "./cmd/api".to_owned()],
             },
+            context: Some("popper-deskpop".into()),
         }
     }
 
@@ -480,6 +483,7 @@ mod tests {
                 operator: Some(false),
                 accept_invalid_certificates: Some(true),
                 telemetry: None,
+                context: None,
             },
             services: [("api".into(), sample_service())].into_iter().collect(),
         };
@@ -530,6 +534,7 @@ mod tests {
                 r#type: RunType::Exec,
                 command: vec!["echo".to_owned()],
             },
+            context: None,
         };
         let cfg = UpConfig {
             common: CommonConfig::default(),
@@ -549,6 +554,7 @@ mod tests {
         );
         assert!(!out.contains("target:"), "no empty target block:\n{out}");
         assert!(out.contains("header_filter"), "filter retained:\n{out}");
+        assert!(!out.contains("context:"), "no empty context:\n{out}");
 
         let parsed: UpConfig = serde_yaml::from_str(&out).unwrap();
         assert_eq!(parsed.services["svc"], svc);
@@ -569,6 +575,7 @@ mod tests {
                 r#type: RunType::Exec,
                 command: vec!["go".to_owned(), "run".to_owned(), "--opt=a,b".to_owned()],
             },
+            context: None,
         };
         let cfg = UpConfig {
             common: CommonConfig::default(),
@@ -613,6 +620,7 @@ mod tests {
                 r#type: RunType::Exec,
                 command: vec!["echo".to_owned()],
             },
+            context: None,
         };
         let cfg = UpConfig {
             common: CommonConfig::default(),

--- a/mirrord/up/src/kube_context.rs
+++ b/mirrord/up/src/kube_context.rs
@@ -1,0 +1,21 @@
+use std::sync::Arc;
+
+/// The kube context for this run of `mirrord up`. Can be used to calculate the kube context for
+/// each target when resolving config or creating service configs and is cheaply clonable because it
+/// contains `Arc`s.
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
+pub struct UpKubeContext {
+    pub command_arg: Option<Arc<str>>,
+    pub common_context: Option<Arc<str>>,
+}
+
+impl UpKubeContext {
+    // Decide with kube context to use for the given target
+    pub fn get_context(&self, target_context: Option<Arc<str>>) -> Option<Arc<str>> {
+        self.command_arg
+            .as_ref()
+            .or(target_context.as_ref())
+            .or(self.common_context.as_ref())
+            .cloned()
+    }
+}

--- a/mirrord/up/src/lib.rs
+++ b/mirrord/up/src/lib.rs
@@ -6,7 +6,7 @@
 #![deny(missing_docs)]
 
 use std::{
-    collections::HashMap,
+    collections::{HashMap, hash_map::Entry},
     ops::Not,
     path::{Path, PathBuf},
     process::{ExitStatus, Stdio},
@@ -18,8 +18,12 @@ use std::{
     time::{Duration, Instant},
 };
 
+pub use config::{
+    IncompatibleTarget, ModeError, SelectError, ServiceMode, SubprocessCfg, UpConfig,
+};
 use config::{ResolvedTarget, SpecifiedTarget, UnresolvedTarget, validate_targets};
 use futures::TryStreamExt;
+pub use init::{InitError, run_wizard};
 use inquire::{Confirm, Select};
 use k8s_openapi::api::core::v1::Namespace;
 use miette::Diagnostic;
@@ -32,24 +36,23 @@ use mirrord_kube::{
     api::kubernetes::{create_kube_config, seeker::KubeResourceSeeker},
     error::KubeApiError,
 };
+use mirrord_progress::{MIRRORD_PROGRESS_ENV, messages::SESSION_READY_MESSAGE};
 use tera::Tera;
 use thiserror::Error;
-use yamlpatch::{Op, Patch, apply_yaml_patches};
-use yamlpath::{Document, route};
-mod config;
-mod init;
-
-pub use config::{
-    IncompatibleTarget, ModeError, SelectError, ServiceMode, SubprocessCfg, UpConfig,
-};
-pub use init::{InitError, run_wizard};
-use mirrord_progress::{MIRRORD_PROGRESS_ENV, messages::SESSION_READY_MESSAGE};
 use tokio::{
     io::{AsyncBufReadExt, BufReader},
     process::Command,
     task::{JoinError, JoinSet},
 };
 use uuid::Uuid;
+use yamlpatch::{Op, Patch, apply_yaml_patches};
+use yamlpath::{Document, route};
+
+use crate::kube_context::UpKubeContext;
+
+mod config;
+mod init;
+mod kube_context;
 
 /// Shared slot that [`run`] fills with the time it took for **all** child
 /// sessions to become ready, measured from process spawn.
@@ -169,11 +172,15 @@ const INFERRED_TARGET_TYPES: [TargetType; 4] = [
 /// key up in the cluster (see [`INFERRED_TARGET_TYPES`] for the search order).
 /// When no workload matches, an interactive wizard lets the user pick a
 /// different namespace and workload, or exit.
+///
+/// If the user has specified a kube context via `--context`, `config.services.*.context` or
+/// `config.common.context`, use this to resolve targets.
 async fn resolve_unresolved_workloads(
     up_config: &UpConfig,
     config_path: &Path,
+    up_context: UpKubeContext,
 ) -> Result<HashMap<UnresolvedTarget, ResolvedTarget>, UpError> {
-    let unresolved = up_config.unresolved_targets();
+    let unresolved = up_config.unresolved_targets(up_context.clone());
 
     let (_, bound_max) = unresolved.size_hint();
 
@@ -182,23 +189,35 @@ async fn resolve_unresolved_workloads(
         return Ok(HashMap::new());
     }
 
-    let kube_config = create_kube_config(
-        up_config.common.accept_invalid_certificates,
-        None::<&str>,
-        None,
-    )
-    .await?;
-    let client = kube::Client::try_from(kube_config).map_err(KubeApiError::from)?;
+    let mut clients = HashMap::new();
 
     let mut map = HashMap::new();
     for unresolved_target in unresolved {
+        let kube_context = up_context
+            .clone()
+            .get_context(unresolved_target.kube_context.clone());
+        let client = match clients.entry(kube_context.clone()) {
+            Entry::Occupied(client) => client.into_mut(),
+            Entry::Vacant(vacant_entry) => {
+                // create the client we need and add it to the HashMap
+                let kube_config = create_kube_config(
+                    up_config.common.accept_invalid_certificates,
+                    None::<&str>,
+                    kube_context.as_deref().map(Into::into),
+                )
+                .await?;
+                let client = kube::Client::try_from(kube_config).map_err(KubeApiError::from)?;
+                vacant_entry.insert(client)
+            }
+        };
+
         let name = &unresolved_target.workload_name;
         let namespace = unresolved_target
             .namespace
             .as_deref()
             .unwrap_or(client.default_namespace());
 
-        let workloads = list_workloads(&client, namespace).await?;
+        let workloads = list_workloads(client, namespace).await?;
         let resolved = match find_by_name(&workloads, name) {
             Some(path) => {
                 println!("{name}: using {path}");
@@ -211,9 +230,12 @@ async fn resolve_unresolved_workloads(
             }
             None => {
                 println!(
-                    "{name}: No workload named \"{name}\" found in namespace \"{namespace}\"."
+                    "{name}: No workload named \"{name}\" found in namespace \"{namespace}\"{}.",
+                    kube_context
+                        .map(|context| format!(" using context \"{context}\""))
+                        .unwrap_or_default()
                 );
-                prompt_for_target(&client, name, config_path).await?
+                prompt_for_target(client, name, config_path).await?
             }
         };
 
@@ -408,14 +430,21 @@ fn save_target(
 pub async fn run(
     up_config: UpConfig,
     config_path: &Path,
+    kube_context_arg: Option<Arc<str>>,
     key: EnvKey,
     correlation_id: Uuid,
     ready: ReadyTracker,
 ) -> Result<(), UpError> {
-    let mut resolved_targets = resolve_unresolved_workloads(&up_config, config_path).await?;
+    let up_context = UpKubeContext {
+        command_arg: kube_context_arg,
+        common_context: up_config.common.context.clone(),
+    };
+
+    let mut resolved_targets =
+        resolve_unresolved_workloads(&up_config, config_path, up_context.clone()).await?;
 
     let service_configs: Vec<SubprocessCfg> = up_config
-        .service_configs(&key, &mut resolved_targets)
+        .service_configs(&key, &mut resolved_targets, up_context)
         .collect();
 
     validate_targets(&service_configs)?;


### PR DESCRIPTION
### Summary

Linear Issue: [COR-1636](https://linear.app/metalbear/issue/COR-1636/mirrord-up-support-context-selection-per-run-or-per-service)
Docs PR: https://github.com/metalbear-co/docs/pull/306

- Allows users to set kubernetes context when running `up`.
- Also updated `up` to run the local UI without `Command::new`.

See commit descriptions for more details.

### Quality Checklist:

- [x] I have documented new code sufficiently
- [x] I have checked and updated the relevant existing docs in code, including removing outdated material
- [x] I have written user-facing website docs for new features, or opened a (sub)issue to do so
- [x] I have checked and updated existing website docs for changed features
- [x] I have tested this change and know it succeeds and fails as expected
- [x] I have written unit tests or purposefully omitted them
- [x] I have explained what this PR introduces and why, and linked to relevant context (e.g. linear issues, related PRs,
  documentation)
- [x] I have introduced a short, clear and well-formatted changelog entry

<!-- need help with the changelog? see ../CONTRIBUTING.md#submitting-a-pull-request -->
<!-- Add more details of your changes below if needed -->