### PR TITLE
INT-618 CockroachDB branch dumps failing on non-public schemas and enum columns

### DIFF
--- a/changelog.d/+cockroachdb-branching-audit-check.internal.md
+++ b/changelog.d/+cockroachdb-branching-audit-check.internal.md
@@ -1,0 +1,1 @@
+Extended the CockroachDB branching e2e test app to verify non-public schema tables.

--- a/tests/go-e2e-cockroachdb-branching/main.go
+++ b/tests/go-e2e-cockroachdb-branching/main.go
@@ -60,6 +60,14 @@ func main() {
 		time.Sleep(1 * time.Second)
 	}
 	log.Printf("ROW COUNT: %d", count)
+
+	// The seed also populates a table in a non-public schema; the dump must create the
+	// schema on the branch and copy its rows like any public table.
+	var auditCount int64
+	if err = db.QueryRow("SELECT count(*) FROM app.audit").Scan(&auditCount); err != nil {
+		log.Printf("audit query failed: %v", err)
+	}
+	log.Printf("AUDIT ROW COUNT: %d", auditCount)
 	log.Println("Verification complete")
 
 	http.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
<!-- Thank you for contributing to mirrord! -->
<!-- Please use the checklist below as a guide for docs, tests and admin tasks for your PR -->
<!-- Feel free to ~strikethrough~ any items that you don't think apply -->

### Quality Checklist:

- [ ] I have documented new code sufficiently
- [ ] I have checked and updated the relevant existing docs in code, including removing outdated material
- [ ] I have written user-facing website docs for new features, or opened a (sub)issue to do so
- [ ] I have checked and updated existing website docs for changed features
- [ ] I have tested this change and know it succeeds and fails as expected
- [ ] I have written unit tests or purposefully omitted them
- [ ] I have written e2e tests or purposefully omitted them
- [ ] I have explained what this PR introduces and why, and linked to relevant context (e.g. linear issues, related PRs,
  documentation)
- [ ] I have introduced a short, clear and well-formatted changelog entry

<!-- need help with the changelog? see ../CONTRIBUTING.md#submitting-a-pull-request -->
<!-- Add more details of your changes below if needed -->