### PR TITLE
Fix the release-branch mirrord CLI build job

### DIFF
--- a/.github/workflows/build-mirrord-cli.yaml
+++ b/.github/workflows/build-mirrord-cli.yaml
@@ -9,10 +9,6 @@ permissions:
 jobs:
   build-mirrord-cli:
     runs-on: ubuntu-24.04
-    # The CLI embeds the layer with `include_bytes!(env!("MIRRORD_LAYER_FILE"))`, so the layer has
-    # to be built first and this has to point at it, otherwise the CLI does not compile.
-    env:
-      MIRRORD_LAYER_FILE: ${{ github.workspace }}/target/debug/libmirrord_layer.so
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: metalbear-co/setup-protoc@770e54d44679c8e1d8fdc06d1d9268fa79fbefb4
@@ -21,17 +17,30 @@ jobs:
       - uses: metalbear-co/setup-rust-toolchain@a8d42d5aa259519dac1faeee20e37c1fb43453a3
         with:
           cache: false
+          rustflags: ""
       - name: Rust cache
         uses: metalbear-co/rust-cache@d49d62d59c5755dd81754c833186b84a82f895fe # v2.9.1+1
         with:
-          shared-key: mirrord
-      - run: cargo build --manifest-path=./Cargo.toml -p mirrord-layer
-      - run: cargo build --manifest-path=./Cargo.toml -p mirrord
+          shared-key: mirrord-cli
+      # `xtask build-cli` builds the layer and the UI frontend and embeds both into the CLI, so it
+      # needs the same zigbuild and pnpm toolchain the release build uses.
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
+      - run: uv tool install cargo-zigbuild==0.22.1
+      - run: uv tool install ziglang==0.15.2 --with-executables-from ziglang
+      - run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - run: ln -sf "$(command -v python-zig)" "$HOME/.local/bin/zig"
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: 24
+      - name: Enable corepack (pnpm-only; leave npm alone for wizard build)
+        run: corepack enable pnpm
+      - name: Build mirrord CLI
+        run: cargo xtask build-cli --platform linux-x86_64
       - name: upload mirrord CLI
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: mirrord-artifacts
           path: |
-            target/debug/mirrord
+            target/x86_64-unknown-linux-gnu/debug/mirrord
           if-no-files-found: error
           retention-days: 2

--- a/.github/workflows/build-mirrord-cli.yaml
+++ b/.github/workflows/build-mirrord-cli.yaml
@@ -9,6 +9,10 @@ permissions:
 jobs:
   build-mirrord-cli:
     runs-on: ubuntu-24.04
+    # The CLI embeds the layer with `include_bytes!(env!("MIRRORD_LAYER_FILE"))`, so the layer has
+    # to be built first and this has to point at it, otherwise the CLI does not compile.
+    env:
+      MIRRORD_LAYER_FILE: ${{ github.workspace }}/target/debug/libmirrord_layer.so
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: metalbear-co/setup-protoc@770e54d44679c8e1d8fdc06d1d9268fa79fbefb4
@@ -21,6 +25,7 @@ jobs:
         uses: metalbear-co/rust-cache@d49d62d59c5755dd81754c833186b84a82f895fe # v2.9.1+1
         with:
           shared-key: mirrord
+      - run: cargo build --manifest-path=./Cargo.toml -p mirrord-layer
       - run: cargo build --manifest-path=./Cargo.toml -p mirrord
       - name: upload mirrord CLI
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a

--- a/changelog.d/+build-mirrord-cli-layer.internal.md
+++ b/changelog.d/+build-mirrord-cli-layer.internal.md
@@ -1,0 +1,1 @@
+Build the layer before the CLI in the release-branch CLI build job, so the CLI can embed it and the IDE end-to-end tests get a working binary.

--- a/changelog.d/+build-mirrord-cli-layer.internal.md
+++ b/changelog.d/+build-mirrord-cli-layer.internal.md
@@ -1,1 +1,1 @@
-Build the layer before the CLI in the release-branch CLI build job, so the CLI can embed it and the IDE end-to-end tests get a working binary.
+Build the CLI with `cargo xtask build-cli` in the release-branch CLI build job, so the binary the IDE end-to-end tests run embeds the layer and the UI frontend.


### PR DESCRIPTION
The `build mirrord CLI` job fails on release branches:

```
mirrord/cli/src/extract.rs:43:31: error: environment variable `MIRRORD_LAYER_FILE` not defined at compile time
mirrord/cli/src/extract.rs:70:36: error: environment variable `MIRRORD_LAYER_FILE` not defined at compile time
```

The job ran `cargo build -p mirrord` on its own, which cannot compile. The CLI embeds the layer with `include_bytes!(env!("MIRRORD_LAYER_FILE"))`, and nothing built the layer or set the variable.

This job runs only on `releases/*` branches, and the release-branch detection in `ci.yaml` was itself matching nothing until #4659, so the breakage was never surfaced. It feeds `intellij_e2e_on_release_branch` and `vscode_e2e_on_release_branch`, which put the uploaded binary on `PATH` and run it.

Rather than duplicating the layer path in YAML, this builds through `cargo xtask build-cli` — the same entry point the release workflow and the e2e job use. xtask builds the layer and the UI frontend and wires both into the CLI, so the artifact the IDE end-to-end tests download is shaped like the released binary rather than a CLI with an empty embedded UI. It needs the zigbuild and pnpm toolchain, installed the way `release.yaml` does, and the artifact moves to the target triple directory zigbuild writes to.

Targets the 3.245.0 release branch so that release PR (#4683) goes green.