### PR TITLE
Fix agent panic after outgoing connection read error

### DIFF
--- a/changelog.d/+outgoing-reset-panic.fixed.md
+++ b/changelog.d/+outgoing-reset-panic.fixed.md
@@ -1,0 +1,1 @@
+Fixed the agent panicking and dropping the session when a outgoing connection ended in a read error.

--- a/mirrord/agent/src/outgoing/router.rs
+++ b/mirrord/agent/src/outgoing/router.rs
@@ -277,7 +277,9 @@ impl<C: ConnectionKind> OutgoingRouter<C> {
     ) -> RouterUpdate {
         match read {
             None => {
-                self.abort_handles.remove(&id);
+                if let Some(handle) = self.abort_handles.remove(&id) {
+                    handle.abort();
+                }
                 if self.sinks.contains_key(&id) {
                     RouterUpdate::ConnEvent {
                         id,
@@ -297,7 +299,9 @@ impl<C: ConnectionKind> OutgoingRouter<C> {
             },
             Some(Err(error)) => {
                 self.sinks.remove(&id);
-                self.abort_handles.remove(&id);
+                if let Some(handle) = self.abort_handles.remove(&id) {
+                    handle.abort();
+                }
                 self.decrement_open_conns_counter();
                 self.queued_updates.push_back(RouterUpdate::ConnEvent {
                     id,

--- a/mirrord/agent/src/util/io/buffered.rs
+++ b/mirrord/agent/src/util/io/buffered.rs
@@ -6,7 +6,7 @@ use std::{
     task::{Context, Poll, Waker},
 };
 
-use futures::{FutureExt, Sink, SinkExt, Stream, StreamExt, channel::mpsc};
+use futures::{FutureExt, Sink, SinkExt, Stream, StreamExt, channel::mpsc, stream::FusedStream};
 use tokio::task::JoinHandle;
 
 /// [`Stream`] wrapper that continuously polls the inner stream in a background task.
@@ -19,7 +19,7 @@ use tokio::task::JoinHandle;
 /// [`ThrottledStream`](super::throttle::ThrottledStream).
 pub struct UnboundedBufferedStream<T> {
     rx: mpsc::UnboundedReceiver<T>,
-    task: JoinHandle<io::Result<()>>,
+    task: Option<JoinHandle<io::Result<()>>>,
 }
 
 impl<T> UnboundedBufferedStream<T> {
@@ -30,7 +30,10 @@ impl<T> UnboundedBufferedStream<T> {
     {
         let (tx, rx) = mpsc::unbounded();
         let task = tokio::spawn(Self::stream_task(stream, tx));
-        Self { rx, task }
+        Self {
+            rx,
+            task: Some(task),
+        }
     }
 
     async fn stream_task<S>(stream: S, tx: mpsc::UnboundedSender<T>) -> io::Result<()>
@@ -47,7 +50,12 @@ impl<T> UnboundedBufferedStream<T> {
     }
 
     fn poll_task_result(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        std::task::ready!(self.task.poll_unpin(cx))??;
+        let Some(task) = self.task.as_mut() else {
+            return Poll::Ready(Ok(()));
+        };
+        let result = std::task::ready!(task.poll_unpin(cx));
+        self.task = None;
+        result??;
         Poll::Ready(Ok(()))
     }
 }
@@ -57,6 +65,9 @@ impl<T> Stream for UnboundedBufferedStream<T> {
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.get_mut();
+        if this.is_terminated() {
+            return Poll::Ready(None);
+        }
         if let Some(item) = std::task::ready!(this.rx.poll_next_unpin(cx)) {
             return Poll::Ready(Some(Ok(item)));
         }
@@ -65,9 +76,17 @@ impl<T> Stream for UnboundedBufferedStream<T> {
     }
 }
 
+impl<T> FusedStream for UnboundedBufferedStream<T> {
+    fn is_terminated(&self) -> bool {
+        self.task.is_none()
+    }
+}
+
 impl<T> Drop for UnboundedBufferedStream<T> {
     fn drop(&mut self) {
-        self.task.abort();
+        if let Some(task) = self.task.as_ref() {
+            task.abort();
+        }
     }
 }
 
@@ -169,5 +188,31 @@ impl<T> Sink<T> for UnboundedBufferedSink<T> {
 impl<T> Drop for UnboundedBufferedSink<T> {
     fn drop(&mut self) {
         self.task.abort();
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::io;
+
+    use futures::{StreamExt, stream};
+
+    use super::UnboundedBufferedStream;
+
+    #[tokio::test]
+    async fn fuses_after_read_error() {
+        let inner = stream::iter(vec![
+            Ok::<u8, io::Error>(1),
+            Err(io::Error::from(io::ErrorKind::ConnectionReset)),
+        ]);
+        let mut stream = UnboundedBufferedStream::new(inner);
+
+        assert_eq!(stream.next().await.unwrap().unwrap(), 1);
+
+        let error = stream.next().await.unwrap().unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::ConnectionReset);
+
+        assert!(stream.next().await.is_none());
+        assert!(stream.next().await.is_none());
     }
 }


### PR DESCRIPTION
<!-- Thank you for contributing to mirrord! -->
<!-- Please use the checklist below as a guide for docs, tests and admin tasks for your PR -->
<!-- Feel free to ~strikethrough~ any items that you don't think apply -->

Fix #4716 

Two fixes
* abort join handles before dropping
* take the join handle from unbounded stream after it completes. so it never gets polled again, for example after we propagate an error.

### Quality Checklist:

- [x] I have documented new code sufficiently
- [x] I have checked and updated the relevant existing docs in code, including removing outdated material
- [x] I have written user-facing website docs for new features, or opened a (sub)issue to do so
- [x] I have checked and updated existing website docs for changed features
- [x] I have tested this change and know it succeeds and fails as expected
- [x] I have written unit tests or purposefully omitted them
- [ ] I have written e2e tests or purposefully omitted them
- [x] I have explained what this PR introduces and why, and linked to relevant context (e.g. linear issues, related PRs,
  documentation)
- [x] I have introduced a short, clear and well-formatted changelog entry

<!-- need help with the changelog? see ../CONTRIBUTING.md#submitting-a-pull-request -->
<!-- Add more details of your changes below if needed -->