### PR TITLE
Improve flake detection

### DIFF
--- a/.github/scripts/flaky-notify.sh
+++ b/.github/scripts/flaky-notify.sh
@@ -6,7 +6,7 @@
 # payload to stdout. Every test is named in the message itself, annotated with the Linear issue
 # tracking it when one is open, so the channel needs no trip to the run to see what is flaking.
 #
-# Usage: flaky-notify.sh <repo> <team-key> <threshold> <runs>
+# Usage: flaky-notify.sh <repo> <team-key> <notify-threshold> <runs-read>
 #
 # Annotates issues only when $LINEAR_ACCESS_KEY is set.
 
@@ -14,7 +14,7 @@ set -euo pipefail
 
 repo=$1
 team_key=$2
-threshold=$3
+notify_threshold=$3
 runs=$4
 
 scripts=$(dirname "$0")
@@ -64,7 +64,7 @@ fi
 jq -n \
   --arg headline "$headline" \
   --arg list "$list" \
-  --arg footer "At least $threshold retries across the last $runs successful \`main\` runs." \
+  --arg footer "At least $notify_threshold retries across the last $runs \`main\` runs that published test reports." \
   '{
     text: $headline,
     blocks: [

--- a/.github/scripts/flaky-tests.sh
+++ b/.github/scripts/flaky-tests.sh
@@ -2,24 +2,30 @@
 #
 # Reports tests that nextest had to retry on `main`, which a green run hides entirely.
 #
-# Reads the JUnit reports each test job uploads, counting a test's `flakyFailure` elements (attempts
-# that failed before it passed) and `rerunFailure` ones (attempts of a test that failed for good).
-# Runs from before those artifacts existed contribute nothing.
+# Reads the JUnit reports CI merges into one `nextest-junit` artifact per successful `main` run,
+# counting a test's `flakyFailure` elements (attempts that failed before it passed) and
+# `rerunFailure` ones (attempts of a test that failed for good).
 #
-# Usage: flaky-tests.sh <repo> <workflow-id> <runs-to-scan> <threshold> [urgent-threshold]
+# Sampling is by run that carried a report, never by run: a run that skipped the test matrix, or
+# whose artifact has expired, is not one of the <samples> and does not consume one. Since only a
+# successful `main` run publishes under that name, listing artifacts by it answers both questions at
+# once, in a single request.
 #
-# Writes a markdown table to stdout. On $GITHUB_OUTPUT it sets `count` / `tests` for the report, and
-# `urgent_count` / `urgent_threshold` / `urgent_tests` for tests at or above <urgent-threshold>,
-# which are flaky enough to warrant their own issue. Both listings are `<retries>\t<test>` lines,
-# most retried first.
+# Usage: flaky-tests.sh <repo> <samples> <notify-threshold> [issue-threshold]
+#
+# Writes a markdown table to stdout. On $GITHUB_OUTPUT it sets `scanned`, `notify_count` and
+# `notify_tests` for the report, and `issue_count` / `issue_threshold` / `issue_tests` for tests at
+# or above <issue-threshold>, which are flaky enough to warrant their own issue. Both listings are
+# `<retries>\t<test>` lines, most retried first.
 
 set -euo pipefail
 
 repo=$1
-workflow=$2
-runs=$3
-threshold=$4
-urgent_threshold=${5:-10}
+samples=$2
+notify_threshold=$3
+issue_threshold=${4:-10}
+
+readonly ARTIFACT=nextest-junit
 
 whole_number() {
   case $2 in
@@ -30,14 +36,14 @@ whole_number() {
   esac
 }
 
-whole_number 'the sample size' "$runs"
-whole_number 'the reporting threshold' "$threshold"
-whole_number 'the issue threshold' "$urgent_threshold"
+whole_number 'the sample size' "$samples"
+whole_number 'the notify threshold' "$notify_threshold"
+whole_number 'the issue threshold' "$issue_threshold"
 
-# A page of runs tops out at 100, and scanning past that would report on more runs than it read.
-if [ "$runs" -gt 100 ]; then
-  echo "::warning::sample size $runs exceeds the 100-run page limit, scanning 100" >&2
-  runs=100
+# One page holds 100 artifacts, and asking for more would report on more runs than it read.
+if [ "$samples" -gt 100 ]; then
+  echo "::warning::sample size $samples exceeds the 100-artifact page limit, sampling 100" >&2
+  samples=100
 fi
 
 work=$(mktemp -d)
@@ -45,20 +51,38 @@ trap 'rm -rf "$work"' EXIT
 
 mkdir -p "$work/reports"
 
-gh api "repos/$repo/actions/workflows/$workflow/runs?per_page=$runs&status=success&branch=main" \
-  --jq '.workflow_runs[].id' > "$work/runs.txt"
+# Newest first, so taking the head of the listing takes the most recent runs. CI publishes this
+# artifact on `main` alone; the branch is checked anyway so that widening that never widens this
+# silently.
+# Trimmed with awk rather than head, which would close the pipe on `gh` mid-write and take the
+# script down with it under `pipefail`.
+gh api "repos/$repo/actions/artifacts?per_page=100&name=$ARTIFACT" \
+  --jq '.artifacts[]? | select(.expired == false) | select(.workflow_run.head_branch == "main")
+        | "\(.id)\t\(.workflow_run.id)"' |
+  awk -v samples="$samples" 'NR <= samples' > "$work/artifacts.tsv"
 
-while read -r run; do
-  gh api "repos/$repo/actions/runs/$run/artifacts?per_page=100" \
-    --jq '.artifacts[]? | select(.expired == false) | select(.name | startswith("nextest-junit-")) | .id' 2>/dev/null |
-    while read -r artifact; do
-      if gh api "repos/$repo/actions/artifacts/$artifact/zip" > "$work/artifact.zip" 2>/dev/null; then
-        unzip -qo "$work/artifact.zip" -d "$work/reports/$run-$artifact" 2>/dev/null || true
-      fi
-    done
-done < "$work/runs.txt"
+selected=$(awk 'END {print NR}' "$work/artifacts.tsv")
 
-python3 - "$work/reports" "$threshold" "$work/ranked.tsv" <<'PY'
+if [ "$selected" -lt "$samples" ]; then
+  echo "::warning::asked for $samples runs, only $selected still carry a $ARTIFACT artifact" >&2
+fi
+
+# Counts the reports read, not the ones picked: one that fails to download or unpack takes its
+# run's retries with it, and counting it would overstate the sample the alert reports on.
+scanned=0
+
+while IFS=$'\t' read -r artifact run; do
+  [ -n "$artifact" ] || continue
+
+  if gh api "repos/$repo/actions/artifacts/$artifact/zip" > "$work/artifact.zip" 2>/dev/null &&
+    unzip -qo "$work/artifact.zip" -d "$work/reports/$run" 2>/dev/null; then
+    scanned=$((scanned + 1))
+  else
+    echo "::warning::could not read the report of run $run" >&2
+  fi
+done < "$work/artifacts.tsv"
+
+python3 - "$work/reports" "$notify_threshold" "$work/ranked.tsv" <<'PY'
 import pathlib, sys
 from collections import Counter
 from xml.etree import ElementTree
@@ -81,23 +105,24 @@ ranked = sorted(retries.items(), key=lambda kv: (-kv[1], kv[0]))
 out.write_text("".join(f"{count}\t{test}\n" for test, count in ranked))
 PY
 
-awk -F'\t' -v t="$threshold" '$1 >= t' "$work/ranked.tsv" > "$work/reported.tsv"
-awk -F'\t' -v t="$urgent_threshold" '$1 >= t' "$work/ranked.tsv" > "$work/urgent.tsv"
+awk -F'\t' -v t="$notify_threshold" '$1 >= t' "$work/ranked.tsv" > "$work/notify.tsv"
+awk -F'\t' -v t="$issue_threshold" '$1 >= t' "$work/ranked.tsv" > "$work/issue.tsv"
 
 echo "| retries | test |"
 echo "|---:|---|"
-awk -F'\t' '{printf "| %s | `%s` |\n", $1, $2}' "$work/reported.tsv"
+awk -F'\t' '{printf "| %s | `%s` |\n", $1, $2}' "$work/notify.tsv"
 
 if [ -n "${GITHUB_OUTPUT:-}" ]; then
   {
-    echo "count=$(awk 'END {print NR}' "$work/reported.tsv")"
-    echo "urgent_count=$(awk 'END {print NR}' "$work/urgent.tsv")"
-    echo "urgent_threshold=$urgent_threshold"
-    echo "tests<<EOF"
-    cat "$work/reported.tsv"
+    echo "scanned=$scanned"
+    echo "notify_count=$(awk 'END {print NR}' "$work/notify.tsv")"
+    echo "issue_count=$(awk 'END {print NR}' "$work/issue.tsv")"
+    echo "issue_threshold=$issue_threshold"
+    echo "notify_tests<<EOF"
+    cat "$work/notify.tsv"
     echo "EOF"
-    echo "urgent_tests<<EOF"
-    cat "$work/urgent.tsv"
+    echo "issue_tests<<EOF"
+    cat "$work/issue.tsv"
     echo "EOF"
   } >> "$GITHUB_OUTPUT"
 fi

--- a/.github/scripts/prune-artifacts.sh
+++ b/.github/scripts/prune-artifacts.sh
@@ -27,11 +27,12 @@ work=$(mktemp -d)
 trap 'rm -rf "$work"' EXIT
 
 # Artifacts something reads after the run ends. Everything else goes, so an artifact meant to outlive
-# its run belongs here. `nextest-junit-*` is what flaky-tests.sh scans, and it scans only successful
-# runs, so pruning those leaves the flake report nothing to find.
+# its run belongs here. `nextest-junit` is the merged report flaky-tests.sh scans; the per-job
+# `nextest-junit-*` it is merged from are disposable, and on a run that never merged them, no longer
+# reachable by anything.
 keep() {
   case "$1" in
-    nextest-junit-*|intproxy_logs_*) return 0 ;;
+    nextest-junit|intproxy_logs_*) return 0 ;;
     *) return 1 ;;
   esac
 }

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -464,6 +464,26 @@ jobs:
           sparse-checkout: .github/scripts
           sparse-checkout-cone-mode: false
 
+      - name: Count the test reports
+        id: reports
+        if: ${{ github.ref == 'refs/heads/main' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          count=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/artifacts?per_page=100" \
+            --jq '[.artifacts[] | select(.name | startswith("nextest-junit-"))] | length')
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+
+      - name: Merge the test reports
+        if: ${{ github.ref == 'refs/heads/main' && steps.reports.outputs.count != '0' }}
+        uses: actions/upload-artifact/merge@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: nextest-junit
+          pattern: nextest-junit-*
+          separate-directories: true
+          delete-merged: true
+          retention-days: 30
+
       - name: Delete inter-job artifacts
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/flaky-test-report.yaml
+++ b/.github/workflows/flaky-test-report.yaml
@@ -5,13 +5,13 @@ on:
     - cron: "0 6 * * 1-5"
   workflow_dispatch:
     inputs:
-      runs:
-        description: "How many recent `main` runs to scan, overriding $CI_FLAKY_SAMPLES"
+      samples:
+        description: "How many `main` runs with test reports to sample, overriding $CI_FLAKY_SAMPLES"
         required: false
-      threshold:
+      notify_threshold:
         description: "Retries before a test is reported, overriding $CI_FLAKY_NOTIFY_THRESHOLD"
         required: false
-      urgent_threshold:
+      issue_threshold:
         description: "Retries before a test gets its own issue, overriding $CI_FLAKY_ISSUE_THRESHOLD"
         required: false
 
@@ -27,24 +27,23 @@ jobs:
       - name: Collect retried tests
         id: collect
         env:
-          CI_FLAKY_ISSUE_THRESHOLD: ${{ inputs.urgent_threshold || vars.CI_FLAKY_ISSUE_THRESHOLD || '10' }}
-          CI_FLAKY_NOTIFY_THRESHOLD: ${{ inputs.threshold || vars.CI_FLAKY_NOTIFY_THRESHOLD || '3' }}
-          CI_FLAKY_SAMPLES: ${{ inputs.runs || vars.CI_FLAKY_SAMPLES || '15' }}
+          CI_FLAKY_ISSUE_THRESHOLD: ${{ inputs.issue_threshold || vars.CI_FLAKY_ISSUE_THRESHOLD || '10' }}
+          CI_FLAKY_NOTIFY_THRESHOLD: ${{ inputs.notify_threshold || vars.CI_FLAKY_NOTIFY_THRESHOLD || '3' }}
+          CI_FLAKY_SAMPLES: ${{ inputs.samples || vars.CI_FLAKY_SAMPLES || '15' }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           .github/scripts/flaky-tests.sh \
             "$GITHUB_REPOSITORY" \
-            ci.yaml \
             "$CI_FLAKY_SAMPLES" \
             "$CI_FLAKY_NOTIFY_THRESHOLD" \
             "$CI_FLAKY_ISSUE_THRESHOLD" | tee -a "$GITHUB_STEP_SUMMARY"
-      - name: File a Linear issue per worst offender
-        if: ${{ steps.collect.outputs.urgent_count != '0' }}
+      - name: File a Linear issue per offending test
+        if: ${{ steps.collect.outputs.issue_count != '0' }}
         env:
-          CI_FLAKY_ISSUE_THRESHOLD: ${{ steps.collect.outputs.urgent_threshold }}
-          CI_FLAKY_SAMPLES: ${{ inputs.runs || vars.CI_FLAKY_SAMPLES || '15' }}
+          CI_FLAKY_ISSUE_THRESHOLD: ${{ steps.collect.outputs.issue_threshold }}
+          CI_FLAKY_SCANNED: ${{ steps.collect.outputs.scanned }}
           LINEAR_ACCESS_KEY: ${{ secrets.LINEAR_ACCESS_KEY }}
-          URGENT_TESTS: ${{ steps.collect.outputs.urgent_tests }}
+          CI_FLAKY_ISSUE_TESTS: ${{ steps.collect.outputs.issue_tests }}
         run: |
           set -euo pipefail
 
@@ -54,29 +53,29 @@ jobs:
             [ -n "$test" ] || continue
 
             printf '`%s` retried %s times across the last %s successful `main` runs, at or over the threshold of %s.\n\n[Latest report](%s)\n' \
-              "$test" "$retries" "$CI_FLAKY_SAMPLES" "$CI_FLAKY_ISSUE_THRESHOLD" "$report" > body.md
+              "$test" "$retries" "$CI_FLAKY_SCANNED" "$CI_FLAKY_ISSUE_THRESHOLD" "$report" > body.md
 
             issue=$(.github/scripts/flaky-issue.sh "$GITHUB_REPOSITORY" MBE "$test" body.md)
             echo "\`$test\` tracked in $issue" >> "$GITHUB_STEP_SUMMARY"
-          done <<< "$URGENT_TESTS"
+          done <<< "$CI_FLAKY_ISSUE_TESTS"
       - name: "Notify #ci-alerts"
-        if: ${{ steps.collect.outputs.count != '0' }}
+        if: ${{ steps.collect.outputs.notify_count != '0' }}
         env:
-          CI_FLAKY_NOTIFY_THRESHOLD: ${{ inputs.threshold || vars.CI_FLAKY_NOTIFY_THRESHOLD || '3' }}
-          CI_FLAKY_SAMPLES: ${{ inputs.runs || vars.CI_FLAKY_SAMPLES || '15' }}
-          COUNT: ${{ steps.collect.outputs.count }}
+          CI_FLAKY_NOTIFY_THRESHOLD: ${{ inputs.notify_threshold || vars.CI_FLAKY_NOTIFY_THRESHOLD || '3' }}
+          CI_FLAKY_SCANNED: ${{ steps.collect.outputs.scanned }}
+          CI_FLAKY_NOTIFY_COUNT: ${{ steps.collect.outputs.notify_count }}
           LINEAR_ACCESS_KEY: ${{ secrets.LINEAR_ACCESS_KEY }}
           SLACK_CI_ALERTS_WEBHOOK_URL: ${{ secrets.SLACK_CI_ALERTS_WEBHOOK_URL }}
-          TESTS: ${{ steps.collect.outputs.tests }}
+          CI_FLAKY_NOTIFY_TESTS: ${{ steps.collect.outputs.notify_tests }}
         run: |
           set -euo pipefail
 
           if [ -z "$SLACK_CI_ALERTS_WEBHOOK_URL" ]; then
-            echo "::warning::$COUNT flaky test(s) but SLACK_CI_ALERTS_WEBHOOK_URL is not set"
+            echo "::warning::$CI_FLAKY_NOTIFY_COUNT flaky test(s) but SLACK_CI_ALERTS_WEBHOOK_URL is not set"
             exit 0
           fi
 
-          payload=$(.github/scripts/flaky-notify.sh "$GITHUB_REPOSITORY" MBE "$CI_FLAKY_NOTIFY_THRESHOLD" "$CI_FLAKY_SAMPLES" <<< "$TESTS")
+          payload=$(.github/scripts/flaky-notify.sh "$GITHUB_REPOSITORY" MBE "$CI_FLAKY_NOTIFY_THRESHOLD" "$CI_FLAKY_SCANNED" <<< "$CI_FLAKY_NOTIFY_TESTS")
 
           curl --fail-with-body --silent --show-error \
             -X POST \

--- a/changelog.d/+improve-flake-detection.internal.md
+++ b/changelog.d/+improve-flake-detection.internal.md
@@ -1,0 +1,1 @@
+Improve flake detection.


### PR DESCRIPTION
The flaky test report sampled a fixed number of recent `main` runs regardless of whether those runs published test reports, so a run that skipped the test matrix or whose artifacts had expired still consumed one of the fifteen samples. Sampling now only counts runs that published a report. The Slack message and the Linear issue body quote the number of runs actually read.

CI now merges each successful `main` run's per-job reports into one `nextest-junit` artifact, which the report finds with a single request by name.
- Collection costs one request plus one download per run, rather than one request per run scanned plus one per report.
- The reports are merged into separate directories, because every job numbers its files from zero.
- `prune-artifacts.sh` keeps the merged artifact instead of the per-job ones, which are disposable once merged (and unreachable on a run that never merged them).

> [!CAUTION]
> Must not be merged before the artifact retention policy is raised to 30 days.

### Slack alert format

🎲 **3 flaky tests on operator main**
•  **7×**  `tests operator::queue_splitting::kafka::tests::mirror_delivers_to_session_and_deployed`
•  **4×**  `operator-db-branching::mssql operator::migrations_scenario::test_mssql_migrations_reuse_conflict`
•  **3×**  `tests operator::multicluster::branching::multicluster_pg_branch_is_created`

At least 3 retries across the last 15 `main` runs that published test reports.