### PR TITLE
Put the IntelliJ e2e job back in the CI gate

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -423,13 +423,14 @@ jobs:
     name: ci
     # We want this to run even if some of the required jobs got skipped
     if: always()
+    # This job prunes the run's inter-job artifacts, so every job that downloads one has to be
+    # listed here. Dropping a job from this list lets the prune run while that job is still going,
+    # and it then fails on a missing artifact.
     needs:
       [
         towncrier_check,
         plan,
-        # The IntelliJ end-to-end suite is too flaky to hold up a release branch. It still runs
-        # and reports, it just does not gate. Put it back once it is dependable again.
-        # intellij_e2e_on_release_branch,
+        intellij_e2e_on_release_branch,
         vscode_e2e_on_release_branch,
         test_agent_image,
         test_cli_image,

--- a/changelog.d/+intellij-e2e-gates-again.internal.md
+++ b/changelog.d/+intellij-e2e-gates-again.internal.md
@@ -1,0 +1,1 @@
+Put the IntelliJ end-to-end job back in the CI gate's needs list, so the gate's artifact prune can no longer delete the mirrord binary while that job is still running.


### PR DESCRIPTION
`ci-success` is both the CI gate and the job that prunes the run's inter-job artifacts. Since the IntelliJ e2e job was commented out of its `needs`, nothing kept the prune behind it — on a run where the other gating jobs finished quickly, the prune deleted `mirrord-artifacts` while IntelliJ was still building the plugin, and IntelliJ then failed on `Artifact not found for name: mirrord-artifacts` rather than on a test.

This puts the dependency back, so IntelliJ gates again and the prune waits for it. Added a comment on `needs` recording that anything downloading an inter-job artifact has to stay listed there.

If the flakiness that motivated dropping it comes back, the fix is to keep it in `needs` for ordering and exclude it from the pass/fail check instead — removing it from `needs` reintroduces this race.

Tested by reading the run that hit it: the prune logged `deleted mirrord-artifacts` at 10:32:21 and the IntelliJ download failed at 10:35:51. CI here only covers that the workflow still parses and that the gate is happy with the job skipped — the job is release-branch-only, so the ordering itself is first exercised on the next release PR.