### PR TITLE
intproxy: fix analytics reporter and session monitor cleanup (COR-1775)

### DIFF
--- a/changelog.d/+analytics-intproxy-drop.internal.md
+++ b/changelog.d/+analytics-intproxy-drop.internal.md
@@ -1,0 +1,1 @@
+Fixed missing analytics due to incorrect intproxy cleanup. Also fixed intproxy timeout error log.

--- a/mirrord/cli/src/internal_proxy.rs
+++ b/mirrord/cli/src/internal_proxy.rs
@@ -45,9 +45,7 @@ use mirrord_session_monitor_protocol::SessionInfo;
 use nix::sys::resource::{Resource, setrlimit};
 use tokio::{net::TcpListener, sync::RwLock};
 use tokio_util::sync::CancellationToken;
-use tracing::Level;
-#[cfg(not(target_os = "windows"))]
-use tracing::warn;
+use tracing::{Level, warn};
 
 #[cfg(not(target_os = "windows"))]
 use crate::util::detach_io;
@@ -117,8 +115,9 @@ fn print_addr(listener: &TcpListener) -> io::Result<()> {
 
 /// Starts the session monitor API server if enabled.
 ///
-/// `@analytics`: optionally, pass a reporter in to be used by the chaos router for chaos metrics
-/// reporting. If `None`, the chaos router will work as normal but will not report metrics.
+/// `@reporter`: a reference to the reporter for chaos metrics which will not prevent the session
+/// monitor from being cancelled. To skip reporting chaos metrics (for example in tests) use
+/// [`Weak::new()`].
 async fn start_session_monitor(
     config: &LayerConfig,
     is_operator: bool,
@@ -325,10 +324,12 @@ pub(crate) async fn proxy(
     let process_logging_interval =
         Duration::from_secs(config.internal_proxy.process_logging_interval);
 
-    // this owns analytics and is the only strong reference, so dropping it will `Drop` inner values
+    // this is the only strong reference to `analytics`, so dropping it will `Drop` the
+    // `ChaosAnalyticsReporter` and `AnalyticsReporter`, sending the analytics data
     let chaos_reporter = Arc::new(RwLock::new(ChaosAnalyticsReporter::new(analytics)));
 
-    // pass session monitor a weak reference to chaos reporter
+    // pass the session monitor a weak reference to chaos reporter so that route handlers with
+    // `AppState` won't prevent it being dropped upon session end
     let (monitor_tx, chaos_rx) =
         start_session_monitor(&config, is_operator, Arc::downgrade(&chaos_reporter)).await;
 

--- a/mirrord/cli/src/internal_proxy.rs
+++ b/mirrord/cli/src/internal_proxy.rs
@@ -19,6 +19,7 @@ use std::{
     io,
     net::{Ipv4Addr, SocketAddr},
     ops::Not,
+    sync::{Arc, Weak},
     time::Duration,
 };
 
@@ -35,14 +36,14 @@ use mirrord_intproxy::{
     agent_conn::{AgentConnectInfo, AgentConnection},
     session_monitor::{
         MonitorTx,
-        chaos::{ChaosWatcherRx, ChaosWatcherTx},
+        chaos::{ChaosWatcherRx, ChaosWatcherTx, analytics::ChaosAnalyticsReporter},
     },
 };
 use mirrord_protocol::{ClientMessage, DaemonMessage, LogLevel, LogMessage};
 use mirrord_session_monitor_protocol::SessionInfo;
 #[cfg(not(target_os = "windows"))]
 use nix::sys::resource::{Resource, setrlimit};
-use tokio::net::TcpListener;
+use tokio::{net::TcpListener, sync::RwLock};
 use tokio_util::sync::CancellationToken;
 use tracing::Level;
 #[cfg(not(target_os = "windows"))]
@@ -121,7 +122,7 @@ fn print_addr(listener: &TcpListener) -> io::Result<()> {
 async fn start_session_monitor(
     config: &LayerConfig,
     is_operator: bool,
-    analytics: Option<AnalyticsReporter>,
+    reporter: Weak<RwLock<ChaosAnalyticsReporter>>,
 ) -> (MonitorTx, ChaosWatcherRx) {
     use tokio::sync::watch;
 
@@ -201,7 +202,7 @@ async fn start_session_monitor(
             api_monitor_rx,
             shutdown,
             ChaosWatcherTx::new(chaos_tx),
-            analytics,
+            reporter,
         )
         .await
         {
@@ -324,9 +325,14 @@ pub(crate) async fn proxy(
     let process_logging_interval =
         Duration::from_secs(config.internal_proxy.process_logging_interval);
 
-    let (monitor_tx, chaos_rx) = start_session_monitor(&config, is_operator, Some(analytics)).await;
+    // this owns analytics and is the only strong reference, so dropping it will `Drop` inner values
+    let chaos_reporter = Arc::new(RwLock::new(ChaosAnalyticsReporter::new(analytics)));
 
-    IntProxy::new_with_connection(
+    // pass session monitor a weak reference to chaos reporter
+    let (monitor_tx, chaos_rx) =
+        start_session_monitor(&config, is_operator, Arc::downgrade(&chaos_reporter)).await;
+
+    let res = IntProxy::new_with_connection(
         agent_conn,
         listener,
         config.feature.fs.readonly_file_buffer,
@@ -347,7 +353,9 @@ pub(crate) async fn proxy(
     )
     .run(first_connection_timeout, consecutive_connection_timeout)
     .await
-    .map_err(From::from)
+    .map_err(From::from);
+
+    res
 }
 
 /// Creates a connection with the agent and handles one round of ping pong.

--- a/mirrord/cli/src/internal_proxy.rs
+++ b/mirrord/cli/src/internal_proxy.rs
@@ -24,7 +24,7 @@ use std::{
 };
 
 use mirrord_analytics::{
-    AnalyticsReporter, CollectAnalytics, Reporter, read_correlation_id_from_env,
+    AnalyticsError, AnalyticsReporter, CollectAnalytics, Reporter, read_correlation_id_from_env,
     read_kube_version_from_env,
 };
 use mirrord_config::{
@@ -354,6 +354,19 @@ pub(crate) async fn proxy(
     .run(first_connection_timeout, consecutive_connection_timeout)
     .await
     .map_err(From::from);
+
+    if res.is_err()
+        && tokio::time::timeout(Duration::from_secs(1), async {
+            chaos_reporter
+                .write()
+                .await
+                .set_inner_error(AnalyticsError::IntProxyFirstConnection);
+        })
+        .await
+        .is_err()
+    {
+        warn!("Error could not be set in analytics")
+    };
 
     res
 }

--- a/mirrord/intproxy/src/session_monitor/api.rs
+++ b/mirrord/intproxy/src/session_monitor/api.rs
@@ -16,7 +16,7 @@ use std::{
     convert::Infallible,
     fs,
     path::{Component, Path, PathBuf},
-    sync::Arc,
+    sync::{Arc, Weak},
     time::Duration,
 };
 
@@ -29,7 +29,6 @@ use axum::{
     },
     routing::{get, post},
 };
-use mirrord_analytics::AnalyticsReporter;
 use mirrord_session_monitor_protocol::{PortSubscription, ProcessInfo, SessionInfo};
 use tokio::sync::{RwLock, broadcast::error::RecvError};
 use tokio_stream::{StreamExt, wrappers::BroadcastStream};
@@ -65,7 +64,7 @@ pub(crate) struct AppState {
     /// storage, and we use this [`ChaosWatcherTx`] to propagate the changes to the many `*Proxy`
     /// (e.g. `OutgoingProxy`).
     pub(crate) chaos_tx: ChaosWatcherTx,
-    pub(crate) reporter: Arc<RwLock<ChaosAnalyticsReporter>>,
+    pub(crate) reporter: Weak<RwLock<ChaosAnalyticsReporter>>,
 }
 
 async fn health() -> impl IntoResponse {
@@ -178,7 +177,7 @@ pub async fn start_api_server(
     monitor_rx: tokio::sync::broadcast::Receiver<MonitorEvent>,
     shutdown: CancellationToken,
     chaos_tx: ChaosWatcherTx,
-    analytics: Option<AnalyticsReporter>,
+    reporter: Weak<RwLock<ChaosAnalyticsReporter>>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let session_id = session_info.session_id.clone();
 
@@ -199,7 +198,7 @@ pub async fn start_api_server(
         monitor_tx,
         shutdown: shutdown.clone(),
         chaos_tx,
-        reporter: Arc::new(RwLock::new(ChaosAnalyticsReporter::new(analytics))),
+        reporter,
     };
 
     tokio::spawn(update_session_info_from_events(state.clone(), monitor_rx));

--- a/mirrord/intproxy/src/session_monitor/chaos/analytics.rs
+++ b/mirrord/intproxy/src/session_monitor/chaos/analytics.rs
@@ -17,7 +17,7 @@ use crate::session_monitor::chaos::rules::{ChaosRule, ChaosSelector};
 
 /// Wraps [`AnalyticsReporter`] for use reporting chaos rule analytics. Stores deleted rules instead
 /// of sending analytics every time a rule is deleted. Sends all rules that were in effect over the
-/// whole session when the session ends via [`Self::report_analytics()`].
+/// whole session when the session ends via [`Self::drop()`].
 pub struct ChaosAnalyticsReporter {
     /// used to report analytics on session end
     inner: AnalyticsReporter,
@@ -71,7 +71,7 @@ impl ChaosAnalyticsReporter {
         });
     }
 
-    /// Call [`AnalyticsReporter::set_error()`] on `self.inner`
+    /// Sets the error on the [`AnalyticsReporter`] in `self.inner`.
     pub fn set_inner_error(&mut self, error: AnalyticsError) {
         self.inner.set_error(error);
     }
@@ -79,7 +79,6 @@ impl ChaosAnalyticsReporter {
 
 impl Drop for ChaosAnalyticsReporter {
     fn drop(&mut self) {
-        // clear all rules and report them to the AnalyticsReporter
         self.clear_session_rules();
 
         let rules_info: Vec<_> = self.dead_rules.drain().map(AnalyticValue::from).collect();

--- a/mirrord/intproxy/src/session_monitor/chaos/analytics.rs
+++ b/mirrord/intproxy/src/session_monitor/chaos/analytics.rs
@@ -15,10 +15,10 @@ use crate::session_monitor::chaos::rules::{ChaosRule, ChaosSelector};
 
 /// Wraps [`AnalyticsReporter`] for use reporting chaos rule analytics. Stores deleted rules instead
 /// of sending analytics every time a rule is deleted. Sends all rules that were in effect over the
-/// whole session when the session ends.
-pub(crate) struct ChaosAnalyticsReporter {
+/// whole session when the session ends via [`Self::report_analytics()`].
+pub struct ChaosAnalyticsReporter {
     /// used to report analytics on session end
-    inner: Option<AnalyticsReporter>,
+    inner: AnalyticsReporter,
 
     /// rules that are currently in use, and the `Instant` they were created
     live_rules: HashMap<ChaosRule, Instant>,
@@ -28,7 +28,7 @@ pub(crate) struct ChaosAnalyticsReporter {
 }
 
 impl ChaosAnalyticsReporter {
-    pub fn new(inner: Option<AnalyticsReporter>) -> Self {
+    pub fn new(inner: AnalyticsReporter) -> Self {
         Self {
             inner,
             live_rules: HashMap::default(),
@@ -61,8 +61,8 @@ impl ChaosAnalyticsReporter {
         };
     }
 
-    // Remove all live rules from `self.live_rules`, and move them to `self.dead_rules` after
-    // converting each into a [`ChaosRuleInfo`].
+    /// Remove all live rules from `self.live_rules`, and move them to `self.dead_rules` after
+    /// converting each into a [`ChaosRuleInfo`].
     pub fn clear_session_rules(&mut self) {
         self.live_rules.drain().for_each(|(rule, start_time)| {
             self.dead_rules.insert((&rule, start_time).into());
@@ -72,17 +72,11 @@ impl ChaosAnalyticsReporter {
 
 impl Drop for ChaosAnalyticsReporter {
     fn drop(&mut self) {
-        // kill all the live rules we have
-        self.live_rules
-            .clone()
-            .iter()
-            .for_each(|(rule, _)| self.delete_rule(rule));
+        // clear all rules and report them to the AnalyticsReporter
+        self.clear_session_rules();
 
-        // report all the dead rules to the AnalyticsReporter
         let rules_info: Vec<_> = self.dead_rules.drain().map(AnalyticValue::from).collect();
-        if let Some(x) = self.inner.as_mut() {
-            x.get_mut().add("rules", rules_info)
-        }
+        self.inner.get_mut().add("rules", rules_info);
     }
 }
 

--- a/mirrord/intproxy/src/session_monitor/chaos/analytics.rs
+++ b/mirrord/intproxy/src/session_monitor/chaos/analytics.rs
@@ -9,7 +9,9 @@ use std::{
     time::Instant,
 };
 
-use mirrord_analytics::{AnalyticValue, Analytics, AnalyticsReporter, CollectAnalytics, Reporter};
+use mirrord_analytics::{
+    AnalyticValue, Analytics, AnalyticsError, AnalyticsReporter, CollectAnalytics, Reporter,
+};
 
 use crate::session_monitor::chaos::rules::{ChaosRule, ChaosSelector};
 
@@ -67,6 +69,11 @@ impl ChaosAnalyticsReporter {
         self.live_rules.drain().for_each(|(rule, start_time)| {
             self.dead_rules.insert((&rule, start_time).into());
         });
+    }
+
+    /// Call [`AnalyticsReporter::set_error()`] on `self.inner`
+    pub fn set_inner_error(&mut self, error: AnalyticsError) {
+        self.inner.set_error(error);
     }
 }
 

--- a/mirrord/intproxy/src/session_monitor/chaos/api.rs
+++ b/mirrord/intproxy/src/session_monitor/chaos/api.rs
@@ -4,6 +4,7 @@ use axum::{
     Json,
     extract::{FromRequest, Path, State},
 };
+use tokio::sync::RwLock;
 use tracing::Level;
 use uuid::Uuid;
 
@@ -134,26 +135,41 @@ pub(super) async fn get_rule(
 /// Helper function to record a new rule creation in `AppState.reporter`, used in the router request
 /// handlers for POST and PUT.
 fn report_create_rule(state: &AppState, rule: &ChaosRule) {
-    match state.reporter.try_write() {
-        Ok(mut reporter) => reporter.create_rule(rule),
-        Err(error) => tracing::trace!("failed to get write lock on analytics reporter: {error}"),
+    match state.reporter.upgrade().as_deref().map(RwLock::try_write) {
+        Some(Ok(mut reporter)) => reporter.create_rule(rule),
+        Some(Err(error)) => {
+            tracing::trace!("failed to get write lock on analytics reporter: {error}")
+        }
+        None => tracing::trace!(
+            "failed to upgrade reference to analytics reporter (reporter was moved or missing)"
+        ),
     }
 }
 
 /// Helper function to record a rule deletion in `AppState.reporter`, used in the router request
 /// handlers for DELETE and PUT.
 fn report_delete_rule(state: &AppState, rule: &ChaosRule) {
-    match state.reporter.try_write() {
-        Ok(mut reporter) => reporter.delete_rule(rule),
-        Err(error) => tracing::trace!("failed to get write lock on analytics reporter: {error}"),
+    match state.reporter.upgrade().as_deref().map(RwLock::try_write) {
+        Some(Ok(mut reporter)) => reporter.delete_rule(rule),
+        Some(Err(error)) => {
+            tracing::trace!("failed to get write lock on analytics reporter: {error}")
+        }
+        None => tracing::trace!(
+            "failed to upgrade reference to analytics reporter (reporter was moved or missing)"
+        ),
     }
 }
 
 /// Helper function to record deletion of all active rules in `AppState.reporter`, used in the
 /// router request handler for DELETE.
 fn report_clear_session_rules(state: &AppState) {
-    match state.reporter.try_write() {
-        Ok(mut reporter) => reporter.clear_session_rules(),
-        Err(error) => tracing::trace!("failed to get write lock on analytics reporter: {error}"),
+    match state.reporter.upgrade().as_deref().map(RwLock::try_write) {
+        Some(Ok(mut reporter)) => reporter.clear_session_rules(),
+        Some(Err(error)) => {
+            tracing::trace!("failed to get write lock on analytics reporter: {error}")
+        }
+        None => tracing::trace!(
+            "failed to upgrade reference to analytics reporter (reporter was moved or missing)"
+        ),
     }
 }

--- a/mirrord/intproxy/tests/session_monitor_round_trip.rs
+++ b/mirrord/intproxy/tests/session_monitor_round_trip.rs
@@ -21,7 +21,7 @@
 
 #![cfg(any(unix, windows))]
 
-use std::{path::PathBuf, time::Duration};
+use std::{path::PathBuf, sync::Weak, time::Duration};
 
 use futures::StreamExt;
 use mirrord_intproxy::session_monitor::{
@@ -116,7 +116,7 @@ impl StartedServer {
                     rx,
                     shutdown,
                     ChaosWatcherTx::new(chaos_tx),
-                    None,
+                    Weak::new(),
                 )
                 .await
             }
@@ -391,7 +391,7 @@ async fn invalid_session_id_with_path_traversal_returns_error() {
         rx,
         shutdown,
         ChaosWatcherTx::new(chaos_tx),
-        None,
+        Weak::new(),
     )
     .await;
 


### PR DESCRIPTION
### Context

- Linear issue: [COR-1775](https://linear.app/metalbear/issue/COR-1775/allow-the-intproxy-session-monitor-to-end-gracefully-on-session-end)
- Initial PR: https://github.com/metalbear-co/mirrord/pull/4677
- Internal discussion: [Slack](https://metalbear.slack.com/archives/C09HK8DDX7U/p1785946062959089)
- Fix working: [PH `client_session_v1` event](https://us.posthog.com/project/29024/events/019fec95-54ce-7073-9f6f-50e88f90bcde/2026-08-10T19%3A50%3A37.413000%2B03%3A00)
  - Additionally ran smoke tests for 20, 50, 100 concurrent runs and all analytics events were received in PH as expected

### Summary

- Analytics were not being reported due to `Drop` not executing when the session monitor was torn down
- The session monitor was not exiting gracefully because each `AppState` held a reference to `AnalyticsReporter`, so `drain` never fully closed it down
- With this change, the session monitor is given only `Weak` references to the `ChaosAnalyticsReporter` (which wraps `AnalyticsReporter`)
- Also as pointed out in the previous PR, the error was not being set on analytics when the intproxy failed on the first connection