### PR TITLE
cli: unify subcommand names and options

### DIFF
--- a/changelog.d/+cor-1727-cli.changed.md
+++ b/changelog.d/+cor-1727-cli.changed.md
@@ -1,0 +1,1 @@
+Made subcommands and options more consistent across the CLI, while keeping old command names as aliases.

--- a/changelog.d/+cor-1727-preview-status.changed.md
+++ b/changelog.d/+cor-1727-preview-status.changed.md
@@ -1,0 +1,1 @@
+Changed `mirrord preview status` to use the same table format as other CLI commands.

--- a/mirrord/cli/src/config.rs
+++ b/mirrord/cli/src/config.rs
@@ -440,7 +440,7 @@ pub(super) struct ExecParams {
     /// Can also be set with the `MIRRORD_KEY` environment variable.
     /// If not provided here, through `MIRRORD_KEY`, or in the config file, a unique key is
     /// generated automatically.
-    #[arg(long)]
+    #[arg(short = 'k', long)]
     pub key: Option<String>,
 }
 
@@ -913,7 +913,7 @@ pub(super) enum OperatorCommand {
         command: SessionCommand,
         /// Load config from config file.
         /// When using -f flag without a value, defaults to "./.mirrord/mirrord.json"
-        #[arg(short = 'f', long, value_hint = ValueHint::FilePath, default_missing_value = "./.mirrord/mirrord.json", num_args = 0..=1)]
+        #[arg(short = 'f', long, value_hint = ValueHint::FilePath, default_missing_value = "./.mirrord/mirrord.json", num_args = 0..=1, global = true)]
         config_file: Option<PathBuf>,
     },
 }
@@ -925,13 +925,19 @@ pub(super) enum OperatorCommand {
 /// Implements [`core::fmt::Display`] to show the user a nice message.
 #[derive(Debug, Subcommand, Clone, Copy)]
 pub(crate) enum SessionCommand {
-    /// Kills the session specified by `id`.
-    Kill {
+    /// Stops one or all operator sessions.
+    #[command(alias = "kill")]
+    Stop {
         /// Id of the session.
-        #[arg(short, long, value_parser=hex_id)]
-        id: u64,
+        #[arg(short, long, value_parser = hex_id, required_unless_present = "all")]
+        id: Option<u64>,
+
+        /// Stop all operator sessions.
+        #[arg(long, conflicts_with = "id")]
+        all: bool,
     },
-    /// Kills all operator sessions.
+    /// Compatibility command for stopping all operator sessions.
+    #[command(hide = true, name = "kill-all")]
     KillAll,
 
     /// Kills _inactive_ sessions, might be useful if an undead session is still being stored in
@@ -943,8 +949,12 @@ pub(crate) enum SessionCommand {
 impl core::fmt::Display for SessionCommand {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            SessionCommand::Kill { id } => write!(f, "mirrord operator kill --id {id}"),
-            SessionCommand::KillAll => write!(f, "mirrord operator kill-all"),
+            SessionCommand::Stop { id: Some(id), .. } => {
+                write!(f, "mirrord operator session stop --id {id}")
+            }
+            SessionCommand::Stop { id: None, .. } | SessionCommand::KillAll => {
+                write!(f, "mirrord operator session stop --all")
+            }
             SessionCommand::RetainActive => write!(f, "mirrord operator retain-active"),
         }
     }
@@ -1179,16 +1189,21 @@ pub(super) struct VpnArgs {
 #[derive(Args, Debug)]
 pub(super) struct DbBranchesArgs {
     /// Specify the namespace to operate on
-    #[arg(short = 'n', long = "namespace")]
+    #[arg(short = 'n', long = "namespace", global = true)]
     pub namespace: Option<String>,
 
     /// Operate on all namespaces
-    #[arg(short = 'A', long = "all-namespaces", conflicts_with = "namespace")]
+    #[arg(
+        short = 'A',
+        long = "all-namespaces",
+        conflicts_with = "namespace",
+        global = true
+    )]
     pub all_namespaces: bool,
 
     /// Load config from config file
     /// When using -f flag without a value, defaults to "./.mirrord/mirrord.json"
-    #[arg(short = 'f', long, value_hint = ValueHint::FilePath, default_missing_value = "./.mirrord/mirrord.json", num_args = 0..=1)]
+    #[arg(short = 'f', long, value_hint = ValueHint::FilePath, default_missing_value = "./.mirrord/mirrord.json", num_args = 0..=1, global = true)]
     pub config_file: Option<PathBuf>,
 
     #[command(subcommand)]
@@ -1205,12 +1220,13 @@ pub(super) enum DbBranchesCommand {
     },
     /// Show active portforward connections for database branches
     Connections,
-    /// Destroy database branches
-    Destroy {
-        /// Destroy all branches
+    /// Stop database branches.
+    #[command(alias = "destroy")]
+    Stop {
+        /// Stop all branches.
         #[arg(long, conflicts_with = "names")]
         all: bool,
-        /// Names of specific branches to destroy
+        /// Names of specific branches to stop.
         #[arg(required_unless_present = "all")]
         names: Vec<String>,
     },
@@ -1281,6 +1297,10 @@ pub struct FixKubeconfig {
 /// Arguments for `mirrord preview` command.
 #[derive(Args, Debug)]
 pub(super) struct PreviewArgs {
+    /// Arguments shared across `mirrord preview` commands.
+    #[command(flatten)]
+    pub common: PreviewCommonArgs,
+
     /// Subcommand to use with `mirrord preview`.
     #[command(subcommand)]
     pub command: PreviewCommand,
@@ -1348,17 +1368,17 @@ pub(super) struct PreviewCommonArgs {
     ///
     /// Can also be set with the `MIRRORD_KEY` environment variable or via the `key` field in the
     /// mirrord config file.
-    #[arg(short = 'k', long)]
+    #[arg(short = 'k', long, global = true)]
     pub key: Option<String>,
 
     /// Load config from config file.
     ///
     /// When using -f flag without a value, defaults to "./.mirrord/mirrord.json"
-    #[arg(short = 'f', long, value_hint = ValueHint::FilePath, default_missing_value = "./.mirrord/mirrord.json", num_args = 0..=1)]
+    #[arg(short = 'f', long, value_hint = ValueHint::FilePath, default_missing_value = "./.mirrord/mirrord.json", num_args = 0..=1, global = true)]
     pub config_file: Option<PathBuf>,
 
     /// Kube context to use from Kubeconfig.
-    #[arg(long)]
+    #[arg(long, global = true)]
     pub context: Option<String>,
 }
 
@@ -1393,9 +1413,6 @@ impl PreviewCommonArgs {
 /// Arguments for `mirrord preview start` command.
 #[derive(Args, Debug)]
 pub(super) struct PreviewStartArgs {
-    #[clap(flatten)]
-    pub common: PreviewCommonArgs,
-
     /// Container image to run in the preview pod.
     ///
     /// The image must be pre-built and pushed to a registry accessible by the cluster.
@@ -1445,8 +1462,11 @@ pub(super) struct PreviewStartArgs {
 
 impl PreviewStartArgs {
     /// Convert CLI arguments to environment variable overrides for config resolution.
-    pub fn as_env_vars(&self) -> HashMap<&'static OsStr, Cow<'_, OsStr>> {
-        let mut envs = self.common.as_env_vars();
+    pub fn as_env_vars<'a>(
+        &'a self,
+        common: &'a PreviewCommonArgs,
+    ) -> HashMap<&'static OsStr, Cow<'a, OsStr>> {
+        let mut envs = common.as_env_vars();
 
         if let Some(image) = &self.image {
             envs.insert(
@@ -1491,17 +1511,14 @@ impl PreviewStartArgs {
 /// Arguments for `mirrord preview status` command.
 #[derive(Args, Debug)]
 pub(super) struct PreviewStatusArgs {
-    #[clap(flatten)]
-    pub common: PreviewCommonArgs,
-
     /// Filter preview environments by a Unix shell-style key glob.
     #[arg(long, value_name = "PATTERN", conflicts_with = "key")]
     pub glob: Option<String>,
 
     /// Namespace to query. Can also be set via `target.namespace` in the mirrord config.
     ///
-    /// When neither this flag nor the config set a namespace, the command implicitly searches
-    /// all namespaces (equivalent to `-A`).
+    /// Defaults to `target.namespace` from the mirrord config, then the kubeconfig default
+    /// namespace.
     #[arg(short = 'n', long = "namespace")]
     pub namespace: Option<String>,
 
@@ -1518,8 +1535,11 @@ pub(super) struct PreviewStatusArgs {
 
 impl PreviewStatusArgs {
     /// Convert CLI arguments to environment variable overrides for config resolution.
-    pub fn as_env_vars(&self) -> HashMap<&'static OsStr, Cow<'_, OsStr>> {
-        let mut envs = self.common.as_env_vars();
+    pub fn as_env_vars<'a>(
+        &'a self,
+        common: &'a PreviewCommonArgs,
+    ) -> HashMap<&'static OsStr, Cow<'a, OsStr>> {
+        let mut envs = common.as_env_vars();
 
         if let Some(namespace) = &self.namespace {
             envs.insert(
@@ -1535,9 +1555,6 @@ impl PreviewStatusArgs {
 /// Arguments for `mirrord preview stop` command.
 #[derive(Args, Debug)]
 pub(super) struct PreviewStopArgs {
-    #[clap(flatten)]
-    pub common: PreviewCommonArgs,
-
     /// Delete preview environments matching a Unix shell-style key glob.
     #[arg(long, value_name = "PATTERN", conflicts_with = "key")]
     pub glob: Option<String>,
@@ -1551,9 +1568,9 @@ pub(super) struct PreviewStopArgs {
 
     /// Namespace to search. Can also be set via `target.namespace` in the mirrord config.
     ///
-    /// When neither this flag nor the config set a namespace, the command implicitly searches
-    /// all namespaces (equivalent to `-A`).
-    #[arg(short = 'n')]
+    /// Defaults to `target.namespace` from the mirrord config, then the kubeconfig default
+    /// namespace.
+    #[arg(short = 'n', long = "namespace")]
     pub namespace: Option<String>,
 
     /// Operate on all namespaces.
@@ -1563,8 +1580,11 @@ pub(super) struct PreviewStopArgs {
 
 impl PreviewStopArgs {
     /// Convert CLI arguments to environment variable overrides for config resolution.
-    pub fn as_env_vars(&self) -> HashMap<&'static OsStr, Cow<'_, OsStr>> {
-        let mut envs = self.common.as_env_vars();
+    pub fn as_env_vars<'a>(
+        &'a self,
+        common: &'a PreviewCommonArgs,
+    ) -> HashMap<&'static OsStr, Cow<'a, OsStr>> {
+        let mut envs = common.as_env_vars();
 
         if let Some(target) = &self.target {
             envs.insert(
@@ -1604,7 +1624,7 @@ pub(super) struct UpArgs {
     /// Can also be set with the `MIRRORD_KEY` environment variable.
     /// If not provided here or through `MIRRORD_KEY`, a key is generated automatically from the
     /// system username.
-    #[arg(long)]
+    #[arg(short = 'k', long)]
     pub key: Option<String>,
 
     /// Start `mirrord ui` in the background.
@@ -1681,7 +1701,7 @@ pub enum UiSubcommand {
     Start,
 
     /// Stop the currently running `mirrord ui` server background task.
-    #[command(visible_alias = "kill")]
+    #[command(alias = "kill")]
     Stop,
 }
 
@@ -1840,6 +1860,15 @@ pub struct SessionCommonArgs {
     #[arg(short = 'n', long = "namespace", global = true)]
     pub namespace: Option<String>,
 
+    /// Operate on all namespaces.
+    #[arg(
+        short = 'A',
+        long = "all-namespaces",
+        conflicts_with = "namespace",
+        global = true
+    )]
+    pub all_namespaces: bool,
+
     /// Load config from config file.
     ///
     /// When using `-f` without a value, defaults to `"./.mirrord/mirrord.json"`.
@@ -1857,13 +1886,13 @@ pub struct SessionCommonArgs {
 /// `mirrord session` subcommands.
 #[derive(Subcommand, Debug)]
 pub enum LocalSessionCommand {
-    /// List mirrord sessions currently running locally and in cluster (in same namespace).
+    /// List mirrord sessions currently running locally and in the cluster.
     #[command(visible_alias = "ls")]
     List(SessionListArgs),
 
-    /// Kill a local mirrord session.
-    #[command(visible_alias = "kill")]
-    Delete(SessionDeleteArgs),
+    /// Stop a local mirrord session.
+    #[command(alias = "delete", alias = "kill")]
+    Stop(SessionDeleteArgs),
 }
 
 impl Default for LocalSessionCommand {
@@ -1892,8 +1921,8 @@ pub struct SessionDeleteArgs {
     #[arg(required_unless_present = "key")]
     pub id: Option<String>,
 
-    /// Kill all local sessions with this key.
-    #[arg(long, conflicts_with = "id")]
+    /// Stop all local sessions with this key.
+    #[arg(short = 'k', long, conflicts_with = "id")]
     pub key: Option<String>,
 }
 
@@ -1941,6 +1970,38 @@ mod tests {
         };
         assert!(args.services.is_empty());
         assert!(matches!(args.command, Some(UpSubcommand::Init { .. })));
+    }
+
+    #[rstest]
+    #[case(&["mirrord", "db-branches", "-n", "dev", "stop", "branch"])]
+    #[case(&["mirrord", "db-branches", "stop", "branch", "-n", "dev"])]
+    #[case(&["mirrord", "session", "-A", "list"])]
+    #[case(&["mirrord", "session", "list", "-A"])]
+    #[case(&["mirrord", "preview", "-f", "config.json", "status"])]
+    #[case(&["mirrord", "preview", "status", "-f", "config.json"])]
+    #[case(&["mirrord", "operator", "session", "-f", "config.json", "stop", "--all"])]
+    #[case(&["mirrord", "operator", "session", "stop", "--all", "-f", "config.json"])]
+    fn global_management_flags_parse_before_and_after_subcommands(#[case] args: &[&str]) {
+        Cli::try_parse_from(args).unwrap();
+    }
+
+    #[rstest]
+    #[case(&["mirrord", "db-branches", "destroy", "branch"])]
+    #[case(&["mirrord", "session", "delete", "session-id"])]
+    #[case(&["mirrord", "session", "kill", "session-id"])]
+    #[case(&["mirrord", "operator", "session", "kill", "--id", "ff"])]
+    #[case(&["mirrord", "operator", "session", "kill-all"])]
+    fn compatibility_commands_still_parse(#[case] args: &[&str]) {
+        Cli::try_parse_from(args).unwrap();
+    }
+
+    #[rstest]
+    #[case(&["mirrord", "exec", "-k", "dev", "binary"])]
+    #[case(&["mirrord", "up", "-k", "dev"])]
+    #[case(&["mirrord", "session", "stop", "-k", "dev"])]
+    #[case(&["mirrord", "kill", "-k", "dev"])]
+    fn key_short_flag_parses(#[case] args: &[&str]) {
+        Cli::try_parse_from(args).unwrap();
     }
 
     /// The multi-cluster session names the operator reports are the session id behind a prefix, so

--- a/mirrord/cli/src/db_branches.rs
+++ b/mirrord/cli/src/db_branches.rs
@@ -195,7 +195,7 @@ pub async fn db_branches_command(args: DbBranchesArgs) -> CliResult<()> {
     match &args.command {
         DbBranchesCommand::Status { names } => status_command(&args, names.as_slice()).await,
         DbBranchesCommand::Connections => connections_command().await,
-        DbBranchesCommand::Destroy { all, names } => destroy_command(&args, *all, names).await,
+        DbBranchesCommand::Stop { all, names } => destroy_command(&args, *all, names).await,
     }
 }
 

--- a/mirrord/cli/src/operator/session.rs
+++ b/mirrord/cli/src/operator/session.rs
@@ -97,11 +97,11 @@ impl SessionCommandHandler {
 
         // We're interested in the `Status`es, so we map the results into those.
         match command {
-            SessionCommand::Kill { id } => session_api
+            SessionCommand::Stop { id: Some(id), .. } => session_api
                 .delete(&format!("{id}"), &Default::default())
                 .await
                 .map(|either| either.right()),
-            SessionCommand::KillAll => session_api
+            SessionCommand::Stop { id: None, .. } | SessionCommand::KillAll => session_api
                 .delete_collection(&Default::default(), &Default::default())
                 .await
                 .map(|either| either.right()),

--- a/mirrord/cli/src/preview.rs
+++ b/mirrord/cli/src/preview.rs
@@ -54,7 +54,10 @@ use mirrord_progress::{Progress, ProgressTracker};
 use tracing::Level;
 
 use crate::{
-    config::{PreviewArgs, PreviewCommand, PreviewStartArgs, PreviewStatusArgs, PreviewStopArgs},
+    config::{
+        PreviewArgs, PreviewCommand, PreviewCommonArgs, PreviewStartArgs, PreviewStatusArgs,
+        PreviewStopArgs,
+    },
     error::{CliError, CliResult},
     user_data::UserData,
 };
@@ -67,10 +70,16 @@ pub(crate) async fn preview_command(
     watch: drain::Watch,
     user_data: &UserData,
 ) -> CliResult<()> {
-    match args.command {
-        PreviewCommand::Start(start_args) => preview_start(start_args, watch, user_data).await,
-        PreviewCommand::Status(status_args) => preview_status(status_args, watch, user_data).await,
-        PreviewCommand::Stop(stop_args) => preview_stop(stop_args, watch, user_data).await,
+    let PreviewArgs { common, command } = args;
+
+    match command {
+        PreviewCommand::Start(start_args) => {
+            preview_start(&common, start_args, watch, user_data).await
+        }
+        PreviewCommand::Status(status_args) => {
+            preview_status(&common, status_args, watch, user_data).await
+        }
+        PreviewCommand::Stop(stop_args) => preview_stop(&common, stop_args, watch, user_data).await,
     }
 }
 
@@ -88,13 +97,14 @@ pub const PREVIEW_SESSION_KEY_LABEL: &str = "preview.mirrord.metalbear.co/key";
 /// the status until `Ready` or failure.
 #[tracing::instrument(level = Level::TRACE, ret, skip_all)]
 async fn preview_start(
+    common: &PreviewCommonArgs,
     args: PreviewStartArgs,
     watch: drain::Watch,
     user_data: &UserData,
 ) -> CliResult<()> {
     let mut progress = ProgressTracker::from_env("mirrord preview start");
 
-    let mut layer_config = load_preview_config(args.as_env_vars(), &mut progress)?;
+    let mut layer_config = load_preview_config(args.as_env_vars(common), &mut progress)?;
 
     let mut analytics = AnalyticsReporter::only_error(
         layer_config.telemetry,
@@ -475,13 +485,14 @@ async fn preview_start(
 /// sessions should be shown.
 #[tracing::instrument(level = Level::TRACE, ret, skip_all)]
 async fn preview_status(
+    common: &PreviewCommonArgs,
     args: PreviewStatusArgs,
     watch: drain::Watch,
     user_data: &UserData,
 ) -> CliResult<()> {
     let mut progress = ProgressTracker::from_env("mirrord preview status");
 
-    let layer_config = load_preview_config(args.as_env_vars(), &mut progress)?;
+    let layer_config = load_preview_config(args.as_env_vars(common), &mut progress)?;
 
     let mut analytics = AnalyticsReporter::only_error(
         layer_config.telemetry,
@@ -491,11 +502,13 @@ async fn preview_status(
         Some(layer_config.key.as_str().to_owned()),
     );
 
-    // Default to all namespaces when no namespace is configured, so `mirrord preview status`
-    // with no flags shows everything.
-    let all_namespaces = args.all_namespaces || layer_config.target.namespace.is_none();
-    let (operator_api, api) =
-        create_preview_api(&layer_config, all_namespaces, &progress, &mut analytics).await?;
+    let (operator_api, api) = create_preview_api(
+        &layer_config,
+        args.all_namespaces,
+        &progress,
+        &mut analytics,
+    )
+    .await?;
 
     // List and filter sessions.
 
@@ -671,13 +684,14 @@ async fn preview_status(
 /// namespace.
 #[tracing::instrument(level = Level::TRACE, ret, skip_all)]
 async fn preview_stop(
+    common: &PreviewCommonArgs,
     args: PreviewStopArgs,
     watch: drain::Watch,
     user_data: &UserData,
 ) -> CliResult<()> {
     let mut progress = ProgressTracker::from_env("mirrord preview stop");
 
-    let layer_config = load_preview_config(args.as_env_vars(), &mut progress)?;
+    let layer_config = load_preview_config(args.as_env_vars(common), &mut progress)?;
 
     let mut analytics = AnalyticsReporter::only_error(
         layer_config.telemetry,
@@ -697,10 +711,13 @@ async fn preview_stop(
         ),
     };
 
-    // Default to all namespaces when no namespace is configured, same as `status`.
-    let all_namespaces = args.all_namespaces || layer_config.target.namespace.is_none();
-    let (operator_api, api) =
-        create_preview_api(&layer_config, all_namespaces, &progress, &mut analytics).await?;
+    let (operator_api, api) = create_preview_api(
+        &layer_config,
+        args.all_namespaces,
+        &progress,
+        &mut analytics,
+    )
+    .await?;
 
     let mut subtask = progress.subtask("finding preview sessions");
 

--- a/mirrord/cli/src/preview.rs
+++ b/mirrord/cli/src/preview.rs
@@ -51,6 +51,7 @@ use mirrord_operator::{
     types::OPERATOR_OWNERSHIP_LABEL,
 };
 use mirrord_progress::{Progress, ProgressTracker};
+use prettytable::{Table, row};
 use tracing::Level;
 
 use crate::{
@@ -571,7 +572,7 @@ async fn preview_status(
     // concurrently so the command costs one round trip rather than one per session.
     let views = multicluster::cluster_views(operator_api.client(), &sessions).await;
 
-    // Display sessions grouped by key.
+    // Display sessions ordered by key.
 
     let mut sessions_by_key: BTreeMap<&str, Vec<&PreviewSession>> = BTreeMap::new();
 
@@ -582,9 +583,18 @@ async fn preview_status(
             .push(session);
     }
 
-    for (key, sessions) in sessions_by_key {
-        println!("  {key}:",);
+    let mut table = Table::new();
+    table.add_row(row![
+        "Key",
+        "Session ID",
+        "Target",
+        "Namespace",
+        "Status",
+        "Clusters",
+        "Message"
+    ]);
 
+    for (key, sessions) in sessions_by_key {
         for session in sessions.iter() {
             let session_name = session.metadata.name.as_deref().unwrap_or("<unknown>");
 
@@ -623,22 +633,15 @@ async fn preview_status(
                 None => "pending".to_owned(),
             };
 
-            println!(
-                "    * {} ({} @ {}): {}",
-                session_name,
-                session.spec.target,
-                session.metadata.namespace.as_deref().unwrap_or("<unknown>"),
-                status
-            );
-
             // Multicluster detail from the previews view, best-effort (older operators do
             // not serve it): the per-cluster phases `preview start` waited on, and any
             // replica degradation - so `status` can actually re-check what `start` reported.
-            if let Some(namespace) = session.metadata.namespace.as_deref()
-                && let Some(view_status) =
-                    views.get(&(namespace.to_owned(), session_name.to_owned()))
-            {
-                if !view_status.clusters.is_empty() {
+            let (clusters, message) = session
+                .metadata
+                .namespace
+                .as_deref()
+                .and_then(|namespace| views.get(&(namespace.to_owned(), session_name.to_owned())))
+                .map(|view_status| {
                     let clusters = view_status
                         .clusters
                         .iter()
@@ -646,17 +649,33 @@ async fn preview_status(
                             format!("{cluster}: {}", status.phase.to_string().to_lowercase())
                         })
                         .join(", ");
-                    println!("        clusters: {clusters}");
-                }
-                if let Some(message) = &view_status.message {
-                    let label = match message.kind {
-                        PreviewMessageKind::Failure => "failure",
-                        PreviewMessageKind::Degraded => "degraded",
-                        PreviewMessageKind::Unknown => "unknown",
-                    };
-                    println!("        {label}: {}", message.text);
-                }
-            }
+
+                    let message = view_status
+                        .message
+                        .as_ref()
+                        .map(|message| {
+                            let label = match message.kind {
+                                PreviewMessageKind::Failure => "failure",
+                                PreviewMessageKind::Degraded => "degraded",
+                                PreviewMessageKind::Unknown => "unknown",
+                            };
+                            format!("{label}: {}", message.text)
+                        })
+                        .unwrap_or_default();
+
+                    (clusters, message)
+                })
+                .unwrap_or_default();
+
+            table.add_row(row![
+                key,
+                session_name,
+                session.spec.target,
+                session.metadata.namespace.as_deref().unwrap_or_default(),
+                status,
+                clusters,
+                message
+            ]);
 
             if let Some(license_fingerprint) =
                 operator_api.operator().spec.license.fingerprint.as_deref()
@@ -675,6 +694,8 @@ async fn preview_status(
             }
         }
     }
+
+    table.printstd();
 
     Ok(())
 }

--- a/mirrord/cli/src/session.rs
+++ b/mirrord/cli/src/session.rs
@@ -47,7 +47,7 @@ pub async fn session_command(args: SessionArgs) -> Result<(), CliError> {
 
     match command.unwrap_or_else(LocalSessionCommand::default) {
         LocalSessionCommand::List(args) => list_command(&common, args).await,
-        LocalSessionCommand::Delete(args) => delete_command(&common, args).await,
+        LocalSessionCommand::Stop(args) => delete_command(&common, args).await,
     }
 }
 
@@ -262,12 +262,15 @@ async fn load_remote_sessions(
         remove_proxy_env();
     }
 
-    let current_namespace = match &layer_config.target.namespace {
-        Some(namespace) => namespace.clone(),
-        None => crate::kube::kube_client_from_layer_config(&layer_config)
-            .await?
-            .default_namespace()
-            .to_owned(),
+    let current_namespace = match (common.all_namespaces, &layer_config.target.namespace) {
+        (true, _) => None,
+        (false, Some(namespace)) => Some(namespace.clone()),
+        (false, None) => Some(
+            crate::kube::kube_client_from_layer_config(&layer_config)
+                .await?
+                .default_namespace()
+                .to_owned(),
+        ),
     };
 
     let progress = NullProgress {};
@@ -282,7 +285,7 @@ async fn load_remote_sessions(
         None => return Ok(Vec::new()),
     };
 
-    let sessions = match list_active_sessions(&api, &current_namespace, key).await {
+    let sessions = match list_active_sessions(&api, current_namespace.as_deref(), key).await {
         Ok(sessions) => sessions,
         // Match on the HTTP code, not `Status::is_not_found`/`is_forbidden`, as they rely on the
         // `reason` string, which is not available for an empty body `404` from an un-upgraded
@@ -293,7 +296,7 @@ async fn load_remote_sessions(
                 "active-sessions API unavailable, falling back to operator status"
             );
 
-            list_active_sessions_fallback(&api, &current_namespace, key)?
+            list_active_sessions_fallback(&api, current_namespace.as_deref(), key)?
         }
         Err(error) => {
             return Err(CliError::OperatorApiFailed(
@@ -307,7 +310,7 @@ async fn load_remote_sessions(
     // UI and browser extension can surface them, but they're not real exec sessions and
     // don't behave like ones (different id shape, no locked ports, no queue-splitting
     // state), so we hide them from `mirrord session` to avoid confusing users into running
-    // e.g. `mirrord session delete` against a preview.
+    // e.g. `mirrord session stop` against a preview.
     Ok(sessions
         .into_iter()
         .filter(|session| !session.is_preview())
@@ -316,10 +319,13 @@ async fn load_remote_sessions(
 
 async fn list_active_sessions(
     api: &OperatorApi<NoClientCert>,
-    namespace: &str,
+    namespace: Option<&str>,
     key: Option<&str>,
 ) -> Result<Vec<OperatorStatusSession>, kube::Error> {
-    let session_api: Api<SessionCrd> = Api::namespaced(api.client().clone(), namespace);
+    let session_api: Api<SessionCrd> = match namespace {
+        Some(namespace) => Api::namespaced(api.client().clone(), namespace),
+        None => Api::all(api.client().clone()),
+    };
 
     let list_params = ListParams {
         field_selector: key
@@ -337,7 +343,7 @@ async fn list_active_sessions(
 
 fn list_active_sessions_fallback(
     api: &OperatorApi<NoClientCert>,
-    namespace: &str,
+    namespace: Option<&str>,
     key: Option<&str>,
 ) -> Result<Vec<OperatorStatusSession>, CliError> {
     Ok(api
@@ -347,7 +353,9 @@ fn list_active_sessions_fallback(
         .ok_or(CliError::OperatorStatusNotFound)?
         .sessions
         .into_iter()
-        .filter(|session| session.namespace.as_deref() == Some(namespace))
+        .filter(|session| {
+            namespace.is_none_or(|namespace| session.namespace.as_deref() == Some(namespace))
+        })
         .filter(|session| {
             key.map(|key| session.key.as_deref() == Some(key))
                 .unwrap_or(true)


### PR DESCRIPTION
## Summary

Fixes all the inconsistencies pointed out by [COR-1727](https://linear.app/metalbear/issue/COR-1727/ensure-consistency-across-cli-subcommands).

Also makes `preview status` use `prettytable` like all the other listing subcommands :)