### PR TITLE
fix(monitor): classify fetch failures by type, not by error message

### DIFF
--- a/changelog.d/+monitor-fetch-failure-classification.internal.md
+++ b/changelog.d/+monitor-fetch-failure-classification.internal.md
@@ -1,0 +1,1 @@
+Classify session monitor fetch failures as `http` or `unreachable` in blocked-event telemetry instead of relying on the browser's error message text.

--- a/packages/monitor/src/api.ts
+++ b/packages/monitor/src/api.ts
@@ -11,6 +11,36 @@ import { emitUserBlocked, emitUserSucceeded } from './analytics'
 
 const HTTP_NOT_FOUND = 404
 
+/**
+ * Raised when the server answered with a non-OK status, as opposed to the request never
+ * completing. Carries the status so callers can tell the two apart without matching on the
+ * message text.
+ */
+export class ApiError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+  ) {
+    super(message)
+    this.name = 'ApiError'
+  }
+}
+
+export type FetchFailure = 'http' | 'unreachable' | 'unknown'
+
+/**
+ * `fetch` rejects with a `TypeError` when the request never completed — the local server
+ * exited, the machine slept, the connection dropped — and the message it carries is
+ * vendor-specific ("Failed to fetch", "NetworkError when attempting to fetch resource.",
+ * "Load failed"). Classifying on the error type keeps an unreachable server distinguishable
+ * from a server that answered badly, in every browser.
+ */
+export function classifyFetchFailure(err: unknown): FetchFailure {
+  if (err instanceof ApiError) return 'http'
+  if (err instanceof TypeError) return 'unreachable'
+  return 'unknown'
+}
+
 let authToken: string | null = null
 
 if (typeof window !== 'undefined') {
@@ -53,6 +83,7 @@ function reportSessionsHealth(
   healthy: boolean,
   error?: string,
   status?: number,
+  failure?: FetchFailure,
 ): void {
   const currentlyHealthy =
     endpoint === 'sessions' ? sessionsHealthy : operatorSessionsHealthy
@@ -67,6 +98,7 @@ function reportSessionsHealth(
       endpoint,
       ...(error !== undefined && { error }),
       ...(status !== undefined && { status }),
+      ...(failure !== undefined && { failure }),
     })
   }
 }
@@ -78,19 +110,25 @@ export const api = {
         credentials: 'include',
       })
       if (!r.ok) {
-        reportSessionsHealth('sessions', false, r.statusText, r.status)
-        throw new Error(`Failed to fetch sessions: ${r.status} ${r.statusText}`)
+        reportSessionsHealth('sessions', false, r.statusText, r.status, 'http')
+        throw new ApiError(
+          `Failed to fetch sessions: ${r.status} ${r.statusText}`,
+          r.status,
+        )
       }
       reportSessionsHealth('sessions', true)
       const data = (await r.json()) as SessionInfo[]
       return data
     } catch (err) {
-      if (
-        !(err instanceof Error) ||
-        !err.message.startsWith('Failed to fetch sessions')
-      ) {
+      if (!(err instanceof ApiError)) {
         const error = err instanceof Error ? err.message : String(err)
-        reportSessionsHealth('sessions', false, error)
+        reportSessionsHealth(
+          'sessions',
+          false,
+          error,
+          undefined,
+          classifyFetchFailure(err),
+        )
       }
       throw err
     }
@@ -109,6 +147,7 @@ export const api = {
           session_id: sessionId,
           status: r.status,
           error: r.statusText,
+          failure: 'http',
         })
       }
       return null
@@ -134,6 +173,7 @@ export const api = {
       emitUserBlocked('session_kill_failed', 'user_action', {
         session_id: sessionId,
         error: err instanceof Error ? err.message : String(err),
+        failure: classifyFetchFailure(err),
       })
       return
     }
@@ -142,6 +182,7 @@ export const api = {
         session_id: sessionId,
         status: r.status,
         error: r.statusText,
+        failure: 'http',
       })
     } else {
       emitUserSucceeded('session_killed', 'user_action', {
@@ -159,7 +200,7 @@ export const api = {
     })
     if (!r.ok) {
       if (r.status === HTTP_NOT_FOUND) return []
-      throw new Error(await chaosErrorMessage(r))
+      throw new ApiError(await chaosErrorMessage(r), r.status)
     }
     return (await r.json()) as ChaosRule[]
   },
@@ -177,8 +218,9 @@ export const api = {
     if (!r.ok) {
       emitUserBlocked('chaos_rule_create_failed', 'user_action', {
         session_id: sessionId,
+        failure: 'http',
       })
-      throw new Error(await chaosErrorMessage(r))
+      throw new ApiError(await chaosErrorMessage(r), r.status)
     }
     emitUserSucceeded('chaos_rule_created', 'user_action', {
       session_id: sessionId,
@@ -201,8 +243,9 @@ export const api = {
       emitUserBlocked('chaos_rule_update_failed', 'user_action', {
         session_id: sessionId,
         rule_id: ruleId,
+        failure: 'http',
       })
-      throw new Error(await chaosErrorMessage(r))
+      throw new ApiError(await chaosErrorMessage(r), r.status)
     }
     emitUserSucceeded('chaos_rule_updated', 'user_action', {
       session_id: sessionId,
@@ -220,8 +263,9 @@ export const api = {
       emitUserBlocked('chaos_rule_delete_failed', 'user_action', {
         session_id: sessionId,
         rule_id: ruleId,
+        failure: 'http',
       })
-      throw new Error(await chaosErrorMessage(r))
+      throw new ApiError(await chaosErrorMessage(r), r.status)
     }
     emitUserSucceeded('chaos_rule_deleted', 'user_action', {
       session_id: sessionId,
@@ -244,21 +288,31 @@ export const api = {
     try {
       const r = await fetch(withToken(path), { credentials: 'include' })
       if (!r.ok) {
-        reportSessionsHealth('operator_sessions', false, r.statusText, r.status)
-        throw new Error(
+        reportSessionsHealth(
+          'operator_sessions',
+          false,
+          r.statusText,
+          r.status,
+          'http',
+        )
+        throw new ApiError(
           `Failed to fetch operator sessions: ${r.status} ${r.statusText}`,
+          r.status,
         )
       }
       reportSessionsHealth('operator_sessions', true)
       const data = (await r.json()) as OperatorSessionsResponse
       return data
     } catch (err) {
-      if (
-        !(err instanceof Error) ||
-        !err.message.startsWith('Failed to fetch operator sessions')
-      ) {
+      if (!(err instanceof ApiError)) {
         const error = err instanceof Error ? err.message : String(err)
-        reportSessionsHealth('operator_sessions', false, error)
+        reportSessionsHealth(
+          'operator_sessions',
+          false,
+          error,
+          undefined,
+          classifyFetchFailure(err),
+        )
       }
       throw err
     }
@@ -316,6 +370,7 @@ export const api = {
       emitUserBlocked('me_fetch_failed', 'user_action', {
         status: r.status,
         error: r.statusText,
+        failure: 'http',
       })
       return { k8sUsername: null }
     }

--- a/packages/monitor/src/components/SessionDetail.tsx
+++ b/packages/monitor/src/components/SessionDetail.tsx
@@ -6,7 +6,7 @@ import type {
   PortSubscription,
   ProcessInfo,
 } from '../types'
-import { api } from '../api'
+import { api, classifyFetchFailure } from '../api'
 import { emitUserBlocked } from '../analytics'
 import { EventType } from '../eventTypes'
 import { expectArray, formatHostPort } from '../utils'
@@ -56,39 +56,42 @@ export default function SessionDetail({
     let cancelled = false
 
     async function hydrateFromSnapshot() {
+      let info: SessionInfo | null
       try {
-        const info = await api.getSession(session.session_id)
-        if (cancelled) return
-
-        if (!info) {
-          console.warn('Session info missing for', session.session_id)
-          return
-        }
-
-        const procs = expectArray<ProcessInfo>(
-          info.processes,
-          'processes',
-          info,
-        ).map((p) => ({
-          pid: p.pid,
-          process_name: p.process_name,
-        }))
-        if (procs.length > 0) setProcesses(procs)
-
-        const ports = expectArray<PortSubscription>(
-          info.port_subscriptions,
-          'port_subscriptions',
-          info,
-        ).map((p) => ({ port: p.port, mode: p.mode }))
-        if (ports.length > 0) setPortSubs(ports)
+        info = await api.getSession(session.session_id)
       } catch (err) {
         const error = err instanceof Error ? err.message : String(err)
         console.warn('Failed to fetch session snapshot', err)
         emitUserBlocked('snapshot_fetch_failed', 'user_action', {
           session_id: session.session_id,
           error,
+          failure: classifyFetchFailure(err),
         })
+        return
       }
+      if (cancelled) return
+
+      if (!info) {
+        console.warn('Session info missing for', session.session_id)
+        return
+      }
+
+      const procs = expectArray<ProcessInfo>(
+        info.processes,
+        'processes',
+        info,
+      ).map((p) => ({
+        pid: p.pid,
+        process_name: p.process_name,
+      }))
+      if (procs.length > 0) setProcesses(procs)
+
+      const ports = expectArray<PortSubscription>(
+        info.port_subscriptions,
+        'port_subscriptions',
+        info,
+      ).map((p) => ({ port: p.port, mode: p.mode }))
+      if (ports.length > 0) setPortSubs(ports)
     }
     void hydrateFromSnapshot()
 

--- a/packages/monitor/src/hooks/useChaosRules.ts
+++ b/packages/monitor/src/hooks/useChaosRules.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { api } from '../api'
+import { api, classifyFetchFailure } from '../api'
 import { emitUserBlocked } from '../analytics'
 import type {
   ChaosEffectKind,
@@ -138,6 +138,7 @@ export function useChaosRules(sessionId: string): UseChaosRules {
           {
             session_id: sessionId,
             error: err instanceof Error ? err.message : String(err),
+            failure: classifyFetchFailure(err),
           },
           err,
         )


### PR DESCRIPTION
## Summary

When a request from the session monitor fails, the blocked-event telemetry it emits carries only the browser's own error message to describe what happened, and that string is vendor specific. The same "the local server never answered" failure arrives as `Failed to fetch` from Chrome, `NetworkError when attempting to fetch resource.` from Firefox and `Load failed` from Safari. A server that was reachable and answered with an error status arrives as a fourth, unrelated string.

The practical effect is that a recurring alert signature cannot be triaged. A local server that exited normally (mirrord stopped, machine slept) and a server that is genuinely broken produce alerts that are indistinguishable without matching English text per browser, and the genuinely broken case is the rarer of the two, so it hides in the noise.

Every blocked event that wraps a fetch now carries a `failure` property:

- `http` — the server answered with a non-OK status
- `unreachable` — the request never completed
- `unknown` — neither could be established

The two are separated by an `ApiError` that carries the response status, since `fetch` rejects with a `TypeError` only when the request itself did not complete. That same type check replaces the error-message prefix matching that previously guarded against double-reporting in the two session pollers, so no failure path is classified by string any more.

Also narrows the snapshot hydration `try` block to just the fetch. A shape or render fault in the code that follows was being reported as `snapshot_fetch_failed`, which is a different failure with a different owner.

No user-visible behaviour changes; error messages surfaced to the user are unchanged.

## Test plan

Ran on this branch:

- `pnpm --filter session-monitor-frontend typecheck`, `lint` and `format:check` — all pass.
- `pnpm --filter mirrord-ui build` — succeeds.
- Loaded the built bundle in headless Chromium against a stub API, with the telemetry endpoint intercepted and the request payloads decoded so the emitted events were read off the wire rather than inferred. Drove four phases against the same page and confirmed the poll timeline (one poll every 2s) matched each phase:

  | phase | stub response | event emitted |
  | --- | --- | --- |
  | healthy | 200 | none |
  | server rejects | 401 | `sessions_unhealthy`, `failure=http`, `status=401` |
  | recovery | 200 | `sessions_healthy` |
  | server gone | connection closed | `sessions_unhealthy`, `failure=unreachable`, no status |

  Confirmed the built bundle hash under test matched the final build, so the artifact exercised is the source in this PR.

Not verified: behaviour against a real `mirrord ui` server or an operator-backed session; the `unknown` branch was not exercised, as neither stub phase produces a non-`TypeError` rejection.
