### PR TITLE
fix(monitor): make setTelemetryEnabled idempotent

### DIFF
--- a/changelog.d/+monitor-opt-in-loop.fixed.md
+++ b/changelog.d/+monitor-opt-in-loop.fixed.md
@@ -1,0 +1,1 @@
+Stop the session monitor UI from re-sending a telemetry opt-in event on every session poll, so an idle `mirrord ui` tab no longer emits a steady stream of redundant events.

--- a/packages/monitor/src/analytics.ts
+++ b/packages/monitor/src/analytics.ts
@@ -5,6 +5,14 @@ const POSTHOG_HOST = 'https://hog.metalbear.com'
 
 let initialized = false
 
+/**
+ * The telemetry state currently applied to posthog, or `null` before init. Tracked because
+ * `posthog.opt_in_capturing()` is not idempotent: every call captures a `$opt_in` event with
+ * `send_instantly`, whether or not the client was already opted in. Callers re-assert the
+ * preference on a timer, so re-applying an unchanged value would emit one event per tick.
+ */
+let appliedTelemetry: boolean | null = null
+
 export function initAnalytics(telemetryEnabled: boolean) {
   if (!telemetryEnabled || initialized) return
   posthog.init(POSTHOG_KEY, {
@@ -36,6 +44,9 @@ export function initAnalytics(telemetryEnabled: boolean) {
     },
   })
   initialized = true
+  // `posthog.init` leaves the client opted in, and init only runs with telemetry enabled, so
+  // capturing is already in the desired state before any `setTelemetryEnabled` call arrives.
+  appliedTelemetry = true
   posthog.capture('session_monitor_opened', { source: 'session-monitor' })
 }
 
@@ -44,9 +55,13 @@ export function initAnalytics(telemetryEnabled: boolean) {
  * flips posthog's opt-in state and starts or stops the session recorder. If init has not
  * run yet (no active sessions, or the user opened with telemetry off), this is a no-op —
  * the `telemetryEnabled` argument passed to `initAnalytics` later will be authoritative.
+ *
+ * Safe to call on every render or poll tick: only an actual change in the preference reaches
+ * posthog.
  */
 export function setTelemetryEnabled(enabled: boolean) {
-  if (!initialized) return
+  if (!initialized || enabled === appliedTelemetry) return
+  appliedTelemetry = enabled
   if (enabled) {
     posthog.opt_in_capturing()
     posthog.startSessionRecording()

--- a/packages/monitor/src/analytics.ts
+++ b/packages/monitor/src/analytics.ts
@@ -6,12 +6,13 @@ const POSTHOG_HOST = 'https://hog.metalbear.com'
 let initialized = false
 
 /**
- * The telemetry state currently applied to posthog, or `null` before init. Tracked because
- * `posthog.opt_in_capturing()` is not idempotent: every call captures a `$opt_in` event with
- * `send_instantly`, whether or not the client was already opted in. Callers re-assert the
- * preference on a timer, so re-applying an unchanged value would emit one event per tick.
+ * The telemetry state currently applied to posthog. Starts `false` to match an uninitialized
+ * client, which captures nothing. Tracked because `posthog.opt_in_capturing()` is not
+ * idempotent: every call captures a `$opt_in` event with `send_instantly`, whether or not the
+ * client was already opted in. Callers re-assert the preference on a timer, so re-applying an
+ * unchanged value would emit one event per tick.
  */
-let appliedTelemetry: boolean | null = null
+let appliedTelemetry = false
 
 export function initAnalytics(telemetryEnabled: boolean) {
   if (!telemetryEnabled || initialized) return


### PR DESCRIPTION
The session monitor UI re-sent a PostHog opt-in event on every session poll.

`App.tsx` applies the telemetry preference in an effect keyed on the polled `sessions` array, which is a fresh object every 2s, so the effect re-runs each tick. `posthog.opt_in_capturing()` has no "already opted in" guard — it captures `$opt_in` with `send_instantly` on every call — so an open `mirrord ui` tab emitted a redundant opt-in event per tick, plus a redundant `startSessionRecording()`.

Guarded in `analytics.ts` by tracking the applied state and returning early when it's unchanged, rather than memoizing in `App.tsx`, so any future caller is protected too. `initAnalytics` seeds the state to `true` because `posthog.init` already leaves the client opted in. Real preference toggles still take effect; only unchanged re-assertions are dropped.

Note the observed rate understates this: backgrounded tabs get their timers throttled by the browser, so a foreground tab polls far more often.

## Testing

`tsc -b` and `eslint`/`prettier` clean on the changed file. Verified the absence of the opt-in guard against the pinned posthog-js 1.364.6 bundle, and confirmed the firing pattern from the captured event timestamps.