### PR TITLE
fix(ci): bump cargo-zigbuild to 0.23.0 for aarch64 linux builds

### DIFF
--- a/.github/workflows/build-mirrord-cli.yaml
+++ b/.github/workflows/build-mirrord-cli.yaml
@@ -25,7 +25,7 @@ jobs:
       # `xtask build-cli` builds the layer and the UI frontend and embeds both into the CLI, so it
       # needs the same zigbuild and pnpm toolchain the release build uses.
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
-      - run: uv tool install cargo-zigbuild==0.22.1
+      - run: uv tool install cargo-zigbuild==0.23.0
       - run: uv tool install ziglang==0.15.2 --with-executables-from ziglang
       - run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       - run: ln -sf "$(command -v python-zig)" "$HOME/.local/bin/zig"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -166,7 +166,10 @@ jobs:
 
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
       - run: uv --version
-      - run: uv tool install cargo-zigbuild==0.22.1
+      # 0.23.0 is the floor: rustc's aarch64-unknown-linux-gnu spec passes
+      # `-Wl,--fix-cortex-a53-843419`, which zig's linker rejects, and only
+      # cargo-zigbuild >= 0.23.0 filters that argument out.
+      - run: uv tool install cargo-zigbuild==0.23.0
       - run: uv tool install ziglang==0.15.2 --with-executables-from ziglang
       - run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       - run: ln -sf "$(command -v python-zig)" "$HOME/.local/bin/zig"
@@ -202,7 +205,7 @@ jobs:
           rustflags: ""
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
       - run: uv --version
-      - run: uv tool install cargo-zigbuild==0.22.1
+      - run: uv tool install cargo-zigbuild==0.23.0
       - run: uv tool install ziglang==0.15.2 --with-executables-from ziglang
       - run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       - run: ln -sf "$(command -v python-zig)" "$HOME/.local/bin/zig"

--- a/changelog.d/+aarch64-release-zigbuild.internal.md
+++ b/changelog.d/+aarch64-release-zigbuild.internal.md
@@ -1,0 +1,1 @@
+Fixed the `aarch64-unknown-linux-gnu` release build, which failed to link after the Rust toolchain update: recent `rustc` passes `-Wl,--fix-cortex-a53-843419` to the linker for that target and `zig` rejects it, so `cargo-zigbuild` is now pinned to a version that filters the argument out.

--- a/mirrord/cli/Dockerfile
+++ b/mirrord/cli/Dockerfile
@@ -13,7 +13,7 @@ COPY . /build/
 
 RUN apt-get update && apt-get install -y python3-pip
 RUN python3 -m pip install --break-system-packages uv==0.11.3
-RUN cargo install cargo-zigbuild --version 0.22.1 --locked
+RUN cargo install cargo-zigbuild --version 0.23.0 --locked
 
 RUN case "$(cat /.platform)" in \
     x86_64-unknown-linux-gnu) platform=linux-x86_64 ;; \

--- a/tests/e2e.Dockerfile
+++ b/tests/e2e.Dockerfile
@@ -100,7 +100,7 @@ RUN set -eux; \
     corepack enable && corepack prepare "pnpm@${PNPM_MAJOR}" --activate; \
     node --version && pnpm --version
 
-ARG CARGO_ZIGBUILD_VERSION=0.22.1
+ARG CARGO_ZIGBUILD_VERSION=0.23.0
 ARG ZIGLANG_VERSION=0.15.2
 
 ENV UV_TOOL_BIN_DIR=/usr/local/bin


### PR DESCRIPTION
The `build_binaries_aarch64-unknown-linux-gnu` release job fails to link: rustc's `aarch64-unknown-linux-gnu` target spec passes `-Wl,--fix-cortex-a53-843419` (rust-lang/rust#155453, merged June), zig's linker rejects it with `unsupported linker arg`, and cargo-zigbuild 0.22.1 doesn't filter it. 0.23.0 does. All zigbuild pins bumped together to keep them in lockstep.

This landed with the nightly-2026-08-13 toolchain update — the aarch64 job is gated on release branches, so nothing on main exercised it.

Verified locally by cross-compiling to `aarch64-unknown-linux-gnu` with nightly-2026-08-13 and zig 0.15.2: fails on 0.22.1 with the exact CI error, links clean on 0.23.0.