### PR TITLE
Partial borrow decoding for mirrord-protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5033,6 +5033,7 @@ dependencies = [
  "log",
  "miette",
  "mirrord-intproxy-protocol",
+ "mirrord-protocol",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
@@ -5351,7 +5352,7 @@ dependencies = [
 
 [[package]]
 name = "mirrord-protocol"
-version = "1.29.0"
+version = "1.29.1"
 dependencies = [
  "actix-codec",
  "bincode",

--- a/changelog.d/+borrow-decode.internal.md
+++ b/changelog.d/+borrow-decode.internal.md
@@ -1,0 +1,1 @@
+Added borrow-decoding capabilities to mirrord-protocol.

--- a/mirrord/agent/src/file.rs
+++ b/mirrord/agent/src/file.rs
@@ -14,6 +14,7 @@ use std::{
     ptr,
 };
 
+use bytes::Bytes;
 use faccess::{AccessMode, PathExt as _};
 use libc::DT_DIR;
 use mirrord_protocol::{FileRequest, FileResponse, RemoteResult, ResponseError, file::*};
@@ -161,7 +162,7 @@ impl FileManager {
                 Some(FileResponse::Seek(seek_result))
             }
             FileRequest::Write(WriteFileRequest { fd, write_bytes }) => {
-                let write_result = self.write(fd, write_bytes.into_vec());
+                let write_result = self.write(fd, write_bytes.0);
                 Some(FileResponse::Write(write_result))
             }
             FileRequest::WriteLimited(WriteLimitedFileRequest {
@@ -169,8 +170,7 @@ impl FileManager {
                 start_from,
                 write_bytes,
             }) => {
-                let write_result =
-                    self.write_limited(remote_fd, start_from, write_bytes.into_vec());
+                let write_result = self.write_limited(remote_fd, start_from, write_bytes.0);
                 Some(FileResponse::WriteLimited(write_result))
             }
             FileRequest::Close(CloseFileRequest { fd }) => self.close(fd),
@@ -361,24 +361,21 @@ impl FileManager {
         self.open_files
             .get_mut(&fd)
             .ok_or(ResponseError::NotFound(fd))
-            .and_then(|remote_file| {
-                if let RemoteFile::File(file) = remote_file {
-                    let mut buffer = vec![0; buffer_size as usize];
-                    let read_amount = file.read(&mut buffer)?;
+            .and_then(|remote_file| match remote_file {
+                RemoteFile::File(file) => Ok(file),
+                RemoteFile::Directory(..) => Err(ResponseError::NotFile(fd)),
+            })
+            .and_then(|file| {
+                let mut buffer = Vec::with_capacity(4096);
+                let read_amount = file.take(buffer_size).read_to_end(&mut buffer)?;
 
-                    // Truncate the buffer based on the actual number of bytes read
-                    buffer.truncate(read_amount);
+                // Create the response with the read bytes and the read amount
+                let response = ReadFileResponse {
+                    bytes: buffer.into(),
+                    read_amount: read_amount as u64,
+                };
 
-                    // Create the response with the read bytes and the read amount
-                    let response = ReadFileResponse {
-                        bytes: buffer.into(),
-                        read_amount: read_amount as u64,
-                    };
-
-                    Ok(response)
-                } else {
-                    Err(ResponseError::NotFile(fd))
-                }
+                Ok(response)
             })
     }
 
@@ -392,27 +389,26 @@ impl FileManager {
         self.open_files
             .get_mut(&fd)
             .ok_or(ResponseError::NotFound(fd))
-            .and_then(|remote_file| {
-                if let RemoteFile::File(file) = remote_file {
-                    let mut buffer = vec![0; buffer_size as usize];
+            .and_then(|remote_file| match remote_file {
+                RemoteFile::File(file) => Ok(file),
+                RemoteFile::Directory(..) => Err(ResponseError::NotFile(fd)),
+            })
+            .and_then(|file| {
+                let mut buffer = vec![0; buffer_size as usize];
+                let read_amount = file.read_at(&mut buffer, start_from)?;
 
-                    let read_amount = file.read_at(&mut buffer, start_from)?;
+                // Truncate the buffer based on the actual number of bytes read
+                buffer.truncate(read_amount);
 
-                    // Truncate the buffer based on the actual number of bytes read
-                    buffer.truncate(read_amount);
+                // Further optimization: Create the response with the read bytes and the read
+                // amount We will no longer send entire buffer filled with
+                // zeroes
+                let response = ReadFileResponse {
+                    bytes: buffer.into(),
+                    read_amount: read_amount as u64,
+                };
 
-                    // Further optimization: Create the response with the read bytes and the read
-                    // amount We will no longer send entire buffer filled with
-                    // zeroes
-                    let response = ReadFileResponse {
-                        bytes: buffer.into(),
-                        read_amount: read_amount as u64,
-                    };
-
-                    Ok(response)
-                } else {
-                    Err(ResponseError::NotFile(fd))
-                }
+                Ok(response)
             })
     }
 
@@ -439,7 +435,7 @@ impl FileManager {
         &mut self,
         fd: u64,
         start_from: u64,
-        buffer: Vec<u8>,
+        buffer: Bytes,
     ) -> RemoteResult<WriteFileResponse> {
         self.open_files
             .get_mut(&fd)
@@ -666,11 +662,7 @@ impl FileManager {
             })
     }
 
-    pub(crate) fn write(
-        &mut self,
-        fd: u64,
-        write_bytes: Vec<u8>,
-    ) -> RemoteResult<WriteFileResponse> {
+    pub(crate) fn write(&mut self, fd: u64, write_bytes: Bytes) -> RemoteResult<WriteFileResponse> {
         trace!(
             "FileManager::write -> fd {:#?} | write_bytes (length) {:#?}",
             fd,

--- a/mirrord/cli/src/port_forward.rs
+++ b/mirrord/cli/src/port_forward.rs
@@ -286,7 +286,7 @@ impl PortForwarder {
                         let Some(sender) = self.task_txs.get(socket_pair) else {
                             unreachable!("sender is always created before this point")
                         };
-                        match sender.send(res.bytes.into_vec()).await {
+                        match sender.send(res.bytes.into()).await {
                             Ok(_) => (),
                             Err(_) => {
                                 self.task_txs.remove(socket_pair);
@@ -1128,7 +1128,7 @@ mod test {
 
     use mirrord_config::feature::network::incoming::{IncomingConfig, IncomingMode};
     use mirrord_protocol::{
-        ClientMessage, DaemonMessage, ToPayload,
+        ClientMessage, DaemonMessage,
         outgoing::{
             DaemonConnect, DaemonConnectV2, DaemonRead, LayerConnectV2, LayerWrite, SocketAddress,
             tcp::{DaemonTcpOutgoing, LayerTcpOutgoing},
@@ -1274,7 +1274,7 @@ mod test {
 
         let expected = ClientMessage::TcpOutgoing(LayerTcpOutgoing::Write(LayerWrite {
             connection_id: 1,
-            bytes: b"data-my-beloved".to_payload(),
+            bytes: b"data-my-beloved".as_slice().into(),
         }));
         assert_eq!(test_connection.recv().await, expected);
 
@@ -1283,7 +1283,7 @@ mod test {
             .send(DaemonMessage::TcpOutgoing(DaemonTcpOutgoing::Read(Ok(
                 DaemonRead {
                     connection_id: 1,
-                    bytes: b"reply-my-beloved".to_payload(),
+                    bytes: b"reply-my-beloved".as_slice().into(),
                 },
             ))))
             .await;
@@ -1307,7 +1307,7 @@ mod test {
             .send(DaemonMessage::TcpOutgoing(DaemonTcpOutgoing::Read(Ok(
                 DaemonRead {
                     connection_id: 1,
-                    bytes: "".to_payload(),
+                    bytes: "".into(),
                 },
             ))))
             .await;
@@ -1408,10 +1408,7 @@ mod test {
             )))
             .await;
 
-        let mut expected_data = vec![
-            (1, b"data-from-1".to_payload()),
-            (2, b"data-from-2".to_payload()),
-        ];
+        let mut expected_data = vec![(1, "data-from-1".into()), (2, "data-from-2".into())];
 
         for _ in 0..2 {
             match test_connection.recv().await {
@@ -1436,7 +1433,7 @@ mod test {
             .send(DaemonMessage::TcpOutgoing(DaemonTcpOutgoing::Read(Ok(
                 DaemonRead {
                     connection_id: 1,
-                    bytes: b"reply-to-1".to_payload(),
+                    bytes: b"reply-to-1".as_slice().into(),
                 },
             ))))
             .await;
@@ -1444,7 +1441,7 @@ mod test {
             .send(DaemonMessage::TcpOutgoing(DaemonTcpOutgoing::Read(Ok(
                 DaemonRead {
                     connection_id: 2,
-                    bytes: b"reply-to-2".to_payload(),
+                    bytes: b"reply-to-2".as_slice().into(),
                 },
             ))))
             .await;
@@ -1511,7 +1508,7 @@ mod test {
         test_connection
             .send(DaemonMessage::Tcp(DaemonTcp::Data(TcpData {
                 connection_id: 1,
-                bytes: b"data-my-beloved".to_payload(),
+                bytes: "data-my-beloved".into(),
             })))
             .await;
 
@@ -1585,7 +1582,7 @@ mod test {
         test_connection
             .send(DaemonMessage::TcpSteal(DaemonTcp::Data(TcpData {
                 connection_id: 1,
-                bytes: b"data-my-beloved".to_payload(),
+                bytes: "data-my-beloved".into(),
             })))
             .await;
 
@@ -1600,7 +1597,7 @@ mod test {
             test_connection.recv().await,
             ClientMessage::TcpSteal(LayerTcpSteal::Data(TcpData {
                 connection_id: 1,
-                bytes: b"reply-my-beloved".to_payload()
+                bytes: "reply-my-beloved".into()
             }))
         );
 
@@ -1694,14 +1691,14 @@ mod test {
         test_connection
             .send(DaemonMessage::Tcp(DaemonTcp::Data(TcpData {
                 connection_id: 1,
-                bytes: b"connection-1-my-beloved".to_payload(),
+                bytes: "connection-1-my-beloved".into(),
             })))
             .await;
 
         test_connection
             .send(DaemonMessage::Tcp(DaemonTcp::Data(TcpData {
                 connection_id: 2,
-                bytes: b"connection-2-my-beloved".to_payload(),
+                bytes: "connection-2-my-beloved".into(),
             })))
             .await;
 
@@ -1813,7 +1810,7 @@ mod test {
             version: Version::HTTP_11,
             headers,
             body: InternalHttpBody(
-                [InternalHttpBodyFrame::Data(b"yay".to_payload())]
+                [InternalHttpBodyFrame::Data("yay".into())]
                     .into_iter()
                     .collect(),
             ),

--- a/mirrord/console/Cargo.toml
+++ b/mirrord/console/Cargo.toml
@@ -22,11 +22,25 @@ required-features = ["binary"]
 
 [features]
 default = []
-binary = ["dep:futures", "dep:tracing", "dep:tracing-subscriber", "dep:tokio", "mirrord-intproxy-protocol/codec-async"]
-async-logger = ["mirrord-intproxy-protocol/codec-async", "dep:futures", "dep:tokio", "dep:drain", "dep:tokio-util"]
+binary = [
+    "dep:futures",
+    "dep:mirrord-protocol",
+    "dep:tracing",
+    "dep:tracing-subscriber",
+    "dep:tokio",
+    "mirrord-intproxy-protocol/codec-async"
+]
+async-logger = [
+    "mirrord-intproxy-protocol/codec-async",
+    "dep:futures",
+    "dep:tokio",
+    "dep:drain",
+    "dep:tokio-util"
+]
 
 [dependencies]
 mirrord-intproxy-protocol = { path = "../intproxy/protocol", features = ["codec"] }
+mirrord-protocol = { path = "../protocol", optional = true }
 
 bincode.workspace = true
 futures = { workspace = true, optional = true }

--- a/mirrord/console/src/lib.rs
+++ b/mirrord/console/src/lib.rs
@@ -6,6 +6,7 @@
 /// These dependencies are only used in the console binary.
 #[cfg(feature = "binary")]
 mod binary_deps {
+    use mirrord_protocol as _;
     use tokio as _;
     use tracing as _;
     use tracing_subscriber as _;

--- a/mirrord/console/src/main.rs
+++ b/mirrord/console/src/main.rs
@@ -1,7 +1,8 @@
-use bincode::Decode;
+use bincode::BorrowDecode;
 use futures::TryStreamExt;
 use mirrord_console::protocol::{Hello, Record};
 use mirrord_intproxy_protocol::codec::AsyncDecoder;
+use mirrord_protocol::DecodeCtx;
 use tokio::{
     io::BufReader,
     net::{TcpListener, TcpStream},
@@ -22,7 +23,7 @@ impl ConnectionWrapper {
 
     async fn next_message<T>(&mut self) -> Option<T>
     where
-        T: Decode<()>,
+        T: for<'de> BorrowDecode<'de, DecodeCtx>,
     {
         let mut decoder: AsyncDecoder<T, _> = AsyncDecoder::new(&mut self.conn);
         decoder

--- a/mirrord/intproxy/protocol/Cargo.toml
+++ b/mirrord/intproxy/protocol/Cargo.toml
@@ -32,5 +32,5 @@ tokio-util = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["full"] }
 
 [features]
-codec = ["dep:thiserror"]
+codec = ["dep:thiserror", "dep:bytes"]
 codec-async = ["codec", "dep:bytes", "dep:futures", "dep:tokio", "dep:tokio-util"]

--- a/mirrord/intproxy/protocol/src/codec.rs
+++ b/mirrord/intproxy/protocol/src/codec.rs
@@ -13,9 +13,11 @@ use std::{
 };
 
 use bincode::{
-    Decode, Encode,
+    BorrowDecode, Encode,
     error::{DecodeError, EncodeError},
 };
+use bytes::BytesMut;
+use mirrord_protocol::DecodeCtx;
 use thiserror::Error;
 
 #[cfg(feature = "codec-async")]
@@ -105,7 +107,7 @@ where
 /// Handles receiving messages of type `T` from the underlying [Write] of type `W`.
 #[derive(Debug)]
 pub struct SyncDecoder<T, R> {
-    buffer: Vec<u8>,
+    buffer: BytesMut,
     reader: R,
     _phantom: std::marker::PhantomData<fn() -> T>,
 }
@@ -114,7 +116,7 @@ impl<T, R> SyncDecoder<T, R> {
     /// Wraps the unerlying IO handler.
     pub fn new(reader: R) -> Self {
         Self {
-            buffer: Vec::with_capacity(BUFFER_SIZE),
+            buffer: BytesMut::with_capacity(BUFFER_SIZE),
             reader,
             _phantom: Default::default(),
         }
@@ -128,7 +130,7 @@ impl<T, R> SyncDecoder<T, R> {
 
 impl<T, R> SyncDecoder<T, R>
 where
-    T: Decode<()>,
+    T: for<'de> BorrowDecode<'de, DecodeCtx>,
     R: Read,
 {
     /// Decodes the next message from the underlying IO handler.
@@ -145,20 +147,24 @@ where
         self.buffer.resize(len as usize, 0);
         self.reader.read_exact(&mut self.buffer)?;
 
-        let value = bincode::decode_from_slice(&self.buffer, bincode::config::standard())?.0;
-
+        let data = self.buffer.split().freeze();
+        let value = DecodeCtx::decode_from_bytes(data)?;
         Ok(Some(value))
     }
 }
 
 /// Creates a new pair of [`SyncEncoder`] and [`SyncDecoder`], using the given synchronous
 /// [`TcpStream`](std::net::TcpStream).
-pub fn make_sync_framed<T1: Encode, T2: Decode<()>>(
+pub fn make_sync_framed<T1, T2>(
     stream: std::net::TcpStream,
 ) -> Result<(
     SyncEncoder<T1, std::net::TcpStream>,
     SyncDecoder<T2, std::net::TcpStream>,
-)> {
+)>
+where
+    T1: Encode,
+    T2: for<'de> BorrowDecode<'de, DecodeCtx>,
+{
     let stream_cloned = stream.try_clone()?;
 
     let sender = SyncEncoder::new(stream);

--- a/mirrord/intproxy/protocol/src/codec/codec_async.rs
+++ b/mirrord/intproxy/protocol/src/codec/codec_async.rs
@@ -6,11 +6,12 @@ use std::{
 };
 
 use bincode::{
-    Decode, Encode,
+    BorrowDecode, Encode,
     enc::{EncoderImpl, write::SizeWriter},
 };
 use bytes::{Buf, BufMut, BytesMut, buf::Writer};
 use futures::{Sink, Stream};
+use mirrord_protocol::DecodeCtx;
 use tokio::{
     io::{AsyncRead, AsyncWrite, ReadBuf},
     net::tcp::{OwnedReadHalf, OwnedWriteHalf},
@@ -159,7 +160,7 @@ enum DecoderState {
 
 impl<T, R> Stream for AsyncDecoder<T, R>
 where
-    T: Decode<()>,
+    T: for<'de> BorrowDecode<'de, DecodeCtx>,
     R: AsyncRead + Unpin,
 {
     type Item = Result<T>;
@@ -211,20 +212,12 @@ where
                 }
 
                 DecoderState::ReadingMessage { .. } => {
-                    let (value, consumed) = bincode::decode_from_slice::<T, _>(
-                        this.buffer.as_ref(),
-                        bincode::config::standard(),
-                    )?;
-                    if consumed < this.buffer.len() {
-                        break Poll::Ready(Some(Err(CodecError::IoError(io::Error::other(
-                            "detected leftover bytes",
-                        )))));
-                    }
+                    let data = this.buffer.split().freeze();
+                    let value = DecodeCtx::decode_from_bytes(data)?;
                     this.state = DecoderState::ReadingPrefix {
                         buffer: Default::default(),
                         filled: 0,
                     };
-                    this.buffer.clear();
                     break Poll::Ready(Some(Ok(value)));
                 }
             }
@@ -234,12 +227,16 @@ where
 
 /// Creates a new pair of [`AsyncEncoder`] and [`AsyncDecoder`], using the given asynchronous
 /// [`TcpStream`](tokio::net::TcpStream).
-pub fn make_async_framed<T1: Encode, T2: Decode<()>>(
+pub fn make_async_framed<T1, T2>(
     stream: tokio::net::TcpStream,
 ) -> (
     AsyncEncoder<T1, OwnedWriteHalf>,
     AsyncDecoder<T2, OwnedReadHalf>,
-) {
+)
+where
+    T1: Encode,
+    T2: for<'de> BorrowDecode<'de, DecodeCtx>,
+{
     let (reader, writer) = stream.into_split();
 
     let sender = AsyncEncoder::new(writer);

--- a/mirrord/intproxy/protocol/src/lib.rs
+++ b/mirrord/intproxy/protocol/src/lib.rs
@@ -8,7 +8,7 @@ use std::{
     net::{IpAddr, SocketAddr},
 };
 
-use bincode::{Decode, Encode};
+use bincode::{BorrowDecode, Decode, Encode};
 use mirrord_protocol::{
     FileRequest, FileResponse, GetEnvVarsRequest, Port, RemoteResult,
     dns::{GetAddrInfoRequestV2, GetAddrInfoResponse},
@@ -35,7 +35,8 @@ pub struct LocalMessage<T> {
 }
 
 /// Messages sent by the layer and handled by the internal proxy.
-#[derive(Encode, Decode, Debug, PartialEq, Eq)]
+#[derive(Encode, BorrowDecode, Debug, PartialEq, Eq)]
+#[bincode(decode_context = "mirrord_protocol::codec::DecodeCtx")]
 pub enum LayerToProxyMessage {
     /// A request to start new `layer <-> proxy` session.
     /// This should be the first message sent by the layer after opening a new connection to the
@@ -308,7 +309,8 @@ pub struct PortUnsubscribe {
 }
 
 /// Messages sent by the internal proxy and handled by the layer.
-#[derive(Clone, Encode, Decode, Debug, PartialEq, Eq)]
+#[derive(Clone, Encode, BorrowDecode, Debug, PartialEq, Eq)]
+#[bincode(decode_context = "mirrord_protocol::codec::DecodeCtx")]
 pub enum ProxyToLayerMessage {
     /// A response to [`NewSessionRequest`]. Contains the identifier of the new `layer <-> proxy`
     /// session.

--- a/mirrord/intproxy/src/proxies/files.rs
+++ b/mirrord/intproxy/src/proxies/files.rs
@@ -991,7 +991,7 @@ impl FilesProxy {
                     read_amount,
                 };
 
-                data.buffer = read.bytes.into_vec();
+                data.buffer = read.bytes.0.into();
                 data.buffer_position = data.fd_position;
                 let message = if update_fd_position {
                     // User originally sent `FileRequest::Read`.

--- a/mirrord/intproxy/src/proxies/incoming.rs
+++ b/mirrord/intproxy/src/proxies/incoming.rs
@@ -629,7 +629,7 @@ impl IncomingProxy {
                 let tx = self.tcp_proxies.get(is_steal).get(&data.connection_id);
 
                 if let Some(tx) = tx {
-                    tx.send(data.bytes.into_vec()).await;
+                    tx.send(data.bytes.0).await;
                 } else {
                     tracing::debug!(
                         connection_id = data.connection_id,

--- a/mirrord/intproxy/src/proxies/incoming/http_gateway.rs
+++ b/mirrord/intproxy/src/proxies/incoming/http_gateway.rs
@@ -477,7 +477,7 @@ mod test {
     };
     use hyper_util::rt::TokioIo;
     use mirrord_protocol::{
-        ConnectionId, ToPayload,
+        ConnectionId,
         tcp::{HttpRequest, InternalHttpRequest, TcpData},
     };
     use mirrord_protocol_io::Connection;
@@ -882,12 +882,10 @@ mod test {
                 semaphore.add_permits(2);
                 match proxy_rx.next().await.unwrap() {
                     ClientMessage::TcpSteal(LayerTcpSteal::HttpResponseFramed(response)) => {
-                        let mut collected = vec![];
+                        let mut collected: Vec<u8> = vec![];
                         for frame in response.internal_response.body.0 {
                             match frame {
-                                InternalHttpBodyFrame::Data(data) => {
-                                    collected.extend(data.into_vec())
-                                }
+                                InternalHttpBodyFrame::Data(data) => collected.extend(data.0),
                                 InternalHttpBodyFrame::Trailers(trailers) => {
                                     panic!("unexpected trailing headers: {trailers:?}");
                                 }
@@ -917,7 +915,7 @@ mod test {
                     )) => {
                         assert_eq!(
                             body.frames,
-                            vec![InternalHttpBodyFrame::Data(b"hello\n".to_payload())],
+                            vec![InternalHttpBodyFrame::Data(b"hello\n".as_slice().into())],
                         );
                         assert!(!body.is_last);
                     }
@@ -931,7 +929,7 @@ mod test {
                     )) => {
                         assert_eq!(
                             body.frames,
-                            vec![InternalHttpBodyFrame::Data(b"hello\n".to_payload())],
+                            vec![InternalHttpBodyFrame::Data(b"hello\n".as_slice().into())],
                         );
                         assert!(body.is_last);
                     }
@@ -1031,7 +1029,7 @@ mod test {
         for _ in 0..2 {
             semaphore.acquire().await.unwrap().forget();
             frame_tx
-                .send(InternalHttpBodyFrame::Data(b"hello\n".to_payload()))
+                .send(InternalHttpBodyFrame::Data(b"hello\n".as_slice().into()))
                 .await
                 .unwrap();
         }

--- a/mirrord/layer-tests/src/intproxy.rs
+++ b/mirrord/layer-tests/src/intproxy.rs
@@ -18,7 +18,7 @@ use mirrord_intproxy::{
     session_monitor::chaos::ChaosWatcherRx,
 };
 use mirrord_protocol::{
-    ClientMessage, ConnectionId, DaemonCodec, DaemonMessage, FileRequest, FileResponse, ToPayload,
+    ClientMessage, ConnectionId, DaemonCodec, DaemonMessage, FileRequest, FileResponse, Payload,
     file::{
         AccessFileRequest, AccessFileResponse, MetadataInternal, OpenFileRequest,
         OpenOptionsInternal, ReadFileRequest, SeekFromInternal, XstatFsResponseV2, XstatRequest,
@@ -384,7 +384,7 @@ impl TestIntProxy {
         self.codec
             .send(DaemonMessage::Tcp(DaemonTcp::Data(TcpData {
                 connection_id,
-                bytes: message_data.to_payload(),
+                bytes: Payload::copy_from(message_data),
             })))
             .await
             .unwrap();
@@ -750,7 +750,7 @@ impl TestIntProxy {
             ClientMessage::FileRequest(FileRequest::Write(
                 mirrord_protocol::file::WriteFileRequest {
                     fd,
-                    write_bytes: contents.to_payload()
+                    write_bytes: Payload::copy_from(contents),
                 }
             ))
         );

--- a/mirrord/layer-tests/tests/issue2807.rs
+++ b/mirrord/layer-tests/tests/issue2807.rs
@@ -5,7 +5,7 @@
 use std::path::PathBuf;
 
 use mirrord_protocol::{
-    ClientMessage, DaemonMessage, FileRequest, FileResponse, ToPayload,
+    ClientMessage, DaemonMessage, FileRequest, FileResponse,
     file::{OpenFileResponse, ReadFileResponse},
     tcp::{DaemonTcp, LayerTcp},
 };
@@ -79,7 +79,7 @@ async fn handle_port_subscriptions(mut intproxy: TestIntProxy) {
                 intproxy
                     .send(DaemonMessage::File(FileResponse::Read(Ok(
                         ReadFileResponse {
-                            bytes: hostname.to_payload(),
+                            bytes: hostname.as_slice().into(),
                             read_amount: hostname.len() as u64,
                         },
                     ))))

--- a/mirrord/layer-tests/tests/node_copyfile.rs
+++ b/mirrord/layer-tests/tests/node_copyfile.rs
@@ -4,7 +4,7 @@
 use core::assert_matches;
 
 use mirrord_protocol::{
-    ClientMessage, DaemonMessage, FileRequest, FileResponse, ToPayload,
+    ClientMessage, DaemonMessage, FileRequest, FileResponse, Payload,
     file::{
         CloseFileRequest, FchmodRequest, FchownRequest, FtruncateRequest, FutimensRequest,
         MetadataInternal, OpenOptionsInternal, ReadFileResponse, ReadLimitedFileRequest,
@@ -35,7 +35,7 @@ async fn node_copyfile() {
     const SRC_FD: u64 = 1;
     const DEST_FD: u64 = 2;
 
-    let payload = "hello".to_payload();
+    let payload = Payload::from("hello");
     let payload_len = payload.len();
 
     intproxy

--- a/mirrord/layer/src/file/hooks.rs
+++ b/mirrord/layer/src/file/hooks.rs
@@ -1344,16 +1344,23 @@ pub(crate) unsafe extern "C" fn rename_detour(
         })
 }
 
-fn vec_to_iovec(bytes: &[u8], iovecs: &[iovec]) {
+/// Copies contents of `bytes` slice to slices in `iovecs`.
+///
+/// # Safety
+///
+/// Caller must ensure that:
+/// 1. Slices in `iovecs` have sufficient capacity to hold all data from `bytes`.
+/// 2. Slices in `iovecs` do not overlap with the `bytes` slice.
+unsafe fn vec_to_iovec(bytes: &[u8], iovecs: &[iovec]) {
     let mut copied = 0;
     let mut iov_index = 0;
 
     while copied < bytes.len() {
-        let iov = &iovecs.get(iov_index).expect("ioevec out of bounds");
+        let iov = iovecs.get(iov_index).expect("ioevec out of bounds");
         let read_ptr = unsafe { bytes.as_ptr().add(copied) };
-        let copy_amount = std::cmp::min(bytes.len(), iov.iov_len);
+        let copy_amount = std::cmp::min(bytes.len() - copied, iov.iov_len);
         let out_buffer = iov.iov_base.cast();
-        unsafe { ptr::copy(read_ptr, out_buffer, copy_amount) };
+        unsafe { ptr::copy_nonoverlapping(read_ptr, out_buffer, copy_amount) };
         copied += copy_amount;
         // we trust iov_index to be in correct size since we checked it before
         iov_index += 1;

--- a/mirrord/layer/src/file/ops.rs
+++ b/mirrord/layer/src/file/ops.rs
@@ -498,7 +498,7 @@ pub(crate) fn unlinkat(dirfd: RawFd, path: Detour<PathBuf>, flags: u32) -> Detou
 pub(crate) fn pwrite(local_fd: RawFd, buffer: &[u8], offset: u64) -> Detour<WriteFileResponse> {
     let remote_fd = get_remote_fd(local_fd)?;
     mirrord_layer_macro::trace!("pwrite: local_fd {local_fd}");
-    let write_bytes = Payload::from(buffer.to_vec());
+    let write_bytes = Payload::copy_from(buffer);
     let writing_file = WriteLimitedFileRequest {
         remote_fd,
         write_bytes,

--- a/mirrord/layer/src/socket/ops.rs
+++ b/mirrord/layer/src/socket/ops.rs
@@ -779,20 +779,17 @@ fn remote_hostname_string() -> Detour<CString> {
         },
     )?;
 
-    let ReadFileResponse { bytes, read_amount } = file::ops::RemoteFile::remote_read(fd, 256)?;
+    let ReadFileResponse { bytes, .. } = file::ops::RemoteFile::remote_read(fd, 256)?;
 
     let _ = file::ops::RemoteFile::remote_close(fd).inspect_err(|fail| {
         trace!("Leaking remote file fd (should be harmless) due to {fail:#?}!")
     });
 
-    CString::new(
-        bytes
-            .into_vec()
-            .into_iter()
-            .take(read_amount as usize - 1)
-            .collect::<Vec<_>>(),
-    )
-    .map(Detour::Success)?
+    let mut bytes = Vec::from(bytes.0);
+    if bytes.ends_with(b"\n") {
+        bytes.pop();
+    }
+    CString::new(bytes).map(Detour::Success)?
 }
 
 /// Resolves a hostname and set result to static global like the original `gethostbyname` does.
@@ -900,19 +897,13 @@ pub(super) fn read_remote_resolv_conf() -> Detour<Vec<u8>> {
         },
     )?;
 
-    let ReadFileResponse { bytes, read_amount } = file::ops::RemoteFile::remote_read(fd, 4096)?;
+    let ReadFileResponse { bytes, .. } = file::ops::RemoteFile::remote_read(fd, 4096)?;
 
     let _ = file::ops::RemoteFile::remote_close(fd).inspect_err(|fail| {
         trace!("Leaking remote file fd (should be harmless) due to {fail:#?}!")
     });
 
-    Detour::Success(
-        bytes
-            .into_vec()
-            .into_iter()
-            .take(read_amount as usize)
-            .collect::<Vec<_>>(),
-    )
+    Detour::Success(bytes.0.into())
 }
 
 /// ## DNS resolution on port `53`

--- a/mirrord/operator/src/client/connection.rs
+++ b/mirrord/operator/src/client/connection.rs
@@ -6,7 +6,7 @@ use std::{
 use futures::{Sink, SinkExt, Stream, StreamExt};
 use hyper::{body::Bytes, upgrade::Upgraded};
 use hyper_util::rt::TokioIo;
-use mirrord_protocol::{ClientMessage, DaemonMessage};
+use mirrord_protocol::{ClientMessage, DaemonMessage, DecodeCtx};
 use thiserror::Error;
 use tokio_tungstenite::{
     WebSocketStream,
@@ -28,22 +28,26 @@ impl Stream for OperatorConnection {
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.get_mut();
 
-        let item = match std::task::ready!(this.0.poll_next_unpin(cx)) {
-            Some(Ok(Message::Binary(msg))) => {
-                match bincode::decode_from_slice(&msg, bincode::config::standard()) {
-                    Ok((message, _)) => Some(Ok(message)),
-                    Err(error) => Some(Err(OperatorConnectionError::DecodeError(error))),
+        loop {
+            let msg = std::task::ready!(this.0.poll_next_unpin(cx));
+            let msg = match msg {
+                Some(Ok(Message::Binary(msg))) => {
+                    let msg = DecodeCtx::decode_from_bytes(msg).map_err(From::from);
+                    Some(msg)
                 }
-            }
-            // Operator only sends binary messages.
-            Some(Ok(unexpected)) => Some(Err(OperatorConnectionError::InvalidMessage(
-                unexpected.into(),
-            ))),
-            Some(Err(error)) => Some(Err(OperatorConnectionError::WsError(error.into()))),
-            None => None,
-        };
-
-        Poll::Ready(item)
+                Some(Ok(Message::Ping(..) | Message::Pong(..))) => {
+                    // `tungstenite` can surface ping messages, but handles them automatically
+                    continue;
+                }
+                Some(Ok(msg @ (Message::Text(..) | Message::Frame(..) | Message::Close(..)))) => {
+                    // We only use binary messages
+                    Some(Err(OperatorConnectionError::InvalidMessage(msg.into())))
+                }
+                Some(Err(error)) => Some(Err(OperatorConnectionError::WsError(error.into()))),
+                None => None,
+            };
+            break Poll::Ready(msg);
+        }
     }
 }
 

--- a/mirrord/protocol-io/src/lib.rs
+++ b/mirrord/protocol-io/src/lib.rs
@@ -14,9 +14,10 @@ use std::{
 };
 
 use actix_codec::{AsyncRead, AsyncWrite, Decoder, Encoder, Framed};
-use bytes::BytesMut;
+use bincode::BorrowDecode;
+use bytes::{Bytes, BytesMut};
 use futures::{Sink, SinkExt, Stream, StreamExt};
-use mirrord_protocol::{ClientMessage, DaemonMessage, ProtocolCodec};
+use mirrord_protocol::{ClientMessage, DaemonMessage, DecodeCtx, ProtocolCodec};
 use rand::seq::IteratorRandom;
 use tokio::{
     pin, select,
@@ -42,7 +43,7 @@ impl<T, I, O> Transport<I, O> for T where
 ///
 /// Implemented by [`Client`] and [`Agent`].
 pub trait ProtocolEndpoint: 'static + Sized + Clone {
-    type InMsg: bincode::Decode<()> + Send + fmt::Debug;
+    type InMsg: for<'de> bincode::BorrowDecode<'de, DecodeCtx> + Send + fmt::Debug;
     type OutMsg: bincode::Encode + Send + fmt::Debug;
 }
 
@@ -73,7 +74,10 @@ impl ProtocolEndpoint for Agent {
 // Same as protocolCodec but outputs raw Vec<u8>s
 struct Codec<I>(PhantomData<I>);
 
-impl<I: bincode::Decode<()>> Decoder for Codec<I> {
+impl<I> Decoder for Codec<I>
+where
+    I: for<'de> BorrowDecode<'de, DecodeCtx>,
+{
     type Item = I;
     type Error = io::Error;
 
@@ -280,12 +284,11 @@ impl<Type: ProtocolEndpoint> fmt::Debug for ConnectionOutput<Type> {
 
 impl<Type: ProtocolEndpoint> ConnectionOutput<Type>
 where
-    Type::OutMsg: bincode::Decode<()>,
+    Type::OutMsg: for<'de> bincode::BorrowDecode<'de, DecodeCtx>,
 {
     pub async fn next(&self) -> Option<Type::OutMsg> {
-        bincode::decode_from_slice(&self.0.next().await, bincode::config::standard())
-            .ok()
-            .map(|e| e.0)
+        let data = Bytes::from(self.0.next().await);
+        DecodeCtx::decode_from_bytes(data).ok()
     }
 }
 

--- a/mirrord/protocol/Cargo.toml
+++ b/mirrord/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mirrord-protocol"
-version = "1.29.0"
+version = "1.29.1"
 authors.workspace = true
 description.workspace = true
 documentation.workspace = true
@@ -47,7 +47,6 @@ strum_macros.workspace = true
 jaq-core.workspace = true
 jaq-std.workspace = true
 jaq-json.workspace = true
-
 
 [target.'cfg(unix)'.dependencies]
 libc.workspace = true

--- a/mirrord/protocol/src/codec.rs
+++ b/mirrord/protocol/src/codec.rs
@@ -7,14 +7,14 @@ use std::{
 
 use actix_codec::{Decoder, Encoder};
 use bincode::{
-    Decode, Encode,
+    BorrowDecode, Decode, Encode,
     enc::{
         EncoderImpl,
         write::{SizeWriter, Writer},
     },
     error::{DecodeError, EncodeError},
 };
-use bytes::{Buf, BytesMut};
+use bytes::{Buf, Bytes, BytesMut};
 use derive_more::{Deref, From, Into};
 use mirrord_macros::protocol_break;
 use semver::VersionReq;
@@ -76,7 +76,8 @@ pub struct GetEnvVarsRequest {
     pub env_vars_select: HashSet<String>,
 }
 
-#[derive(Encode, Decode, Debug, PartialEq, Eq, Clone, strum_macros::IntoStaticStr)]
+#[derive(Encode, BorrowDecode, Debug, PartialEq, Eq, Clone, strum_macros::IntoStaticStr)]
+#[bincode(decode_context = "crate::codec::DecodeCtx")]
 #[strum(serialize_all = "lowercase")]
 pub enum FileRequest {
     Open(OpenFileRequest),
@@ -145,7 +146,8 @@ pub static CLIENT_READY_FOR_LOGS: LazyLock<VersionReq> =
     LazyLock::new(|| ">=1.3.1".parse().expect("Bad Identifier"));
 
 /// `-layer` --> `-agent` messages.
-#[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
+#[derive(Encode, BorrowDecode, Debug, PartialEq, Eq, Clone)]
+#[bincode(decode_context = "crate::codec::DecodeCtx")]
 pub enum ClientMessage {
     Close,
     /// TCP sniffer message.
@@ -206,7 +208,8 @@ pub enum ClientMessage {
 /// Type alias for `Result`s that should be returned from mirrord-agent to mirrord-layer.
 pub type RemoteResult<T> = Result<T, ResponseError>;
 
-#[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
+#[derive(Encode, BorrowDecode, Debug, PartialEq, Eq, Clone)]
+#[bincode(decode_context = "crate::codec::DecodeCtx")]
 pub enum FileResponse {
     Open(RemoteResult<OpenFileResponse>),
     Read(RemoteResult<ReadFileResponse>),
@@ -234,7 +237,8 @@ pub enum FileResponse {
 }
 
 /// `-agent` --> `-layer` messages.
-#[derive(Encode, Decode, PartialEq, Eq, Clone, Debug)]
+#[derive(Encode, BorrowDecode, PartialEq, Eq, Clone, Debug)]
+#[bincode(decode_context = "crate::codec::DecodeCtx")]
 #[protocol_break(2)]
 #[allow(deprecated)] // We can't remove deprecated variants without breaking the protocol
 pub enum DaemonMessage {
@@ -279,49 +283,115 @@ impl core::fmt::Debug for RemoteEnvVars {
     }
 }
 
+/// Opaque [`BorrowDecoder`](bincode::de::BorrowDecoder) context for decoding mirrord-protocol
+/// messages.
+///
+/// Allows for decoding the data without actually moving the bytes in memory,
+/// while still keeping the message types static. Note that this is only available
+/// when decoding a message from a full raw bytes chunk (e.g. WebSocket binary message).
+///
+/// # How it works
+///
+/// Outside of this crate, this context is meant to be used only via [`Self::decode_from_bytes`]
+/// (when you have the full message bytes) or [`ProtocolCodec`] (when you're processing a framed
+/// stream).
+///
+/// Internally, this context keeps the full raw message [`Bytes`] (if available).
+/// This [`Bytes`] instance is used by all [`Payload`](crate::Payload)s used in mirrord-protocol,
+/// which borrow from it via cheap [`Bytes::slice_ref`].
+pub struct DecodeCtx(
+    /// This is only [`None`] when decoding from a data stream.
+    Option<Bytes>,
+);
+
+impl DecodeCtx {
+    /// Returns the full raw bytes of the message being decoded, if available.
+    pub(crate) fn data(&self) -> Option<&Bytes> {
+        self.0.as_ref()
+    }
+
+    /// Borrow-decodes a message from raw bytes, providing [`DecodeCtx`] context.
+    ///
+    /// If the message does not use the whole buffer, returns an error (leftover bytes).
+    pub fn decode_from_bytes<M>(bytes: Bytes) -> Result<M, DecodeError>
+    where
+        M: for<'de> BorrowDecode<'de, Self>,
+    {
+        let context = Self(Some(bytes.clone()));
+        bincode::borrow_decode_from_slice_with_context::<_, M, _>(
+            &bytes,
+            bincode::config::standard(),
+            context,
+        )
+        .and_then(|output| {
+            if output.1 != bytes.len() {
+                Err(DecodeError::Other("detected leftover bytes"))
+            } else {
+                Ok(output.0)
+            }
+        })
+    }
+
+    /// Decodes a message from raw bytes received on a data stream, providing [`DecodeCtx`] context.
+    ///
+    /// This does not do borrow decoding.
+    pub fn decode_from_data_stream<M>(buffer: &[u8]) -> Result<(M, usize), DecodeError>
+    where
+        M: for<'de> BorrowDecode<'de, Self>,
+    {
+        bincode::borrow_decode_from_slice_with_context::<_, M, _>(
+            buffer,
+            bincode::config::standard(),
+            Self(None),
+        )
+    }
+}
+
 pub struct ProtocolCodec<I, O> {
-    config: bincode::config::Configuration,
     /// Phantom fields to make this struct generic over message types.
     _phantom_incoming_message: PhantomData<I>,
     _phantom_outgoing_message: PhantomData<O>,
 }
 
 impl<I, O> Copy for ProtocolCodec<I, O> {}
+
 impl<I, O> Clone for ProtocolCodec<I, O> {
     fn clone(&self) -> Self {
         *self
     }
 }
 
-// Codec to be used by the client side to receive `DaemonMessage`s from the agent and send
-// `ClientMessage`s to the agent.
+/// Codec to be used when receiving [`DaemonMessage`]s and sending [`ClientMessage`]s.
 pub type ClientCodec = ProtocolCodec<DaemonMessage, ClientMessage>;
-// Codec to be used by the agent side to receive `ClientMessage`s from the client and send
-// `DaemonMessage`s to the client.
+
+/// Codec to be used when receiving [`ClientMessage`]s and sending [`DaemonMessage`]s.
 pub type DaemonCodec = ProtocolCodec<ClientMessage, DaemonMessage>;
 
 impl<I, O> Default for ProtocolCodec<I, O> {
     fn default() -> Self {
         Self {
-            config: bincode::config::standard(),
             _phantom_incoming_message: Default::default(),
             _phantom_outgoing_message: Default::default(),
         }
     }
 }
 
-impl<I: bincode::Decode<()>, O> Decoder for ProtocolCodec<I, O> {
+impl<I, O> Decoder for ProtocolCodec<I, O>
+where
+    I: for<'de> bincode::BorrowDecode<'de, DecodeCtx>,
+{
     type Item = I;
     type Error = io::Error;
 
     fn decode(&mut self, src: &mut BytesMut) -> io::Result<Option<Self::Item>> {
-        match bincode::decode_from_slice(&src[..], self.config) {
-            Ok((message, read)) => {
-                src.advance(read);
+        // We don't know the length of the message, so we can't do borrow decoding here.
+        match DecodeCtx::decode_from_data_stream::<I>(src) {
+            Ok((message, consumed)) => {
+                src.advance(consumed);
                 Ok(Some(message))
             }
             Err(DecodeError::UnexpectedEnd { .. }) => Ok(None),
-            Err(err) => Err(io::Error::other(err.to_string())),
+            Err(error) => Err(io::Error::other(error)),
         }
     }
 }
@@ -333,7 +403,8 @@ impl<I, O: bincode::Encode> Encoder<O> for ProtocolCodec<I, O> {
         // First, calculate the size of encoded message, and eagerly reserve enough space in the
         // buffer. This guarantees at most one allocation.
         let size = {
-            let mut size_writer = EncoderImpl::new(SizeWriter::default(), self.config);
+            let mut size_writer =
+                EncoderImpl::new(SizeWriter::default(), bincode::config::standard());
             msg.encode(&mut size_writer).map_err(io::Error::other)?;
             size_writer.into_writer().bytes_written
         };
@@ -349,7 +420,8 @@ impl<I, O: bincode::Encode> Encoder<O> for ProtocolCodec<I, O> {
             }
         }
 
-        bincode::encode_into_writer(msg, WriterAdapter(dst), self.config).map_err(io::Error::other)
+        bincode::encode_into_writer(msg, WriterAdapter(dst), bincode::config::standard())
+            .map_err(io::Error::other)
     }
 }
 
@@ -358,7 +430,7 @@ mod tests {
     use bytes::{BufMut, BytesMut};
 
     use super::*;
-    use crate::{Payload, tcp::TcpData};
+    use crate::tcp::TcpData;
 
     #[test]
     fn sanity_client_encode_decode() {
@@ -384,7 +456,7 @@ mod tests {
 
         let msg = DaemonMessage::Tcp(DaemonTcp::Data(TcpData {
             connection_id: 1,
-            bytes: Payload::from(vec![1, 2, 3]),
+            bytes: [1, 2, 3].as_slice().into(),
         }));
 
         daemon_codec.encode(msg.clone(), &mut buf).unwrap();

--- a/mirrord/protocol/src/file.rs
+++ b/mirrord/protocol/src/file.rs
@@ -9,7 +9,7 @@ use std::os::unix::fs::DirEntryExt;
 use std::{fs::Metadata, os::unix::prelude::MetadataExt};
 use std::{io::SeekFrom, path::PathBuf, sync::LazyLock};
 
-use bincode::{Decode, Encode};
+use bincode::{BorrowDecode, Decode, Encode};
 #[cfg(target_os = "linux")]
 use nix::sys::statfs::Statfs;
 use semver::VersionReq;
@@ -375,7 +375,8 @@ pub struct ReadFileRequest {
     pub buffer_size: u64,
 }
 
-#[derive(Encode, Decode, PartialEq, Eq, Clone)]
+#[derive(Encode, BorrowDecode, PartialEq, Eq, Clone)]
+#[bincode(decode_context = "crate::codec::DecodeCtx")]
 pub struct ReadFileResponse {
     pub bytes: Payload,
     pub read_amount: u64,
@@ -384,7 +385,7 @@ pub struct ReadFileResponse {
 impl fmt::Debug for ReadFileResponse {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ReadFileResponse")
-            .field("bytes (length)", &self.bytes.len())
+            .field("bytes", &self.bytes)
             .field("read_amount", &self.read_amount)
             .finish()
     }
@@ -478,7 +479,8 @@ impl From<SeekFrom> for SeekFromInternal {
     }
 }
 
-#[derive(Encode, Decode, PartialEq, Eq, Clone)]
+#[derive(Encode, BorrowDecode, PartialEq, Eq, Clone)]
+#[bincode(decode_context = "crate::codec::DecodeCtx")]
 pub struct WriteFileRequest {
     pub fd: u64,
     pub write_bytes: Payload,
@@ -488,7 +490,7 @@ impl fmt::Debug for WriteFileRequest {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("WriteFileRequest")
             .field("fd", &self.fd)
-            .field("write_bytes (length)", &self.write_bytes.len())
+            .field("write_bytes (length)", &self.write_bytes)
             .finish()
     }
 }
@@ -498,7 +500,8 @@ pub struct WriteFileResponse {
     pub written_amount: u64,
 }
 
-#[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
+#[derive(Encode, BorrowDecode, Debug, PartialEq, Eq, Clone)]
+#[bincode(decode_context = "crate::codec::DecodeCtx")]
 pub struct WriteLimitedFileRequest {
     pub remote_fd: u64,
     pub start_from: u64,

--- a/mirrord/protocol/src/lib.rs
+++ b/mirrord/protocol/src/lib.rs
@@ -75,7 +75,7 @@ use std::{collections::HashSet, ops::Deref, sync::LazyLock};
 
 pub use codec::*;
 pub use error::*;
-pub use payload::{Payload, ToPayload};
+pub use payload::Payload;
 use semver::VersionReq;
 
 pub type Port = u16;

--- a/mirrord/protocol/src/outgoing.rs
+++ b/mirrord/protocol/src/outgoing.rs
@@ -7,7 +7,7 @@ use std::{
     sync::LazyLock,
 };
 
-use bincode::{Decode, Encode};
+use bincode::{BorrowDecode, Decode, Encode};
 use semver::VersionReq;
 
 use crate::{ConnectionId, Payload, RemoteResult, SerializationError, uid::Uid};
@@ -164,7 +164,8 @@ pub struct LayerConnect {
 }
 
 /// `user` wants to write `bytes` to remote host identified by `connection_id`.
-#[derive(Encode, Decode, PartialEq, Eq, Clone)]
+#[derive(Encode, BorrowDecode, PartialEq, Eq, Clone)]
+#[bincode(decode_context = "crate::codec::DecodeCtx")]
 pub struct LayerWrite {
     pub connection_id: ConnectionId,
     pub bytes: Payload,
@@ -174,7 +175,7 @@ impl fmt::Debug for LayerWrite {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("LayerWrite")
             .field("connection_id", &self.connection_id)
-            .field("bytes (length)", &self.bytes.len())
+            .field("bytes", &self.bytes)
             .finish()
     }
 }
@@ -192,7 +193,8 @@ pub struct DaemonConnect {
     pub local_address: SocketAddress,
 }
 
-#[derive(Encode, Decode, PartialEq, Eq, Clone)]
+#[derive(Encode, BorrowDecode, PartialEq, Eq, Clone)]
+#[bincode(decode_context = "crate::codec::DecodeCtx")]
 pub struct DaemonRead {
     pub connection_id: ConnectionId,
     pub bytes: Payload,

--- a/mirrord/protocol/src/outgoing/seqpacket.rs
+++ b/mirrord/protocol/src/outgoing/seqpacket.rs
@@ -1,8 +1,11 @@
+use bincode::BorrowDecode;
+
 use super::*;
 use crate::RemoteResult;
 
 /// Layer messages for the `SOCK_SEQPACKET` socket.
-#[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
+#[derive(Encode, BorrowDecode, Debug, PartialEq, Eq, Clone)]
+#[bincode(decode_context = "crate::codec::DecodeCtx")]
 pub enum LayerSeqpacket {
     /// Write one packet to the remote address the agent is connected to.
     Write(LayerWrite),
@@ -16,7 +19,8 @@ pub enum LayerSeqpacket {
 }
 
 /// Daemon messages for the `SOCK_SEQPACKET` socket.
-#[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
+#[derive(Encode, BorrowDecode, Debug, PartialEq, Eq, Clone)]
+#[bincode(decode_context = "crate::codec::DecodeCtx")]
 pub enum DaemonSeqpacket {
     /// Read one packet from the connection.
     Read(RemoteResult<DaemonRead>),

--- a/mirrord/protocol/src/outgoing/tcp.rs
+++ b/mirrord/protocol/src/outgoing/tcp.rs
@@ -1,7 +1,10 @@
+use bincode::BorrowDecode;
+
 use super::*;
 use crate::RemoteResult;
 
-#[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
+#[derive(Encode, BorrowDecode, Debug, PartialEq, Eq, Clone)]
+#[bincode(decode_context = "crate::codec::DecodeCtx")]
 pub enum LayerTcpOutgoing {
     /// User is interested in connecting via tcp to some remote address, specified in
     /// [`LayerConnect`].
@@ -27,7 +30,8 @@ pub enum LayerTcpOutgoing {
     ConnectV2(LayerConnectV2),
 }
 
-#[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
+#[derive(Encode, BorrowDecode, Debug, PartialEq, Eq, Clone)]
+#[bincode(decode_context = "crate::codec::DecodeCtx")]
 pub enum DaemonTcpOutgoing {
     /// The agent attempted a connection to the remote address specified by
     /// [`LayerTcpOutgoing::Connect`], and it might've been successful or not.

--- a/mirrord/protocol/src/outgoing/udp.rs
+++ b/mirrord/protocol/src/outgoing/udp.rs
@@ -1,7 +1,10 @@
+use bincode::BorrowDecode;
+
 use super::*;
 use crate::RemoteResult;
 
-#[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
+#[derive(Encode, BorrowDecode, Debug, PartialEq, Eq, Clone)]
+#[bincode(decode_context = "crate::codec::DecodeCtx")]
 pub enum LayerUdpOutgoing {
     /// User is interested in connecting via udp to some remote address, specified in
     /// [`LayerConnect`].
@@ -32,7 +35,8 @@ pub enum LayerUdpOutgoing {
     ConnectV2(LayerConnectV2),
 }
 
-#[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
+#[derive(Encode, BorrowDecode, Debug, PartialEq, Eq, Clone)]
+#[bincode(decode_context = "crate::codec::DecodeCtx")]
 pub enum DaemonUdpOutgoing {
     /// The agent attempted a connection to the remote address specified by
     /// [`LayerUdpOutgoing::Connect`], and it might've been successful or not.

--- a/mirrord/protocol/src/payload.rs
+++ b/mirrord/protocol/src/payload.rs
@@ -1,48 +1,83 @@
-use std::ops::{Deref, DerefMut};
+use std::{
+    fmt,
+    ops::{Deref, DerefMut},
+};
 
-use bincode::{Decode, Encode};
+use bincode::{
+    BorrowDecode, Encode,
+    de::BorrowDecoder,
+    enc::Encoder,
+    error::{DecodeError, EncodeError},
+};
 use bytes::Bytes;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde::{
+    Deserialize, Deserializer, Serialize, Serializer,
+    de::{self, SeqAccess, Visitor},
+};
 
-/// Payload is a wrapper for bytes, is used as message body in the protocol and by agent and
-/// intproxy as zero copy message payload
-#[derive(Eq, PartialEq, Hash, Clone, Default)]
+use crate::DecodeCtx;
+
+/// Wrapper type for [`Bytes`].
+///
+/// Provides [`Encode`]/[`BorrowDecode`]/[`Serialize`]/[`Deserialize`] implementations.
+#[derive(PartialEq, Eq, Hash, PartialOrd, Ord, Clone, Default)]
 pub struct Payload(pub Bytes);
 
 impl Payload {
-    pub fn into_vec(self) -> Vec<u8> {
-        self.0.into()
+    pub fn copy_from<T: AsRef<[u8]> + ?Sized>(data: &T) -> Self {
+        Self(Bytes::copy_from_slice(data.as_ref()))
     }
 }
 
-impl std::fmt::Debug for Payload {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_tuple("Payload")
-            .field(&format_args!("{} bytes", self.0.len()))
-            .finish()
+impl Encode for Payload {
+    fn encode<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
+        self.0.as_ref().encode(encoder)
     }
 }
 
-/// Convert a type ref to a payload probably cloning the data if self is not copyable
-pub trait ToPayload {
-    fn to_payload(&self) -> Payload;
-}
-
-impl ToPayload for &[u8] {
-    fn to_payload(&self) -> Payload {
-        Payload(Bytes::from(self.to_vec()))
+impl<'de> BorrowDecode<'de, DecodeCtx> for Payload {
+    fn borrow_decode<D: BorrowDecoder<'de, Context = DecodeCtx>>(
+        decoder: &mut D,
+    ) -> Result<Self, DecodeError> {
+        let slice = <&'de [u8]>::borrow_decode(decoder)?;
+        let owned = match decoder.context().data() {
+            Some(owned) => owned.slice_ref(slice),
+            // Data will be discarded anyway.
+            None => slice.to_owned().into(),
+        };
+        Ok(Self(owned))
     }
 }
 
-impl<const N: usize> ToPayload for [u8; N] {
-    fn to_payload(&self) -> Payload {
-        Payload(Bytes::from(self.to_vec()))
+impl Serialize for Payload {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_bytes(self.0.as_ref())
     }
 }
 
-impl ToPayload for str {
-    fn to_payload(&self) -> Payload {
-        Payload(Bytes::from(self.to_owned().into_bytes()))
+impl<'de> Deserialize<'de> for Payload {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer
+            .deserialize_byte_buf(SmartBytesVisitor)
+            .map(Self)
+    }
+}
+
+impl fmt::Debug for Payload {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} byte(s)", self.0.len())
+    }
+}
+
+impl AsRef<[u8]> for Payload {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
     }
 }
 
@@ -60,53 +95,71 @@ impl DerefMut for Payload {
     }
 }
 
-impl<B: Into<Bytes>> From<B> for Payload {
-    fn from(bytes: B) -> Self {
-        Payload(bytes.into())
+impl<T> From<T> for Payload
+where
+    Bytes: From<T>,
+{
+    fn from(value: T) -> Self {
+        Self(value.into())
     }
 }
 
-impl Encode for Payload {
-    fn encode<E: bincode::enc::Encoder>(
-        &self,
-        encoder: &mut E,
-    ) -> Result<(), bincode::error::EncodeError> {
-        self.0.as_ref().encode(encoder)
+impl From<Payload> for Vec<u8> {
+    fn from(value: Payload) -> Self {
+        value.0.into()
     }
 }
 
-impl<Context> bincode::Decode<Context> for Payload {
-    fn decode<D: bincode::de::Decoder<Context = Context>>(
-        decoder: &mut D,
-    ) -> Result<Self, bincode::error::DecodeError> {
-        let bytes: Vec<u8> = Decode::decode(decoder)?;
-        Ok(Payload(Bytes::from(bytes)))
-    }
-}
-impl<'de, Context> bincode::BorrowDecode<'de, Context> for Payload {
-    fn borrow_decode<D: bincode::de::BorrowDecoder<'de, Context = Context>>(
-        decoder: &mut D,
-    ) -> Result<Self, bincode::error::DecodeError> {
-        let bytes: Vec<u8> = bincode::BorrowDecode::borrow_decode(decoder)?;
-        Ok(Payload(Bytes::from(bytes)))
-    }
-}
+/// Used in [`Deserialize`] implementation of [`Payload`].
+///
+/// [`Vec<u8>`] deserialize implementation extracts it from the [`Deserializer`] byte by byte,
+/// using the same implementation as all other [`Vec`]s. This is extremely inefficient.
+/// This implementation attempts to pull all bytes at once, if possible.
+struct SmartBytesVisitor;
 
-impl Serialize for Payload {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+impl<'de> Visitor<'de> for SmartBytesVisitor {
+    type Value = Bytes;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("byte array")
+    }
+
+    fn visit_seq<V>(self, mut visitor: V) -> Result<Self::Value, V::Error>
     where
-        S: Serializer,
+        V: SeqAccess<'de>,
     {
-        serializer.serialize_bytes(&self.0)
+        let mut bytes = Vec::with_capacity(visitor.size_hint().unwrap_or(0));
+        while let Some(b) = visitor.next_element()? {
+            bytes.push(b);
+        }
+        Ok(Bytes::from(bytes))
     }
-}
 
-impl<'de> Deserialize<'de> for Payload {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
     where
-        D: Deserializer<'de>,
+        E: de::Error,
     {
-        let bytes = Vec::<u8>::deserialize(deserializer).map(Bytes::from)?;
-        Ok(Payload(bytes))
+        Ok(Bytes::copy_from_slice(v))
+    }
+
+    fn visit_byte_buf<E>(self, v: Vec<u8>) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Bytes::from(v))
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Bytes::copy_from_slice(v.as_bytes()))
+    }
+
+    fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Bytes::from(v))
     }
 }

--- a/mirrord/protocol/src/tcp.rs
+++ b/mirrord/protocol/src/tcp.rs
@@ -9,7 +9,7 @@ use std::{
     task::{Context, Poll},
 };
 
-use bincode::{Decode, Encode};
+use bincode::{BorrowDecode, Decode, Encode};
 use bytes::Bytes;
 use derive_more::{Deref, Display};
 use http_body_util::BodyExt;
@@ -48,7 +48,8 @@ pub struct NewTcpConnectionV2 {
     pub transport: IncomingTrafficTransportType,
 }
 
-#[derive(Encode, Decode, PartialEq, Eq, Clone)]
+#[derive(Encode, BorrowDecode, PartialEq, Eq, Clone)]
+#[bincode(decode_context = "crate::codec::DecodeCtx")]
 pub struct TcpData {
     pub connection_id: ConnectionId,
     pub bytes: Payload,
@@ -58,7 +59,7 @@ impl fmt::Debug for TcpData {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("TcpData")
             .field("connection_id", &self.connection_id)
-            .field("bytes (length)", &self.bytes.len())
+            .field("bytes", &self.bytes)
             .finish()
     }
 }
@@ -98,7 +99,8 @@ pub enum LayerTcp {
 ///
 /// They are the same for both `steal` and `mirror` modes, even though their layer
 /// counterparts ([`LayerTcpSteal`] and [`LayerTcp`]) are different.
-#[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
+#[derive(Encode, BorrowDecode, Debug, PartialEq, Eq, Clone)]
+#[bincode(decode_context = "crate::codec::DecodeCtx")]
 pub enum DaemonTcp {
     NewConnectionV1(NewTcpConnectionV1),
     Data(TcpData),
@@ -495,7 +497,8 @@ impl MirrorType {
 ///
 /// Stolen traffic might have an additional overhead when compared to mirrored traffic, as
 /// we have an intermmediate HTTP server to handle filtering (based on HTTP headers, etc).
-#[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
+#[derive(Encode, BorrowDecode, Debug, PartialEq, Eq, Clone)]
+#[bincode(decode_context = "crate::codec::DecodeCtx")]
 pub enum LayerTcpSteal {
     /// User is interested in stealing traffic on this `Port`, so add it to the list of
     /// ports that the stealer is filtering.

--- a/mirrord/protocol/src/vpn.rs
+++ b/mirrord/protocol/src/vpn.rs
@@ -1,6 +1,6 @@
 use std::{fmt, net::IpAddr};
 
-use bincode::{Decode, Encode};
+use bincode::{BorrowDecode, Decode, Encode};
 
 use crate::Payload;
 
@@ -11,7 +11,8 @@ pub struct NetworkConfiguration {
     pub gateway: IpAddr,
 }
 
-#[derive(Encode, Decode, PartialEq, Eq, Clone)]
+#[derive(Encode, BorrowDecode, PartialEq, Eq, Clone)]
+#[bincode(decode_context = "crate::codec::DecodeCtx")]
 pub enum ClientVpn {
     GetNetworkConfiguration,
     OpenSocket,
@@ -23,16 +24,14 @@ impl fmt::Debug for ClientVpn {
         match self {
             ClientVpn::GetNetworkConfiguration => f.debug_tuple("GetNetworkConfiguration").finish(),
             ClientVpn::OpenSocket => f.debug_tuple("OpenSocket").finish(),
-            ClientVpn::Packet(packet) => f
-                .debug_tuple("Packet")
-                .field(&format!("{} bytes", packet.len()))
-                .finish(),
+            ClientVpn::Packet(packet) => f.debug_tuple("Packet").field(&packet).finish(),
         }
     }
 }
 
 /// Messages related to Tcp handler from server.
-#[derive(Encode, Decode, PartialEq, Eq, Clone)]
+#[derive(Encode, BorrowDecode, PartialEq, Eq, Clone)]
+#[bincode(decode_context = "crate::codec::DecodeCtx")]
 pub enum ServerVpn {
     NetworkConfiguration(NetworkConfiguration),
     Packet(Payload),
@@ -45,10 +44,7 @@ impl fmt::Debug for ServerVpn {
                 .debug_tuple("NetworkConfiguration")
                 .field(&config)
                 .finish(),
-            ServerVpn::Packet(packet) => f
-                .debug_tuple("Packet")
-                .field(&format!("{} bytes", packet.len()))
-                .finish(),
+            ServerVpn::Packet(packet) => f.debug_tuple("Packet").field(&packet).finish(),
         }
     }
 }

--- a/mirrord/vpn/src/linux.rs
+++ b/mirrord/vpn/src/linux.rs
@@ -111,7 +111,7 @@ async fn agent_fetch_file<const B: u64>(
     let request = FileRequest::Close(CloseFileRequest { fd });
     agent.send(ClientMessage::FileRequest(request)).await;
 
-    Ok(bytes.into_vec())
+    Ok(bytes.into())
 }
 
 pub async fn mount_linux<'a>(

--- a/mirrord/vpn/src/tunnel.rs
+++ b/mirrord/vpn/src/tunnel.rs
@@ -39,7 +39,7 @@ where
                     match message {
                         None => break 'main,
                         Some(DaemonMessage::Vpn(ServerVpn::Packet(packet))) => {
-                            if let Err(error) = stream.send(packet.into_vec()).await {
+                            if let Err(error) = stream.send(packet.into()).await {
                                 tracing::warn!(%error, "unable to pipe back packet")
                             }
                         }


### PR DESCRIPTION
<!-- Thank you for contributing to mirrord! -->
<!-- Please use the checklist below as a guide for docs, tests and admin tasks for your PR -->
<!-- Feel free to ~strikethrough~ any items that you don't think apply -->

This is only a partial success. We're able to borrow decode `Payload` type when the message comes from WebSocket stream.

Full borrow decoding would require changing the types throughout the whole protocol, which would affect much more code. IMHO it might be better to just rollout a new version of the protocol.

Also fixed a pre-existing bug in layer's readv/preadv detour

### Quality Checklist:

- [x] I have documented new code sufficiently
- [x] I have checked and updated the relevant existing docs in code, including removing outdated material
- ~[ ] I have written user-facing website docs for new features, or opened a (sub)issue to do so~
- ~[ ] I have checked and updated existing website docs for changed features~
- [x] I have tested this change and know it succeeds and fails as expected
- [x] I have written unit tests or purposefully omitted them
- [x] I have written e2e tests or purposefully omitted them
- [x] I have explained what this PR introduces and why, and linked to relevant context (e.g. linear issues, related PRs,
  documentation)
- [x] I have introduced a short, clear and well-formatted changelog entry

<!-- need help with the changelog? see ../CONTRIBUTING.md#submitting-a-pull-request -->
<!-- Add more details of your changes below if needed -->