### PR TITLE
Raise default agent CPU limit to 1 core

### DIFF
--- a/changelog.d/+agent-cpu-limit.changed.md
+++ b/changelog.d/+agent-cpu-limit.changed.md
@@ -1,0 +1,1 @@
+Raised the default CPU limit on agent pods from `100m` to `1` core, so agents are not throttled under heavier traffic. Set `agent.resources` to override.

--- a/mirrord-schema.json
+++ b/mirrord-schema.json
@@ -612,7 +612,7 @@
         },
         "resources": {
           "title": "agent.resources {#agent-resources}",
-          "description": "Set pod resource requirements. (not with ephemeral agents)\nDefault is\n```json\n{\n  \"agent\": {\n    \"resources\": {\n      \"requests\":\n      {\n        \"cpu\": \"1m\",\n        \"memory\": \"1Mi\"\n      },\n      \"limits\":\n      {\n        \"cpu\": \"100m\",\n        \"memory\": \"100Mi\"\n      }\n    }\n  }\n}\n```",
+          "description": "Set pod resource requirements. (not with ephemeral agents)\nDefault is\n```json\n{\n  \"agent\": {\n    \"resources\": {\n      \"requests\":\n      {\n        \"cpu\": \"1m\",\n        \"memory\": \"1Mi\"\n      },\n      \"limits\":\n      {\n        \"cpu\": \"1\",\n        \"memory\": \"100Mi\"\n      }\n    }\n  }\n}\n```",
           "anyOf": [
             {
               "$ref": "#/$defs/io.k8s.api.core.v1.ResourceRequirements"

--- a/mirrord/config/src/agent.rs
+++ b/mirrord/config/src/agent.rs
@@ -284,7 +284,7 @@ pub struct AgentConfig {
     ///       },
     ///       "limits":
     ///       {
-    ///         "cpu": "100m",
+    ///         "cpu": "1",
     ///         "memory": "100Mi"
     ///       }
     ///     }

--- a/mirrord/kube/src/api/container/job.rs
+++ b/mirrord/kube/src/api/container/job.rs
@@ -453,7 +453,7 @@ mod test {
                                     },
                                     "limits":
                                     {
-                                        "cpu": "100m",
+                                        "cpu": "1",
                                         "memory": "100Mi"
                                     },
                                 }
@@ -599,7 +599,7 @@ mod test {
                                     },
                                     "limits":
                                     {
-                                        "cpu": "100m",
+                                        "cpu": "1",
                                         "memory": "100Mi"
                                     },
                                 }

--- a/mirrord/kube/src/api/container/pod.rs
+++ b/mirrord/kube/src/api/container/pod.rs
@@ -73,7 +73,7 @@ impl ContainerVariant for PodVariant<'_> {
                 },
                 "limits":
                 {
-                    "cpu": "100m",
+                    "cpu": "1",
                     "memory": "100Mi"
                 },
             }))


### PR DESCRIPTION
## Summary

Bumps the default CPU limit on mirrord agent pods from `100m` to `1` core. `100m` throttles the agent under heavier traffic; a full core gives it room to work.

Requests are unchanged (`1m` CPU / `1Mi` memory), so this does not change scheduling pressure — only the ceiling. `agent.resources` still overrides the whole block.

## Changes

- `mirrord/kube/src/api/container/pod.rs` — the default `ResourceRequirements` used when `agent.resources` is unset
- `mirrord/config/src/agent.rs` — doc comment for `agent.resources`, plus regenerated `mirrord-schema.json`
- `mirrord/kube/src/api/container/job.rs` — expected JSON in the container tests