### PR TITLE
Show preview idle state in UI

### DIFF
--- a/changelog.d/+preview-idle-state-ui.changed.md
+++ b/changelog.d/+preview-idle-state-ui.changed.md
@@ -1,0 +1,1 @@
+`mirrord ui` now shows the state, e.g. idling or active, of preview sessions.

--- a/mirrord/cli/src/ui/server.rs
+++ b/mirrord/cli/src/ui/server.rs
@@ -31,7 +31,10 @@ use kube::{
     config::{Config, KubeConfigOptions, Kubeconfig},
 };
 use mirrord_config::target::{Target, TargetDisplay};
-use mirrord_operator::crd::{MirrordOperatorCrd, OPERATOR_STATUS_NAME, Session, SessionHttpFilter};
+use mirrord_operator::crd::{
+    MirrordOperatorCrd, OPERATOR_STATUS_NAME, PreviewSessionInfo, Session, SessionHttpFilter,
+    preview::PreviewSessionPhase,
+};
 use mirrord_session_monitor_client::{
     SESSION_SENTINEL_EXTENSION, SessionClient, SessionEndpoint, connect_to_session,
     session_endpoints,
@@ -153,6 +156,74 @@ impl FromStr for OperatorSessionTarget {
     }
 }
 
+/// Information of a preview environment required by frontend.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OperatorPreviewSession {
+    pub id: String,
+    pub key: String,
+    pub namespace: String,
+    pub target: Option<OperatorSessionTarget>,
+    pub created_at: String,
+    #[serde(default)]
+    pub duration_secs: u64,
+    pub phase: OperatorPreviewPhase,
+    /// How long the preview has been idle. `None` unless `phase` is
+    /// [`OperatorPreviewPhase::Idle`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub idle_secs: Option<u64>,
+}
+
+/// Lifecycle phase of a preview environment, lower-cased for the frontend.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum OperatorPreviewPhase {
+    Initializing,
+    Waiting,
+    Ready,
+    Failed,
+    Idle,
+    Unknown,
+}
+
+impl From<PreviewSessionPhase> for OperatorPreviewPhase {
+    fn from(phase: PreviewSessionPhase) -> Self {
+        match phase {
+            PreviewSessionPhase::Initializing => Self::Initializing,
+            PreviewSessionPhase::Waiting => Self::Waiting,
+            PreviewSessionPhase::Ready => Self::Ready,
+            PreviewSessionPhase::Failed => Self::Failed,
+            PreviewSessionPhase::Idle => Self::Idle,
+            PreviewSessionPhase::Unknown => Self::Unknown,
+        }
+    }
+}
+
+impl OperatorPreviewSession {
+    pub(crate) fn from_preview(preview: &PreviewSessionInfo) -> Option<Self> {
+        Some(Self {
+            id: preview.id.clone(),
+            key: preview.key.clone(),
+            namespace: preview.namespace.clone(),
+            target: OperatorSessionTarget::from_str(&preview.target).ok(),
+            created_at: created_at_from_duration(preview.duration_secs)?,
+            duration_secs: preview.duration_secs,
+            phase: preview.phase.into(),
+            idle_secs: preview.idle_secs,
+        })
+    }
+}
+
+fn created_at_from_duration(duration_secs: u64) -> Option<String> {
+    SystemTime::now()
+        .checked_sub(Duration::from_secs(duration_secs))
+        .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+        .map(|d| d.as_secs())
+        .and_then(|secs| i64::try_from(secs).ok())
+        .and_then(|secs| Timestamp::from_second(secs).ok())
+        .map(|ts| ts.to_string())
+}
+
 impl OperatorSessionSummary {
     pub(crate) fn from_session(session: &Session) -> Option<Self> {
         let id = session.id.clone()?;
@@ -165,13 +236,7 @@ impl OperatorSessionSummary {
 
         let target = OperatorSessionTarget::from_str(&session.target).ok();
 
-        let created_at = SystemTime::now()
-            .checked_sub(Duration::from_secs(session.duration_secs))
-            .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
-            .map(|d| d.as_secs())
-            .and_then(|secs| i64::try_from(secs).ok())
-            .and_then(|secs| Timestamp::from_second(secs).ok())
-            .map(|ts| ts.to_string())?;
+        let created_at = created_at_from_duration(session.duration_secs)?;
         let http_filter = session.http_filter.as_ref().map(|f| SessionHttpFilter {
             header_filter: f.header_filter.clone(),
         });
@@ -1415,6 +1480,42 @@ mod tests {
             );
             assert_eq!(summary.owner.username, "alice");
             assert_eq!(summary.owner.k8s_username, "alice@ex");
+        }
+
+        #[test]
+        fn preview_carries_its_phase_and_idle_time() {
+            let preview = PreviewSessionInfo {
+                id: "preview-uid".to_owned(),
+                namespace: "default".to_owned(),
+                key: "alice-session".to_owned(),
+                target: "deployment/web".to_owned(),
+                duration_secs: 600,
+                phase: PreviewSessionPhase::Idle,
+                idle_secs: Some(60),
+            };
+
+            let preview = OperatorPreviewSession::from_preview(&preview).unwrap();
+
+            assert_eq!(preview.id, "preview-uid");
+            assert_eq!(preview.key, "alice-session");
+            assert_eq!(
+                preview.target.as_ref().map(|t| t.name.as_str()),
+                Some("web")
+            );
+            assert_eq!(preview.phase, OperatorPreviewPhase::Idle);
+            assert_eq!(preview.idle_secs, Some(60));
+        }
+
+        #[test]
+        fn preview_phase_serializes_lowercase() {
+            assert_eq!(
+                serde_json::to_value(OperatorPreviewPhase::Idle).unwrap(),
+                serde_json::json!("idle"),
+            );
+            assert_eq!(
+                serde_json::to_value(OperatorPreviewPhase::Initializing).unwrap(),
+                serde_json::json!("initializing"),
+            );
         }
 
         #[tokio::test]

--- a/mirrord/cli/src/ui/server/v2.rs
+++ b/mirrord/cli/src/ui/server/v2.rs
@@ -35,9 +35,9 @@ use serde::{Deserialize, Serialize};
 use tracing::warn;
 
 use super::{
-    AppState, OperatorLicense, OperatorLockedPort, OperatorQueueSplits, OperatorSessionOwner,
-    OperatorSessionSummary, OperatorSessionTarget, UiResult, client_for_context, get_session,
-    kill_session, list_sessions, session_events_sse,
+    AppState, OperatorLicense, OperatorLockedPort, OperatorPreviewSession, OperatorQueueSplits,
+    OperatorSessionOwner, OperatorSessionSummary, OperatorSessionTarget, UiResult,
+    client_for_context, get_session, kill_session, list_sessions, session_events_sse,
 };
 use crate::ui::error::ApiError;
 
@@ -127,6 +127,11 @@ struct OperatorSessionsResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     reason: Option<String>,
     sessions: Vec<OperatorSession>,
+    /// Preview environments info.
+    /// For backward compatibility, preview session info is also chained into `sessions` where
+    /// released clients read. But new info of preview should be added in `preview_sessions`.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    preview_sessions: Vec<OperatorPreviewSession>,
 }
 
 /// One cluster session. This is [`OperatorSessionSummary`] minus `durationSecs`: age is derived
@@ -164,12 +169,18 @@ impl From<OperatorSessionSummary> for OperatorSession {
     }
 }
 
+struct OperatorStatusSummary {
+    sessions: Vec<OperatorSessionSummary>,
+    preview_sessions: Vec<OperatorPreviewSession>,
+    license: OperatorLicense,
+}
+
 /// Fetches the operator's live sessions and license for `context` in one request. Returns a
 /// human-readable reason when the context is unreachable or the operator isn't installed.
 async fn fetch_operator(
     state: &AppState,
     context: Option<&str>,
-) -> Result<(Vec<OperatorSessionSummary>, OperatorLicense), String> {
+) -> Result<OperatorStatusSummary, String> {
     let client = cached_client(state, context)
         .await
         .map_err(|err| format!("kube client init failed: {err}"))?;
@@ -187,15 +198,25 @@ async fn fetch_operator(
         fingerprint: operator.spec.license.fingerprint.clone(),
         organization: operator.spec.license.organization.clone(),
     };
-    let sessions = operator
-        .status
-        .as_ref()
+    let status = operator.status.as_ref();
+    let sessions = status
         .map(|status| status.sessions.as_slice())
         .unwrap_or_default()
         .iter()
         .filter_map(OperatorSessionSummary::from_session)
         .collect();
-    Ok((sessions, license))
+    let preview_sessions = status
+        .map(|status| status.preview_sessions.as_slice())
+        .unwrap_or_default()
+        .iter()
+        .filter_map(OperatorPreviewSession::from_preview)
+        .collect();
+
+    Ok(OperatorStatusSummary {
+        sessions,
+        preview_sessions,
+        license,
+    })
 }
 
 async fn operator_sessions(
@@ -203,22 +224,32 @@ async fn operator_sessions(
     Query(query): Query<OperatorSessionsQuery>,
 ) -> axum::Json<OperatorSessionsResponse> {
     let response = match fetch_operator(&state, query.context.as_deref()).await {
-        Ok((sessions, _license)) => {
-            let sessions = sessions
+        Ok(snapshot) => {
+            let in_namespace = |namespace: &str| {
+                query
+                    .namespace
+                    .as_deref()
+                    .is_none_or(|selected| namespace == selected)
+            };
+
+            let sessions = snapshot
+                .sessions
                 .into_iter()
-                .filter(|session| {
-                    query
-                        .namespace
-                        .as_deref()
-                        .is_none_or(|namespace| session.namespace == namespace)
-                })
+                .filter(|session| in_namespace(&session.namespace))
                 .map(OperatorSession::from)
                 .collect();
+            let preview_sessions = snapshot
+                .preview_sessions
+                .into_iter()
+                .filter(|preview| in_namespace(&preview.namespace))
+                .collect();
+
             OperatorSessionsResponse {
                 context: query.context,
                 status: OperatorStatus::Available,
                 reason: None,
                 sessions,
+                preview_sessions,
             }
         }
         Err(reason) => {
@@ -228,6 +259,7 @@ async fn operator_sessions(
                 status: OperatorStatus::Unavailable,
                 reason: Some(reason),
                 sessions: Vec::new(),
+                preview_sessions: Vec::new(),
             }
         }
     };
@@ -244,7 +276,7 @@ async fn operator_license(
     let license = fetch_operator(&state, query.context.as_deref())
         .await
         .ok()
-        .map(|(_sessions, license)| license);
+        .map(|summary| summary.license);
     axum::Json(license)
 }
 

--- a/mirrord/operator/src/crd.rs
+++ b/mirrord/operator/src/crd.rs
@@ -329,6 +329,11 @@ impl CopyTargetEntryCompat {
 /// _CRD-ish_ that we get from `mirrord operator status`.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, JsonSchema)]
 pub struct MirrordOperatorStatus {
+    /// Active exec and CI sessions, plus an entry per preview environment.
+    ///
+    /// mirrord CLI versions before 3.246.0 and browser extension versions before 0.7.0 read
+    /// preview environments from here, so those entries stay for as long as these versions are
+    /// supported. New preview information belongs in [`Self::preview_sessions`].
     pub sessions: Vec<Session>,
     pub statistics: Option<MirrordOperatorStatusStatistics>,
 
@@ -342,6 +347,27 @@ pub struct MirrordOperatorStatus {
     /// Active multi-cluster sessions (only on primary with multi-cluster enabled).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub multi_cluster_sessions: Option<Vec<MultiClusterSessionInfo>>,
+
+    /// Active preview environments.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub preview_sessions: Vec<PreviewSessionInfo>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct PreviewSessionInfo {
+    pub id: String,
+    pub namespace: String,
+    pub key: String,
+    pub target: String,
+    pub duration_secs: u64,
+
+    /// Current phase of the preview environment.
+    pub phase: preview::PreviewSessionPhase,
+
+    /// How long this preview environment has been idling.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub idle_secs: Option<u64>,
 }
 
 /// Display representation of a multi-cluster session for `mirrord operator status`.
@@ -468,6 +494,9 @@ impl LockedPortCompat {
 /// and the browser extension can surface them, but they don't behave like normal sessions
 /// (different id shape, no locked ports, no queue-splitting state), so the CLI's
 /// session-management surfaces should filter them out.
+///
+/// Those entries exist for clients that predate [`MirrordOperatorStatus::preview_sessions`].
+/// Everything else should read previews from that field.
 pub const PREVIEW_SESSION_USER: &str = "preview-env";
 
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]

--- a/packages/monitor/src/App.tsx
+++ b/packages/monitor/src/App.tsx
@@ -29,6 +29,7 @@ import {
   leaveViaExtension,
   type ExtensionState,
 } from './extensionBridge'
+import { withPreviewSessions } from './utils'
 
 const LOCAL_POLL_INTERVAL = 2000
 const OPERATOR_POLL_INTERVAL = 5000
@@ -237,7 +238,9 @@ export default function App({
     api
       .listOperatorSessions(effectiveContext, selectedNamespace)
       .then((resp) => {
-        setOperatorSessions(resp.sessions)
+        setOperatorSessions(
+          withPreviewSessions(resp.sessions, resp.previewSessions),
+        )
         setWatchStatus(
           resp.status === 'available'
             ? { status: 'watching' }

--- a/packages/monitor/src/components/OperatorList.tsx
+++ b/packages/monitor/src/components/OperatorList.tsx
@@ -1,7 +1,14 @@
 import { useMemo } from 'react'
 import { Users, FlaskConical, Key as KeyIcon } from 'lucide-react'
 import type { OperatorSessionSummary } from '../types'
-import { firstName, relativeTimeFromIso } from '../utils'
+import {
+  firstName,
+  isPreviewSession,
+  previewPhaseLabel,
+  previewPhaseTone,
+  relativeTimeFromIso,
+  type PreviewTone,
+} from '../utils'
 import { strings } from '../strings'
 import SessionRow from './SessionRow'
 import Avatar from './Avatar'
@@ -36,12 +43,6 @@ function matchesQuery(s: OperatorSessionSummary, q: string): boolean {
     .join(' ')
     .toLowerCase()
   return haystack.includes(q)
-}
-
-const PREVIEW_OWNER_USERNAME = 'preview-env'
-
-function isPreviewSession(s: { owner: { username: string } }): boolean {
-  return s.owner.username === PREVIEW_OWNER_USERNAME
 }
 
 export default function OperatorList({
@@ -153,39 +154,71 @@ function KeyGroupSection({
           {group.sessions.length}
         </span>
       </div>
-      {group.sessions.map((s) => (
-        <SessionRow
-          key={s.id}
-          selected={selectedId === s.id}
-          onClick={() => onSelect(s.id)}
-          lead={
-            isPreviewSession(s) ? (
-              <PreviewBadge />
-            ) : (
-              <Avatar name={s.owner.username} seed={s.owner.k8sUsername} />
-            )
-          }
-          target={s.target ? `${s.target.kind}/${s.target.name}` : 'targetless'}
-          meta={[
-            isPreviewSession(s) ? 'preview env' : firstName(s.owner.username),
-            s.namespace,
-            relativeTimeFromIso(s.createdAt),
-          ]}
-          leftStrip={joined ? 'hsl(var(--primary))' : undefined}
-        />
-      ))}
+      {group.sessions.map((s) => {
+        const phase = s.preview ? previewPhaseLabel(s.preview) : null
+        // Previews served by an operator that doesn't report their phase are assumed to be up,
+        // which is what the sidebar showed before the phase was available at all.
+        const tone = s.preview ? previewPhaseTone(s.preview) : 'live'
+        return (
+          <SessionRow
+            key={s.id}
+            selected={selectedId === s.id}
+            onClick={() => onSelect(s.id)}
+            lead={
+              isPreviewSession(s) ? (
+                <PreviewBadge tone={tone} label={phase} />
+              ) : (
+                <Avatar name={s.owner.username} seed={s.owner.k8sUsername} />
+              )
+            }
+            target={
+              s.target ? `${s.target.kind}/${s.target.name}` : 'targetless'
+            }
+            meta={[
+              isPreviewSession(s) ? 'preview env' : firstName(s.owner.username),
+              ...(phase
+                ? [<PhaseLabel key="phase" tone={tone} label={phase} />]
+                : []),
+              s.namespace,
+              relativeTimeFromIso(s.createdAt),
+            ]}
+            leftStrip={joined ? 'hsl(var(--primary))' : undefined}
+          />
+        )
+      })}
     </div>
   )
 }
 
-function PreviewBadge() {
+const PREVIEW_BADGE_TONE: Record<PreviewTone, string> = {
+  live: 'bg-emerald-500/15 text-emerald-600 dark:text-emerald-300',
+  pending: 'bg-amber-500/15 text-amber-600 dark:text-amber-300',
+  idle: 'bg-muted text-muted-foreground',
+  failed: 'bg-destructive/15 text-destructive',
+}
+
+function PreviewBadge({
+  tone,
+  label,
+}: {
+  tone: PreviewTone
+  label: string | null
+}) {
   return (
     <span
-      className="inline-flex items-center justify-center rounded-full bg-emerald-500/15 text-emerald-600 dark:text-emerald-300"
+      className={`inline-flex items-center justify-center rounded-full ${PREVIEW_BADGE_TONE[tone]}`}
       style={{ width: 26, height: 26 }}
-      title="preview environment"
+      title={label ? `preview environment (${label})` : 'preview environment'}
     >
       <FlaskConical className="h-3.5 w-3.5" />
+    </span>
+  )
+}
+
+function PhaseLabel({ tone, label }: { tone: PreviewTone; label: string }) {
+  return (
+    <span className={tone === 'failed' ? 'text-destructive font-medium' : ''}>
+      {label}
     </span>
   )
 }

--- a/packages/monitor/src/components/OperatorSessionDetail.tsx
+++ b/packages/monitor/src/components/OperatorSessionDetail.tsx
@@ -8,6 +8,12 @@ import type {
 } from '../types'
 import type { ExtensionState } from '../extensionBridge'
 import { strings } from '../strings'
+import {
+  isPreviewSession,
+  previewPhaseLabel,
+  previewPhaseTone,
+  type PreviewTone,
+} from '../utils'
 import JoinBar from './JoinBar'
 import MetadataStrip from './MetadataStrip'
 
@@ -15,6 +21,14 @@ const SECS_PER_MIN = 60
 const MINS_PER_HOUR = 60
 const MS_PER_SEC = 1000
 const UPTIME_TICK_MS = 1000
+
+// Matches the badge in the sidebar: green only while a deployment is actually backing the preview.
+const STATUS_DOT_TONE: Record<PreviewTone, string> = {
+  live: 'bg-emerald-500',
+  pending: 'bg-amber-500',
+  idle: 'bg-muted-foreground',
+  failed: 'bg-destructive',
+}
 
 interface OperatorSessionDetailProps {
   session: OperatorSessionSummary
@@ -66,7 +80,11 @@ export default function OperatorSessionDetail({
     : 'targetless'
   const lockedPorts = session.lockedPorts ?? []
   const splits = session.queueSplits
-  const isPreview = session.owner.username === 'preview-env'
+  const isPreview = isPreviewSession(session)
+  const preview = session.preview
+  const phaseLabel = preview ? previewPhaseLabel(preview) : null
+  // Only a preview reports a phase; everything else here is a running exec session.
+  const tone = preview ? previewPhaseTone(preview) : 'live'
 
   const baseSecs = session.durationSecs ?? 0
   const [uptime, setUptime] = useState(baseSecs)
@@ -86,7 +104,9 @@ export default function OperatorSessionDetail({
       <div className="border-border surface-inset shrink-0 border-b px-4 py-2">
         <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
           <div className="flex min-w-0 items-center gap-2">
-            <span className="h-2 w-2 shrink-0 rounded-full bg-emerald-500" />
+            <span
+              className={`h-2 w-2 shrink-0 rounded-full ${STATUS_DOT_TONE[tone]}`}
+            />
             <span className="text-title text-foreground truncate font-mono">
               {targetLabel}
             </span>
@@ -101,10 +121,14 @@ export default function OperatorSessionDetail({
               <Badge
                 variant="outline"
                 style={{ fontSize: 10 }}
-                className="text-muted-foreground border-border inline-flex h-4 shrink-0 items-center gap-1 px-1.5 py-0 font-medium"
+                className={`inline-flex h-4 shrink-0 items-center gap-1 px-1.5 py-0 font-medium ${
+                  tone === 'failed'
+                    ? 'text-destructive border-destructive/40'
+                    : 'text-muted-foreground border-border'
+                }`}
               >
                 <FlaskConical className="h-2.5 w-2.5" />
-                {strings.operatorDetail.previewBadge}
+                {phaseLabel ?? strings.operatorDetail.previewBadge}
               </Badge>
             )}
           </div>

--- a/packages/monitor/src/types.ts
+++ b/packages/monitor/src/types.ts
@@ -78,6 +78,27 @@ export interface OperatorQueueSplits {
   kafka: number
 }
 
+// Lifecycle of a preview environment.
+export type PreviewPhase =
+  | 'initializing'
+  | 'waiting'
+  | 'ready'
+  | 'failed'
+  | 'idle'
+  | 'unknown'
+
+export interface OperatorPreviewSession {
+  id: string
+  key: string
+  namespace: string
+  target: OperatorSessionTarget | null
+  createdAt: string
+  durationSecs?: number
+  phase: PreviewPhase
+  // Only set while `phase` is `idle`.
+  idleSecs?: number
+}
+
 export interface OperatorSessionSummary {
   id: string
   key: string
@@ -89,6 +110,7 @@ export interface OperatorSessionSummary {
   lockedPorts?: OperatorLockedPort[]
   queueSplits?: OperatorQueueSplits
   httpFilter?: OperatorSessionHttpFilter | null
+  preview?: OperatorPreviewSession
 }
 
 // Reachability of the operator, as the sidebar consumes it. The v2 server only ever produces
@@ -119,6 +141,8 @@ export interface OperatorSessionsResponse {
   status: 'available' | 'unavailable'
   reason?: string
   sessions: OperatorSessionSummary[]
+  // Absent against operators that don't report preview environments separately.
+  previewSessions?: OperatorPreviewSession[]
 }
 
 // Chaos rules ("mirrord chaos"), scoped to a local exec session (see mirrord-intproxy's

--- a/packages/monitor/src/utils.ts
+++ b/packages/monitor/src/utils.ts
@@ -1,8 +1,94 @@
+import type { OperatorPreviewSession, OperatorSessionSummary } from './types'
+
 const MS_PER_SEC = 1000
 const SECS_PER_MIN = 60
 const MINS_PER_HOUR = 60
 const SECS_PER_HOUR = 3600
 const SECS_PER_DAY = 86400
+
+// Owner the operator gives the preview entries it folds into its session list. Reading previews
+// from `previewSessions` is what identifies them; this is the fallback for operators that don't
+// report that list.
+const PREVIEW_OWNER_USERNAME = 'preview-env'
+
+export function isPreviewSession(session: OperatorSessionSummary): boolean {
+  return (
+    session.preview !== undefined ||
+    session.owner.username === PREVIEW_OWNER_USERNAME
+  )
+}
+
+// Builds the cluster session list the sidebar renders, taking preview environments from
+// `previewSessions` and dropping the entries the operator folds into `sessions` for clients that
+// read them from there, so previews aren't listed twice.
+export function withPreviewSessions(
+  sessions: OperatorSessionSummary[],
+  previews: OperatorPreviewSession[] | undefined,
+): OperatorSessionSummary[] {
+  if (!previews?.length) return sessions
+
+  const previewIds = new Set(previews.map((preview) => preview.id))
+
+  return sessions
+    .filter((session) => !previewIds.has(session.id))
+    .concat(previews.map(previewAsSession))
+}
+
+function previewAsSession(
+  preview: OperatorPreviewSession,
+): OperatorSessionSummary {
+  return {
+    id: preview.id,
+    key: preview.key,
+    namespace: preview.namespace,
+    owner: {
+      username: PREVIEW_OWNER_USERNAME,
+      k8sUsername: PREVIEW_OWNER_USERNAME,
+    },
+    target: preview.target,
+    createdAt: preview.createdAt,
+    ...(preview.durationSecs === undefined
+      ? {}
+      : { durationSecs: preview.durationSecs }),
+    preview,
+  }
+}
+
+export type PreviewTone = 'live' | 'pending' | 'idle' | 'failed'
+
+export function previewPhaseTone(preview: OperatorPreviewSession): PreviewTone {
+  switch (preview.phase) {
+    case 'ready':
+      return 'live'
+    case 'initializing':
+    case 'waiting':
+      return 'pending'
+    case 'idle':
+      return 'idle'
+    case 'failed':
+      return 'failed'
+    case 'unknown':
+      return 'idle'
+  }
+}
+
+export function previewPhaseLabel(
+  preview: OperatorPreviewSession,
+): string | null {
+  switch (preview.phase) {
+    case 'idle':
+      return preview.idleSecs === undefined
+        ? 'idle'
+        : `idle ${formatDurationSecs(preview.idleSecs)}`
+    case 'initializing':
+    case 'waiting':
+    case 'failed':
+      return preview.phase
+    case 'ready':
+    case 'unknown':
+      return null
+  }
+}
 
 export function formatUptime(startedAt: string): string {
   const parsed = /^\d+$/.test(startedAt)


### PR DESCRIPTION
<!-- Thank you for contributing to mirrord! -->
<!-- Please use the checklist below as a guide for docs, tests and admin tasks for your PR -->
<!-- Feel free to ~strikethrough~ any items that you don't think apply -->

Make `mirrord ui` display preview sessions' state, e.g. idle or active.

Before this change, mirrord ui relying on reading preview from `operator.statue.sessions`. Note that operator folds preview info into the `operator.status.sessions` array. To introduce `phase` which is a preview only thing, I added `preview_sessions` under operator status so the schema is dedicated for preview.

I imagine making preview environment managed by aggregated preview resource APIs would be nicer (CLI could just call `Api<PreviewSession>::list_resources`, and not rely on operator status to carry preview info), but that is a much much bigger rewrite. Until that day, we can live with this I think.

Operator changes required are in this PR: https://github.com/metalbear-co/operator/pull/2184

### Quality Checklist:

- [x] I have documented new code sufficiently
- [x] I have checked and updated the relevant existing docs in code, including removing outdated material
- [ ] I have written user-facing website docs for new features, or opened a (sub)issue to do so
- [ ] I have checked and updated existing website docs for changed features
- [x] I have tested this change and know it succeeds and fails as expected
- [ ] I have written unit tests or purposefully omitted them
- [ ] I have written e2e tests or purposefully omitted them
- [x] I have explained what this PR introduces and why, and linked to relevant context (e.g. linear issues, related PRs,
  documentation)
- [x] I have introduced a short, clear and well-formatted changelog entry

<!-- need help with the changelog? see ../CONTRIBUTING.md#submitting-a-pull-request -->
<!-- Add more details of your changes below if needed -->