### PR TITLE
Report flakes when Linear is unavailable or CI is red

### DIFF
--- a/.github/scripts/flaky-issue.sh
+++ b/.github/scripts/flaky-issue.sh
@@ -9,7 +9,7 @@
 #
 # Usage: flaky-issue.sh <repo> <team-key> <test> [<body-file>]
 #
-# Prints the issue identifier. Requires $LINEAR_ACCESS_KEY.
+# Prints the issue identifier. Requires $LINEAR_APP_TOKEN, which `linear-token.sh` mints.
 
 set -euo pipefail
 
@@ -31,7 +31,7 @@ api() {
   local response
   response=$(curl --fail-with-body --silent --show-error \
     -X POST https://api.linear.app/graphql \
-    -H "Authorization: $LINEAR_ACCESS_KEY" \
+    -H "Authorization: Bearer $LINEAR_APP_TOKEN" \
     -H 'Content-Type: application/json' \
     --data "$1")
 

--- a/.github/scripts/flaky-notify.sh
+++ b/.github/scripts/flaky-notify.sh
@@ -8,7 +8,7 @@
 #
 # Usage: flaky-notify.sh <repo> <team-key> <notify-threshold> <runs-read>
 #
-# Annotates issues only when $LINEAR_ACCESS_KEY is set.
+# Annotates issues only when $LINEAR_APP_TOKEN is set.
 
 set -euo pipefail
 
@@ -24,8 +24,11 @@ while IFS=$'\t' read -r retries name; do
   [ -n "$name" ] || continue
 
   issue=""
-  if [ -n "${LINEAR_ACCESS_KEY:-}" ]; then
-    issue=$("$scripts/flaky-issue.sh" "$repo" "$team_key" "$name" < /dev/null)
+  if [ -n "${LINEAR_APP_TOKEN:-}" ]; then
+    if ! issue=$("$scripts/flaky-issue.sh" "$repo" "$team_key" "$name" < /dev/null); then
+      echo "::warning::could not reach Linear for the issue tracking $name" >&2
+      issue=""
+    fi
   fi
 
   if [ -n "$issue" ]; then

--- a/.github/scripts/flaky-tests.sh
+++ b/.github/scripts/flaky-tests.sh
@@ -2,14 +2,15 @@
 #
 # Reports tests that nextest had to retry on `main`, which a green run hides entirely.
 #
-# Reads the JUnit reports CI merges into one `nextest-junit` artifact per successful `main` run,
-# counting a test's `flakyFailure` elements (attempts that failed before it passed) and
-# `rerunFailure` ones (attempts of a test that failed for good).
+# Reads the JUnit reports CI merges into one `nextest-junit` artifact per `main` run, counting a
+# test's `flakyFailure` elements (attempts that failed before it passed) and `rerunFailure` ones
+# (attempts of a test that failed for good). A run that failed publishes the reports of the jobs it
+# did get through, since a broken `main` retries tests like any other.
 #
 # Sampling is by run that carried a report, never by run: a run that skipped the test matrix, or
 # whose artifact has expired, is not one of the <samples> and does not consume one. Since only a
-# successful `main` run publishes under that name, listing artifacts by it answers both questions at
-# once, in a single request.
+# `main` run publishes under that name, listing artifacts by it answers both questions at once, in a
+# single request.
 #
 # Usage: flaky-tests.sh <repo> <samples> <notify-threshold> [issue-threshold]
 #

--- a/.github/scripts/linear-token.sh
+++ b/.github/scripts/linear-token.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+#
+# Mints an app actor token for Linear's API and prints it.
+#
+# Usage: linear-token.sh
+#
+# Requires $LINEAR_APP_CLIENT_ID and $LINEAR_APP_CLIENT_SECRET. The token acts as the application
+# rather than as whoever registered it, and lasts 30 days.
+
+set -euo pipefail
+
+if [ -z "${LINEAR_APP_CLIENT_ID:-}" ] || [ -z "${LINEAR_APP_CLIENT_SECRET:-}" ]; then
+  echo "LINEAR_APP_CLIENT_ID and LINEAR_APP_CLIENT_SECRET must both be set" >&2
+  exit 1
+fi
+
+refused() {
+  local detail
+  detail=$(jq -r '.error_description // .error // empty' <<< "$1" 2> /dev/null || true)
+  printf 'Linear refused to mint a token: %s\n' "${detail:-$1}" >&2
+  exit 1
+}
+
+if ! response=$(curl --fail-with-body --silent --show-error \
+  -X POST https://api.linear.app/oauth/token \
+  --data-urlencode grant_type=client_credentials \
+  --data-urlencode "client_id=$LINEAR_APP_CLIENT_ID" \
+  --data-urlencode "client_secret=$LINEAR_APP_CLIENT_SECRET" \
+  --data-urlencode scope=read,write); then
+  refused "$response"
+fi
+
+token=$(jq -r '.access_token // empty' <<< "$response")
+
+[ -n "$token" ] || refused "$response"
+
+printf '%s\n' "$token"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -447,23 +447,8 @@ jobs:
       contents: read
       actions: write
     steps:
-      - name: Check required jobs passed
-        # We have to do it in the shell since if it's in the if condition
-        # then skipping is considered success by branch protection rules
-        env:
-          NEEDS_JSON: ${{ toJSON(needs) }}
-        run: |
-          failing=$(echo "$NEEDS_JSON" | jq -r 'to_entries[] | select(.value.result != "success" and .value.result != "skipped") | "\(.key): \(.value.result)"')
-          if [ -n "$failing" ]; then
-            echo "$failing"
-            exit 1
-          fi
-
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          sparse-checkout: .github/scripts
-          sparse-checkout-cone-mode: false
-
+      # Both report steps run ahead of the gate below, because a run that failed still retried the
+      # tests it got through, and those retries are exactly what the flake report is looking for.
       - name: Count the test reports
         id: reports
         if: ${{ github.ref == 'refs/heads/main' }}
@@ -483,6 +468,23 @@ jobs:
           separate-directories: true
           delete-merged: true
           retention-days: 30
+
+      - name: Check required jobs passed
+        # We have to do it in the shell since if it's in the if condition
+        # then skipping is considered success by branch protection rules
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          failing=$(echo "$NEEDS_JSON" | jq -r 'to_entries[] | select(.value.result != "success" and .value.result != "skipped") | "\(.key): \(.value.result)"')
+          if [ -n "$failing" ]; then
+            echo "$failing"
+            exit 1
+          fi
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: false
 
       - name: Delete inter-job artifacts
         env:

--- a/.github/workflows/flaky-test-report.yaml
+++ b/.github/workflows/flaky-test-report.yaml
@@ -42,29 +42,37 @@ jobs:
         env:
           CI_FLAKY_ISSUE_THRESHOLD: ${{ steps.collect.outputs.issue_threshold }}
           CI_FLAKY_SCANNED: ${{ steps.collect.outputs.scanned }}
-          LINEAR_ACCESS_KEY: ${{ secrets.LINEAR_ACCESS_KEY }}
+          LINEAR_APP_CLIENT_ID: ${{ secrets.LINEAR_APP_CLIENT_ID }}
+          LINEAR_APP_CLIENT_SECRET: ${{ secrets.LINEAR_APP_CLIENT_SECRET }}
           CI_FLAKY_ISSUE_TESTS: ${{ steps.collect.outputs.issue_tests }}
         run: |
           set -euo pipefail
+
+          LINEAR_APP_TOKEN=$(.github/scripts/linear-token.sh)
+          echo "::add-mask::$LINEAR_APP_TOKEN"
+          export LINEAR_APP_TOKEN
 
           report="https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
 
           while IFS=$'\t' read -r retries test; do
             [ -n "$test" ] || continue
 
-            printf '`%s` retried %s times across the last %s successful `main` runs, at or over the threshold of %s.\n\n[Latest report](%s)\n' \
+            printf '`%s` retried %s times across the last %s `main` runs that published test reports, at or over the threshold of %s.\n\n[Latest report](%s)\n' \
               "$test" "$retries" "$CI_FLAKY_SCANNED" "$CI_FLAKY_ISSUE_THRESHOLD" "$report" > body.md
 
             issue=$(.github/scripts/flaky-issue.sh "$GITHUB_REPOSITORY" MBE "$test" body.md)
             echo "\`$test\` tracked in $issue" >> "$GITHUB_STEP_SUMMARY"
           done <<< "$CI_FLAKY_ISSUE_TESTS"
       - name: "Notify #ci-alerts"
-        if: ${{ steps.collect.outputs.notify_count != '0' }}
+        # Runs on the collection alone, so that a Linear that fails the step above still leaves the
+        # channel with the report.
+        if: ${{ !cancelled() && steps.collect.outcome == 'success' && steps.collect.outputs.notify_count != '0' }}
         env:
           CI_FLAKY_NOTIFY_THRESHOLD: ${{ inputs.notify_threshold || vars.CI_FLAKY_NOTIFY_THRESHOLD || '3' }}
           CI_FLAKY_SCANNED: ${{ steps.collect.outputs.scanned }}
           CI_FLAKY_NOTIFY_COUNT: ${{ steps.collect.outputs.notify_count }}
-          LINEAR_ACCESS_KEY: ${{ secrets.LINEAR_ACCESS_KEY }}
+          LINEAR_APP_CLIENT_ID: ${{ secrets.LINEAR_APP_CLIENT_ID }}
+          LINEAR_APP_CLIENT_SECRET: ${{ secrets.LINEAR_APP_CLIENT_SECRET }}
           SLACK_CI_ALERTS_WEBHOOK_URL: ${{ secrets.SLACK_CI_ALERTS_WEBHOOK_URL }}
           CI_FLAKY_NOTIFY_TESTS: ${{ steps.collect.outputs.notify_tests }}
         run: |
@@ -73,6 +81,14 @@ jobs:
           if [ -z "$SLACK_CI_ALERTS_WEBHOOK_URL" ]; then
             echo "::warning::$CI_FLAKY_NOTIFY_COUNT flaky test(s) but SLACK_CI_ALERTS_WEBHOOK_URL is not set"
             exit 0
+          fi
+
+          # Annotating the report is worth a warning at most: the tests it names are the point.
+          if LINEAR_APP_TOKEN=$(.github/scripts/linear-token.sh); then
+            echo "::add-mask::$LINEAR_APP_TOKEN"
+            export LINEAR_APP_TOKEN
+          else
+            echo "::warning::could not mint a Linear token; the report will carry no issue numbers"
           fi
 
           payload=$(.github/scripts/flaky-notify.sh "$GITHUB_REPOSITORY" MBE "$CI_FLAKY_NOTIFY_THRESHOLD" "$CI_FLAKY_SCANNED" <<< "$CI_FLAKY_NOTIFY_TESTS")

--- a/changelog.d/+flake-alert-delivery.internal.md
+++ b/changelog.d/+flake-alert-delivery.internal.md
@@ -1,0 +1,1 @@
+Report flaky tests even when Linear is unavailable or the run failed.


### PR DESCRIPTION
The flake report wasn't using the correct credentials. It's been updated to use an OAuth client ID (`LINEAR_APP_CLIENT_ID`) and and client secret (`LINEAR_APP_CLIENT_SECRET`), minted per run.


Linear failures are best-effort now: there's graceful fallback where possible and the Slack notification isn't gated on its success.

The report steps were moved ahead of the required-jobs gate, so a failed run's JUnit reports are still merged.
