### PR TITLE
Fix CI execution and idle time calculations

### DIFF
--- a/.github/scripts/ci-duration.sh
+++ b/.github/scripts/ci-duration.sh
@@ -2,12 +2,12 @@
 #
 # Measures a CI run against its budgets and builds the Slack alert for it.
 #
-# Splits the run into the time its jobs spent executing, the longest any one job waited for a
-# runner, and the wall time between queueing and finishing, holding the first two to their budgets
-# and both to the median of recent successful `main` runs. A run GitHub stopped at a job timeout
-# gets its own alert naming the jobs it killed, which the budgets would otherwise never see.
+# Splits the run's wall time into the part with at least one job running and the part with none,
+# holding each to its budget and the wall time to the median of recent successful `main` runs. A run
+# GitHub stopped at a job timeout gets its own alert naming the jobs it killed, which the budgets
+# would otherwise never see.
 #
-# Usage: ci-duration.sh <repo> <run-id> <conclusion> <budget> <queue-budget> <median-runs>
+# Usage: ci-duration.sh <repo> <run-id> <conclusion> <budget> <idle-budget> <median-runs>
 #
 # Writes the run's numbers to $GITHUB_STEP_SUMMARY, and the webhook payload to stdout when a budget
 # was breached or the run was killed.
@@ -18,7 +18,7 @@ repo=$1
 run_id=$2
 conclusion=$3
 budget=$4
-queue_budget=$5
+idle_budget=$5
 median_runs=$6
 
 short=${repo#*/}
@@ -33,7 +33,7 @@ whole_number() {
 }
 
 whole_number 'the execution budget' "$budget"
-whole_number 'the queue budget' "$queue_budget"
+whole_number 'the idle budget' "$idle_budget"
 whole_number 'the sample size' "$median_runs"
 
 # A page of runs tops out at 100, and sampling past that would report a median over more runs than
@@ -42,6 +42,9 @@ if [ "$median_runs" -gt 100 ]; then
   echo "::warning::sample size $median_runs exceeds the 100-run page limit, sampling 100" >&2
   median_runs=100
 fi
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
 
 run=$(gh api "repos/$repo/actions/runs/$run_id")
 jobs=$(gh api --paginate "repos/$repo/actions/runs/$run_id/jobs?per_page=100" --jq '.jobs[]' | jq -s '.')
@@ -54,27 +57,85 @@ minutes() {
   echo $(( ( $(date -d "$2" +%s) - $(date -d "$1" +%s) + 30 ) / 60 ))
 }
 
-# A run's own clock starts once GitHub picks it up, so the wait for a runner is only visible per
-# job, and the one job that waited longest is what held the run back.
-execution=$(minutes "$(field .run_started_at)" "$(field .updated_at)")
-total=$(minutes "$(field .created_at)" "$(field .updated_at)")
-queued=$(jq -r '
-  [.[] | select(.created_at != null and .started_at != null)
-   | (.started_at | fromdateiso8601) - (.created_at | fromdateiso8601)]
-  | (max // 0) / 60 | round' <<< "$jobs")
+total=$(minutes "$(field .run_started_at)" "$(field .updated_at)")
 
-median=$(gh api \
-  "repos/$repo/actions/workflows/$(field .workflow_id)/runs?status=success&branch=main&per_page=$median_runs" \
-  --jq '
-    [.workflow_runs[]
-     | ((.updated_at | fromdateiso8601) - (.run_started_at | fromdateiso8601)) / 60]
-    | sort
-    | length as $n
-    | if $n == 0 then 0
-      elif $n % 2 == 1 then .[$n / 2 | floor]
-      else (.[$n / 2 - 1 | floor] + .[$n / 2 | floor]) / 2
-      end
-    | round')
+# Every figure covers a single attempt. A re-run resets `run_started_at` but not `created_at`, and a
+# partial re-run carries the jobs that already passed into the new attempt with their original
+# timestamps, so job intervals are clipped to the attempt's own window before anything is counted.
+#
+# Work is what a run spent with at least one job running, so overlapping jobs count once and the
+# gaps between them do not. What is left over is the run sitting idle, waiting on runners: a job's
+# own wait cannot stand in for it, since the rest of the matrix usually keeps working through it.
+worked_minutes() {
+  jq -r --arg from "$2" --arg to "$3" '
+    ($from | fromdateiso8601) as $opened
+    | ($to | fromdateiso8601) as $closed
+    | [.[] | select(.started_at != null and .completed_at != null)
+       | {s: ([(.started_at | fromdateiso8601), $opened] | max),
+          e: ([(.completed_at | fromdateiso8601), $closed] | min)}
+       | select(.e > .s)]
+    | sort_by(.s)
+    | reduce .[] as $job ([];
+        if length > 0 and $job.s <= .[-1].e
+        then .[0:-1] + [{s: .[-1].s, e: ([.[-1].e, $job.e] | max)}]
+        else . + [$job]
+        end)
+    | map(.e - .s) | add // 0
+    | . / 60 | round' <<< "$1"
+}
+
+run_jobs() {
+  gh api --paginate "repos/$repo/actions/runs/$1/jobs?per_page=100" --jq '.jobs[]' | jq -s '.'
+}
+
+median_of() {
+  sort -n | awk '{ v[NR] = $1 } END {
+    if (NR == 0) { print 0 }
+    else if (NR % 2) { print v[(NR + 1) / 2] }
+    else { printf "%d\n", (v[NR / 2] + v[NR / 2 + 1]) / 2 + 0.5 }
+  }'
+}
+
+execution=$(worked_minutes "$jobs" "$(field .run_started_at)" "$(field .updated_at)")
+idle=$(( total - execution ))
+[ "$idle" -ge 0 ] || idle=0
+
+# How many sampled runs to read at once. The REST API tolerates this comfortably; much more risks
+# a secondary rate limit, which costs more than it saves.
+readonly PARALLEL=8
+
+# One jobs request per sampled run, so this only runs once a budget has already been breached. A run
+# whose jobs cannot be read is left out of the medians rather than taking the alert down with it.
+sample_medians() {
+  local id opened closed wall running=0 sample
+
+  sample=$(gh api \
+    "repos/$repo/actions/workflows/$(field .workflow_id)/runs?status=success&branch=main&per_page=$median_runs")
+
+  while IFS=$'\t' read -r id opened closed wall; do
+    [ -n "$id" ] || continue
+
+    {
+      if worked=$(worked_minutes "$(run_jobs "$id")" "$opened" "$closed" 2> /dev/null); then
+        printf '%s\t%s\t%s\n' "$worked" "$(( wall > worked ? wall - worked : 0 ))" "$wall" \
+          > "$work/$id.tsv"
+      fi
+
+      exit 0
+    } &
+
+    running=$((running + 1))
+
+    if [ "$running" -ge "$PARALLEL" ]; then
+      wait -n
+      running=$((running - 1))
+    fi
+  done < <(jq -r '.workflow_runs[]
+    | "\(.id)\t\(.run_started_at)\t\(.updated_at)\t\((((.updated_at | fromdateiso8601) - (.run_started_at | fromdateiso8601)) / 60) | round)"' <<< "$sample")
+
+  wait
+  cat "$work"/*.tsv 2> /dev/null || true
+}
 
 pr=$(gh api "repos/$repo/commits/$(field .head_sha)/pulls" --jq '.[0].number // empty' || true)
 
@@ -91,11 +152,11 @@ job_lines() {
 
 bullets() {
   local retained=()
-  local retries name
+  local ran name
 
-  while IFS=$'\t' read -r retries name; do
+  while IFS=$'\t' read -r ran name; do
     [ -n "$name" ] || continue
-    retained+=("$(printf '•  *%sm*  `%s`' "$retries" "$name")")
+    retained+=("$(printf '•  *%sm*  `%s`' "$ran" "$name")")
   done
 
   [ "${#retained[@]}" -eq 0 ] || printf '%s\n' "${retained[@]}"
@@ -124,36 +185,40 @@ timed_out_jobs() {
 killed=$(timed_out_jobs)
 
 if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
-  printf 'CI run took %sm executing (budget %sm, median %sm), waited %sm for a runner (budget %sm), %sm in total.\n' \
-    "$execution" "$budget" "$median" "$queued" "$queue_budget" "$total" >> "$GITHUB_STEP_SUMMARY"
+  printf 'CI run worked %sm (budget %sm), idled %sm (budget %sm), %sm in total.\n' \
+    "$execution" "$budget" "$idle" "$idle_budget" "$total" >> "$GITHUB_STEP_SUMMARY"
 fi
 
 if [ -n "$killed" ]; then
   headline="$short CI was killed after ${total}m"
-  facts=$(printf '•  *Execution*  %sm  ·  median %sm\n•  *Total*  %sm\n•  *Change*  %s' \
-    "$execution" "$median" "$total" "$change")
+  facts=$(printf '•  *Execution*  %sm\n•  *Total*  %sm\n•  *Change*  %s' \
+    "$execution" "$total" "$change")
   detail=$(printf '*Jobs GitHub stopped*\n%s' "$(bullets <<< "$killed")")
   footer='GitHub stops a job once it passes its `timeout-minutes`.'
   emoji=':skull:'
 elif [ "$conclusion" != "success" ]; then
   exit 0
-elif [ "$execution" -gt "$budget" ] || [ "$queued" -gt "$queue_budget" ]; then
-  if [ "$execution" -gt "$budget" ] && [ "$queued" -gt "$queue_budget" ]; then
-    headline="$short CI took ${execution}m and waited ${queued}m for a runner"
+elif [ "$execution" -gt "$budget" ] || [ "$idle" -gt "$idle_budget" ]; then
+  if [ "$execution" -gt "$budget" ] && [ "$idle" -gt "$idle_budget" ]; then
+    headline="$short CI worked ${execution}m and idled ${idle}m"
     emoji=':stopwatch:'
   elif [ "$execution" -gt "$budget" ]; then
-    headline="$short CI took ${execution}m"
+    headline="$short CI worked ${execution}m"
     emoji=':stopwatch:'
   else
-    headline="$short CI waited ${queued}m for a runner"
+    headline="$short CI idled ${idle}m waiting for runners"
     emoji=':hourglass:'
   fi
 
-  facts=$(printf '•  *Execution*  %sm  ·  budget %sm  ·  median %sm\n•  *Queued*  %sm  ·  budget %sm\n•  *Total*  %sm\n•  *Change*  %s' \
-    "$execution" "$budget" "$median" "$queued" "$queue_budget" "$total" "$change")
+  sampled=$(sample_medians)
+
+  facts=$(printf '•  *Execution*  %sm  ·  budget %sm  ·  median %sm\n•  *Idle*  %sm  ·  budget %sm  ·  median %sm\n•  *Total*  %sm  ·  median %sm\n•  *Change*  %s' \
+    "$execution" "$budget" "$(cut -f1 <<< "$sampled" | median_of)" \
+    "$idle" "$idle_budget" "$(cut -f2 <<< "$sampled" | median_of)" \
+    "$total" "$(cut -f3 <<< "$sampled" | median_of)" "$change")
   detail=$(printf '*Slowest jobs*\n%s' \
     "$(job_lines '.[] | select(.started_at != null)' | sort -rn | head -3 | bullets)")
-  footer="Execution excludes the wait for a runner. Median over the last $median_runs successful \`main\` runs."
+  footer="Execution counts the time at least one job was running; idle is the rest. Medians over the last $median_runs successful \`main\` runs."
 else
   exit 0
 fi

--- a/.github/workflows/ci-duration-monitor.yaml
+++ b/.github/workflows/ci-duration-monitor.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Compare the run against its budgets
         env:
           CI_OVERTIME_EXEC_BUDGET_MINS: ${{ vars.CI_OVERTIME_EXEC_BUDGET_MINS || '40' }}
-          CI_OVERTIME_QUEUE_BUDGET_MINS: ${{ vars.CI_OVERTIME_QUEUE_BUDGET_MINS || '10' }}
+          CI_OVERTIME_IDLE_BUDGET_MINS: ${{ vars.CI_OVERTIME_IDLE_BUDGET_MINS || '10' }}
           CI_OVERTIME_SAMPLES: ${{ vars.CI_OVERTIME_SAMPLES || '20' }}
           CONCLUSION: ${{ github.event.workflow_run.conclusion }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -39,7 +39,7 @@ jobs:
             "$RUN_ID" \
             "$CONCLUSION" \
             "$CI_OVERTIME_EXEC_BUDGET_MINS" \
-            "$CI_OVERTIME_QUEUE_BUDGET_MINS" \
+            "$CI_OVERTIME_IDLE_BUDGET_MINS" \
             "$CI_OVERTIME_SAMPLES")
 
           [ -n "$payload" ] || exit 0

--- a/changelog.d/+ci-duration-idle.internal.md
+++ b/changelog.d/+ci-duration-idle.internal.md
@@ -1,0 +1,1 @@
+Report CI execution and idle time separately in the duration alert.


### PR DESCRIPTION
Execution is the time at least one job was running: overlapping jobs count once, and the gaps between them do not count at all. Idle is the remaining wall time.

Execution, idle and total each carry their own median—fetched only when a budget is breached.

`CI_OVERTIME_QUEUE_BUDGET_MINS` becomes `CI_OVERTIME_IDLE_BUDGET_MINS`.

### Alert before the changes

:stopwatch: **mirrord CI took 56m and waited 38m for a runner**
•  **Execution**  56m  ·  budget 40m  ·  median 25m
•  **Queued**     38m  ·  budget 10m
•  **Total**      56m
•  **Change**     mirrord#4713

**Slowest jobs**

•  **27m**  `macos_tests / macos-tests`
•  **19m**  `windows_tests / windows-tests`
•  **17m**  `e2e / e2e (containerd/minikube)`

Execution excludes the wait for a runner. Median over the last 20 successful `main` runs.

### Alert after the changes

:stopwatch: **mirrord CI worked 46m**

•  **Execution**  46m  ·  budget 40m  ·  median 25m
•  **Idle**       10m  ·  budget 10m  ·  median 0m
•  **Total**      56m  ·  median 27m
•  **Change**     mirrord#4713

**Slowest jobs**

•  **27m**  `macos_tests / macos-tests`
•  **19m**  `windows_tests / windows-tests`
•  **17m**  `e2e / e2e (containerd/minikube)`

Execution counts the time at least one job was running; idle is the rest. Medians over the last 20 successful `main` runs.