### PR TITLE
remove greptile includeAuthors list from config

### DIFF
--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -1,21 +1,3 @@
 {
-  "includeAuthors": [
-    "0x00A5",
-    "aviramha",
-    "cristeigabriela",
-    "DmitryDodzin",
-    "eyalb181",
-    "gememma",
-    "giIuis",
-    "hank-metalbear",
-    "iniw",
-    "itsamegraf",
-    "meowjesty",
-    "MintSoup",
-    "Razz4780",
-    "skreborn",
-    "t4lz",
-    "vladrbg"
-  ],
   "disabledLabels": ["no-greptile"]
 }

--- a/changelog.d/+remove-greptile-include-authors.internal.md
+++ b/changelog.d/+remove-greptile-include-authors.internal.md
@@ -1,0 +1,1 @@
+Remove the included authors list for Greptile auto-reviews.


### PR DESCRIPTION
Removing since this list was added in order to help control our Greptile bill, but now this repo gets free reviews from Greptile. Thanks Greptile!