### PR TITLE
Fail fast mirrord up unsupported stuff on windows.

### DIFF
--- a/changelog.d/+cor-1811.fixed.md
+++ b/changelog.d/+cor-1811.fixed.md
@@ -1,0 +1,1 @@
+Fail `mirrord up` before starting sessions on Windows when a selected service uses `mirrord container` or an API key would route it through mirrord for CI, and default `mirrord up init` to `mirrord exec`.

--- a/mirrord/cli/src/ci.rs
+++ b/mirrord/cli/src/ci.rs
@@ -36,7 +36,7 @@ pub(crate) mod stop;
 /// commands when the operator is available.
 ///
 /// Should be set in their CI to the value they got from [`generate_ci_api_key`].
-const MIRRORD_CI_API_KEY: &str = "MIRRORD_CI_API_KEY";
+pub(crate) const MIRRORD_CI_API_KEY: &str = "MIRRORD_CI_API_KEY";
 
 /// Alias for mirrord-for-ci results.
 type CiResult<T> = Result<T, crate::ci::error::CiError>;

--- a/mirrord/cli/src/up.rs
+++ b/mirrord/cli/src/up.rs
@@ -116,6 +116,11 @@ async fn run_up(args: UpArgs, analytics: &mut AnalyticsReporter) -> Result<(), U
         up_config.override_mode(mode);
     }
 
+    #[cfg(target_os = "windows")]
+    up_config
+        .validate_windows(std::env::var_os(crate::ci::MIRRORD_CI_API_KEY).is_some())
+        .map_err(UpError::from)?;
+
     analytics.get_mut().add("has_custom_key", key.is_provided());
 
     // Generated once per invocation and propagated to every child session so
@@ -188,7 +193,8 @@ impl From<&UpCliError> for ErrorCategory {
             | UpCliError::Up(UpError::Select(_))
             | UpCliError::Up(UpError::Validation(_))
             | UpCliError::Up(UpError::Tera(_))
-            | UpCliError::Up(UpError::Mode(_)) => Self::ConfigValidation,
+            | UpCliError::Up(UpError::Mode(_))
+            | UpCliError::Up(UpError::WindowsUnsupported(_)) => Self::ConfigValidation,
             UpCliError::Up(UpError::ServiceCrashed { .. }) => Self::ServiceCrash,
             UpCliError::Up(UpError::Io(_))
             | UpCliError::Up(UpError::Panic(_))

--- a/mirrord/up/src/config.rs
+++ b/mirrord/up/src/config.rs
@@ -503,6 +503,9 @@ impl UpConfig {
         self.common.telemetry.unwrap_or(true)
     }
 
+    /// When running `mirrord up` on Windows, validates that the up config doesn't have anything
+    /// that is unsupported, for example a service that's configured to run with `mirrord
+    /// container`, or a service that's configured to run with `mirrord exec` for CI.
     pub fn validate_windows(&self, ci_key_present: bool) -> Result<(), WindowsSupportError> {
         self.services
             .iter()

--- a/mirrord/up/src/config.rs
+++ b/mirrord/up/src/config.rs
@@ -310,6 +310,18 @@ pub struct UpConfig {
     pub services: HashMap<Arc<str>, ServiceConfig>,
 }
 
+/// A selected `mirrord up` configuration that would delegate to commands unsupported on Windows.
+#[derive(Debug, Error, Diagnostic)]
+pub enum WindowsSupportError {
+    /// A service uses `mirrord container`.
+    #[error("`mirrord container` is not supported on Windows for service: {0}")]
+    Container(Arc<str>),
+
+    /// One or more exec services would be rerouted through mirrord for CI.
+    #[error("mirrord for CI is not supported on Windows")]
+    Ci,
+}
+
 impl ServiceConfig {
     /// Build a ([`LayerConfig`], [`RunConfig`]) pair for this service.
     fn assemble(
@@ -489,6 +501,19 @@ impl UpConfig {
     /// True unless the user opted out of telemetry.
     pub fn telemetry_enabled(&self) -> bool {
         self.common.telemetry.unwrap_or(true)
+    }
+
+    /// `mirrord up` doesn't work with `mirrord container` and `mirrord ci`, so we
+    /// validate here that no service in the user's `up` config would try to use those.
+    pub fn validate_windows(&self, ci_key_present: bool) -> Result<(), WindowsSupportError> {
+        self.services
+            .iter()
+            .find_map(|(name, service)| match &service.run.r#type {
+                RunType::Container => Some(WindowsSupportError::Container(Arc::clone(name))),
+                RunType::Exec if ci_key_present => Some(WindowsSupportError::Ci),
+                RunType::Exec => None,
+            })
+            .map_or(Ok(()), Err)
     }
 
     /// Force services to run in `mode`, discarding the `default_mode` set in the config file.
@@ -735,6 +760,25 @@ mod tests {
         serde_yaml::from_str(yaml).unwrap()
     }
 
+    fn windows_validation_fixture() -> UpConfig {
+        parse(
+            r#"
+            services:
+              exec:
+                run:
+                  command: ["node"]
+              zeta-container:
+                run:
+                  type: container
+                  command: ["docker"]
+              alpha-container:
+                run:
+                  type: container
+                  command: ["docker"]
+            "#,
+        )
+    }
+
     #[test]
     fn defaults_applied_when_omitted() {
         let config = parse(
@@ -831,6 +875,45 @@ mod tests {
                 ]
             }
         );
+    }
+
+    #[test]
+    fn windows_validation_accepts_exec_without_ci() {
+        let mut config = windows_validation_fixture();
+        config.select_services(&["exec".to_owned()]).unwrap();
+
+        config.validate_windows(false).unwrap();
+    }
+
+    #[test]
+    fn windows_validation_ignores_skipped_container_services() {
+        let mut config = parse(
+            r#"
+            services:
+              exec:
+                run:
+                  command: ["node"]
+              skipped-container:
+                skip: true
+                run:
+                  type: container
+                  command: ["docker"]
+            "#,
+        );
+        config.select_services(&[]).unwrap();
+
+        config.validate_windows(false).unwrap();
+    }
+
+    #[test]
+    fn windows_validation_rejects_ci_for_exec_services() {
+        let mut config = windows_validation_fixture();
+        config.select_services(&["exec".to_owned()]).unwrap();
+
+        assert!(matches!(
+            config.validate_windows(true),
+            Err(WindowsSupportError::Ci)
+        ));
     }
 
     #[test]

--- a/mirrord/up/src/config.rs
+++ b/mirrord/up/src/config.rs
@@ -503,8 +503,6 @@ impl UpConfig {
         self.common.telemetry.unwrap_or(true)
     }
 
-    /// `mirrord up` doesn't work with `mirrord container` and `mirrord ci`, so we
-    /// validate here that no service in the user's `up` config would try to use those.
     pub fn validate_windows(&self, ci_key_present: bool) -> Result<(), WindowsSupportError> {
         self.services
             .iter()

--- a/mirrord/up/src/init.rs
+++ b/mirrord/up/src/init.rs
@@ -322,11 +322,7 @@ fn prompt_env_overrides() -> Result<Option<HashMap<String, String>>, InitError> 
 }
 
 fn prompt_run() -> Result<RunConfig, InitError> {
-    let r#type = Select::new(
-        "Run with `mirrord exec` or `mirrord container`?",
-        RunType::VARIANTS.to_vec(),
-    )
-    .prompt()?;
+    let r#type = prompt_run_type()?;
 
     let command_str = Text::new("Local command (e.g. `go run ./cmd/api`):")
         .with_validator(|s: &str| {
@@ -343,6 +339,22 @@ fn prompt_run() -> Result<RunConfig, InitError> {
         .collect();
 
     Ok(RunConfig { r#type, command })
+}
+
+fn prompt_run_type() -> Result<RunType, InitError> {
+    #[cfg(target_os = "windows")]
+    {
+        Ok(RunType::Exec)
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        Ok(Select::new(
+            "Run with `mirrord exec` or `mirrord container`?",
+            RunType::VARIANTS.to_vec(),
+        )
+        .prompt()?)
+    }
 }
 
 /// Serializes the wizard's [`UpConfig`] to a minimal YAML skeleton.
@@ -474,6 +486,12 @@ mod tests {
             },
             context: Some("popper-deskpop".into()),
         }
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn windows_run_type_defaults_to_exec_without_prompting() {
+        assert_eq!(prompt_run_type().unwrap(), RunType::Exec);
     }
 
     #[test]

--- a/mirrord/up/src/lib.rs
+++ b/mirrord/up/src/lib.rs
@@ -20,6 +20,7 @@ use std::{
 
 pub use config::{
     IncompatibleTarget, ModeError, SelectError, ServiceMode, SubprocessCfg, UpConfig,
+    WindowsSupportError,
 };
 use config::{ResolvedTarget, SpecifiedTarget, UnresolvedTarget, validate_targets};
 use futures::TryStreamExt;
@@ -101,6 +102,11 @@ pub enum UpError {
     #[error(transparent)]
     #[diagnostic(transparent)]
     Mode(#[from] ModeError),
+
+    /// The selected services would delegate to commands unsupported on Windows.
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    WindowsUnsupported(#[from] WindowsSupportError),
 
     /// A child mirrord service exited with a non-zero status.
     #[error("Service {name} crashed with exit status {status}")]


### PR DESCRIPTION
<!-- Thank you for contributing to mirrord! -->
<!-- Please use the checklist below as a guide for docs, tests and admin tasks for your PR -->
<!-- Feel free to ~strikethrough~ any items that you don't think apply -->

- Issue: https://linear.app/metalbear/issue/COR-1811/fail-fast-when-mirrord-up-cannot-run-its-sessions-on-windows

If the user has a service configured to use `container` (`mirrord container`) or we detect that `mirrord ci` would be used, we fail the run before anything really starts.

### Quality Checklist:

- [x] I have documented new code sufficiently
- [ ] I have checked and updated the relevant existing docs in code, including removing outdated material
- [ ] I have written user-facing website docs for new features, or opened a (sub)issue to do so
- [ ] I have checked and updated existing website docs for changed features
- [ ] I have tested this change and know it succeeds and fails as expected
- [x] I have written unit tests or purposefully omitted them
- [ ] I have written e2e tests or purposefully omitted them
- [x] I have explained what this PR introduces and why, and linked to relevant context (e.g. linear issues, related PRs,
  documentation)
- [x] I have introduced a short, clear and well-formatted changelog entry

<!-- need help with the changelog? see ../CONTRIBUTING.md#submitting-a-pull-request -->
<!-- Add more details of your changes below if needed -->