### PR TITLE
Add `config_patch` to the mirrord up config yaml.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5810,6 +5810,7 @@ dependencies = [
  "futures",
  "inquire",
  "itertools 0.14.0",
+ "json-patch",
  "k8s-openapi",
  "kube",
  "miette",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,6 +154,7 @@ itertools = "0.14.0"
 jaq-core = "2.2.1"
 jaq-json = "1.1.3"
 jaq-std = "2.1.2"
+json-patch = { version = "4.2", default-features = false }
 k8s-cri = "0.11"
 k8s-openapi = { version = "0.28", features = ["v1_32"] }
 kube = { git = "https://github.com/metalbear-co/kube.git", rev = "6cbb2e8bef0b905edcecc7e0cf8e1804f7b02c67", default-features = false, features = [

--- a/changelog.d/+cor-1789-config-patch.changed.md
+++ b/changelog.d/+cor-1789-config-patch.changed.md
@@ -1,0 +1,1 @@
+Adds a `config_patch` option to the mirrord up config, where you can use this to patch the config of individual services with custom values.

--- a/mirrord/cli/src/up.rs
+++ b/mirrord/cli/src/up.rs
@@ -187,6 +187,7 @@ impl From<&UpCliError> for ErrorCategory {
             | UpCliError::Up(UpError::Parse(_))
             | UpCliError::Up(UpError::Select(_))
             | UpCliError::Up(UpError::Validation(_))
+            | UpCliError::Up(UpError::ConfigPatch(_))
             | UpCliError::Up(UpError::Tera(_))
             | UpCliError::Up(UpError::Mode(_)) => Self::ConfigValidation,
             UpCliError::Up(UpError::ServiceCrashed { .. }) => Self::ServiceCrash,

--- a/mirrord/up/Cargo.toml
+++ b/mirrord/up/Cargo.toml
@@ -21,6 +21,7 @@ mirrord-progress = { path = "../progress/" }
 
 futures.workspace = true
 itertools.workspace = true
+json-patch.workspace = true
 k8s-openapi.workspace = true
 kube.workspace = true
 serde = { workspace = true, features = ["derive", "rc"] }

--- a/mirrord/up/src/config.rs
+++ b/mirrord/up/src/config.rs
@@ -296,6 +296,13 @@ pub struct ServiceConfig {
     #[serde(default)]
     pub(crate) context: Option<Arc<str>>,
 
+    /// A JSON patch to apply to the service's configuration.
+    ///
+    /// Not to be relied upon, `mirrord up` tries to do the right thing by default, so you should
+    /// only reach for this when truly needed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) config_patch: Option<serde_json::Value>,
+
     pub(crate) run: RunConfig,
 }
 
@@ -319,7 +326,7 @@ impl ServiceConfig {
         key: EnvKey,
         resolved_targets: &mut HashMap<UnresolvedTarget, ResolvedTarget>,
         up_context: UpKubeContext,
-    ) -> (LayerConfig, RunConfig) {
+    ) -> Result<(LayerConfig, RunConfig), ConfigPatchErrorKind> {
         let mut cfg = LayerFileConfig {
             accept_invalid_certificates: defaults.accept_invalid_certificates,
             operator: defaults.operator,
@@ -391,9 +398,13 @@ impl ServiceConfig {
         }
 
         cfg.feature.network.incoming.ignore_ports = self.ignore_ports.into_iter().collect();
-        cfg.key = key;
+        cfg.key = key.clone();
 
-        (cfg, self.run)
+        if let Some(patch) = self.config_patch {
+            cfg = apply_config_patch(cfg, patch, &key)?;
+        }
+
+        Ok((cfg, self.run))
     }
 
     fn resolve_target(
@@ -404,6 +415,76 @@ impl ServiceConfig {
         self.target
             .as_resolved(name, up_context.get_context(self.context.clone()))
     }
+}
+
+/// Error produced when a service's `config_patch` cannot produce a valid mirrord config.
+#[derive(Debug, Error, Diagnostic)]
+#[error("invalid `config_patch` for service `{service}`: {source}")]
+pub struct ConfigPatchError {
+    service: Arc<str>,
+    #[source]
+    source: ConfigPatchErrorKind,
+}
+
+#[derive(Debug, Error)]
+enum ConfigPatchErrorKind {
+    #[error("failed to serialize the generated mirrord config: {0}")]
+    Serialize(serde_json::Error),
+
+    #[error("the merged result does not match the mirrord config schema: {0}")]
+    Schema(serde_json::Error),
+
+    #[error("the merged mirrord config failed validation: {0}")]
+    Validation(#[from] mirrord_config::config::ConfigError),
+}
+
+/// Here we merge the `config` with the `patch` (`config_patch` from the `mirrord-up.yaml` config
+/// file) for the service.
+///
+/// ```text
+/// mirrord-up.yaml
+///     │
+///     ├─ Tera renders the entire YAML
+///     │    {{ key }}, {{ git_branch }}, get_env(...)
+///     │
+///     ├─ YAML is deserialized into UpConfig
+///     │
+///     └─ For each selected service
+///          │
+///          ├─ Generate the normal mirrord-up LayerConfig
+///          ├─ Apply that service's config_patch
+///          ├─ Validate the merged config
+///          └─ Encode the final LayerConfig
+/// ```
+fn apply_config_patch(
+    config: LayerConfig,
+    patch: serde_json::Value,
+    key: &EnvKey,
+) -> Result<LayerConfig, ConfigPatchErrorKind> {
+    let mut merged = serde_json::to_value(config).map_err(ConfigPatchErrorKind::Serialize)?;
+
+    // `LayerConfig` preserves whether a key was provided or generated in its serialized form,
+    // while a user-facing mirrord config represents it as a string.
+    if let Some(object) = merged.as_object_mut() {
+        object.insert(
+            "key".to_owned(),
+            serde_json::Value::String(key.as_str().to_owned()),
+        );
+    }
+
+    json_patch::merge(&mut merged, &patch);
+
+    let file_config: LayerFileConfig =
+        serde_json::from_value(merged).map_err(ConfigPatchErrorKind::Schema)?;
+
+    // The generated config already contains all environment-derived settings. Isolating this
+    // second generation pass keeps environment variables from unexpectedly overriding the patch.
+    let mut context = ConfigContext::default().strict_env(true);
+    let mut config = file_config.generate_config(&mut context)?;
+    config.key = key.clone();
+    config.verify(&mut context)?;
+
+    Ok(config)
 }
 
 /// All the information necessary to start and manage one of the child
@@ -535,41 +616,48 @@ impl UpConfig {
         Ok(())
     }
 
-    /// Produces an iterator of [`SubprocessCfg`]s, one per service
-    /// defined in the configuration.
+    /// Produces one [`SubprocessCfg`] per service defined in the configuration.
     ///
     /// `resolved_targets` must be a [`HashMap`] with an entry for
     /// every item yielded by the iterator returned from
     /// [`Self::unresolved_targets`] -- this method will panic
     /// otherwise. Entries that are used to resolve a target will be
     /// removed from the `resolved_targets`.
-    pub(crate) fn service_configs<'a>(
+    pub(crate) fn service_configs(
         self,
-        key: &'a EnvKey,
-        resolved_targets: &'a mut HashMap<UnresolvedTarget, ResolvedTarget>,
+        key: &EnvKey,
+        resolved_targets: &mut HashMap<UnresolvedTarget, ResolvedTarget>,
         up_context: UpKubeContext,
-    ) -> impl Iterator<Item = SubprocessCfg> + use<'a> {
+    ) -> Result<Vec<SubprocessCfg>, ConfigPatchError> {
         let Self {
             common: defaults,
             services,
         } = self;
 
-        services.into_iter().map(move |(service_name, svc)| {
-            let mode = svc.default_mode;
-            let (config, run) = svc.assemble(
-                &service_name,
-                &defaults,
-                key.clone(),
-                resolved_targets,
-                up_context.clone(),
-            );
-            SubprocessCfg {
-                config,
-                service_name,
-                run,
-                mode,
-            }
-        })
+        services
+            .into_iter()
+            .map(|(service_name, svc)| {
+                let mode = svc.default_mode;
+                let (config, run) = svc
+                    .assemble(
+                        &service_name,
+                        &defaults,
+                        key.clone(),
+                        resolved_targets,
+                        up_context.clone(),
+                    )
+                    .map_err(|source| ConfigPatchError {
+                        service: service_name.clone(),
+                        source,
+                    })?;
+                Ok(SubprocessCfg {
+                    config,
+                    service_name,
+                    run,
+                    mode,
+                })
+            })
+            .collect()
     }
 
     /// Produces an iterator of [`UnresolvedTarget`]s that yields an
@@ -648,6 +736,7 @@ impl CollectAnalytics for &UpConfig {
         let mut count_ignore_ports: u32 = 0;
         let mut count_skip: u32 = 0;
         let mut count_context: u32 = 0;
+        let mut count_config_patch: u32 = 0;
 
         let mut count_exec: u32 = 0;
         let mut count_container: u32 = 0;
@@ -665,6 +754,7 @@ impl CollectAnalytics for &UpConfig {
                 skip,
                 run,
                 context,
+                config_patch,
             } = svc;
 
             if *target != TargetConfig::UNSPECIFIED {
@@ -692,6 +782,9 @@ impl CollectAnalytics for &UpConfig {
             if context.is_some() {
                 count_context += 1;
             }
+            if config_patch.is_some() {
+                count_config_patch += 1;
+            }
 
             match run.r#type {
                 RunType::Exec => count_exec += 1,
@@ -707,6 +800,7 @@ impl CollectAnalytics for &UpConfig {
         config_fields_used.add("ignore_ports", count_ignore_ports);
         config_fields_used.add("skip", count_skip);
         config_fields_used.add("context", count_context);
+        config_fields_used.add("config_patch", count_config_patch);
         analytics.add("config_fields_used", config_fields_used);
 
         let mut run_types = Analytics::default();
@@ -889,7 +983,7 @@ mod tests {
                 &mut HashMap::new(),
                 UpKubeContext::default(),
             )
-            .collect::<Vec<_>>();
+            .unwrap();
         assert_eq!(services.len(), 1);
 
         let service = services.pop().unwrap();
@@ -900,6 +994,108 @@ mod tests {
                 .feature
                 .split_queues
                 .is_all_wildcard(&EnvKey::Provided("sqs-session".to_owned()))
+        );
+    }
+
+    #[test]
+    fn config_patch_overrides_generated_split_queues_and_renders_key() {
+        let key = EnvKey::Provided("jadwiga".to_owned());
+        let mut services = crate::template(
+            r#"
+            services:
+              worker:
+                target:
+                  path: "deployment/sqs-printer"
+                config_patch:
+                  feature:
+                    split_queues:
+                      "*":
+                        queue_type: SQS
+                        jq_filter: '.Body | fromjson | .headers["x-origin"] == "{{ key }}"'
+                run:
+                  command: ["echo"]
+            "#,
+            &key,
+        )
+        .unwrap()
+        .service_configs(&key, &mut HashMap::new(), UpKubeContext::default())
+        .unwrap();
+
+        let service = services.pop().unwrap();
+        assert_eq!(
+            service
+                .config
+                .feature
+                .split_queues
+                .sqs_jq_filters()
+                .collect::<Vec<_>>(),
+            [(
+                "*",
+                r#".Body | fromjson | .headers["x-origin"] == "jadwiga""#
+            )]
+        );
+    }
+
+    #[test]
+    fn config_patch_schema_error_names_service_and_actual_error() {
+        let error = parse(
+            r#"
+            services:
+              worker:
+                target: none
+                config_patch:
+                  feature:
+                    split_queues: NOT_A_SPLIT_QUEUE_CONFIG
+                run:
+                  command: ["echo"]
+            "#,
+        )
+        .service_configs(
+            &EnvKey::Provided("jagiellon".to_owned()),
+            &mut HashMap::new(),
+            UpKubeContext::default(),
+        )
+        .err()
+        .expect("invalid split queue shape should fail schema validation");
+
+        let error = error.to_string();
+        assert!(error.contains("service `worker`"), "{error}");
+        assert!(
+            error.contains("a map from queue id to its filter, or a list of queue split entries"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn config_patch_semantic_error_names_service_and_actual_error() {
+        let error = parse(
+            r#"
+            services:
+              worker:
+                target: none
+                config_patch:
+                  feature:
+                    split_queues:
+                      "*":
+                        queue_type: SQS
+                        jq_filter: "["
+                run:
+                  command: ["echo"]
+            "#,
+        )
+        .service_configs(
+            &EnvKey::Provided("jadwiga".to_owned()),
+            &mut HashMap::new(),
+            UpKubeContext::default(),
+        )
+        .err()
+        .expect("invalid jq should fail config validation");
+
+        let error = error.to_string();
+        assert!(error.contains("service `worker`"), "{error}");
+        assert!(
+            error.contains("Queue splitting config is invalid"),
+            "{error}"
         );
     }
 
@@ -935,7 +1131,7 @@ mod tests {
             &mut HashMap::new(),
             UpKubeContext::default(),
         )
-        .collect::<Vec<_>>();
+        .unwrap();
         assert_eq!(services.len(), 1);
         let service = services.pop().unwrap();
 
@@ -974,7 +1170,7 @@ mod tests {
             &mut HashMap::new(),
             UpKubeContext::default(),
         )
-        .collect::<Vec<_>>();
+        .unwrap();
         assert_eq!(services.len(), 1);
         let service = services.pop().unwrap();
 
@@ -1045,7 +1241,7 @@ mod tests {
                 &mut HashMap::new(),
                 UpKubeContext::default(),
             )
-            .collect::<Vec<_>>();
+            .unwrap();
 
             validate_targets(&services).unwrap_or_else(|err| panic!("{path} rejected: {err}"));
         }
@@ -1080,7 +1276,7 @@ mod tests {
             &mut HashMap::new(),
             UpKubeContext::default(),
         )
-        .collect::<Vec<_>>();
+        .unwrap();
 
         let ModeError::IncompatibleTargets(incompatible) =
             validate_targets(&services).expect_err("`a` and `c` are not usable in replace mode");
@@ -1337,6 +1533,8 @@ mod tests {
 
         let subprocesses: HashMap<String, SubprocessCfg> = config
             .service_configs(&key, &mut resolved_targets, UpKubeContext::default())
+            .unwrap()
+            .into_iter()
             .map(|cfg| (cfg.service_name.to_string(), cfg))
             .collect();
 
@@ -1396,7 +1594,7 @@ mod tests {
 
         config
             .service_configs(&key, &mut resolved_targets, UpKubeContext::default())
-            .for_each(drop);
+            .unwrap();
     }
 
     /// The resolution step must key its answers by the exact
@@ -1423,7 +1621,7 @@ mod tests {
 
         config
             .service_configs(&key, &mut resolved_targets, UpKubeContext::default())
-            .for_each(drop);
+            .unwrap();
     }
 
     #[test]
@@ -1450,7 +1648,7 @@ mod tests {
 
         config
             .service_configs(&key, &mut resolved_targets, UpKubeContext::default())
-            .for_each(drop);
+            .unwrap();
     }
 
     // -- Service selection --
@@ -1602,7 +1800,8 @@ mod tests {
                     "http_filter": 0,
                     "ignore_ports": 0,
                     "skip": 0,
-                    "context": 0
+                    "context": 0,
+                    "config_patch": 0
                 },
                 "run_types": {
                     "exec": 1,
@@ -1666,6 +1865,9 @@ mod tests {
               svc-c:
                 target:
                   path: "deployment/other"
+                config_patch:
+                  feature:
+                    hostname: false
                 run:
                   command: ["echo"]
             "#,
@@ -1679,6 +1881,7 @@ mod tests {
         assert_eq!(result["config_fields_used"]["ignore_ports"], 1);
         assert_eq!(result["config_fields_used"]["default_mode"], 0);
         assert_eq!(result["config_fields_used"]["context"], 1);
+        assert_eq!(result["config_fields_used"]["config_patch"], 1);
         assert_eq!(result["run_types"]["exec"], 2);
         assert_eq!(result["run_types"]["container"], 1);
     }

--- a/mirrord/up/src/config.rs
+++ b/mirrord/up/src/config.rs
@@ -461,21 +461,22 @@ fn apply_config_patch(
     patch: serde_json::Value,
     key: &EnvKey,
 ) -> Result<LayerConfig, ConfigPatchErrorKind> {
-    let mut merged = serde_json::to_value(config).map_err(ConfigPatchErrorKind::Serialize)?;
+    let mut layer_config_json =
+        serde_json::to_value(config).map_err(ConfigPatchErrorKind::Serialize)?;
 
     // `LayerConfig` preserves whether a key was provided or generated in its serialized form,
     // while a user-facing mirrord config represents it as a string.
-    if let Some(object) = merged.as_object_mut() {
+    if let Some(object) = layer_config_json.as_object_mut() {
         object.insert(
             "key".to_owned(),
             serde_json::Value::String(key.as_str().to_owned()),
         );
     }
 
-    json_patch::merge(&mut merged, &patch);
+    json_patch::merge(&mut layer_config_json, &patch);
 
     let file_config: LayerFileConfig =
-        serde_json::from_value(merged).map_err(ConfigPatchErrorKind::Schema)?;
+        serde_json::from_value(layer_config_json).map_err(ConfigPatchErrorKind::Schema)?;
 
     // The generated config already contains all environment-derived settings. Isolating this
     // second generation pass keeps environment variables from unexpectedly overriding the patch.

--- a/mirrord/up/src/init.rs
+++ b/mirrord/up/src/init.rs
@@ -176,6 +176,7 @@ fn prompt_service(
             skip: false,
             run,
             context: None,
+            config_patch: None,
         },
     ))
 }
@@ -473,6 +474,7 @@ mod tests {
                 command: vec!["go".to_owned(), "run".to_owned(), "./cmd/api".to_owned()],
             },
             context: Some("popper-deskpop".into()),
+            config_patch: None,
         }
     }
 
@@ -535,6 +537,7 @@ mod tests {
                 command: vec!["echo".to_owned()],
             },
             context: None,
+            config_patch: None,
         };
         let cfg = UpConfig {
             common: CommonConfig::default(),
@@ -576,6 +579,7 @@ mod tests {
                 command: vec!["go".to_owned(), "run".to_owned(), "--opt=a,b".to_owned()],
             },
             context: None,
+            config_patch: None,
         };
         let cfg = UpConfig {
             common: CommonConfig::default(),
@@ -621,6 +625,7 @@ mod tests {
                 command: vec!["echo".to_owned()],
             },
             context: None,
+            config_patch: None,
         };
         let cfg = UpConfig {
             common: CommonConfig::default(),

--- a/mirrord/up/src/lib.rs
+++ b/mirrord/up/src/lib.rs
@@ -19,7 +19,8 @@ use std::{
 };
 
 pub use config::{
-    IncompatibleTarget, ModeError, SelectError, ServiceMode, SubprocessCfg, UpConfig,
+    ConfigPatchError, IncompatibleTarget, ModeError, SelectError, ServiceMode, SubprocessCfg,
+    UpConfig,
 };
 use config::{ResolvedTarget, SpecifiedTarget, UnresolvedTarget, validate_targets};
 use futures::TryStreamExt;
@@ -92,6 +93,11 @@ pub enum UpError {
     #[error("mirrord-up config validation failed: {0}")]
     Validation(#[from] ConfigError),
 
+    /// A per-service config patch did not produce a valid mirrord config.
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    ConfigPatch(#[from] ConfigPatchError),
+
     /// The user's service selection couldn't be satisfied.
     #[error(transparent)]
     #[diagnostic(transparent)]
@@ -141,7 +147,7 @@ pub enum UpError {
     Tera(#[from] tera::Error),
 }
 
-fn template(content: &str, key: &EnvKey) -> Result<UpConfig, UpError> {
+fn render_template(content: &str, key: &EnvKey) -> Result<String, tera::Error> {
     let mut tera = Tera::default();
     tera.add_raw_template("main", content)?;
 
@@ -151,8 +157,11 @@ fn template(content: &str, key: &EnvKey) -> Result<UpConfig, UpError> {
         ctx.insert("git_branch", git_branch);
     }
 
-    let rendered = tera.render("main", &ctx)?;
+    tera.render("main", &ctx)
+}
 
+fn template(content: &str, key: &EnvKey) -> Result<UpConfig, UpError> {
+    let rendered = render_template(content, key)?;
     Ok(serde_yaml::from_str(&rendered)?)
 }
 
@@ -447,9 +456,7 @@ pub async fn run(
     let mut resolved_targets =
         resolve_unresolved_workloads(&up_config, config_path, up_context.clone()).await?;
 
-    let service_configs: Vec<SubprocessCfg> = up_config
-        .service_configs(&key, &mut resolved_targets, up_context)
-        .collect();
+    let service_configs = up_config.service_configs(&key, &mut resolved_targets, up_context)?;
 
     validate_targets(&service_configs)?;
 
@@ -600,6 +607,44 @@ services:
         assert_eq!(
             config.services["logger"].env.r#override.as_ref().unwrap()["SESSION_KEY"],
             "debug-run"
+        );
+    }
+
+    #[test]
+    fn config_patches_are_rendered_with_up_config() {
+        let yaml = r#"
+services:
+  worker:
+    target: none
+    config_patch:
+      feature:
+        split_queues:
+          "*":
+            queue_type: SQS
+            jq_filter: '.Body | .session == "{{ key }}"'
+    run:
+      command: ["echo", "{{ key }}"]
+  api:
+    target: none
+    config_patch:
+      feature:
+        env:
+          override:
+            SESSION_ID: "{{ key }}"
+    run:
+      command: ["echo"]
+"#;
+
+        let config = template(yaml, &EnvKey::Provided("jagiellon".to_owned())).unwrap();
+        assert_eq!(config.services["worker"].run.command, ["echo", "jagiellon"]);
+        assert_eq!(
+            config.services["worker"].config_patch.as_ref().unwrap()["feature"]["split_queues"]["*"]
+                ["jq_filter"],
+            r#".Body | .session == "jagiellon""#
+        );
+        assert_eq!(
+            config.services["api"].config_patch.as_ref().unwrap()["feature"]["env"]["override"]["SESSION_ID"],
+            "jagiellon"
         );
     }
 }


### PR DESCRIPTION
<!-- Thank you for contributing to mirrord! -->
<!-- Please use the checklist below as a guide for docs, tests and admin tasks for your PR -->
<!-- Feel free to ~strikethrough~ any items that you don't think apply -->
- Issue: https://linear.app/metalbear/issue/COR-1789/add-per-service-config-patch-support-to-mirrord-up

Adds a `config_patch` option to the mirrord up config, where you can use this to patch the
config of individual services with custom values, for example:

```yaml
common:
  operator: true

services:
  meow-service:
    target:
      path: deployment/cats
      namespace: felines
    default_mode: split
    config_patch:
      feature:
        split_queues:
          "*":
            queue_type: SQS
            jq_filter: '.Body | fromjson | .headers["x-lmnd-origin-env-id"] == "{{ key }}"'
    run:
      command:
        - node
        - app.mjs
```

### Quality Checklist:

- [x] I have documented new code sufficiently
- [ ] I have checked and updated the relevant existing docs in code, including removing outdated material
- [ ] I have written user-facing website docs for new features, or opened a (sub)issue to do so
- [ ] I have checked and updated existing website docs for changed features
- [x] I have tested this change and know it succeeds and fails as expected
- [x] I have written unit tests or purposefully omitted them
- [ ] I have written e2e tests or purposefully omitted them
- [x] I have explained what this PR introduces and why, and linked to relevant context (e.g. linear issues, related PRs,
  documentation)
- [ ] I have introduced a short, clear and well-formatted changelog entry

<!-- need help with the changelog? see ../CONTRIBUTING.md#submitting-a-pull-request -->
<!-- Add more details of your changes below if needed -->

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>