### PR TITLE
Fix the release-branch mirrord CLI build job

### DIFF
--- a/.github/workflows/build-mirrord-cli.yaml
+++ b/.github/workflows/build-mirrord-cli.yaml
@@ -17,16 +17,30 @@ jobs:
       - uses: metalbear-co/setup-rust-toolchain@a8d42d5aa259519dac1faeee20e37c1fb43453a3
         with:
           cache: false
+          rustflags: ""
       - name: Rust cache
         uses: metalbear-co/rust-cache@d49d62d59c5755dd81754c833186b84a82f895fe # v2.9.1+1
         with:
-          shared-key: mirrord
-      - run: cargo build --manifest-path=./Cargo.toml -p mirrord
+          shared-key: mirrord-cli
+      # `xtask build-cli` builds the layer and the UI frontend and embeds both into the CLI, so it
+      # needs the same zigbuild and pnpm toolchain the release build uses.
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
+      - run: uv tool install cargo-zigbuild==0.22.1
+      - run: uv tool install ziglang==0.15.2 --with-executables-from ziglang
+      - run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - run: ln -sf "$(command -v python-zig)" "$HOME/.local/bin/zig"
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: 24
+      - name: Enable corepack (pnpm-only; leave npm alone for wizard build)
+        run: corepack enable pnpm
+      - name: Build mirrord CLI
+        run: cargo xtask build-cli --platform linux-x86_64
       - name: upload mirrord CLI
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: mirrord-artifacts
           path: |
-            target/debug/mirrord
+            target/x86_64-unknown-linux-gnu/debug/mirrord
           if-no-files-found: error
           retention-days: 2

--- a/changelog.d/+build-mirrord-cli-layer.internal.md
+++ b/changelog.d/+build-mirrord-cli-layer.internal.md
@@ -1,0 +1,1 @@
+Build the CLI with `cargo xtask build-cli` in the release-branch CLI build job, so the binary the IDE end-to-end tests run embeds the layer and the UI frontend.


### PR DESCRIPTION
The `build mirrord CLI` job fails on release branches:

```
mirrord/cli/src/extract.rs:43:31: error: environment variable `MIRRORD_LAYER_FILE` not defined at compile time
mirrord/cli/src/extract.rs:70:36: error: environment variable `MIRRORD_LAYER_FILE` not defined at compile time
```

The job ran `cargo build -p mirrord` on its own, which cannot compile. The CLI embeds the layer with `include_bytes!(env!("MIRRORD_LAYER_FILE"))`, and nothing built the layer or set the variable.

The job runs only on `releases/*` branches, and the release-branch detection in `ci.yaml` was itself matching nothing until #4659, so the breakage was never surfaced. It feeds `intellij_e2e_on_release_branch` and `vscode_e2e_on_release_branch`, which put the uploaded binary on `PATH` and run it.

Setting `MIRRORD_LAYER_FILE` in the workflow would fix the compile, but it would also put the layer path in a third place that has to track how the CLI embeds it — which is the shape of the bug in the first place, and it still leaves the artifact with an empty embedded UI. So this builds through `cargo xtask build-cli` instead, the same entry point the release workflow and the e2e job use: it builds the layer and the UI frontend and wires both into the CLI. That needs the zigbuild and pnpm toolchain, installed the way `release.yaml` does, and the artifact moves to the target triple directory zigbuild writes to.

### Verification

CI does not exercise this job on ordinary pull requests — `plan` only sets `release_branch` for `releases/*` head refs, and repository rules (correctly) forbid pushing such a branch by hand. Verified instead by dispatching a trimmed CI on a throwaway branch that calls the reusable workflow directly.

Note that #4683 is blocked on this. That release branch cannot pick the fix up on its own, since `auto-release-pr` cuts release branches from main and force-pushes them.