### PR TITLE
Expose CRD state through status and print columns

### DIFF
--- a/changelog.d/+copy-target-expiry.added.md
+++ b/changelog.d/+copy-target-expiry.added.md
@@ -1,0 +1,1 @@
+Copy targets report when they become eligible for deletion.

--- a/changelog.d/+crd-print-columns.added.md
+++ b/changelog.d/+crd-print-columns.added.md
@@ -1,0 +1,1 @@
+`kubectl get` shows phase, readiness, target, and timing details for mirrord resources.

--- a/changelog.d/+profile-accepted.added.md
+++ b/changelog.d/+profile-accepted.added.md
@@ -1,0 +1,1 @@
+Profiles and queue registries report whether the operator accepted them.

--- a/changelog.d/+ready-conditions.added.md
+++ b/changelog.d/+ready-conditions.added.md
@@ -1,0 +1,1 @@
+Branch databases and preview sessions report a `Ready` condition.

--- a/mirrord/cli/src/preview.rs
+++ b/mirrord/cli/src/preview.rs
@@ -396,6 +396,9 @@ async fn preview_start(
                                     subtask.failure(None);
                                     return Err(CliError::PreviewSessionFailed(failure_message));
                                 }
+                                PreviewSessionPhase::Paused => {
+                                    last_known_phase = "preview session is paused";
+                                }
                                 PreviewSessionPhase::Unknown => last_known_phase = "unknown",
                             }
                         }
@@ -629,6 +632,7 @@ async fn preview_status(
                     .unwrap_or("unknown")
                     .to_owned(),
                 Some(PreviewSessionPhase::Idle) => "idle (waiting for traffic)".to_owned(),
+                Some(PreviewSessionPhase::Paused) => "paused".to_owned(),
                 Some(PreviewSessionPhase::Unknown) => "unknown".to_owned(),
                 None => "pending".to_owned(),
             };

--- a/mirrord/cli/src/ui/server.rs
+++ b/mirrord/cli/src/ui/server.rs
@@ -183,6 +183,7 @@ pub enum OperatorPreviewPhase {
     Ready,
     Failed,
     Idle,
+    Paused,
     Unknown,
 }
 
@@ -194,6 +195,7 @@ impl From<PreviewSessionPhase> for OperatorPreviewPhase {
             PreviewSessionPhase::Ready => Self::Ready,
             PreviewSessionPhase::Failed => Self::Failed,
             PreviewSessionPhase::Idle => Self::Idle,
+            PreviewSessionPhase::Paused => Self::Paused,
             PreviewSessionPhase::Unknown => Self::Unknown,
         }
     }
@@ -1460,6 +1462,7 @@ mod tests {
                 kafka: None,
                 key: Some(key.to_owned()),
                 http_filter: None,
+                created_at: None,
             }
         }
 

--- a/mirrord/operator/src/client.rs
+++ b/mirrord/operator/src/client.rs
@@ -55,7 +55,7 @@ use crate::{
     crd::{
         MirrordClusterOperatorUserCredential, MirrordOperatorCrd, NewOperatorFeature,
         OPERATOR_STATUS_NAME, TargetCrd,
-        copy_target::{CopyTargetCrd, CopyTargetSpec, CopyTargetStatus},
+        copy_target::{CopyTargetCrd, CopyTargetPhase, CopyTargetSpec},
         db_branching::{
             branch_database::BranchDatabase, mongodb::MongodbBranchDatabase,
             mysql::MysqlBranchDatabase, pg::PgBranchDatabase,
@@ -1486,7 +1486,7 @@ impl OperatorApi<PreparedClientCert> {
                 copied
                     .status
                     .as_ref()
-                    .and_then(|copy_crd| copy_crd.creator_session.id.as_deref())
+                    .and_then(|copy_crd| copy_crd.creator_session().id.as_deref())
             };
 
             let connect_url = Self::copy_target_connect_url(
@@ -1596,7 +1596,7 @@ impl OperatorApi<PreparedClientCert> {
                 let session_id = copied
                     .status
                     .as_ref()
-                    .and_then(|copy_crd| copy_crd.creator_session.id.as_deref());
+                    .and_then(|copy_crd| copy_crd.creator_session().id.as_deref());
                 let session = self.make_operator_session(
                     session_id,
                     connect_url,
@@ -1702,7 +1702,7 @@ impl OperatorApi<PreparedClientCert> {
                 copied
                     .status
                     .as_ref()
-                    .and_then(|copy_crd| copy_crd.creator_session.id.as_deref())
+                    .and_then(|copy_crd| copy_crd.creator_session().id.as_deref())
             };
 
             let connect_url = Self::copy_target_connect_url(
@@ -2275,8 +2275,8 @@ impl OperatorApi<PreparedClientCert> {
             .find(|copy_target| {
                 copy_target.spec == copy_target_spec
                     && copy_target.status.as_ref().is_some_and(|status| {
-                        status.creator_session.user_id.as_ref() == Some(&user_id)
-                            && status.phase.as_deref() != Some(CopyTargetStatus::PHASE_FAILED)
+                        status.creator_session().user_id.as_ref() == Some(&user_id)
+                            && status.phase() != Some(&CopyTargetPhase::Failed)
                     })
             });
 
@@ -2318,28 +2318,27 @@ impl OperatorApi<PreparedClientCert> {
         let mut wait_subtask: Option<P> = None;
 
         loop {
-            let phase = copied
-                .status
-                .as_ref()
-                .and_then(|status| status.phase.as_deref());
+            let phase = copied.status.as_ref().and_then(|status| status.phase());
             match phase {
-                Some(CopyTargetStatus::PHASE_IN_PROGRESS) => {
+                Some(CopyTargetPhase::InProgress) => {
                     if wait_subtask.is_none() {
                         wait_subtask.replace(progress.subtask("waiting for the copy to be ready"));
                     }
                 }
-                Some(CopyTargetStatus::PHASE_READY) | None => {
+                Some(CopyTargetPhase::Ready) | None => {
                     if let Some(mut subtask) = wait_subtask {
                         subtask.success(None);
                     }
                     break Ok(copied);
                 }
-                Some(CopyTargetStatus::PHASE_FAILED) => {
+                Some(CopyTargetPhase::Failed) => {
                     break Err(OperatorApiError::CopiedTargetFailed {
-                        message: copied.status.and_then(|status| status.failure_message),
+                        message: copied
+                            .status
+                            .and_then(|status| status.failure_message().map(str::to_owned)),
                     });
                 }
-                Some(other) => {
+                Some(CopyTargetPhase::Unknown(other)) => {
                     break Err(OperatorApiError::CopiedTargetFailed {
                         message: Some(format!("unknown phase `{other}`")),
                     });

--- a/mirrord/operator/src/client/database_branches.rs
+++ b/mirrord/operator/src/client/database_branches.rs
@@ -1668,7 +1668,11 @@ pub async fn ensure_branch_migrations<P: Progress>(
         db.and_then(|db| db.status.as_ref())
             .and_then(|status| status.migrations.as_ref())
             .is_some_and(|run| {
-                run.observed_generation >= generation && run.phase != MigrationPhase::Running
+                run.observed_generation >= generation
+                    && matches!(
+                        run.phase,
+                        MigrationPhase::Succeeded | MigrationPhase::Failed
+                    )
             })
     });
 

--- a/mirrord/operator/src/crd.rs
+++ b/mirrord/operator/src/crd.rs
@@ -737,6 +737,11 @@ pub enum NewOperatorFeature {
     /// schema rejecting the CR (those fields used to be required).
     GenericBranchProfileDefaults,
 
+    /// This operator publishes a `Ready` condition on the `MirrordClusterSession`s it owns, so a
+    /// multi-cluster primary can wait for this cluster to report a child session ready instead of
+    /// assuming it is ready the moment it was created.
+    SessionReadyCondition,
+
     /// This variant is what a client sees when the operator includes a feature the client is not
     /// yet aware of, because it was introduced in a version newer than the client's.
     #[schemars(skip)]
@@ -799,6 +804,7 @@ impl Display for NewOperatorFeature {
             NewOperatorFeature::GenericBranchProfileDefaults => {
                 "generic db branch profile defaults"
             }
+            NewOperatorFeature::SessionReadyCondition => "session readiness reporting",
             NewOperatorFeature::Unknown => "unknown feature",
         };
         f.write_str(name)

--- a/mirrord/operator/src/crd.rs
+++ b/mirrord/operator/src/crd.rs
@@ -6,7 +6,7 @@ use std::{
 
 use k8s_openapi::{
     ByteString,
-    apimachinery::pkg::apis::meta::v1::{MicroTime, OwnerReference},
+    apimachinery::pkg::apis::meta::v1::{Condition, MicroTime, OwnerReference, Time},
 };
 use kube::CustomResource;
 use kube_target::{KubeTarget, UnknownTargetType};
@@ -518,6 +518,8 @@ pub struct Session {
     pub key: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub http_filter: Option<SessionHttpFilter>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<Time>,
 }
 
 impl Session {
@@ -1026,9 +1028,17 @@ impl ActiveSqsSplits {
 #[derive(Clone, Debug, Default, Deserialize, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")] // sqs_details -> sqsDetails
 pub struct WorkloadQueueRegistryStatus {
-    /// Optional even though it's currently the only field, because in the future there will be
-    /// fields for other queue types.
+    /// Active SQS splits.
     pub sqs_details: Option<ActiveSqsSplits>,
+
+    /// Observed generation of the spec.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub observed_generation: Option<i64>,
+
+    /// Standard conditions.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[schemars(extend("x-kubernetes-list-type" = "map", "x-kubernetes-list-map-keys" = ["type"]))]
+    pub conditions: Vec<Condition>,
 }
 
 /// Defines a Custom Resource that holds a central configuration for splitting queues for a
@@ -1040,9 +1050,15 @@ pub struct WorkloadQueueRegistryStatus {
     group = "queues.mirrord.metalbear.co",
     version = "v1alpha",
     kind = "MirrordWorkloadQueueRegistry",
+    category = "mirrord",
     shortname = "qs",
     status = "WorkloadQueueRegistryStatus",
-    namespaced
+    namespaced,
+    printcolumn = r#"{"name":"Target Kind", "type":"string", "description":"Kind of the consumer workload.", "jsonPath":".spec.consumer.workloadType"}"#,
+    printcolumn = r#"{"name":"Target Name", "type":"string", "description":"Name of the consumer workload.", "jsonPath":".spec.consumer.name"}"#,
+    printcolumn = r#"{"name":"Accepted", "type":"string", "description":"Whether the operator resolved this registry into a split configuration.", "jsonPath":".status.conditions[?(@.type==\"Accepted\")].status"}"#,
+    printcolumn = r#"{"name":"Detail", "type":"string", "description":"Why the registry could not be resolved.", "jsonPath":".status.conditions[?(@.type==\"Accepted\")].message", "priority":1}"#,
+    printcolumn = r#"{"name":"Age", "type":"date", "description":"Time since the resource was created.", "jsonPath":".metadata.creationTimestamp"}"#
 )]
 #[serde(rename_all = "camelCase")]
 pub struct MirrordWorkloadQueueRegistrySpec {
@@ -1148,9 +1164,14 @@ pub fn is_session_ready(session: Option<&MirrordSqsSession>) -> bool {
     group = "queues.mirrord.metalbear.co",
     version = "v1alpha",
     kind = "MirrordSQSSession",
+    category = "mirrord",
     root = "MirrordSqsSession", // for Rust naming conventions (Sqs, not SQS)
     status = "SqsSessionStatus",
-    namespaced
+    namespaced,
+    printcolumn = r#"{"name":"Target Kind", "type":"string", "description":"Kind of the target workload.", "jsonPath":".spec.queueConsumer.workloadType"}"#,
+    printcolumn = r#"{"name":"Target Name", "type":"string", "description":"Name of the target workload.", "jsonPath":".spec.queueConsumer.name"}"#,
+    printcolumn = r#"{"name":"Session", "type":"string", "description":"mirrord session id that owns this split.", "jsonPath":".spec.sessionId", "priority":1}"#,
+    printcolumn = r#"{"name":"Age", "type":"date", "description":"Time since the resource was created.", "jsonPath":".metadata.creationTimestamp"}"#
 )]
 #[serde(rename_all = "camelCase")] // queue_filters -> queueFilters
 pub struct MirrordSqsSessionSpec {

--- a/mirrord/operator/src/crd/copy_target.rs
+++ b/mirrord/operator/src/crd/copy_target.rs
@@ -1,3 +1,6 @@
+use std::borrow::Cow;
+
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::Time;
 use kube::CustomResource;
 use mirrord_config::{feature::split_queues::SplitQueuesConfig, target::Target};
 use schemars::JsonSchema;
@@ -13,7 +16,7 @@ use crate::crd::Session;
     version = "v1",
     kind = "CopyTarget",
     root = "CopyTargetCrd",
-    status = "CopyTargetStatus",
+    status = "CopyTargetStatusCompat",
     namespaced
 )]
 pub struct CopyTargetSpec {
@@ -53,26 +56,112 @@ pub struct CopyTargetSpec {
 
 /// This is the `status` field for [`CopyTargetCrd`].
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct CopyTargetStatus {
     /// The session object of the original operator session that created this CopyTarget.
     pub creator_session: Session,
     /// Current phase of the copy.
     ///
-    /// Either `InProgress`, `Ready`, or `Failed`.
-    /// Stored as a string for some future compatibility.
+    /// Not filled by older operator versions.
+    pub phase: Option<CopyTargetPhase>,
+    /// Optional message describing the reason for copy failure.
+    ///
+    /// Only set when `phase` is `Failed`.
+    pub failure_message: Option<String>,
+    /// When the copy becomes eligible for deletion.
+    pub expires_at: Option<Time>,
+}
+
+/// Legacy form of [`CopyTargetStatus].
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
+pub struct CopyTargetStatusLegacy {
+    /// The session object of the original operator session that created this CopyTarget.
+    pub creator_session: Session,
+    /// Current phase of the copy.
     ///
     /// Not filled by older operator versions.
-    pub phase: Option<String>,
+    pub phase: Option<CopyTargetPhase>,
     /// Optional message describing the reason for copy failure.
     ///
     /// Only set when `phase` is `Failed`.
     pub failure_message: Option<String>,
 }
 
-impl CopyTargetStatus {
-    pub const PHASE_IN_PROGRESS: &'static str = "InProgress";
-    pub const PHASE_READY: &'static str = "Ready";
-    pub const PHASE_FAILED: &'static str = "Failed";
+/// The shape a copy target's status is served in.
+///
+/// Current clients read [`CopyTargetStatus`]; clients released before it read
+/// [`CopyTargetStatusLegacy`], which the operator serves them instead. Untagged, so either shape
+/// deserializes: the two are unambiguous because one requires `creatorSession` and the other
+/// `creator_session`.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum CopyTargetStatusCompat {
+    Modern(CopyTargetStatus),
+    Legacy(CopyTargetStatusLegacy),
+}
+
+impl JsonSchema for CopyTargetStatusCompat {
+    fn schema_name() -> Cow<'static, str> {
+        "CopyTargetStatus".into()
+    }
+
+    fn json_schema(schema_gen: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        CopyTargetStatus::json_schema(schema_gen)
+    }
+}
+
+impl CopyTargetStatusCompat {
+    pub fn creator_session(&self) -> &Session {
+        match self {
+            Self::Modern(status) => &status.creator_session,
+            Self::Legacy(status) => &status.creator_session,
+        }
+    }
+
+    pub fn phase(&self) -> Option<&CopyTargetPhase> {
+        match self {
+            Self::Modern(status) => status.phase.as_ref(),
+            Self::Legacy(status) => status.phase.as_ref(),
+        }
+    }
+
+    pub fn failure_message(&self) -> Option<&str> {
+        match self {
+            Self::Modern(status) => status.failure_message.as_deref(),
+            Self::Legacy(status) => status.failure_message.as_deref(),
+        }
+    }
+
+    /// Absent in the legacy shape, which has no field for it.
+    pub fn expires_at(&self) -> Option<&Time> {
+        match self {
+            Self::Modern(status) => status.expires_at.as_ref(),
+            Self::Legacy(_) => None,
+        }
+    }
+
+    /// Rewrites this status into the shape a client released before `expiresAt` reads.
+    #[must_use]
+    pub fn into_legacy(self) -> Self {
+        match self {
+            Self::Modern(status) => Self::Legacy(CopyTargetStatusLegacy {
+                creator_session: status.creator_session,
+                phase: status.phase,
+                failure_message: status.failure_message,
+            }),
+            legacy => legacy,
+        }
+    }
+}
+
+/// Stage a copied pod has reached.
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+pub enum CopyTargetPhase {
+    InProgress,
+    Ready,
+    Failed,
+    #[serde(untagged)]
+    Unknown(String),
 }
 
 /// Generates a permissive schema for [`CopyTargetSpec::split_queues`].
@@ -89,4 +178,50 @@ fn split_queues_schema(_generator: &mut schemars::SchemaGenerator) -> schemars::
         serde_json::Value::Bool(true),
     );
     schema
+}
+
+#[cfg(test)]
+mod status_compat {
+    use super::*;
+
+    fn session() -> serde_json::Value {
+        serde_json::json!({"duration_secs": 1, "user": "u", "target": "t"})
+    }
+
+    fn modern() -> CopyTargetStatusCompat {
+        serde_json::from_value(serde_json::json!({
+            "creatorSession": session(),
+            "phase": "Ready",
+            "expiresAt": "2026-01-01T00:00:00Z",
+        }))
+        .expect("the modern shape deserializes")
+    }
+
+    #[test]
+    fn a_current_client_is_served_the_expiry() {
+        let value = serde_json::to_value(modern()).expect("serializes");
+
+        assert!(value.get("creatorSession").is_some(), "{value}");
+        assert!(value.get("expiresAt").is_some(), "{value}");
+    }
+
+    #[test]
+    fn a_legacy_client_is_served_neither() {
+        let value = serde_json::to_value(modern().into_legacy()).expect("serializes");
+
+        assert!(value.get("creator_session").is_some(), "{value}");
+        assert!(value.get("creatorSession").is_none(), "{value}");
+        assert!(value.get("expiresAt").is_none(), "{value}");
+    }
+
+    #[test]
+    fn each_shape_deserializes_to_its_own_variant() {
+        let legacy: CopyTargetStatusCompat =
+            serde_json::from_value(serde_json::json!({"creator_session": session()}))
+                .expect("the legacy shape deserializes");
+
+        assert!(matches!(legacy, CopyTargetStatusCompat::Legacy(..)));
+        assert!(matches!(modern(), CopyTargetStatusCompat::Modern(..)));
+        assert_eq!(legacy.expires_at(), None);
+    }
 }

--- a/mirrord/operator/src/crd/db_branching/branch_database.rs
+++ b/mirrord/operator/src/crd/db_branching/branch_database.rs
@@ -27,8 +27,17 @@ use crate::crd::session::KubeResourceTarget;
     group = "dbs.mirrord.metalbear.co",
     version = "v1alpha1",
     kind = "BranchDatabase",
+    category = "mirrord",
     status = "BranchDatabaseStatus",
-    namespaced
+    namespaced,
+    printcolumn = r#"{"name":"Phase", "type":"string", "description":"Lifecycle phase of the branch database.", "jsonPath":".status.phase"}"#,
+    printcolumn = r#"{"name":"Ready", "type":"string", "description":"Whether the resource is ready to use.", "jsonPath":".status.conditions[?(@.type==\"Ready\")].status"}"#,
+    printcolumn = r#"{"name":"Pod", "type":"string", "description":"Pod backing the branch database.", "jsonPath":".status.podName"}"#,
+    printcolumn = r#"{"name":"Expires", "type":"string", "description":"When the branch database is scheduled to be deleted.", "jsonPath":".status.expireTime"}"#,
+    printcolumn = r#"{"name":"Migrations", "type":"string", "description":"Outcome of the branch's schema migrations.", "jsonPath":".status.migrations.phase", "priority":1}"#,
+    printcolumn = r#"{"name":"Copy", "type":"string", "description":"Outcome of a generic branch's copy Job.", "jsonPath":".status.copy.phase", "priority":1}"#,
+    printcolumn = r#"{"name":"Error", "type":"string", "description":"Why the branch database failed.", "jsonPath":".status.error", "priority":1}"#,
+    printcolumn = r#"{"name":"Age", "type":"date", "description":"Time since the resource was created.", "jsonPath":".metadata.creationTimestamp"}"#
 )]
 #[serde(rename_all = "camelCase")]
 pub struct BranchDatabaseSpec {

--- a/mirrord/operator/src/crd/db_branching/core.rs
+++ b/mirrord/operator/src/crd/db_branching/core.rs
@@ -280,6 +280,10 @@ pub enum BranchDatabasePhase {
     Ready,
     /// The branch database creation failed.
     Failed,
+    /// A phase this build does not recognise.
+    #[schemars(skip)]
+    #[serde(other)]
+    Unknown,
 }
 
 impl std::fmt::Display for BranchDatabasePhase {
@@ -288,6 +292,7 @@ impl std::fmt::Display for BranchDatabasePhase {
             BranchDatabasePhase::Init => write!(f, "Init"),
             BranchDatabasePhase::Pending => write!(f, "Pending"),
             BranchDatabasePhase::Ready => write!(f, "Ready"),
+            BranchDatabasePhase::Unknown => write!(f, "Unknown"),
             BranchDatabasePhase::Failed => write!(f, "Failed"),
         }
     }
@@ -340,6 +345,10 @@ pub enum MigrationPhase {
     Running,
     Succeeded,
     Failed,
+    /// A phase this build does not recognise.
+    #[schemars(skip)]
+    #[serde(other)]
+    Unknown,
 }
 
 /// IAM authentication configuration for connecting to cloud-managed databases.
@@ -417,6 +426,13 @@ impl JsonSchema for IamAuthConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn unknown_migration_phase_deserializes_as_unknown() {
+        let phase: MigrationPhase = serde_json::from_value(serde_json::json!("SomeFuturePhase"))
+            .expect("unknown phases should fall back to Unknown");
+        assert_eq!(phase, MigrationPhase::Unknown);
+    }
 
     /// The client config's flat engine-specific keys survive the conversion into the CRD spec:
     /// fixed slots keep their own resolution, and every `extra` key is carried across.

--- a/mirrord/operator/src/crd/db_branching/core.rs
+++ b/mirrord/operator/src/crd/db_branching/core.rs
@@ -4,7 +4,7 @@ use std::{
     fmt::Formatter,
 };
 
-use k8s_openapi::apimachinery::pkg::apis::meta::v1::MicroTime;
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::{Condition, MicroTime};
 use mirrord_config::feature::database_branches::{
     ConnectionParamsConfig, ConnectionSourceType, ParamSource, SingleOrVec,
     TargetEnvironmentVariableSource,
@@ -315,6 +315,10 @@ pub struct BranchDatabaseStatus {
     /// generation bumps.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub copy: Option<MigrationRun>,
+    /// Standard conditions.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[schemars(extend("x-kubernetes-list-type" = "map", "x-kubernetes-list-map-keys" = ["type"]))]
+    pub conditions: Vec<Condition>,
 }
 
 /// Outcome of running a branch's migrations.

--- a/mirrord/operator/src/crd/db_branching/mongodb.rs
+++ b/mirrord/operator/src/crd/db_branching/mongodb.rs
@@ -17,8 +17,16 @@ pub use super::core::{
     group = "dbs.mirrord.metalbear.co",
     version = "v1alpha1",
     kind = "MongodbBranchDatabase",
+    category = "mirrord",
     status = "BranchDatabaseStatus",
-    namespaced
+    namespaced,
+    printcolumn = r#"{"name":"Phase", "type":"string", "description":"Lifecycle phase of the branch database.", "jsonPath":".status.phase"}"#,
+    printcolumn = r#"{"name":"Ready", "type":"string", "description":"Whether the resource is ready to use.", "jsonPath":".status.conditions[?(@.type==\"Ready\")].status"}"#,
+    printcolumn = r#"{"name":"Pod", "type":"string", "description":"Pod backing the branch database.", "jsonPath":".status.podName"}"#,
+    printcolumn = r#"{"name":"Expires", "type":"string", "description":"When the branch database is scheduled to be deleted.", "jsonPath":".status.expireTime"}"#,
+    printcolumn = r#"{"name":"Migrations", "type":"string", "description":"Outcome of the branch's schema migrations.", "jsonPath":".status.migrations.phase", "priority":1}"#,
+    printcolumn = r#"{"name":"Error", "type":"string", "description":"Why the branch database failed.", "jsonPath":".status.error", "priority":1}"#,
+    printcolumn = r#"{"name":"Age", "type":"date", "description":"Time since the resource was created.", "jsonPath":".metadata.creationTimestamp"}"#
 )]
 #[serde(rename_all = "camelCase")]
 pub struct MongodbBranchDatabaseSpec {

--- a/mirrord/operator/src/crd/db_branching/mysql.rs
+++ b/mirrord/operator/src/crd/db_branching/mysql.rs
@@ -17,8 +17,16 @@ pub use super::core::{
     group = "dbs.mirrord.metalbear.co",
     version = "v1alpha1",
     kind = "MysqlBranchDatabase",
+    category = "mirrord",
     status = "BranchDatabaseStatus",
-    namespaced
+    namespaced,
+    printcolumn = r#"{"name":"Phase", "type":"string", "description":"Lifecycle phase of the branch database.", "jsonPath":".status.phase"}"#,
+    printcolumn = r#"{"name":"Ready", "type":"string", "description":"Whether the resource is ready to use.", "jsonPath":".status.conditions[?(@.type==\"Ready\")].status"}"#,
+    printcolumn = r#"{"name":"Pod", "type":"string", "description":"Pod backing the branch database.", "jsonPath":".status.podName"}"#,
+    printcolumn = r#"{"name":"Expires", "type":"string", "description":"When the branch database is scheduled to be deleted.", "jsonPath":".status.expireTime"}"#,
+    printcolumn = r#"{"name":"Migrations", "type":"string", "description":"Outcome of the branch's schema migrations.", "jsonPath":".status.migrations.phase", "priority":1}"#,
+    printcolumn = r#"{"name":"Error", "type":"string", "description":"Why the branch database failed.", "jsonPath":".status.error", "priority":1}"#,
+    printcolumn = r#"{"name":"Age", "type":"date", "description":"Time since the resource was created.", "jsonPath":".metadata.creationTimestamp"}"#
 )]
 #[serde(rename_all = "camelCase")]
 pub struct MysqlBranchDatabaseSpec {

--- a/mirrord/operator/src/crd/db_branching/pg.rs
+++ b/mirrord/operator/src/crd/db_branching/pg.rs
@@ -18,8 +18,16 @@ pub use super::core::{
     group = "dbs.mirrord.metalbear.co",
     version = "v1alpha1",
     kind = "PgBranchDatabase",
+    category = "mirrord",
     status = "BranchDatabaseStatus",
-    namespaced
+    namespaced,
+    printcolumn = r#"{"name":"Phase", "type":"string", "description":"Lifecycle phase of the branch database.", "jsonPath":".status.phase"}"#,
+    printcolumn = r#"{"name":"Ready", "type":"string", "description":"Whether the resource is ready to use.", "jsonPath":".status.conditions[?(@.type==\"Ready\")].status"}"#,
+    printcolumn = r#"{"name":"Pod", "type":"string", "description":"Pod backing the branch database.", "jsonPath":".status.podName"}"#,
+    printcolumn = r#"{"name":"Expires", "type":"string", "description":"When the branch database is scheduled to be deleted.", "jsonPath":".status.expireTime"}"#,
+    printcolumn = r#"{"name":"Migrations", "type":"string", "description":"Outcome of the branch's schema migrations.", "jsonPath":".status.migrations.phase", "priority":1}"#,
+    printcolumn = r#"{"name":"Error", "type":"string", "description":"Why the branch database failed.", "jsonPath":".status.error", "priority":1}"#,
+    printcolumn = r#"{"name":"Age", "type":"date", "description":"Time since the resource was created.", "jsonPath":".metadata.creationTimestamp"}"#
 )]
 #[serde(rename_all = "camelCase")]
 pub struct PgBranchDatabaseSpec {

--- a/mirrord/operator/src/crd/kafka.rs
+++ b/mirrord/operator/src/crd/kafka.rs
@@ -12,9 +12,11 @@ use serde::{Deserialize, Serialize};
     group = "queues.mirrord.metalbear.co",
     version = "v1alpha",
     kind = "MirrordKafkaEphemeralTopic",
+    category = "mirrord",
     namespaced,
-    printcolumn = r#"{"name":"NAME", "type":"string", "description":"Name of the topic.", "jsonPath":".spec.name"}"#,
-    printcolumn = r#"{"name":"CLIENT-CONFIG", "type":"string", "description":"Name of MirrordKafkaClientProperties to use when creating Kafka client.", "jsonPath":".spec.clientConfig"}"#
+    printcolumn = r#"{"name":"Name", "type":"string", "description":"Name of the topic.", "jsonPath":".spec.name"}"#,
+    printcolumn = r#"{"name":"Client Config", "type":"string", "description":"Name of MirrordKafkaClientProperties to use when creating Kafka client.", "jsonPath":".spec.clientConfig"}"#,
+    printcolumn = r#"{"name":"Age", "type":"date", "description":"Time since the resource was created.", "jsonPath":".metadata.creationTimestamp"}"#
 )]
 #[serde(rename_all = "camelCase")]
 pub struct MirrordKafkaEphemeralTopicSpec {

--- a/mirrord/operator/src/crd/preview.rs
+++ b/mirrord/operator/src/crd/preview.rs
@@ -7,7 +7,10 @@
 
 use std::{collections::BTreeMap, time::Duration};
 
-use k8s_openapi::{apimachinery::pkg::apis::meta::v1::MicroTime, jiff::Timestamp};
+use k8s_openapi::{
+    apimachinery::pkg::apis::meta::v1::{Condition, MicroTime},
+    jiff::Timestamp,
+};
 use kube::{
     Api, Client, CustomResource,
     api::{Patch, PatchParams},
@@ -228,7 +231,7 @@ impl PreviewSession {
 }
 
 /// Status of a preview session resource.
-#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct PreviewSessionStatus {
     /// Current lifecycle phase of the session.
@@ -271,14 +274,19 @@ pub struct PreviewSessionStatus {
     /// idle), and cleared when the session becomes `Ready` again.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub idle_since: Option<MicroTime>,
+
+    /// Standard conditions.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[schemars(extend("x-kubernetes-list-type" = "map", "x-kubernetes-list-map-keys" = ["type"]))]
+    pub conditions: Vec<Condition>,
 }
 
 /// Phase of a preview session's lifecycle.
 ///
 /// The session transitions linearly through `Initializing` → `Waiting` → `Ready`.
 /// Sessions with idle mode enabled may additionally move between `Ready`, `Idle`, and
-/// `Waiting` (while waking) any number of times. Any phase may transition to `Failed`
-/// on error.
+/// `Waiting` (while waking) any number of times. `Paused` is entered and left only by
+/// explicit request. Any phase may transition to `Failed` on error.
 #[derive(
     Clone, Copy, Debug, Deserialize, Serialize, JsonSchema, Eq, PartialEq, strum_macros::Display,
 )]
@@ -310,77 +318,33 @@ pub enum PreviewSessionPhase {
 #[serde(rename_all = "camelCase")]
 pub struct PreviewStatusUpdate {
     #[serde(skip_serializing_if = "Option::is_none")]
-    phase: Option<PreviewSessionPhase>,
+    pub phase: Option<PreviewSessionPhase>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    started_at: Option<MicroTime>,
+    pub started_at: Option<MicroTime>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    failure_message: Option<String>,
+    pub failure_message: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    failed_at: Option<MicroTime>,
+    pub failed_at: Option<MicroTime>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    expires_at: Option<MicroTime>,
+    pub expires_at: Option<MicroTime>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    share_host: Option<String>,
+    pub share_host: Option<String>,
 
     /// Double `Option` so the merge patch can distinguish "leave unchanged" (outer `None`,
     /// skipped) from "clear the field" (`Some(None)`, serialized as an explicit `null`).
     #[serde(skip_serializing_if = "Option::is_none")]
-    idle_since: Option<Option<MicroTime>>,
+    pub idle_since: Option<Option<MicroTime>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub conditions: Option<Vec<Condition>>,
 }
 
 impl PreviewStatusUpdate {
-    /// Creates an empty status update.
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Sets `.status.phase`.
-    pub fn phase(mut self, phase: PreviewSessionPhase) -> Self {
-        self.phase = Some(phase);
-        self
-    }
-
-    /// Sets `.status.startedAt`.
-    pub fn started_at(mut self, started_at: MicroTime) -> Self {
-        self.started_at = Some(started_at);
-        self
-    }
-
-    /// Sets `.status.failureMessage`.
-    pub fn failure_message(mut self, failure_message: String) -> Self {
-        self.failure_message = Some(failure_message);
-        self
-    }
-
-    /// Sets `.status.failedAt`.
-    pub fn failed_at(mut self, failed_at: MicroTime) -> Self {
-        self.failed_at = Some(failed_at);
-        self
-    }
-
-    /// Sets `.status.expiresAt`.
-    pub fn expires_at(mut self, expires_at: Option<MicroTime>) -> Self {
-        self.expires_at = expires_at;
-        self
-    }
-
-    /// Sets `.status.shareHost`.
-    pub fn share_host(mut self, share_host: String) -> Self {
-        self.share_host = Some(share_host);
-        self
-    }
-
-    /// Sets `.status.idleSince`. Passing `None` clears the field with an explicit `null`.
-    pub fn idle_since(mut self, idle_since: Option<MicroTime>) -> Self {
-        self.idle_since = Some(idle_since);
-        self
-    }
-
     /// Patches the status sub-resource with a merge patch.
     pub async fn patch(
         self,
@@ -630,12 +594,15 @@ mod tests {
 
     #[test]
     fn idle_since_update_distinguishes_clear_from_unchanged() {
-        let unchanged = serde_json::to_value(PreviewStatusUpdate::new())
+        let unchanged = serde_json::to_value(PreviewStatusUpdate::default())
             .expect("status update should serialize");
         assert_eq!(unchanged, json!({}));
 
-        let cleared = serde_json::to_value(PreviewStatusUpdate::new().idle_since(None))
-            .expect("status update should serialize");
+        let cleared = serde_json::to_value(PreviewStatusUpdate {
+            idle_since: Some(None),
+            ..Default::default()
+        })
+        .expect("status update should serialize");
         assert_eq!(cleared, json!({ "idleSince": null }));
     }
 }

--- a/mirrord/operator/src/crd/preview.rs
+++ b/mirrord/operator/src/crd/preview.rs
@@ -40,9 +40,18 @@ use crate::client::connect_params::BranchDbNames;
     group = "preview.mirrord.metalbear.co",
     version = "v1alpha",
     kind = "PreviewSession",
+    category = "mirrord",
     root = "PreviewSession",
     status = "PreviewSessionStatus",
-    namespaced
+    namespaced,
+    printcolumn = r#"{"name":"Phase", "type":"string", "description":"Lifecycle phase of the preview session.", "jsonPath":".status.phase"}"#,
+    printcolumn = r#"{"name":"Ready", "type":"string", "description":"Whether the resource is ready to use.", "jsonPath":".status.conditions[?(@.type==\"Ready\")].status"}"#,
+    printcolumn = r#"{"name":"Started", "type":"date", "description":"When the operator started processing this session.", "jsonPath":".status.startedAt", "priority":1}"#,
+    printcolumn = r#"{"name":"Expires", "type":"string", "description":"When the session is scheduled to be cleaned up.", "jsonPath":".status.expiresAt", "priority":1}"#,
+    printcolumn = r#"{"name":"Idle", "type":"date", "description":"When the session was scaled to zero.", "jsonPath":".status.idleSince", "priority":1}"#,
+    printcolumn = r#"{"name":"Share Host", "type":"string", "description":"Host the preview is shared on.", "jsonPath":".status.shareHost"}"#,
+    printcolumn = r#"{"name":"Failure", "type":"string", "description":"Why the session failed.", "jsonPath":".status.failureMessage", "priority":1}"#,
+    printcolumn = r#"{"name":"Age", "type":"date", "description":"Time since the resource was created.", "jsonPath":".metadata.creationTimestamp"}"#
 )]
 #[serde(rename_all = "camelCase")]
 pub struct PreviewSessionSpec {
@@ -285,6 +294,9 @@ pub enum PreviewSessionPhase {
     /// Preview pods are scaled to zero, but the session keeps listening for traffic.
     /// Incoming traffic wakes the session (back through `Waiting` to `Ready`).
     Idle,
+    /// Preview pods are scaled to zero because someone paused the session. Unlike `Idle`,
+    /// traffic does not wake it: it stays here until it is explicitly resumed.
+    Paused,
     /// For future compatibility.
     #[serde(other)]
     Unknown,

--- a/mirrord/operator/src/crd/profile.rs
+++ b/mirrord/operator/src/crd/profile.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::Condition;
 use kube::CustomResource;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -18,7 +19,13 @@ use serde_json::Value;
 #[kube(
     group = "profiles.mirrord.metalbear.co",
     version = "v1alpha",
-    kind = "MirrordClusterProfile"
+    kind = "MirrordClusterProfile",
+    category = "mirrord",
+    status = "ProfileStatus",
+    printcolumn = r#"{"name":"Accepted", "type":"string", "description":"Whether the CLI can apply this profile.", "jsonPath":".status.conditions[?(@.type==\"Accepted\")].status"}"#,
+    printcolumn = r#"{"name":"Reason", "type":"string", "description":"Why the profile cannot be applied.", "jsonPath":".status.conditions[?(@.type==\"Accepted\")].reason"}"#,
+    printcolumn = r#"{"name":"Detail", "type":"string", "description":"Which part of the profile the CLI rejects.", "jsonPath":".status.conditions[?(@.type==\"Accepted\")].message", "priority":1}"#,
+    printcolumn = r#"{"name":"Age", "type":"date", "description":"Time since the resource was created.", "jsonPath":".metadata.creationTimestamp"}"#
 )]
 #[serde(rename_all = "camelCase")]
 pub struct MirrordClusterProfileSpec {
@@ -51,7 +58,13 @@ pub struct MirrordClusterProfileSpec {
     group = "profiles.mirrord.metalbear.co",
     version = "v1alpha",
     kind = "MirrordProfile",
-    namespaced
+    category = "mirrord",
+    namespaced,
+    status = "ProfileStatus",
+    printcolumn = r#"{"name":"Accepted", "type":"string", "description":"Whether the CLI can apply this profile.", "jsonPath":".status.conditions[?(@.type==\"Accepted\")].status"}"#,
+    printcolumn = r#"{"name":"Reason", "type":"string", "description":"Why the profile cannot be applied.", "jsonPath":".status.conditions[?(@.type==\"Accepted\")].reason"}"#,
+    printcolumn = r#"{"name":"Detail", "type":"string", "description":"Which part of the profile the CLI rejects.", "jsonPath":".status.conditions[?(@.type==\"Accepted\")].message", "priority":1}"#,
+    printcolumn = r#"{"name":"Age", "type":"date", "description":"Time since the resource was created.", "jsonPath":".metadata.creationTimestamp"}"#
 )]
 #[serde(rename_all = "camelCase")]
 pub struct MirrordProfileSpec {
@@ -81,6 +94,23 @@ pub struct FeatureAdjustment {
     #[schemars(skip)]
     #[serde(flatten, skip_serializing)]
     pub unknown_fields: HashMap<String, Value>,
+}
+
+/// Whether the operator has observed a profile and judged it usable.
+///
+/// A profile is applied by the *CLI*, not the operator, and the CLI hard-errors on an unknown field
+/// or an unrecognised change. Until this status existed the author of a profile learned that only
+/// when somebody selected it and their session failed.
+#[derive(Clone, Debug, Default, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ProfileStatus {
+    /// `metadata.generation` of the spec the operator last reconciled.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub observed_generation: Option<i64>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[schemars(extend("x-kubernetes-list-type" = "map", "x-kubernetes-list-map-keys" = ["type"]))]
+    pub conditions: Vec<Condition>,
 }
 
 /// An adjustment to some mirrord feature.

--- a/mirrord/operator/src/crd/rabbitmq.rs
+++ b/mirrord/operator/src/crd/rabbitmq.rs
@@ -117,8 +117,14 @@ pub fn is_session_ready(session: Option<&MirrordRmqSession>) -> bool {
     group = "queues.mirrord.metalbear.co",
     version = "v1alpha",
     kind = "MirrordRMQSession",
+    category = "mirrord",
     root = "MirrordRmqSession", // for Rust naming conventions (Rmq, not RMQ)
-    status = "RmqSessionStatus"
+    status = "RmqSessionStatus",
+    printcolumn = r#"{"name":"Namespace", "type":"string", "description":"Namespace of the target workload.", "jsonPath":".spec.namespace"}"#,
+    printcolumn = r#"{"name":"Target Kind", "type":"string", "description":"Kind of the target workload.", "jsonPath":".spec.queueConsumer.workloadType"}"#,
+    printcolumn = r#"{"name":"Target Name", "type":"string", "description":"Name of the target workload.", "jsonPath":".spec.queueConsumer.name"}"#,
+    printcolumn = r#"{"name":"Session", "type":"string", "description":"mirrord session id that owns this split.", "jsonPath":".spec.sessionId", "priority":1}"#,
+    printcolumn = r#"{"name":"Age", "type":"date", "description":"Time since the resource was created.", "jsonPath":".metadata.creationTimestamp"}"#
 )]
 #[serde(rename_all = "camelCase")] // queue_filters -> queueFilters
 pub struct MirrordRmqSessionSpec {


### PR DESCRIPTION
Resolves INT-611.

Every CRD joins the `mirrord` category and declares an `Age` column. Branch databases and preview sessions carry a `Ready` condition, so `kubectl wait --for=condition=Ready` works instead of polling a phase. Profiles and queue registries report whether the operator accepted them, with the verdict and its reason as columns.

The copy target phase was a bare string and is now an enum whose unknown variant keeps the raw value, so a phase named by a newer operator still deserializes and the CLI can report what it actually saw. The branch database phase gains the same catch-all; previously an unrecognised phase failed the whole object and wedged the controller reading it.

The copy target status also reports `expiresAt`, when an unused copy becomes eligible for deletion. A CLI older than 3.251.0 gets the legacy spelling and no expiry; a client that does not identify itself, such as kubectl, gets the current one.