### PR TITLE
change examples to the recommended way which is  object and not string

### DIFF
--- a/changelog.d/+config-docs-examples.internal.md
+++ b/changelog.d/+config-docs-examples.internal.md
@@ -1,0 +1,1 @@
+Configuration docs now show target as an object rather than a string in examples, matching the recommended format.

--- a/mirrord/config/src/target.rs
+++ b/mirrord/config/src/target.rs
@@ -98,7 +98,8 @@ fn make_simple_target_custom_schema(generator: &mut SchemaGenerator) -> Schema {
 ///    }
 ///  }
 /// }
-///
+///```
+/// 
 /// Equivalent shortened setup with a target:
 ///
 ///```json
@@ -121,6 +122,7 @@ fn make_simple_target_custom_schema(generator: &mut SchemaGenerator) -> Schema {
 ///    }
 ///  }
 /// }
+/// ```
 ///
 /// Shortened setup with a target container:
 ///

--- a/mirrord/config/src/target.rs
+++ b/mirrord/config/src/target.rs
@@ -69,17 +69,18 @@ fn make_simple_target_custom_schema(generator: &mut SchemaGenerator) -> Schema {
 
 /// Specifies the target and namespace to target.
 ///
-/// The simplified configuration supports:
-///
-/// - `targetless`
-/// - `pod/{pod-name}[/container/{container-name}]`;
-/// - `deployment/{deployment-name}[/container/{container-name}]`;
-/// - `rollout/{rollout-name}[/container/{container-name}]`;
-/// - `job/{job-name}[/container/{container-name}]`;
-/// - `cronjob/{cronjob-name}[/container/{container-name}]`;
-/// - `statefulset/{statefulset-name}[/container/{container-name}]`;
-/// - `service/{service-name}[/container/{container-name}]`;
-/// - `label/{key}={value}[,{key}={value}...][/container/{container-name}]`;
+/// The JSON configuration supports:
+/// | Target type | JSON object equivalent |
+/// |---|---|
+/// | targetless | `{ "target": "targetless" }` |
+/// | pod | `{ "target": { "pod": "pod-name", "container": "container-name" } }` |
+/// | deployment | `{ "target": { "deployment": "deployment-name", "container": "container-name" } }` |
+/// | rollout | `{ "target": { "rollout": "rollout-name", "container": "container-name" } }` |
+/// | job | `{ "target": { "job": "job-name", "container": "container-name" } }` |
+/// | cronjob | `{ "target": { "cron_job": "cronjob-name", "container": "container-name" } }` |
+/// | statefulset | `{ "target": { "stateful_set": "statefulset-name", "container": "container-name" } }` |
+/// | service | `{ "target": { "service": "service-name", "container": "container-name" } }` |
+/// | label | `{ "target": { "labels": { "key": "value" }, "container": "container-name" } }` |
 ///
 /// Please note that:
 ///
@@ -87,7 +88,18 @@ fn make_simple_target_custom_schema(generator: &mut SchemaGenerator) -> Schema {
 /// - `job` and `cronjob` targets use the [`copy_target`](#feature-copy_target) feature, which
 ///   mirrord enables automatically for them
 ///
-/// Shortened setup with a target:
+/// Recommended object setup:
+///
+/// ```json
+/// {
+///  "target": {
+///    "path": {
+///      "pod": "bear-pod"
+///    }
+///  }
+/// }
+///
+/// Equivalent shortened setup with a target:
 ///
 ///```json
 /// {
@@ -97,6 +109,18 @@ fn make_simple_target_custom_schema(generator: &mut SchemaGenerator) -> Schema {
 ///
 /// The setup above will result in a session targeting the `bear-pod` Kubernetes pod
 /// in the user's default namespace. A target container will be chosen by mirrord.
+///
+/// Recommended object setup with a target container:
+///
+/// ```json
+/// {
+///  "target": {
+///    "path": {
+///      "pod": "bear-pod",
+///      "container": "bear-pod-container"
+///    }
+///  }
+/// }
 ///
 /// Shortened setup with a target container:
 ///
@@ -109,7 +133,7 @@ fn make_simple_target_custom_schema(generator: &mut SchemaGenerator) -> Schema {
 /// The setup above will result in a session targeting the `bear-pod-container` container
 /// in the `bear-pod` Kubernetes pod in the user's default namespace.
 ///
-/// Complete setup with a target container:
+/// Complete object setup with a target container:
 ///
 /// ```json
 /// {
@@ -153,22 +177,19 @@ pub struct TargetConfig {
     /// to work with.
     ///
     /// Supports:
-    /// - `targetless`
-    /// - `pod/{pod-name}[/container/{container-name}]`;
-    /// - `deployment/{deployment-name}[/container/{container-name}]`;
-    /// - `rollout/{rollout-name}[/container/{container-name}]`;
-    /// - `job/{job-name}[/container/{container-name}]`; (requires mirrord Operator; uses the
-    ///   [`copy_target`](#feature-copy_target) feature, which mirrord enables automatically)
-    /// - `cronjob/{cronjob-name}[/container/{container-name}]`; (requires mirrord Operator; uses
-    ///   the [`copy_target`](#feature-copy_target) feature, which mirrord enables automatically)
-    /// - `statefulset/{statefulset-name}[/container/{container-name}]`; (requires mirrord
-    ///   Operator)
-    /// - `service/{service-name}[/container/{container-name}]`; (requires mirrord Operator)
-    /// - `replicaset/{replicaset-name}[/container/{container-name}]`; (requires mirrord Operator)
-    /// - `label/{key}={value}[,{key}={value}...][/container/{container-name}]`; (requires mirrord
-    ///   Operator)
-    /// - `{ "labels": { "app": "api", "tier": "web" }, "container": "api" }`; (requires mirrord
-    ///   Operator)
+    ///
+    /// | Target type | Requires | JSON equivalent |
+    /// |---|---|---|
+    /// | targetless | — | `"targetless"` |
+    /// | pod | — | `{ "pod": "pod-name", "container": "container-name" }` |
+    /// | deployment | — | `{ "deployment": "deployment-name", "container": "container-name" }` |
+    /// | rollout | — | `{ "rollout": "rollout-name", "container": "container-name" }` |
+    /// | job | mirrord Operator; auto-enables [`copy_target`](#feature-copy_target) | `{ "job": "job-name", "container": "container-name" }` |
+    /// | cronjob | mirrord Operator; auto-enables [`copy_target`](#feature-copy_target) | `{ "cron_job": "cronjob-name", "container": "container-name" }` |
+    /// | statefulset | mirrord Operator | `{ "stateful_set": "statefulset-name", "container": "container-name" }` |
+    /// | service | mirrord Operator | `{ "service": "service-name", "container": "container-name" }` |
+    /// | replicaset | mirrord Operator | `{ "replica_set": "replicaset-name", "container": "container-name" }` |
+    /// | label | mirrord Operator | `{ "labels": { "app": "api", "tier": "web" }, "container": "api" }` |
     #[serde(skip_serializing_if = "Option::is_none")]
     pub path: Option<Target>,
 

--- a/mirrord/config/src/target.rs
+++ b/mirrord/config/src/target.rs
@@ -98,8 +98,8 @@ fn make_simple_target_custom_schema(generator: &mut SchemaGenerator) -> Schema {
 ///    }
 ///  }
 /// }
-///```
-/// 
+/// ```
+///
 /// Equivalent shortened setup with a target:
 ///
 ///```json


### PR DESCRIPTION
Updates the docs configuration to include the recommended object over the string target