### PR TITLE
Stop gating release branches on the IntelliJ e2e job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -427,7 +427,9 @@ jobs:
       [
         towncrier_check,
         plan,
-        intellij_e2e_on_release_branch,
+        # The IntelliJ end-to-end suite is too flaky to hold up a release branch. It still runs
+        # and reports, it just does not gate. Put it back once it is dependable again.
+        # intellij_e2e_on_release_branch,
         vscode_e2e_on_release_branch,
         test_agent_image,
         test_cli_image,

--- a/changelog.d/+intellij-e2e-not-gating.internal.md
+++ b/changelog.d/+intellij-e2e-not-gating.internal.md
@@ -1,0 +1,1 @@
+Drop the IntelliJ end-to-end job from the CI gate on release branches, so that a failure there no longer blocks the branch. The job still runs and reports.


### PR DESCRIPTION
The IntelliJ end-to-end suite is too flaky to hold up a release branch, so it is commented out of the `ci-success` needs list.

The job itself is untouched — it still runs on release branches and reports its result. It just no longer contributes to the `ci` check that branch protection requires. The line is commented rather than deleted so it is a one-line revert once the suite is dependable again.

Note that `ci-success` no longer waits on the job, so `ci` can go green while the IntelliJ run is still in flight.