### PR TITLE
Read the Kafka split topic from its earliest offset in the test consumer

### DIFF
--- a/.vale/styles/config/vocabularies/Metalbear/accept.txt
+++ b/.vale/styles/config/vocabularies/Metalbear/accept.txt
@@ -178,6 +178,11 @@ Greptile
 # Cloud services
 SNS
 
+# Kafka
+rebalance
+rebalances
+rebalancing
+
 # Common tech acronyms
 LLM
 LLMs

--- a/changelog.d/+kafka-oversized-hang.internal.md
+++ b/changelog.d/+kafka-oversized-hang.internal.md
@@ -1,0 +1,1 @@
+Read the split topic from its earliest offset in the Kafka E2E consumer, so messages forwarded while the consumer group is still rebalancing aren't skipped.

--- a/tests/kafka-consumer/src/main.rs
+++ b/tests/kafka-consumer/src/main.rs
@@ -54,6 +54,13 @@ async fn main() -> anyhow::Result<()> {
         .set("bootstrap.servers", &config.address)
         .set("group.id", &config.group)
         .set("enable.auto.commit", "false")
+        // This consumer joins the target workload's group, so its assignment waits on the same
+        // rebalance the operator's forwarder does - up to `session.timeout.ms` while the restarted
+        // target is evicted. The forwarder writes into the split topic as soon as it is assigned,
+        // which can land before this consumer is. librdkafka's default "latest" would then start
+        // past those messages and never deliver them; "earliest" reads the split topic from the
+        // start. The topic is created per session, so that is exactly this session's messages.
+        .set("auto.offset.reset", "earliest")
         // Allow fetching messages larger than the librdkafka 1 MB default so the oversized-message
         // test can pull a payload above 1 MB from the split topic.
         .set("fetch.message.max.bytes", "10485760")


### PR DESCRIPTION
Resolves INT-603.

`oversized_message` hung intermittently and was killed at nextest's 360s cap after roughly 55s of actual work.

The operator reports a split session ready before the target's consumer group has rebalanced. The test consumer joins that same group, so its assignment waits out `session.timeout.ms` while the restarted target is evicted (measured at 45s locally). The forwarder is assigned at the end of that window and forwards correctly, protected by its own `auto.offset.reset=earliest`. The test consumer was assigned ~130ms later with librdkafka's default `latest` and no committed offset, so it started past the forwarded message and blocked forever.

`earliest` is safe here because the split topic is created per session, so it reads only this session's messages.
