### PR TITLE
fix(monitor): stop stacking cluster-session polls and bound how long one runs

### DIFF
--- a/changelog.d/+monitor-operator-poll-overlap.fixed.md
+++ b/changelog.d/+monitor-operator-poll-overlap.fixed.md
@@ -1,0 +1,1 @@
+Stopped the session monitor stacking cluster-session polls on top of each other, and gave each one a timeout so a slow cluster is reported as a timeout instead of an unreachable server.

--- a/packages/monitor/src/App.tsx
+++ b/packages/monitor/src/App.tsx
@@ -21,7 +21,7 @@ import {
   emitUserBlocked,
   emitUserSucceeded,
 } from './analytics'
-import { api } from './api'
+import { api, isTimeout } from './api'
 import { useTelemetryPref } from './hooks/useTelemetryPref'
 import {
   pingExtension,
@@ -33,6 +33,13 @@ import {
 const LOCAL_POLL_INTERVAL = 2000
 const OPERATOR_POLL_INTERVAL = 5000
 const EXTENSION_POLL_INTERVAL = 4000
+
+// Listing cluster sessions round-trips through the operator to the Kubernetes API, so it can
+// outlast its own poll interval on a slow or unreachable cluster. Bounding it keeps a stalled
+// request from holding one of the origin's few connections until the browser gives up on it.
+const MS_PER_SEC = 1000
+const OPERATOR_POLL_TIMEOUT_SEC = 15
+const OPERATOR_POLL_TIMEOUT = OPERATOR_POLL_TIMEOUT_SEC * MS_PER_SEC
 
 /**
  * Theme is owned by the `mirrord-ui` shell (so a single top-right toggle controls both tabs). The
@@ -233,9 +240,21 @@ export default function App({
     }
   }, [effectiveContext])
 
+  // A poll still in flight when the next tick arrives. Ticking regardless would stack one cluster
+  // round-trip per interval against an endpoint that is already too slow to keep up, and the
+  // browser allows only a handful of concurrent connections per origin — the local-session poll
+  // shares them.
+  const operatorPollInFlight = useRef(false)
+
   const refreshOperatorSessions = useCallback(() => {
+    if (operatorPollInFlight.current) return
+    operatorPollInFlight.current = true
     api
-      .listOperatorSessions(effectiveContext, selectedNamespace)
+      .listOperatorSessions(
+        effectiveContext,
+        selectedNamespace,
+        AbortSignal.timeout(OPERATOR_POLL_TIMEOUT),
+      )
       .then((resp) => {
         setOperatorSessions(resp.sessions)
         setWatchStatus(
@@ -249,7 +268,15 @@ export default function App({
       })
       .catch((err: unknown) => {
         console.error(err)
-        setWatchStatus({ status: 'unavailable', reason: String(err) })
+        setWatchStatus({
+          status: 'unavailable',
+          reason: isTimeout(err)
+            ? `operator did not answer within ${OPERATOR_POLL_TIMEOUT_SEC}s`
+            : String(err),
+        })
+      })
+      .finally(() => {
+        operatorPollInFlight.current = false
       })
   }, [effectiveContext, selectedNamespace])
 

--- a/packages/monitor/src/api.ts
+++ b/packages/monitor/src/api.ts
@@ -45,6 +45,15 @@ async function chaosErrorMessage(r: Response): Promise<string> {
   return body || `${r.status} ${r.statusText}`
 }
 
+/**
+ * True for the rejection `AbortSignal.timeout` produces. A request we gave up on says the endpoint
+ * was too slow, which is a different fault from one the browser could not send at all — and the
+ * message it carries ("signal timed out", "The operation timed out", ...) is vendor-specific.
+ */
+export function isTimeout(err: unknown): boolean {
+  return err instanceof DOMException && err.name === 'TimeoutError'
+}
+
 let sessionsHealthy = true
 let operatorSessionsHealthy = true
 
@@ -233,6 +242,7 @@ export const api = {
   listOperatorSessions: async (
     context: string | null,
     namespace: string | null,
+    signal: AbortSignal,
   ): Promise<OperatorSessionsResponse> => {
     const params = new URLSearchParams()
     if (context) params.set('context', context)
@@ -242,7 +252,10 @@ export const api = {
       ? `/api/v2/operator/sessions?${qs}`
       : '/api/v2/operator/sessions'
     try {
-      const r = await fetch(withToken(path), { credentials: 'include' })
+      const r = await fetch(withToken(path), {
+        credentials: 'include',
+        signal,
+      })
       if (!r.ok) {
         reportSessionsHealth('operator_sessions', false, r.statusText, r.status)
         throw new Error(
@@ -253,7 +266,9 @@ export const api = {
       const data = (await r.json()) as OperatorSessionsResponse
       return data
     } catch (err) {
-      if (
+      if (isTimeout(err)) {
+        reportSessionsHealth('operator_sessions', false, 'timed out')
+      } else if (
         !(err instanceof Error) ||
         !err.message.startsWith('Failed to fetch operator sessions')
       ) {


### PR DESCRIPTION
## Summary

The session monitor polls cluster sessions every 5s. That request round-trips through the operator to the Kubernetes API, so on a slow or unreachable cluster it can take far longer than 5s — but the poll fired on every tick regardless, and nothing bounded how long one could run.

Two consequences, both measured locally against a stub server that accepts `/api/v2/operator/sessions` and never answers it (see the test plan):

- **Connection starvation.** Requests accumulated one per tick and were never released, until all six of Chrome's per-origin HTTP/1.1 connections were held open. The local-session poll shares that origin, so it was starved too — it managed roughly half its normal rate while the cluster poll was stalled.
- **A silent failure.** A stalled request never rejects, so no health transition was reported at all until the browser eventually gave up on its own, minutes later. In telemetry that arrives as an unreachable-server signature long after the fact, which is not what happened.

This change:

- skips a tick while the previous cluster poll is still in flight, so at most one is ever outstanding
- bounds each poll with `AbortSignal.timeout`, so a stalled request is released rather than pinning a connection
- reports a poll we gave up on as `timed out` instead of letting the browser's vendor-specific network message ("Failed to fetch", "NetworkError when attempting to fetch resource.", "Load failed") stand in for it, and says so in the watch-status text the user sees

The distinction matters for triage: a cluster too slow to answer and a local server that is gone produce the same browser error today, and they need different responses.

## Test plan

Ran locally, not reasoned about. Harness: an express server on a loopback port serving the real built `packages/ui/dist`, stubbing the kube/session endpoints, and accepting `/api/v2/operator/sessions` without ever responding. Playwright chromium drives it for a 42s window; the server counts concurrent in-flight cluster requests, and `hog.metalbear.com` is intercepted so the captured events are read off the wire (decoded from the gzipped request body) rather than inferred.

A/B against the same driver and stub, `main` built from `git checkout origin/main -- <the two files>`. Bundle hashes differed between the two builds, confirming the control actually applied.

| | `main` | this branch |
|---|---|---|
| cluster-poll requests opened | 6 | 3 |
| **max concurrent** | **6** | **1** |
| requests released before the window ended | 0 | 2 |
| local-session polls served | 11 | 21 |
| `sessions_unhealthy` reported in the window | 0 | 1, `error: "timed out"` |

On `main` the request starts stop after the sixth (1.1s, 1.2s, 6.3s, 11.2s, 16.3s, 21.3s and then nothing for the remaining 21s) — the connection pool is full. On this branch each poll is released at the 15s bound and the local poll runs at full rate throughout.

Gates: `session-monitor-frontend` typecheck / lint / format:check, and `mirrord-ui` typecheck / lint / format:check / build.

**Not verified:** behaviour against a real operator and a real slow cluster. The stalled endpoint was stubbed, so the 15s bound has not been checked against a cluster that is merely slow rather than hung — if real clusters routinely take longer than that to list sessions, the bound is the number to revisit.
