### PR TITLE
Improve CI alerts

### DIFF
--- a/.github/scripts/ci-duration.sh
+++ b/.github/scripts/ci-duration.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+#
+# Measures a CI run against its budgets and builds the Slack alert for it.
+#
+# Splits the run into the time its jobs spent executing, the longest any one job waited for a
+# runner, and the wall time between queueing and finishing, holding the first two to their budgets
+# and both to the median of recent successful `main` runs. A run GitHub stopped at a job timeout
+# gets its own alert naming the jobs it killed, which the budgets would otherwise never see.
+#
+# Usage: ci-duration.sh <repo> <run-id> <conclusion> <budget> <queue-budget> <median-runs>
+#
+# Writes the run's numbers to $GITHUB_STEP_SUMMARY, and the webhook payload to stdout when a budget
+# was breached or the run was killed.
+
+set -euo pipefail
+
+repo=$1
+run_id=$2
+conclusion=$3
+budget=$4
+queue_budget=$5
+median_runs=$6
+
+short=${repo#*/}
+
+run=$(gh api "repos/$repo/actions/runs/$run_id")
+jobs=$(gh api --paginate "repos/$repo/actions/runs/$run_id/jobs?per_page=100" --jq '.jobs[]' | jq -s '.')
+
+field() {
+  jq -r "$1" <<< "$run"
+}
+
+minutes() {
+  echo $(( ( $(date -d "$2" +%s) - $(date -d "$1" +%s) + 30 ) / 60 ))
+}
+
+# A run's own clock starts once GitHub picks it up, so the wait for a runner is only visible per
+# job, and the one job that waited longest is what held the run back.
+execution=$(minutes "$(field .run_started_at)" "$(field .updated_at)")
+total=$(minutes "$(field .created_at)" "$(field .updated_at)")
+queued=$(jq -r '
+  [.[] | select(.created_at != null and .started_at != null)
+   | (.started_at | fromdateiso8601) - (.created_at | fromdateiso8601)]
+  | (max // 0) / 60 | round' <<< "$jobs")
+
+median=$(gh api \
+  "repos/$repo/actions/workflows/$(field .workflow_id)/runs?status=success&branch=main&per_page=$median_runs" \
+  --jq '
+    [.workflow_runs[]
+     | ((.updated_at | fromdateiso8601) - (.run_started_at | fromdateiso8601)) / 60]
+    | sort
+    | length as $n
+    | if $n == 0 then 0
+      elif $n % 2 == 1 then .[$n / 2 | floor]
+      else (.[$n / 2 - 1 | floor] + .[$n / 2 | floor]) / 2
+      end
+    | round')
+
+pr=$(gh api "repos/$repo/commits/$(field .head_sha)/pulls" --jq '.[0].number // empty' || true)
+
+if [ -n "$pr" ]; then
+  change="<https://github.com/$repo/pull/$pr|$short#$pr>"
+else
+  sha=$(field .head_sha)
+  change="<https://github.com/$repo/commit/$sha|\`${sha:0:7}\`>"
+fi
+
+job_lines() {
+  jq -r "$1"' | "\(((( .completed_at // .started_at) | fromdateiso8601) - (.started_at | fromdateiso8601)) / 60 | round)\t\(.name)"' <<< "$jobs"
+}
+
+bullets() {
+  local retained=()
+  local retries name
+
+  while IFS=$'\t' read -r retries name; do
+    [ -n "$name" ] || continue
+    retained+=("$(printf '•  *%sm*  `%s`' "$retries" "$name")")
+  done
+
+  [ "${#retained[@]}" -eq 0 ] || printf '%s\n' "${retained[@]}"
+}
+
+# GitHub cancels a job that passes its `timeout-minutes`, which reads exactly like a job a human or
+# a concurrency rule stopped until you find the annotation it leaves behind.
+timed_out_jobs() {
+  local id name started completed messages
+
+  while IFS=$'\t' read -r id name started completed; do
+    [ -n "$id" ] || continue
+
+    messages=$(gh api "repos/$repo/check-runs/$id/annotations" --jq '.[].message' || true)
+
+    case $messages in
+      *'exceeded the maximum execution time'*)
+        printf '%s\t%s\n' "$(minutes "$started" "$completed")" "$name"
+        ;;
+    esac
+  done < <(jq -r '.[]
+    | select(.conclusion == "cancelled") | select(.started_at != null)
+    | "\(.id)\t\(.name)\t\(.started_at)\t\(.completed_at // .started_at)"' <<< "$jobs")
+}
+
+killed=$(timed_out_jobs)
+
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  printf 'CI run took %sm executing (budget %sm, median %sm), waited %sm for a runner (budget %sm), %sm in total.\n' \
+    "$execution" "$budget" "$median" "$queued" "$queue_budget" "$total" >> "$GITHUB_STEP_SUMMARY"
+fi
+
+if [ -n "$killed" ]; then
+  headline="$short CI was killed after ${total}m"
+  facts=$(printf '•  *Execution*  %sm  ·  median %sm\n•  *Total*  %sm\n•  *Change*  %s' \
+    "$execution" "$median" "$total" "$change")
+  detail=$(printf '*Jobs GitHub stopped*\n%s' "$(bullets <<< "$killed")")
+  footer='GitHub stops a job once it passes its `timeout-minutes`.'
+  emoji=':skull:'
+elif [ "$conclusion" != "success" ]; then
+  exit 0
+elif [ "$execution" -gt "$budget" ] || [ "$queued" -gt "$queue_budget" ]; then
+  if [ "$execution" -gt "$budget" ] && [ "$queued" -gt "$queue_budget" ]; then
+    headline="$short CI took ${execution}m and waited ${queued}m for a runner"
+    emoji=':stopwatch:'
+  elif [ "$execution" -gt "$budget" ]; then
+    headline="$short CI took ${execution}m"
+    emoji=':stopwatch:'
+  else
+    headline="$short CI waited ${queued}m for a runner"
+    emoji=':hourglass:'
+  fi
+
+  facts=$(printf '•  *Execution*  %sm  ·  budget %sm  ·  median %sm\n•  *Queued*  %sm  ·  budget %sm\n•  *Total*  %sm\n•  *Change*  %s' \
+    "$execution" "$budget" "$median" "$queued" "$queue_budget" "$total" "$change")
+  detail=$(printf '*Slowest jobs*\n%s' \
+    "$(job_lines '.[] | select(.started_at != null)' | sort -rn | head -3 | bullets)")
+  footer="Execution excludes the wait for a runner. Median over the last $median_runs successful \`main\` runs."
+else
+  exit 0
+fi
+
+jq -n \
+  --arg headline "$headline" \
+  --arg emoji "$emoji" \
+  --arg facts "$facts" \
+  --arg detail "$detail" \
+  --arg footer "$footer" \
+  '{
+    text: $headline,
+    blocks: [
+      {type: "header", text: {type: "plain_text", text: ($emoji + " " + $headline), emoji: true}},
+      {type: "section", text: {type: "mrkdwn", text: $facts}},
+      {type: "section", text: {type: "mrkdwn", text: $detail}},
+      {type: "context", elements: [{type: "mrkdwn", text: $footer}]}
+    ]
+  }'

--- a/.github/scripts/ci-duration.sh
+++ b/.github/scripts/ci-duration.sh
@@ -23,6 +23,26 @@ median_runs=$6
 
 short=${repo#*/}
 
+whole_number() {
+  case $2 in
+    '' | *[!0-9]*)
+      echo "$1 must be a whole number, got '$2'" >&2
+      exit 1
+      ;;
+  esac
+}
+
+whole_number 'the execution budget' "$budget"
+whole_number 'the queue budget' "$queue_budget"
+whole_number 'the sample size' "$median_runs"
+
+# A page of runs tops out at 100, and sampling past that would report a median over more runs than
+# it read.
+if [ "$median_runs" -gt 100 ]; then
+  echo "::warning::sample size $median_runs exceeds the 100-run page limit, sampling 100" >&2
+  median_runs=100
+fi
+
 run=$(gh api "repos/$repo/actions/runs/$run_id")
 jobs=$(gh api --paginate "repos/$repo/actions/runs/$run_id/jobs?per_page=100" --jq '.jobs[]' | jq -s '.')
 
@@ -89,7 +109,7 @@ timed_out_jobs() {
   while IFS=$'\t' read -r id name started completed; do
     [ -n "$id" ] || continue
 
-    messages=$(gh api "repos/$repo/check-runs/$id/annotations" --jq '.[].message' || true)
+    messages=$(gh api --paginate "repos/$repo/check-runs/$id/annotations" --jq '.[].message')
 
     case $messages in
       *'exceeded the maximum execution time'*)

--- a/.github/scripts/flaky-issue.sh
+++ b/.github/scripts/flaky-issue.sh
@@ -2,9 +2,10 @@
 #
 # Reports, files, or updates the Linear issue tracking a test that retries on `main`.
 #
-# Keeps one issue per test: with a <body-file> it files that issue when none is open and comments on
-# it when one is, so a daily report updates a single issue rather than opening one per run. Without
-# a <body-file> it only looks the issue up, printing nothing when none is open.
+# Keeps one issue per test, found by the attachment the report leaves on it rather than by its
+# title, so retitling an issue in Linear does not orphan it. With a <body-file> it files that issue
+# when none is open and comments on it when one is; without one it only looks the issue up, printing
+# nothing when none is open.
 #
 # Usage: flaky-issue.sh <repo> <team-key> <test> [<body-file>]
 #
@@ -17,7 +18,12 @@ team_key=$2
 name=$3
 body_file=${4:-}
 
-title="Flaky test in $repo: $name"
+label=flake
+title="Flaky test in ${repo#*/}: $name"
+
+# Doubles as the attachment's link and as the key the next run finds the issue by, so it has to be
+# derived from nothing but the test itself.
+key_url="https://github.com/$repo/search?q=$(jq -rn --arg q "$name" '$q | @uri')&type=code"
 
 # GraphQL reports failures in the body with HTTP 200, so the response has to be inspected rather
 # than left to curl's status handling.
@@ -37,17 +43,17 @@ api() {
   printf '%s' "$response"
 }
 
-query=$(jq -n --arg title "$title" --arg key "$team_key" '{
-  query: "query($title: String!, $key: String!) {
-    issues(filter: { title: { eq: $title }, team: { key: { eq: $key } } }) {
-      nodes { id identifier state { type } }
+existing=$(api "$(jq -n --arg url "$key_url" '{
+  query: "query($url: String!) {
+    attachmentsForURL(url: $url) {
+      nodes { issue { id identifier state { type } team { key } } }
     }
   }",
-  variables: { title: $title, key: $key }
-}')
-
-existing=$(api "$query" | jq -r '
-  [.data.issues.nodes[]? | select(.state.type != "completed" and .state.type != "canceled")][0] // empty
+  variables: { url: $url }
+}')" | jq -r --arg key "$team_key" '
+  [.data.attachmentsForURL.nodes[]?.issue
+   | select(.team.key == $key)
+   | select(.state.type != "completed" and .state.type != "canceled")][0] // empty
   | @json')
 
 if [ -z "$body_file" ]; then
@@ -58,9 +64,8 @@ fi
 body=$(cat "$body_file")
 
 if [ -n "$existing" ]; then
-  id=$(printf '%s' "$existing" | jq -r .id)
   identifier=$(printf '%s' "$existing" | jq -r .identifier)
-  mutation=$(jq -n --arg id "$id" --arg body "$body" '{
+  mutation=$(jq -n --arg id "$(printf '%s' "$existing" | jq -r .id)" --arg body "$body" '{
     query: "mutation($id: String!, $body: String!) {
       commentCreate(input: { issueId: $id, body: $body }) { success }
     }",
@@ -85,21 +90,68 @@ if [ -z "$team_id" ]; then
   exit 1
 fi
 
-mutation=$(jq -n --arg team "$team_id" --arg title "$title" --arg body "$body" '{
-  query: "mutation($team: String!, $title: String!, $body: String!) {
-    issueCreate(input: { teamId: $team, title: $title, description: $body, priority: 1 }) {
+label_id=$(api "$(jq -n --arg name "$label" '{
+  query: "query($name: String!) {
+    issueLabels(filter: { name: { eq: $name } }) { nodes { id team { key } } }
+  }",
+  variables: { name: $name }
+}')" | jq -r --arg key "$team_key" '
+  [.data.issueLabels.nodes[]? | select(.team == null or .team.key == $key)][0].id // empty')
+
+if [ -z "$label_id" ]; then
+  echo "::warning::no Linear label named $label, filing $title without it" >&2
+fi
+
+created=$(api "$(jq -n \
+  --arg team "$team_id" \
+  --arg title "$title" \
+  --arg body "$body" \
+  --arg label "$label_id" '{
+  query: "mutation($team: String!, $title: String!, $body: String!, $labels: [String!]) {
+    issueCreate(input: {
+      teamId: $team, title: $title, description: $body, priority: 1, labelIds: $labels
+    }) {
       success
-      issue { identifier }
+      issue { id identifier }
     }
   }",
-  variables: { team: $team, title: $title, body: $body }
-}')
-
-created=$(api "$mutation" | jq -r '.data.issueCreate | select(.success == true) | .issue.identifier // empty')
+  variables: {
+    team: $team,
+    title: $title,
+    body: $body,
+    labels: (if $label == "" then [] else [$label] end)
+  }
+}')" | jq -r '.data.issueCreate | select(.success == true) | .issue // empty')
 
 if [ -z "$created" ]; then
   echo "Linear rejected the new issue" >&2
   exit 1
 fi
 
-echo "$created"
+attached=$(api "$(jq -n \
+  --arg id "$(printf '%s' "$created" | jq -r .id)" \
+  --arg url "$key_url" \
+  --arg title "Flaky test" \
+  --arg name "$name" \
+  --arg repo "$repo" '{
+  query: "mutation($id: String!, $url: String!, $title: String!, $name: String!, $metadata: JSONObject!) {
+    attachmentCreate(input: {
+      issueId: $id, url: $url, title: $title, subtitle: $name, metadata: $metadata
+    }) { success }
+  }",
+  variables: {
+    id: $id,
+    url: $url,
+    title: $title,
+    name: $name,
+    metadata: { source: "flaky-test-report", repository: $repo, test: $name }
+  }
+}')" | jq -r '.data.attachmentCreate.success')
+
+# Without the attachment the next run cannot find this issue and files a duplicate.
+if [ "$attached" != "true" ]; then
+  echo "Linear rejected the attachment keying $title" >&2
+  exit 1
+fi
+
+printf '%s' "$created" | jq -r .identifier

--- a/.github/scripts/flaky-issue.sh
+++ b/.github/scripts/flaky-issue.sh
@@ -1,22 +1,23 @@
 #!/usr/bin/env bash
 #
-# Files (or updates) the Linear issue tracking tests that retry too often on `main`.
+# Reports, files, or updates the Linear issue tracking a test that retries on `main`.
 #
-# Creates one urgent issue per repository and comments on it thereafter, so a daily report updates a
-# single issue rather than opening one per run.
+# Keeps one issue per test: with a <body-file> it files that issue when none is open and comments on
+# it when one is, so a daily report updates a single issue rather than opening one per run. Without
+# a <body-file> it only looks the issue up, printing nothing when none is open.
 #
-# Usage: flaky-issue.sh <repo> <team-key> <body-file>
+# Usage: flaky-issue.sh <repo> <team-key> <test> [<body-file>]
 #
-# Requires $LINEAR_ACCESS_KEY.
+# Prints the issue identifier. Requires $LINEAR_ACCESS_KEY.
 
 set -euo pipefail
 
 repo=$1
 team_key=$2
-body_file=$3
+name=$3
+body_file=${4:-}
 
-title="Flaky tests on main: $repo"
-body=$(cat "$body_file")
+title="Flaky test in $repo: $name"
 
 # GraphQL reports failures in the body with HTTP 200, so the response has to be inspected rather
 # than left to curl's status handling.
@@ -48,6 +49,13 @@ query=$(jq -n --arg title "$title" --arg key "$team_key" '{
 existing=$(api "$query" | jq -r '
   [.data.issues.nodes[]? | select(.state.type != "completed" and .state.type != "canceled")][0] // empty
   | @json')
+
+if [ -z "$body_file" ]; then
+  printf '%s' "$existing" | jq -r '.identifier // empty'
+  exit 0
+fi
+
+body=$(cat "$body_file")
 
 if [ -n "$existing" ]; then
   id=$(printf '%s' "$existing" | jq -r .id)

--- a/.github/scripts/flaky-issue.sh
+++ b/.github/scripts/flaky-issue.sh
@@ -148,9 +148,32 @@ attached=$(api "$(jq -n \
   }
 }')" | jq -r '.data.attachmentCreate.success')
 
-# Without the attachment the next run cannot find this issue and files a duplicate.
+# The attachment is the only thing the next run finds this issue by, so an issue that failed to get
+# one is unreachable and would be filed again every day. Trash it, leaving the reason behind for
+# whoever finds it there, rather than let it accumulate copies.
 if [ "$attached" != "true" ]; then
-  echo "Linear rejected the attachment keying $title" >&2
+  echo "Linear rejected the attachment keying $title, trashing the issue" >&2
+
+  issue_id=$(printf '%s' "$created" | jq -r .id)
+  note='Filed by the flaky test report, which then failed to attach the key it finds this issue by.
+Trashed so the next report can file a clean one. The test is still flaky.'
+
+  api "$(jq -n --arg id "$issue_id" --arg body "$note" '{
+    query: "mutation($id: String!, $body: String!) {
+      commentCreate(input: { issueId: $id, body: $body }) { success }
+    }",
+    variables: { id: $id, body: $body }
+  }')" > /dev/null || true
+
+  trashed=$(api "$(jq -n --arg id "$issue_id" '{
+    query: "mutation($id: String!) { issueDelete(id: $id) { success } }",
+    variables: { id: $id }
+  }')" | jq -r '.data.issueDelete.success') || trashed=false
+
+  if [ "$trashed" != "true" ]; then
+    echo "$title is left unkeyed in Linear and will be filed again tomorrow" >&2
+  fi
+
   exit 1
 fi
 

--- a/.github/scripts/flaky-notify.sh
+++ b/.github/scripts/flaky-notify.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+#
+# Builds the Slack payload announcing tests that retry on `main`.
+#
+# Reads the `<retries>\t<test>` listing `flaky-tests.sh` produces on stdin and writes the webhook
+# payload to stdout. Every test is named in the message itself, annotated with the Linear issue
+# tracking it when one is open, so the channel needs no trip to the run to see what is flaking.
+#
+# Usage: flaky-notify.sh <repo> <team-key> <threshold> <runs>
+#
+# Annotates issues only when $LINEAR_ACCESS_KEY is set.
+
+set -euo pipefail
+
+repo=$1
+team_key=$2
+threshold=$3
+runs=$4
+
+scripts=$(dirname "$0")
+bullets=()
+
+while IFS=$'\t' read -r retries name; do
+  [ -n "$name" ] || continue
+
+  issue=""
+  if [ -n "${LINEAR_ACCESS_KEY:-}" ]; then
+    issue=$("$scripts/flaky-issue.sh" "$repo" "$team_key" "$name" < /dev/null)
+  fi
+
+  if [ -n "$issue" ]; then
+    bullets+=("$(printf '•  *%s×*  `%s`  ·  %s' "$retries" "$name" "$issue")")
+  else
+    bullets+=("$(printf '•  *%s×*  `%s`' "$retries" "$name")")
+  fi
+done
+
+count=${#bullets[@]}
+if [ "$count" -eq 0 ]; then
+  echo "nothing to report" >&2
+  exit 1
+fi
+
+list=$(printf '%s\n' "${bullets[@]}")
+
+# A Slack section caps out at 3000 characters, which a thoroughly broken `main` can cross.
+dropped=0
+while [ "${#list}" -gt 2900 ] && [ "${#bullets[@]}" -gt 1 ]; do
+  unset 'bullets[-1]'
+  dropped=$((dropped + 1))
+  list=$(printf '%s\n' "${bullets[@]}")
+done
+
+if [ "$dropped" -ne 0 ]; then
+  list=$(printf '%s\n_…and %s more._' "$list" "$dropped")
+fi
+
+if [ "$count" -eq 1 ]; then
+  headline="1 flaky test on ${repo#*/} main"
+else
+  headline="$count flaky tests on ${repo#*/} main"
+fi
+
+jq -n \
+  --arg headline "$headline" \
+  --arg list "$list" \
+  --arg footer "At least $threshold retries across the last $runs successful \`main\` runs." \
+  '{
+    text: $headline,
+    blocks: [
+      {type: "header", text: {type: "plain_text", text: (":game_die: " + $headline), emoji: true}},
+      {type: "section", text: {type: "mrkdwn", text: $list}},
+      {type: "context", elements: [{type: "mrkdwn", text: $footer}]}
+    ]
+  }'

--- a/.github/scripts/flaky-tests.sh
+++ b/.github/scripts/flaky-tests.sh
@@ -21,6 +21,25 @@ runs=$3
 threshold=$4
 urgent_threshold=${5:-10}
 
+whole_number() {
+  case $2 in
+    '' | *[!0-9]*)
+      echo "$1 must be a whole number, got '$2'" >&2
+      exit 1
+      ;;
+  esac
+}
+
+whole_number 'the sample size' "$runs"
+whole_number 'the reporting threshold' "$threshold"
+whole_number 'the issue threshold' "$urgent_threshold"
+
+# A page of runs tops out at 100, and scanning past that would report on more runs than it read.
+if [ "$runs" -gt 100 ]; then
+  echo "::warning::sample size $runs exceeds the 100-run page limit, scanning 100" >&2
+  runs=100
+fi
+
 work=$(mktemp -d)
 trap 'rm -rf "$work"' EXIT
 

--- a/.github/scripts/flaky-tests.sh
+++ b/.github/scripts/flaky-tests.sh
@@ -8,9 +8,10 @@
 #
 # Usage: flaky-tests.sh <repo> <workflow-id> <runs-to-scan> <threshold> [urgent-threshold]
 #
-# Writes a markdown table to stdout. On $GITHUB_OUTPUT it sets `count` / `worst` / `table` for the
-# report, and `urgent_count` / `urgent_table` for tests at or above <urgent-threshold>, which are
-# flaky enough to warrant their own issue.
+# Writes a markdown table to stdout. On $GITHUB_OUTPUT it sets `count` / `tests` for the report, and
+# `urgent_count` / `urgent_threshold` / `urgent_tests` for tests at or above <urgent-threshold>,
+# which are flaky enough to warrant their own issue. Both listings are `<retries>\t<test>` lines,
+# most retried first.
 
 set -euo pipefail
 
@@ -61,36 +62,23 @@ ranked = sorted(retries.items(), key=lambda kv: (-kv[1], kv[0]))
 out.write_text("".join(f"{count}\t{test}\n" for test, count in ranked))
 PY
 
-over=$(awk -F'\t' -v t="$threshold" '$1 >= t' "$work/ranked.tsv" | wc -l)
-urgent=$(awk -F'\t' -v t="$urgent_threshold" '$1 >= t' "$work/ranked.tsv" | wc -l)
-worst=$(head -1 "$work/ranked.tsv" | cut -f1)
-worst=${worst:-0}
+awk -F'\t' -v t="$threshold" '$1 >= t' "$work/ranked.tsv" > "$work/reported.tsv"
+awk -F'\t' -v t="$urgent_threshold" '$1 >= t' "$work/ranked.tsv" > "$work/urgent.tsv"
 
-{
-  echo "| retries | test |"
-  echo "|---:|---|"
-  awk -F'\t' -v t="$threshold" '$1 >= t {printf "| %s | `%s` |\n", $1, $2}' "$work/ranked.tsv"
-} > "$work/table.md"
-
-{
-  echo "| retries | test |"
-  echo "|---:|---|"
-  awk -F'\t' -v t="$urgent_threshold" '$1 >= t {printf "| %s | `%s` |\n", $1, $2}' "$work/ranked.tsv"
-} > "$work/urgent.md"
-
-cat "$work/table.md"
+echo "| retries | test |"
+echo "|---:|---|"
+awk -F'\t' '{printf "| %s | `%s` |\n", $1, $2}' "$work/reported.tsv"
 
 if [ -n "${GITHUB_OUTPUT:-}" ]; then
   {
-    echo "count=$over"
-    echo "worst=$worst"
-    echo "urgent_count=$urgent"
+    echo "count=$(awk 'END {print NR}' "$work/reported.tsv")"
+    echo "urgent_count=$(awk 'END {print NR}' "$work/urgent.tsv")"
     echo "urgent_threshold=$urgent_threshold"
-    echo "urgent_table<<EOF"
-    cat "$work/urgent.md"
+    echo "tests<<EOF"
+    cat "$work/reported.tsv"
     echo "EOF"
-    echo "table<<EOF"
-    cat "$work/table.md"
+    echo "urgent_tests<<EOF"
+    cat "$work/urgent.tsv"
     echo "EOF"
   } >> "$GITHUB_OUTPUT"
 fi

--- a/.github/workflows/ci-duration-monitor.yaml
+++ b/.github/workflows/ci-duration-monitor.yaml
@@ -7,52 +7,50 @@ on:
     branches: [main]
 
 permissions:
-  contents: read
   actions: read
-
-env:
-  BUDGET_MINUTES: 40
+  checks: read
+  contents: read
+  pull-requests: read
 
 jobs:
   check-duration:
     # A run that failed stopped at its first failing job, so its duration measures how quickly CI
     # broke rather than how long the work takes. Comparing that against the budget reports the
-    # healthiest-looking numbers exactly when CI is at its most broken.
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    # healthiest-looking numbers exactly when CI is at its most broken. Those runs still reach the
+    # script, which looks past the budgets for jobs GitHub killed at their timeout.
+    if: ${{ github.event.workflow_run.conclusion != 'skipped' }}
     runs-on: ubuntu-24.04
     steps:
-      - name: Compare the run against the budget
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Compare the run against its budgets
         env:
+          CI_OVERTIME_EXEC_BUDGET_MINS: ${{ vars.CI_OVERTIME_EXEC_BUDGET_MINS || '40' }}
+          CI_OVERTIME_QUEUE_BUDGET_MINS: ${{ vars.CI_OVERTIME_QUEUE_BUDGET_MINS || '10' }}
+          CI_OVERTIME_SAMPLES: ${{ vars.CI_OVERTIME_SAMPLES || '20' }}
+          CONCLUSION: ${{ github.event.workflow_run.conclusion }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SLACK_CI_ALERTS_WEBHOOK_URL: ${{ secrets.SLACK_CI_ALERTS_WEBHOOK_URL }}
           RUN_ID: ${{ github.event.workflow_run.id }}
+          SLACK_CI_ALERTS_WEBHOOK_URL: ${{ secrets.SLACK_CI_ALERTS_WEBHOOK_URL }}
         run: |
           set -euo pipefail
 
-          read -r started updated < <(
-            gh api "repos/$GITHUB_REPOSITORY/actions/runs/$RUN_ID" \
-              --jq '"\(.run_started_at) \(.updated_at)"'
-          )
+          payload=$(.github/scripts/ci-duration.sh \
+            "$GITHUB_REPOSITORY" \
+            "$RUN_ID" \
+            "$CONCLUSION" \
+            "$CI_OVERTIME_EXEC_BUDGET_MINS" \
+            "$CI_OVERTIME_QUEUE_BUDGET_MINS" \
+            "$CI_OVERTIME_SAMPLES")
 
-          minutes=$(( ( $(date -d "$updated" +%s) - $(date -d "$started" +%s) ) / 60 ))
-          echo "run $RUN_ID took ${minutes}m (budget ${BUDGET_MINUTES}m)"
-          echo "CI run took ${minutes}m against a ${BUDGET_MINUTES}m budget." >> "$GITHUB_STEP_SUMMARY"
+          [ -n "$payload" ] || exit 0
 
-          if [ "$minutes" -le "$BUDGET_MINUTES" ]; then
-            exit 0
-          fi
-
-          run_url="https://github.com/$GITHUB_REPOSITORY/actions/runs/$RUN_ID"
-          text=$(printf ':stopwatch: *CI took %sm on `%s`* (budget %sm)\n• *Commit:* `%s`\n• *Run:* <%s|Open GitHub Actions>' \
-            "$minutes" "$GITHUB_REPOSITORY" "$BUDGET_MINUTES" "${{ github.event.workflow_run.head_sha }}" "$run_url")
-
-          if [ -z "${SLACK_CI_ALERTS_WEBHOOK_URL:-}" ]; then
-            echo "::warning::CI took ${minutes}m but SLACK_CI_ALERTS_WEBHOOK_URL is not set"
+          if [ -z "$SLACK_CI_ALERTS_WEBHOOK_URL" ]; then
+            echo "::warning::run $RUN_ID breached its budgets but SLACK_CI_ALERTS_WEBHOOK_URL is not set"
             exit 0
           fi
 
           curl --fail-with-body --silent --show-error \
             -X POST \
             -H 'Content-type: application/json' \
-            --data "$(jq -Rn --arg text "$text" '{text: $text}')" \
+            --data "$payload" \
             "$SLACK_CI_ALERTS_WEBHOOK_URL"

--- a/.github/workflows/flaky-test-report.yaml
+++ b/.github/workflows/flaky-test-report.yaml
@@ -41,38 +41,48 @@ jobs:
             "$RUNS" \
             "$THRESHOLD" \
             "$URGENT_THRESHOLD" | tee -a "$GITHUB_STEP_SUMMARY"
-      - name: File a Linear issue for the worst offenders
+      - name: File a Linear issue per worst offender
         if: ${{ steps.collect.outputs.urgent_count != '0' }}
         env:
           LINEAR_ACCESS_KEY: ${{ secrets.LINEAR_ACCESS_KEY }}
-          URGENT_COUNT: ${{ steps.collect.outputs.urgent_count }}
+          RUNS: ${{ inputs.runs || '15' }}
+          URGENT_TESTS: ${{ steps.collect.outputs.urgent_tests }}
           URGENT_THRESHOLD: ${{ steps.collect.outputs.urgent_threshold }}
-          URGENT_TABLE: ${{ steps.collect.outputs.urgent_table }}
         run: |
           set -euo pipefail
 
           report="https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
-          printf '%s test(s) retried at least %s times across the scanned `main` runs.\n\n%s\n[Latest report](%s)\n' \
-            "$URGENT_COUNT" "$URGENT_THRESHOLD" "$URGENT_TABLE" "$report" > body.md
 
-          issue=$(.github/scripts/flaky-issue.sh "$GITHUB_REPOSITORY" MBE body.md)
-          echo "Tracked in $issue" >> "$GITHUB_STEP_SUMMARY"
+          while IFS=$'\t' read -r retries test; do
+            [ -n "$test" ] || continue
+
+            printf '`%s` retried %s times across the last %s successful `main` runs, at or over the threshold of %s.\n\n[Latest report](%s)\n' \
+              "$test" "$retries" "$RUNS" "$URGENT_THRESHOLD" "$report" > body.md
+
+            issue=$(.github/scripts/flaky-issue.sh "$GITHUB_REPOSITORY" MBE "$test" body.md)
+            echo "\`$test\` tracked in $issue" >> "$GITHUB_STEP_SUMMARY"
+          done <<< "$URGENT_TESTS"
       - name: "Notify #ci-alerts"
         if: ${{ steps.collect.outputs.count != '0' }}
         env:
+          COUNT: ${{ steps.collect.outputs.count }}
+          LINEAR_ACCESS_KEY: ${{ secrets.LINEAR_ACCESS_KEY }}
+          RUNS: ${{ inputs.runs || '15' }}
           SLACK_CI_ALERTS_WEBHOOK_URL: ${{ secrets.SLACK_CI_ALERTS_WEBHOOK_URL }}
+          TESTS: ${{ steps.collect.outputs.tests }}
+          THRESHOLD: ${{ inputs.threshold || '3' }}
         run: |
-          summary="https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
-          text=$(printf ':game_die: *%s test(s) retrying on `%s` main* (worst: %s retries)\n• *Report:* <%s|Open GitHub Actions>' \
-            "${{ steps.collect.outputs.count }}" "$GITHUB_REPOSITORY" "${{ steps.collect.outputs.worst }}" "$summary")
+          set -euo pipefail
 
           if [ -z "$SLACK_CI_ALERTS_WEBHOOK_URL" ]; then
-            echo "::warning::${{ steps.collect.outputs.count }} flaky tests but no webhook configured"
+            echo "::warning::$COUNT flaky test(s) but SLACK_CI_ALERTS_WEBHOOK_URL is not set"
             exit 0
           fi
+
+          payload=$(.github/scripts/flaky-notify.sh "$GITHUB_REPOSITORY" MBE "$THRESHOLD" "$RUNS" <<< "$TESTS")
 
           curl --fail-with-body --silent --show-error \
             -X POST \
             -H 'Content-type: application/json' \
-            --data "$(jq -Rn --arg text "$text" '{text: $text}')" \
+            --data "$payload" \
             "$SLACK_CI_ALERTS_WEBHOOK_URL"

--- a/.github/workflows/flaky-test-report.yaml
+++ b/.github/workflows/flaky-test-report.yaml
@@ -6,17 +6,14 @@ on:
   workflow_dispatch:
     inputs:
       runs:
-        description: "How many recent `main` runs to scan"
+        description: "How many recent `main` runs to scan, overriding $CI_FLAKY_SAMPLES"
         required: false
-        default: "15"
       threshold:
-        description: "Retries before a test is reported"
+        description: "Retries before a test is reported, overriding $CI_FLAKY_NOTIFY_THRESHOLD"
         required: false
-        default: "3"
       urgent_threshold:
-        description: "Retries before a test gets its own issue"
+        description: "Retries before a test gets its own issue, overriding $CI_FLAKY_ISSUE_THRESHOLD"
         required: false
-        default: "10"
 
 permissions:
   contents: read
@@ -30,24 +27,24 @@ jobs:
       - name: Collect retried tests
         id: collect
         env:
+          CI_FLAKY_ISSUE_THRESHOLD: ${{ inputs.urgent_threshold || vars.CI_FLAKY_ISSUE_THRESHOLD || '10' }}
+          CI_FLAKY_NOTIFY_THRESHOLD: ${{ inputs.threshold || vars.CI_FLAKY_NOTIFY_THRESHOLD || '3' }}
+          CI_FLAKY_SAMPLES: ${{ inputs.runs || vars.CI_FLAKY_SAMPLES || '15' }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RUNS: ${{ inputs.runs || '15' }}
-          THRESHOLD: ${{ inputs.threshold || '3' }}
-          URGENT_THRESHOLD: ${{ inputs.urgent_threshold || '10' }}
         run: |
           .github/scripts/flaky-tests.sh \
             "$GITHUB_REPOSITORY" \
             ci.yaml \
-            "$RUNS" \
-            "$THRESHOLD" \
-            "$URGENT_THRESHOLD" | tee -a "$GITHUB_STEP_SUMMARY"
+            "$CI_FLAKY_SAMPLES" \
+            "$CI_FLAKY_NOTIFY_THRESHOLD" \
+            "$CI_FLAKY_ISSUE_THRESHOLD" | tee -a "$GITHUB_STEP_SUMMARY"
       - name: File a Linear issue per worst offender
         if: ${{ steps.collect.outputs.urgent_count != '0' }}
         env:
+          CI_FLAKY_ISSUE_THRESHOLD: ${{ steps.collect.outputs.urgent_threshold }}
+          CI_FLAKY_SAMPLES: ${{ inputs.runs || vars.CI_FLAKY_SAMPLES || '15' }}
           LINEAR_ACCESS_KEY: ${{ secrets.LINEAR_ACCESS_KEY }}
-          RUNS: ${{ inputs.runs || '15' }}
           URGENT_TESTS: ${{ steps.collect.outputs.urgent_tests }}
-          URGENT_THRESHOLD: ${{ steps.collect.outputs.urgent_threshold }}
         run: |
           set -euo pipefail
 
@@ -57,7 +54,7 @@ jobs:
             [ -n "$test" ] || continue
 
             printf '`%s` retried %s times across the last %s successful `main` runs, at or over the threshold of %s.\n\n[Latest report](%s)\n' \
-              "$test" "$retries" "$RUNS" "$URGENT_THRESHOLD" "$report" > body.md
+              "$test" "$retries" "$CI_FLAKY_SAMPLES" "$CI_FLAKY_ISSUE_THRESHOLD" "$report" > body.md
 
             issue=$(.github/scripts/flaky-issue.sh "$GITHUB_REPOSITORY" MBE "$test" body.md)
             echo "\`$test\` tracked in $issue" >> "$GITHUB_STEP_SUMMARY"
@@ -65,12 +62,12 @@ jobs:
       - name: "Notify #ci-alerts"
         if: ${{ steps.collect.outputs.count != '0' }}
         env:
+          CI_FLAKY_NOTIFY_THRESHOLD: ${{ inputs.threshold || vars.CI_FLAKY_NOTIFY_THRESHOLD || '3' }}
+          CI_FLAKY_SAMPLES: ${{ inputs.runs || vars.CI_FLAKY_SAMPLES || '15' }}
           COUNT: ${{ steps.collect.outputs.count }}
           LINEAR_ACCESS_KEY: ${{ secrets.LINEAR_ACCESS_KEY }}
-          RUNS: ${{ inputs.runs || '15' }}
           SLACK_CI_ALERTS_WEBHOOK_URL: ${{ secrets.SLACK_CI_ALERTS_WEBHOOK_URL }}
           TESTS: ${{ steps.collect.outputs.tests }}
-          THRESHOLD: ${{ inputs.threshold || '3' }}
         run: |
           set -euo pipefail
 
@@ -79,7 +76,7 @@ jobs:
             exit 0
           fi
 
-          payload=$(.github/scripts/flaky-notify.sh "$GITHUB_REPOSITORY" MBE "$THRESHOLD" "$RUNS" <<< "$TESTS")
+          payload=$(.github/scripts/flaky-notify.sh "$GITHUB_REPOSITORY" MBE "$CI_FLAKY_NOTIFY_THRESHOLD" "$CI_FLAKY_SAMPLES" <<< "$TESTS")
 
           curl --fail-with-body --silent --show-error \
             -X POST \

--- a/changelog.d/+ci-alert-hardening.internal.md
+++ b/changelog.d/+ci-alert-hardening.internal.md
@@ -1,0 +1,1 @@
+Check the CI alert thresholds and drop Linear issues the report can't find.

--- a/changelog.d/+ci-alert-thresholds.internal.md
+++ b/changelog.d/+ci-alert-thresholds.internal.md
@@ -1,0 +1,1 @@
+Read the flaky test report thresholds from repository variables.

--- a/changelog.d/+ci-duration-breakdown.internal.md
+++ b/changelog.d/+ci-duration-breakdown.internal.md
@@ -1,0 +1,1 @@
+Alert on CI execution time, runner wait, and job timeouts against the recent median.

--- a/changelog.d/+flaky-alert-inline.internal.md
+++ b/changelog.d/+flaky-alert-inline.internal.md
@@ -1,0 +1,1 @@
+Name every flaky test and the Linear issue tracking it directly in the CI alert.

--- a/changelog.d/+flaky-issue-attachment.internal.md
+++ b/changelog.d/+flaky-issue-attachment.internal.md
@@ -1,0 +1,1 @@
+Key each flaky test's Linear issue on an attachment and label it `flake`.


### PR DESCRIPTION
- The flaky test alert posted a count, the worst retry number, and a link to the run, so finding out which test was flaking meant opening GitHub Actions. It now names every reported test with its retry count, plus the Linear issue tracking it when one is open.
- Flaky tests were tracked by a single aggregate issue per repository, matched by title, which a rename in Linear would orphan. Each test now gets its own issue, labelled `flake` and keyed on an attachment carrying the repository and test name.
- The duration alert compared one total against a fixed budget, hiding time spent waiting for a runner and saying nothing about which job was slow. It now reports execution, queue, and total time separately, holds the first two to their own budgets and the median of recent successful `main` runs, and names the slowest jobs and the pull request that triggered it.
- A run GitHub killed at a job timeout produced no alert at all, because only successful runs were measured. Those now get their own alert naming the jobs it stopped, identified from the job annotations rather than from a cancelled conclusion, which a manual cancel and a fail-fast matrix produce too.
- Thresholds were hardcoded in the workflows. They now come from repository variables, keeping the same values as defaults.

### Variables

| Variable | Default |
|---|---|
| `CI_OVERTIME_EXEC_BUDGET_MINS` | 40 |
| `CI_OVERTIME_QUEUE_BUDGET_MINS` | 10 |
| `CI_OVERTIME_SAMPLES` | 20 |
| `CI_FLAKY_SAMPLES` | 15 |
| `CI_FLAKY_NOTIFY_THRESHOLD` | 3 |
| `CI_FLAKY_ISSUE_THRESHOLD` | 10 |

### Slack alert format

🎲 **3 flaky tests on operator main**
•  **7×**  `tests operator::queue_splitting::kafka::tests::mirror_delivers_to_session_and_deployed`
•  **4×**  `operator-db-branching::mssql operator::migrations_scenario::test_mssql_migrations_reuse_conflict`
•  **3×**  `tests operator::multicluster::branching::multicluster_pg_branch_is_created`

At least 3 retries across the last 15 successful `main` runs.