### PR TITLE
Skip the CI duration check on runs that failed

### DIFF
--- a/.github/workflows/ci-duration-monitor.yaml
+++ b/.github/workflows/ci-duration-monitor.yaml
@@ -15,6 +15,10 @@ env:
 
 jobs:
   check-duration:
+    # A run that failed stopped at its first failing job, so its duration measures how quickly CI
+    # broke rather than how long the work takes. Comparing that against the budget reports the
+    # healthiest-looking numbers exactly when CI is at its most broken.
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-24.04
     steps:
       - name: Compare the run against the budget

--- a/changelog.d/+ci-duration-success-only.internal.md
+++ b/changelog.d/+ci-duration-success-only.internal.md
@@ -1,0 +1,1 @@
+Compare only successful CI runs against the duration budget.


### PR DESCRIPTION
Resolves MBE-2038.

The monitor compared every completed run against the budget, including failed ones. A failed run stops at its first failing job, so its duration measures how quickly CI broke rather than how long the work takes.