### PR TITLE
Cache CI downloads through a local HTTP proxy

### DIFF
--- a/.github/workflows/build-mirrord-cli.yaml
+++ b/.github/workflows/build-mirrord-cli.yaml
@@ -11,6 +11,15 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      # Routes the job's downloads through a local caching proxy. Trialling it here first: this
+      # job fetches protoc, uv, a ziglang wheel, a Node tarball and a full pnpm install, and is
+      # the heaviest downloader that runs neither in the CI runner image nor on macOS.
+      - name: Start HTTP cache proxy
+        uses: aviramha/cicache@75f906c99687704ba80640bfc1ffaea0b3536273 # v0.1.0
+        with:
+          # Large artifacts are the win; a high floor keeps the entry count down so this competes
+          # less with the Rust caches for the repository's cache budget.
+          min-size: "131072"
       - uses: metalbear-co/setup-protoc@770e54d44679c8e1d8fdc06d1d9268fa79fbefb4
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -44,3 +53,9 @@ jobs:
             target/x86_64-unknown-linux-gnu/debug/mirrord
           if-no-files-found: error
           retention-days: 2
+      # Drains the upload queue and prints the hit rate. Has to run even when the job fails, or
+      # nothing is stored for later runs.
+      - name: Stop HTTP cache proxy
+        continue-on-error: true
+        if: ${{ always() }}
+        uses: aviramha/cicache/cleanup@75f906c99687704ba80640bfc1ffaea0b3536273 # v0.1.0

--- a/.github/workflows/build-mirrord-cli.yaml
+++ b/.github/workflows/build-mirrord-cli.yaml
@@ -15,7 +15,7 @@ jobs:
       # job fetches protoc, uv, a ziglang wheel, a Node tarball and a full pnpm install, and is
       # the heaviest downloader that runs neither in the CI runner image nor on macOS.
       - name: Start HTTP cache proxy
-        uses: aviramha/cicache@01ec6277924fdf25c1ada5be0874a65b9469db39 # v0.1.3
+        uses: aviramha/cicache@4a25bfdb846911d73d40200fd7d97f4c74ddc4cd # v0.1.4
         with:
           # Large artifacts are the win; a high floor keeps the entry count down so this competes
           # less with the Rust caches for the repository's cache budget.
@@ -66,4 +66,4 @@ jobs:
       - name: Stop HTTP cache proxy
         continue-on-error: true
         if: ${{ always() }}
-        uses: aviramha/cicache/cleanup@01ec6277924fdf25c1ada5be0874a65b9469db39 # v0.1.3
+        uses: aviramha/cicache/cleanup@4a25bfdb846911d73d40200fd7d97f4c74ddc4cd # v0.1.4

--- a/.github/workflows/build-mirrord-cli.yaml
+++ b/.github/workflows/build-mirrord-cli.yaml
@@ -19,7 +19,7 @@ jobs:
         with:
           # Large artifacts are the win; a high floor keeps the entry count down so this competes
           # less with the Rust caches for the repository's cache budget.
-          min-size: "131072"
+          min-size: "1048576"
           # Bumped past the keys an earlier version of the proxy left reserved but never
           # committed; the service reports those as existing while serving nothing for them.
           key-prefix: "cicache-v2"

--- a/.github/workflows/build-mirrord-cli.yaml
+++ b/.github/workflows/build-mirrord-cli.yaml
@@ -19,7 +19,7 @@ jobs:
         with:
           # Large artifacts are the win; a high floor keeps the entry count down so this competes
           # less with the Rust caches for the repository's cache budget.
-          min-size: "131072"
+          min-size: "4194304"
       # frida's build script fetches its devkit with a TLS stack carrying its own root store, so
       # it ignores SSL_CERT_FILE and cannot be talked through an intercepting proxy over HTTPS.
       # Requesting the same artifact over plain HTTP keeps that hop on localhost; the proxy then

--- a/.github/workflows/build-mirrord-cli.yaml
+++ b/.github/workflows/build-mirrord-cli.yaml
@@ -15,7 +15,7 @@ jobs:
       # job fetches protoc, uv, a ziglang wheel, a Node tarball and a full pnpm install, and is
       # the heaviest downloader that runs neither in the CI runner image nor on macOS.
       - name: Start HTTP cache proxy
-        uses: aviramha/cicache@d5e1b0c8bf87fdf48d7726b51aa0e16b3156c04e # v0.1.1
+        uses: aviramha/cicache@88c715f19ca5f152fc77a6305689df2f9b143ead # v0.1.2
         with:
           # Large artifacts are the win; a high floor keeps the entry count down so this competes
           # less with the Rust caches for the repository's cache budget.
@@ -58,4 +58,4 @@ jobs:
       - name: Stop HTTP cache proxy
         continue-on-error: true
         if: ${{ always() }}
-        uses: aviramha/cicache/cleanup@d5e1b0c8bf87fdf48d7726b51aa0e16b3156c04e # v0.1.1
+        uses: aviramha/cicache/cleanup@88c715f19ca5f152fc77a6305689df2f9b143ead # v0.1.2

--- a/.github/workflows/build-mirrord-cli.yaml
+++ b/.github/workflows/build-mirrord-cli.yaml
@@ -15,7 +15,7 @@ jobs:
       # job fetches protoc, uv, a ziglang wheel, a Node tarball and a full pnpm install, and is
       # the heaviest downloader that runs neither in the CI runner image nor on macOS.
       - name: Start HTTP cache proxy
-        uses: aviramha/cicache@53b9220da9a6d323a92d0a283df6d1cf0042d43f # v0.2.2
+        uses: aviramha/cicache@cb12b27235839cafd30183b4395629169f5824bd # v0.2.3
         with:
           # Large artifacts are the win; a high floor keeps the entry count down so this competes
           # less with the Rust caches for the repository's cache budget.
@@ -69,4 +69,4 @@ jobs:
       - name: Stop HTTP cache proxy
         continue-on-error: true
         if: ${{ always() }}
-        uses: aviramha/cicache/cleanup@53b9220da9a6d323a92d0a283df6d1cf0042d43f # v0.2.2
+        uses: aviramha/cicache/cleanup@cb12b27235839cafd30183b4395629169f5824bd # v0.2.3

--- a/.github/workflows/build-mirrord-cli.yaml
+++ b/.github/workflows/build-mirrord-cli.yaml
@@ -15,7 +15,7 @@ jobs:
       # job fetches protoc, uv, a ziglang wheel, a Node tarball and a full pnpm install, and is
       # the heaviest downloader that runs neither in the CI runner image nor on macOS.
       - name: Start HTTP cache proxy
-        uses: aviramha/cicache@e2ce39ac4f3f8bee46a48fa3db0113737dd12099 # v0.3.0
+        uses: aviramha/cicache@2dac7392897df52ee1f9c11166e5e8a91b01ab55 # v0.3.1
         with:
           # Large artifacts are the win; a high floor keeps the entry count down so this competes
           # less with the Rust caches for the repository's cache budget.
@@ -69,4 +69,4 @@ jobs:
       - name: Stop HTTP cache proxy
         continue-on-error: true
         if: ${{ always() }}
-        uses: aviramha/cicache/cleanup@e2ce39ac4f3f8bee46a48fa3db0113737dd12099 # v0.3.0
+        uses: aviramha/cicache/cleanup@2dac7392897df52ee1f9c11166e5e8a91b01ab55 # v0.3.1

--- a/.github/workflows/build-mirrord-cli.yaml
+++ b/.github/workflows/build-mirrord-cli.yaml
@@ -15,11 +15,19 @@ jobs:
       # job fetches protoc, uv, a ziglang wheel, a Node tarball and a full pnpm install, and is
       # the heaviest downloader that runs neither in the CI runner image nor on macOS.
       - name: Start HTTP cache proxy
-        uses: aviramha/cicache@88c715f19ca5f152fc77a6305689df2f9b143ead # v0.1.2
+        uses: aviramha/cicache@01ec6277924fdf25c1ada5be0874a65b9469db39 # v0.1.3
         with:
           # Large artifacts are the win; a high floor keeps the entry count down so this competes
           # less with the Rust caches for the repository's cache budget.
           min-size: "131072"
+      # frida's build script fetches its devkit with a TLS stack carrying its own root store, so
+      # it ignores SSL_CERT_FILE and cannot be talked through an intercepting proxy over HTTPS.
+      # Requesting the same artifact over plain HTTP keeps that hop on localhost; the proxy then
+      # fetches it over HTTPS upstream and caches it. Harmless without a proxy, where GitHub just
+      # redirects back to HTTPS.
+      - name: Fetch the frida devkit through the cache proxy
+        if: ${{ runner.os != 'Windows' }}
+        run: echo "FRIDA_DOWNLOAD_CDN=http://github.com/frida/frida/releases/download" >> "$GITHUB_ENV"
       - uses: metalbear-co/setup-protoc@770e54d44679c8e1d8fdc06d1d9268fa79fbefb4
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -58,4 +66,4 @@ jobs:
       - name: Stop HTTP cache proxy
         continue-on-error: true
         if: ${{ always() }}
-        uses: aviramha/cicache/cleanup@88c715f19ca5f152fc77a6305689df2f9b143ead # v0.1.2
+        uses: aviramha/cicache/cleanup@01ec6277924fdf25c1ada5be0874a65b9469db39 # v0.1.3

--- a/.github/workflows/build-mirrord-cli.yaml
+++ b/.github/workflows/build-mirrord-cli.yaml
@@ -15,7 +15,7 @@ jobs:
       # job fetches protoc, uv, a ziglang wheel, a Node tarball and a full pnpm install, and is
       # the heaviest downloader that runs neither in the CI runner image nor on macOS.
       - name: Start HTTP cache proxy
-        uses: aviramha/cicache@4a25bfdb846911d73d40200fd7d97f4c74ddc4cd # v0.1.4
+        uses: aviramha/cicache@f432b5a08611d79ff8a589312d1497cfd7dd4050 # v0.1.5
         with:
           # Large artifacts are the win; a high floor keeps the entry count down so this competes
           # less with the Rust caches for the repository's cache budget.
@@ -66,4 +66,4 @@ jobs:
       - name: Stop HTTP cache proxy
         continue-on-error: true
         if: ${{ always() }}
-        uses: aviramha/cicache/cleanup@4a25bfdb846911d73d40200fd7d97f4c74ddc4cd # v0.1.4
+        uses: aviramha/cicache/cleanup@f432b5a08611d79ff8a589312d1497cfd7dd4050 # v0.1.5

--- a/.github/workflows/build-mirrord-cli.yaml
+++ b/.github/workflows/build-mirrord-cli.yaml
@@ -15,7 +15,7 @@ jobs:
       # job fetches protoc, uv, a ziglang wheel, a Node tarball and a full pnpm install, and is
       # the heaviest downloader that runs neither in the CI runner image nor on macOS.
       - name: Start HTTP cache proxy
-        uses: aviramha/cicache@d7a986e0f1fa67ba0abe97cc25abcd61a8c27f49 # v0.2.0
+        uses: aviramha/cicache@41c6b73e1200efc1eb4c6cfa641986ba12f354e8 # v0.2.1
         with:
           # Large artifacts are the win; a high floor keeps the entry count down so this competes
           # less with the Rust caches for the repository's cache budget.
@@ -66,4 +66,4 @@ jobs:
       - name: Stop HTTP cache proxy
         continue-on-error: true
         if: ${{ always() }}
-        uses: aviramha/cicache/cleanup@d7a986e0f1fa67ba0abe97cc25abcd61a8c27f49 # v0.2.0
+        uses: aviramha/cicache/cleanup@41c6b73e1200efc1eb4c6cfa641986ba12f354e8 # v0.2.1

--- a/.github/workflows/build-mirrord-cli.yaml
+++ b/.github/workflows/build-mirrord-cli.yaml
@@ -15,7 +15,7 @@ jobs:
       # job fetches protoc, uv, a ziglang wheel, a Node tarball and a full pnpm install, and is
       # the heaviest downloader that runs neither in the CI runner image nor on macOS.
       - name: Start HTTP cache proxy
-        uses: aviramha/cicache@cb12b27235839cafd30183b4395629169f5824bd # v0.2.3
+        uses: aviramha/cicache@e2ce39ac4f3f8bee46a48fa3db0113737dd12099 # v0.3.0
         with:
           # Large artifacts are the win; a high floor keeps the entry count down so this competes
           # less with the Rust caches for the repository's cache budget.
@@ -69,4 +69,4 @@ jobs:
       - name: Stop HTTP cache proxy
         continue-on-error: true
         if: ${{ always() }}
-        uses: aviramha/cicache/cleanup@cb12b27235839cafd30183b4395629169f5824bd # v0.2.3
+        uses: aviramha/cicache/cleanup@e2ce39ac4f3f8bee46a48fa3db0113737dd12099 # v0.3.0

--- a/.github/workflows/build-mirrord-cli.yaml
+++ b/.github/workflows/build-mirrord-cli.yaml
@@ -19,7 +19,7 @@ jobs:
         with:
           # Large artifacts are the win; a high floor keeps the entry count down so this competes
           # less with the Rust caches for the repository's cache budget.
-          min-size: "4194304"
+          min-size: "131072"
           # Bumped past the keys an earlier version of the proxy left reserved but never
           # committed; the service reports those as existing while serving nothing for them.
           key-prefix: "cicache-v2"

--- a/.github/workflows/build-mirrord-cli.yaml
+++ b/.github/workflows/build-mirrord-cli.yaml
@@ -15,7 +15,7 @@ jobs:
       # job fetches protoc, uv, a ziglang wheel, a Node tarball and a full pnpm install, and is
       # the heaviest downloader that runs neither in the CI runner image nor on macOS.
       - name: Start HTTP cache proxy
-        uses: aviramha/cicache@75f906c99687704ba80640bfc1ffaea0b3536273 # v0.1.0
+        uses: aviramha/cicache@d5e1b0c8bf87fdf48d7726b51aa0e16b3156c04e # v0.1.1
         with:
           # Large artifacts are the win; a high floor keeps the entry count down so this competes
           # less with the Rust caches for the repository's cache budget.
@@ -58,4 +58,4 @@ jobs:
       - name: Stop HTTP cache proxy
         continue-on-error: true
         if: ${{ always() }}
-        uses: aviramha/cicache/cleanup@75f906c99687704ba80640bfc1ffaea0b3536273 # v0.1.0
+        uses: aviramha/cicache/cleanup@d5e1b0c8bf87fdf48d7726b51aa0e16b3156c04e # v0.1.1

--- a/.github/workflows/build-mirrord-cli.yaml
+++ b/.github/workflows/build-mirrord-cli.yaml
@@ -15,11 +15,14 @@ jobs:
       # job fetches protoc, uv, a ziglang wheel, a Node tarball and a full pnpm install, and is
       # the heaviest downloader that runs neither in the CI runner image nor on macOS.
       - name: Start HTTP cache proxy
-        uses: aviramha/cicache@41c6b73e1200efc1eb4c6cfa641986ba12f354e8 # v0.2.1
+        uses: aviramha/cicache@53b9220da9a6d323a92d0a283df6d1cf0042d43f # v0.2.2
         with:
           # Large artifacts are the win; a high floor keeps the entry count down so this competes
           # less with the Rust caches for the repository's cache budget.
           min-size: "4194304"
+          # Bumped past the keys an earlier version of the proxy left reserved but never
+          # committed; the service reports those as existing while serving nothing for them.
+          key-prefix: "cicache-v2"
       # frida's build script fetches its devkit with a TLS stack carrying its own root store, so
       # it ignores SSL_CERT_FILE and cannot be talked through an intercepting proxy over HTTPS.
       # Requesting the same artifact over plain HTTP keeps that hop on localhost; the proxy then
@@ -66,4 +69,4 @@ jobs:
       - name: Stop HTTP cache proxy
         continue-on-error: true
         if: ${{ always() }}
-        uses: aviramha/cicache/cleanup@41c6b73e1200efc1eb4c6cfa641986ba12f354e8 # v0.2.1
+        uses: aviramha/cicache/cleanup@53b9220da9a6d323a92d0a283df6d1cf0042d43f # v0.2.2

--- a/.github/workflows/build-mirrord-cli.yaml
+++ b/.github/workflows/build-mirrord-cli.yaml
@@ -15,7 +15,7 @@ jobs:
       # job fetches protoc, uv, a ziglang wheel, a Node tarball and a full pnpm install, and is
       # the heaviest downloader that runs neither in the CI runner image nor on macOS.
       - name: Start HTTP cache proxy
-        uses: aviramha/cicache@7e295ea73e080960835b7dd2c2b6c4150294acc4 # v0.1.6
+        uses: aviramha/cicache@d7a986e0f1fa67ba0abe97cc25abcd61a8c27f49 # v0.2.0
         with:
           # Large artifacts are the win; a high floor keeps the entry count down so this competes
           # less with the Rust caches for the repository's cache budget.
@@ -66,4 +66,4 @@ jobs:
       - name: Stop HTTP cache proxy
         continue-on-error: true
         if: ${{ always() }}
-        uses: aviramha/cicache/cleanup@7e295ea73e080960835b7dd2c2b6c4150294acc4 # v0.1.6
+        uses: aviramha/cicache/cleanup@d7a986e0f1fa67ba0abe97cc25abcd61a8c27f49 # v0.2.0

--- a/.github/workflows/build-mirrord-cli.yaml
+++ b/.github/workflows/build-mirrord-cli.yaml
@@ -15,11 +15,14 @@ jobs:
       # job fetches protoc, uv, a ziglang wheel, a Node tarball and a full pnpm install, and is
       # the heaviest downloader that runs neither in the CI runner image nor on macOS.
       - name: Start HTTP cache proxy
-        uses: aviramha/cicache@2dac7392897df52ee1f9c11166e5e8a91b01ab55 # v0.3.1
+        uses: aviramha/cicache@37dffe6651493698a2eb079e9bdca5da22fc013f # v0.4.2
         with:
-          # Large artifacts are the win; a high floor keeps the entry count down so this competes
-          # less with the Rust caches for the repository's cache budget.
-          min-size: "1048576"
+          # Objects of 1 MiB and up get entries of their own, where they deduplicate across jobs
+          # and runs. Everything smaller shares one packed entry: the cache API charges per entry
+          # against a limit shared by the whole run, so ~1300 small crates stored individually
+          # exhaust it, while packed they cost two calls.
+          min-size: "32768"
+          pack-threshold: "1048576"
           # Bumped past the keys an earlier version of the proxy left reserved but never
           # committed; the service reports those as existing while serving nothing for them.
           key-prefix: "cicache-v2"
@@ -69,4 +72,4 @@ jobs:
       - name: Stop HTTP cache proxy
         continue-on-error: true
         if: ${{ always() }}
-        uses: aviramha/cicache/cleanup@2dac7392897df52ee1f9c11166e5e8a91b01ab55 # v0.3.1
+        uses: aviramha/cicache/cleanup@37dffe6651493698a2eb079e9bdca5da22fc013f # v0.4.2

--- a/.github/workflows/build-mirrord-cli.yaml
+++ b/.github/workflows/build-mirrord-cli.yaml
@@ -15,7 +15,7 @@ jobs:
       # job fetches protoc, uv, a ziglang wheel, a Node tarball and a full pnpm install, and is
       # the heaviest downloader that runs neither in the CI runner image nor on macOS.
       - name: Start HTTP cache proxy
-        uses: aviramha/cicache@f432b5a08611d79ff8a589312d1497cfd7dd4050 # v0.1.5
+        uses: aviramha/cicache@7e295ea73e080960835b7dd2c2b6c4150294acc4 # v0.1.6
         with:
           # Large artifacts are the win; a high floor keeps the entry count down so this competes
           # less with the Rust caches for the repository's cache budget.
@@ -66,4 +66,4 @@ jobs:
       - name: Stop HTTP cache proxy
         continue-on-error: true
         if: ${{ always() }}
-        uses: aviramha/cicache/cleanup@f432b5a08611d79ff8a589312d1497cfd7dd4050 # v0.1.5
+        uses: aviramha/cicache/cleanup@7e295ea73e080960835b7dd2c2b6c4150294acc4 # v0.1.6

--- a/.github/workflows/build-mirrord-cli.yaml
+++ b/.github/workflows/build-mirrord-cli.yaml
@@ -15,7 +15,7 @@ jobs:
       # job fetches protoc, uv, a ziglang wheel, a Node tarball and a full pnpm install, and is
       # the heaviest downloader that runs neither in the CI runner image nor on macOS.
       - name: Start HTTP cache proxy
-        uses: aviramha/cicache@37dffe6651493698a2eb079e9bdca5da22fc013f # v0.4.2
+        uses: aviramha/cicache@fa5c0c8d5c75a3f5a1b2e1a5d14d90b0ff63660d # v0.4.3
         with:
           # Objects of 1 MiB and up get entries of their own, where they deduplicate across jobs
           # and runs. Everything smaller shares one packed entry: the cache API charges per entry
@@ -72,4 +72,4 @@ jobs:
       - name: Stop HTTP cache proxy
         continue-on-error: true
         if: ${{ always() }}
-        uses: aviramha/cicache/cleanup@37dffe6651493698a2eb079e9bdca5da22fc013f # v0.4.2
+        uses: aviramha/cicache/cleanup@fa5c0c8d5c75a3f5a1b2e1a5d14d90b0ff63660d # v0.4.3

--- a/.github/workflows/check-lint.yaml
+++ b/.github/workflows/check-lint.yaml
@@ -150,10 +150,10 @@ jobs:
         if: ${{ runner.os != 'Windows' }}
         uses: aviramha/cicache@2dac7392897df52ee1f9c11166e5e8a91b01ab55 # v0.3.1
         with:
-          # Only genuinely large artifacts. The cache service is rate limited per job, so the
-          # floor has to keep the number of stored objects in the tens rather than the thousands;
-          # it also leaves more of the repository's cache budget to the Rust caches.
-          min-size: "4194304"
+          # Covers about 85% of the bytes this job downloads across ~150 objects. Lower floors
+          # add little: most of what is left is small crates, and objects are what cost calls to
+          # the rate limited cache API.
+          min-size: "131072"
           # Bumped past the keys an earlier version of the proxy left reserved but never
           # committed; the service reports those as existing while serving nothing for them.
           key-prefix: "cicache-v2"

--- a/.github/workflows/check-lint.yaml
+++ b/.github/workflows/check-lint.yaml
@@ -148,7 +148,7 @@ jobs:
       - name: Start HTTP cache proxy
         continue-on-error: true
         if: ${{ runner.os != 'Windows' }}
-        uses: aviramha/cicache@53b9220da9a6d323a92d0a283df6d1cf0042d43f # v0.2.2
+        uses: aviramha/cicache@cb12b27235839cafd30183b4395629169f5824bd # v0.2.3
         with:
           # Only genuinely large artifacts. The cache service is rate limited per job, so the
           # floor has to keep the number of stored objects in the tens rather than the thousands;
@@ -207,7 +207,7 @@ jobs:
       - name: Stop HTTP cache proxy
         continue-on-error: true
         if: ${{ always() && runner.os != 'Windows' }}
-        uses: aviramha/cicache/cleanup@53b9220da9a6d323a92d0a283df6d1cf0042d43f # v0.2.2
+        uses: aviramha/cicache/cleanup@cb12b27235839cafd30183b4395629169f5824bd # v0.2.3
   shear:
     if: ${{ inputs.run_rust }}
     name: 'cargo shear'

--- a/.github/workflows/check-lint.yaml
+++ b/.github/workflows/check-lint.yaml
@@ -148,7 +148,7 @@ jobs:
       - name: Start HTTP cache proxy
         continue-on-error: true
         if: ${{ runner.os != 'Windows' }}
-        uses: aviramha/cicache@4a25bfdb846911d73d40200fd7d97f4c74ddc4cd # v0.1.4
+        uses: aviramha/cicache@f432b5a08611d79ff8a589312d1497cfd7dd4050 # v0.1.5
         with:
           # Large artifacts are the win here; a high floor keeps the entry count down so this
           # competes less with the Rust caches for the repository's cache budget.
@@ -203,7 +203,7 @@ jobs:
       - name: Stop HTTP cache proxy
         continue-on-error: true
         if: ${{ always() && runner.os != 'Windows' }}
-        uses: aviramha/cicache/cleanup@4a25bfdb846911d73d40200fd7d97f4c74ddc4cd # v0.1.4
+        uses: aviramha/cicache/cleanup@f432b5a08611d79ff8a589312d1497cfd7dd4050 # v0.1.5
   shear:
     if: ${{ inputs.run_rust }}
     name: 'cargo shear'

--- a/.github/workflows/check-lint.yaml
+++ b/.github/workflows/check-lint.yaml
@@ -148,12 +148,15 @@ jobs:
       - name: Start HTTP cache proxy
         continue-on-error: true
         if: ${{ runner.os != 'Windows' }}
-        uses: aviramha/cicache@41c6b73e1200efc1eb4c6cfa641986ba12f354e8 # v0.2.1
+        uses: aviramha/cicache@53b9220da9a6d323a92d0a283df6d1cf0042d43f # v0.2.2
         with:
           # Only genuinely large artifacts. The cache service is rate limited per job, so the
           # floor has to keep the number of stored objects in the tens rather than the thousands;
           # it also leaves more of the repository's cache budget to the Rust caches.
           min-size: "4194304"
+          # Bumped past the keys an earlier version of the proxy left reserved but never
+          # committed; the service reports those as existing while serving nothing for them.
+          key-prefix: "cicache-v2"
       # frida's build script fetches its devkit with a TLS stack carrying its own root store, so
       # it ignores SSL_CERT_FILE and cannot be talked through an intercepting proxy over HTTPS.
       # Requesting the same artifact over plain HTTP keeps that hop on localhost; the proxy then
@@ -204,7 +207,7 @@ jobs:
       - name: Stop HTTP cache proxy
         continue-on-error: true
         if: ${{ always() && runner.os != 'Windows' }}
-        uses: aviramha/cicache/cleanup@41c6b73e1200efc1eb4c6cfa641986ba12f354e8 # v0.2.1
+        uses: aviramha/cicache/cleanup@53b9220da9a6d323a92d0a283df6d1cf0042d43f # v0.2.2
   shear:
     if: ${{ inputs.run_rust }}
     name: 'cargo shear'

--- a/.github/workflows/check-lint.yaml
+++ b/.github/workflows/check-lint.yaml
@@ -148,7 +148,7 @@ jobs:
       - name: Start HTTP cache proxy
         continue-on-error: true
         if: ${{ runner.os != 'Windows' }}
-        uses: aviramha/cicache@37dffe6651493698a2eb079e9bdca5da22fc013f # v0.4.2
+        uses: aviramha/cicache@fa5c0c8d5c75a3f5a1b2e1a5d14d90b0ff63660d # v0.4.3
         with:
           # Objects of 1 MiB and up get entries of their own, where they deduplicate across jobs
           # and runs. Everything smaller shares one packed entry: the cache API charges per entry
@@ -209,7 +209,7 @@ jobs:
       - name: Stop HTTP cache proxy
         continue-on-error: true
         if: ${{ always() && runner.os != 'Windows' }}
-        uses: aviramha/cicache/cleanup@37dffe6651493698a2eb079e9bdca5da22fc013f # v0.4.2
+        uses: aviramha/cicache/cleanup@fa5c0c8d5c75a3f5a1b2e1a5d14d90b0ff63660d # v0.4.3
   shear:
     if: ${{ inputs.run_rust }}
     name: 'cargo shear'

--- a/.github/workflows/check-lint.yaml
+++ b/.github/workflows/check-lint.yaml
@@ -148,7 +148,7 @@ jobs:
       - name: Start HTTP cache proxy
         continue-on-error: true
         if: ${{ runner.os != 'Windows' }}
-        uses: aviramha/cicache@cb12b27235839cafd30183b4395629169f5824bd # v0.2.3
+        uses: aviramha/cicache@e2ce39ac4f3f8bee46a48fa3db0113737dd12099 # v0.3.0
         with:
           # Only genuinely large artifacts. The cache service is rate limited per job, so the
           # floor has to keep the number of stored objects in the tens rather than the thousands;
@@ -207,7 +207,7 @@ jobs:
       - name: Stop HTTP cache proxy
         continue-on-error: true
         if: ${{ always() && runner.os != 'Windows' }}
-        uses: aviramha/cicache/cleanup@cb12b27235839cafd30183b4395629169f5824bd # v0.2.3
+        uses: aviramha/cicache/cleanup@e2ce39ac4f3f8bee46a48fa3db0113737dd12099 # v0.3.0
   shear:
     if: ${{ inputs.run_rust }}
     name: 'cargo shear'

--- a/.github/workflows/check-lint.yaml
+++ b/.github/workflows/check-lint.yaml
@@ -150,10 +150,11 @@ jobs:
         if: ${{ runner.os != 'Windows' }}
         uses: aviramha/cicache@2dac7392897df52ee1f9c11166e5e8a91b01ab55 # v0.3.1
         with:
-          # Covers about 85% of the bytes this job downloads across ~150 objects. Lower floors
-          # add little: most of what is left is small crates, and objects are what cost calls to
-          # the rate limited cache API.
-          min-size: "131072"
+          # Covers about 70% of the bytes this job downloads across ~17 objects. The floor is
+          # set by the cache API's rate limit rather than by what is worth caching: every stored
+          # object costs two calls, the limit is shared across the jobs running at once, and a
+          # 128 KiB floor put ~150 objects per job over it.
+          min-size: "1048576"
           # Bumped past the keys an earlier version of the proxy left reserved but never
           # committed; the service reports those as existing while serving nothing for them.
           key-prefix: "cicache-v2"

--- a/.github/workflows/check-lint.yaml
+++ b/.github/workflows/check-lint.yaml
@@ -148,7 +148,7 @@ jobs:
       - name: Start HTTP cache proxy
         continue-on-error: true
         if: ${{ runner.os != 'Windows' }}
-        uses: aviramha/cicache@e2ce39ac4f3f8bee46a48fa3db0113737dd12099 # v0.3.0
+        uses: aviramha/cicache@2dac7392897df52ee1f9c11166e5e8a91b01ab55 # v0.3.1
         with:
           # Only genuinely large artifacts. The cache service is rate limited per job, so the
           # floor has to keep the number of stored objects in the tens rather than the thousands;
@@ -207,7 +207,7 @@ jobs:
       - name: Stop HTTP cache proxy
         continue-on-error: true
         if: ${{ always() && runner.os != 'Windows' }}
-        uses: aviramha/cicache/cleanup@e2ce39ac4f3f8bee46a48fa3db0113737dd12099 # v0.3.0
+        uses: aviramha/cicache/cleanup@2dac7392897df52ee1f9c11166e5e8a91b01ab55 # v0.3.1
   shear:
     if: ${{ inputs.run_rust }}
     name: 'cargo shear'

--- a/.github/workflows/check-lint.yaml
+++ b/.github/workflows/check-lint.yaml
@@ -148,11 +148,12 @@ jobs:
       - name: Start HTTP cache proxy
         continue-on-error: true
         if: ${{ runner.os != 'Windows' }}
-        uses: aviramha/cicache@f432b5a08611d79ff8a589312d1497cfd7dd4050 # v0.1.5
+        uses: aviramha/cicache@7e295ea73e080960835b7dd2c2b6c4150294acc4 # v0.1.6
         with:
-          # Large artifacts are the win here; a high floor keeps the entry count down so this
-          # competes less with the Rust caches for the repository's cache budget.
-          min-size: "131072"
+          # Only genuinely large artifacts. The cache service is rate limited per job, so the
+          # floor has to keep the number of stored objects in the tens rather than the thousands;
+          # it also leaves more of the repository's cache budget to the Rust caches.
+          min-size: "4194304"
       # frida's build script fetches its devkit with a TLS stack carrying its own root store, so
       # it ignores SSL_CERT_FILE and cannot be talked through an intercepting proxy over HTTPS.
       # Requesting the same artifact over plain HTTP keeps that hop on localhost; the proxy then
@@ -203,7 +204,7 @@ jobs:
       - name: Stop HTTP cache proxy
         continue-on-error: true
         if: ${{ always() && runner.os != 'Windows' }}
-        uses: aviramha/cicache/cleanup@f432b5a08611d79ff8a589312d1497cfd7dd4050 # v0.1.5
+        uses: aviramha/cicache/cleanup@7e295ea73e080960835b7dd2c2b6c4150294acc4 # v0.1.6
   shear:
     if: ${{ inputs.run_rust }}
     name: 'cargo shear'

--- a/.github/workflows/check-lint.yaml
+++ b/.github/workflows/check-lint.yaml
@@ -148,7 +148,7 @@ jobs:
       - name: Start HTTP cache proxy
         continue-on-error: true
         if: ${{ runner.os != 'Windows' }}
-        uses: aviramha/cicache@01ec6277924fdf25c1ada5be0874a65b9469db39 # v0.1.3
+        uses: aviramha/cicache@4a25bfdb846911d73d40200fd7d97f4c74ddc4cd # v0.1.4
         with:
           # Large artifacts are the win here; a high floor keeps the entry count down so this
           # competes less with the Rust caches for the repository's cache budget.
@@ -203,7 +203,7 @@ jobs:
       - name: Stop HTTP cache proxy
         continue-on-error: true
         if: ${{ always() && runner.os != 'Windows' }}
-        uses: aviramha/cicache/cleanup@01ec6277924fdf25c1ada5be0874a65b9469db39 # v0.1.3
+        uses: aviramha/cicache/cleanup@4a25bfdb846911d73d40200fd7d97f4c74ddc4cd # v0.1.4
   shear:
     if: ${{ inputs.run_rust }}
     name: 'cargo shear'

--- a/.github/workflows/check-lint.yaml
+++ b/.github/workflows/check-lint.yaml
@@ -148,7 +148,7 @@ jobs:
       - name: Start HTTP cache proxy
         continue-on-error: true
         if: ${{ runner.os != 'Windows' }}
-        uses: aviramha/cicache@d7a986e0f1fa67ba0abe97cc25abcd61a8c27f49 # v0.2.0
+        uses: aviramha/cicache@41c6b73e1200efc1eb4c6cfa641986ba12f354e8 # v0.2.1
         with:
           # Only genuinely large artifacts. The cache service is rate limited per job, so the
           # floor has to keep the number of stored objects in the tens rather than the thousands;
@@ -204,7 +204,7 @@ jobs:
       - name: Stop HTTP cache proxy
         continue-on-error: true
         if: ${{ always() && runner.os != 'Windows' }}
-        uses: aviramha/cicache/cleanup@d7a986e0f1fa67ba0abe97cc25abcd61a8c27f49 # v0.2.0
+        uses: aviramha/cicache/cleanup@41c6b73e1200efc1eb4c6cfa641986ba12f354e8 # v0.2.1
   shear:
     if: ${{ inputs.run_rust }}
     name: 'cargo shear'

--- a/.github/workflows/check-lint.yaml
+++ b/.github/workflows/check-lint.yaml
@@ -148,13 +148,14 @@ jobs:
       - name: Start HTTP cache proxy
         continue-on-error: true
         if: ${{ runner.os != 'Windows' }}
-        uses: aviramha/cicache@2dac7392897df52ee1f9c11166e5e8a91b01ab55 # v0.3.1
+        uses: aviramha/cicache@37dffe6651493698a2eb079e9bdca5da22fc013f # v0.4.2
         with:
-          # Covers about 70% of the bytes this job downloads across ~17 objects. The floor is
-          # set by the cache API's rate limit rather than by what is worth caching: every stored
-          # object costs two calls, the limit is shared across the jobs running at once, and a
-          # 128 KiB floor put ~150 objects per job over it.
-          min-size: "1048576"
+          # Objects of 1 MiB and up get entries of their own, where they deduplicate across jobs
+          # and runs. Everything smaller shares one packed entry: the cache API charges per entry
+          # against a limit shared by the whole run, so ~1300 small crates stored individually
+          # exhaust it, while packed they cost two calls.
+          min-size: "32768"
+          pack-threshold: "1048576"
           # Bumped past the keys an earlier version of the proxy left reserved but never
           # committed; the service reports those as existing while serving nothing for them.
           key-prefix: "cicache-v2"
@@ -208,7 +209,7 @@ jobs:
       - name: Stop HTTP cache proxy
         continue-on-error: true
         if: ${{ always() && runner.os != 'Windows' }}
-        uses: aviramha/cicache/cleanup@2dac7392897df52ee1f9c11166e5e8a91b01ab55 # v0.3.1
+        uses: aviramha/cicache/cleanup@37dffe6651493698a2eb079e9bdca5da22fc013f # v0.4.2
   shear:
     if: ${{ inputs.run_rust }}
     name: 'cargo shear'

--- a/.github/workflows/check-lint.yaml
+++ b/.github/workflows/check-lint.yaml
@@ -143,6 +143,16 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+      # Routes this job's downloads through a local caching proxy backed by the Actions cache.
+      # Never fatal: if it does not start, the job just downloads the way it did before.
+      - name: Start HTTP cache proxy
+        continue-on-error: true
+        if: ${{ runner.os != 'Windows' }}
+        uses: aviramha/cicache@88c715f19ca5f152fc77a6305689df2f9b143ead # v0.1.2
+        with:
+          # Large artifacts are the win here; a high floor keeps the entry count down so this
+          # competes less with the Rust caches for the repository's cache budget.
+          min-size: "131072"
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: 24
@@ -180,6 +190,12 @@ jobs:
         run: |
           echo "One or more cargo lint checks failed."
           exit 1
+      # Drains the upload queue and prints the hit rate. Has to run even when the job fails, or
+      # nothing is stored for later runs.
+      - name: Stop HTTP cache proxy
+        continue-on-error: true
+        if: ${{ always() && runner.os != 'Windows' }}
+        uses: aviramha/cicache/cleanup@88c715f19ca5f152fc77a6305689df2f9b143ead # v0.1.2
   shear:
     if: ${{ inputs.run_rust }}
     name: 'cargo shear'

--- a/.github/workflows/check-lint.yaml
+++ b/.github/workflows/check-lint.yaml
@@ -148,7 +148,7 @@ jobs:
       - name: Start HTTP cache proxy
         continue-on-error: true
         if: ${{ runner.os != 'Windows' }}
-        uses: aviramha/cicache@7e295ea73e080960835b7dd2c2b6c4150294acc4 # v0.1.6
+        uses: aviramha/cicache@d7a986e0f1fa67ba0abe97cc25abcd61a8c27f49 # v0.2.0
         with:
           # Only genuinely large artifacts. The cache service is rate limited per job, so the
           # floor has to keep the number of stored objects in the tens rather than the thousands;
@@ -204,7 +204,7 @@ jobs:
       - name: Stop HTTP cache proxy
         continue-on-error: true
         if: ${{ always() && runner.os != 'Windows' }}
-        uses: aviramha/cicache/cleanup@7e295ea73e080960835b7dd2c2b6c4150294acc4 # v0.1.6
+        uses: aviramha/cicache/cleanup@d7a986e0f1fa67ba0abe97cc25abcd61a8c27f49 # v0.2.0
   shear:
     if: ${{ inputs.run_rust }}
     name: 'cargo shear'

--- a/.github/workflows/check-lint.yaml
+++ b/.github/workflows/check-lint.yaml
@@ -148,11 +148,19 @@ jobs:
       - name: Start HTTP cache proxy
         continue-on-error: true
         if: ${{ runner.os != 'Windows' }}
-        uses: aviramha/cicache@88c715f19ca5f152fc77a6305689df2f9b143ead # v0.1.2
+        uses: aviramha/cicache@01ec6277924fdf25c1ada5be0874a65b9469db39 # v0.1.3
         with:
           # Large artifacts are the win here; a high floor keeps the entry count down so this
           # competes less with the Rust caches for the repository's cache budget.
           min-size: "131072"
+      # frida's build script fetches its devkit with a TLS stack carrying its own root store, so
+      # it ignores SSL_CERT_FILE and cannot be talked through an intercepting proxy over HTTPS.
+      # Requesting the same artifact over plain HTTP keeps that hop on localhost; the proxy then
+      # fetches it over HTTPS upstream and caches it. Harmless without a proxy, where GitHub just
+      # redirects back to HTTPS.
+      - name: Fetch the frida devkit through the cache proxy
+        if: ${{ runner.os != 'Windows' }}
+        run: echo "FRIDA_DOWNLOAD_CDN=http://github.com/frida/frida/releases/download" >> "$GITHUB_ENV"
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: 24
@@ -195,7 +203,7 @@ jobs:
       - name: Stop HTTP cache proxy
         continue-on-error: true
         if: ${{ always() && runner.os != 'Windows' }}
-        uses: aviramha/cicache/cleanup@88c715f19ca5f152fc77a6305689df2f9b143ead # v0.1.2
+        uses: aviramha/cicache/cleanup@01ec6277924fdf25c1ada5be0874a65b9469db39 # v0.1.3
   shear:
     if: ${{ inputs.run_rust }}
     name: 'cargo shear'

--- a/.github/workflows/check-rust-docs.yaml
+++ b/.github/workflows/check-rust-docs.yaml
@@ -19,6 +19,16 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      # Routes this job's downloads through a local caching proxy backed by the Actions cache.
+      # Never fatal: if it does not start, the job just downloads the way it did before.
+      - name: Start HTTP cache proxy
+        continue-on-error: true
+        if: ${{ runner.os != 'Windows' }}
+        uses: aviramha/cicache@88c715f19ca5f152fc77a6305689df2f9b143ead # v0.1.2
+        with:
+          # Large artifacts are the win here; a high floor keeps the entry count down so this
+          # competes less with the Rust caches for the repository's cache budget.
+          min-size: "131072"
       - uses: metalbear-co/setup-protoc@770e54d44679c8e1d8fdc06d1d9268fa79fbefb4
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -31,3 +41,9 @@ jobs:
         with:
           shared-key: mirrord
       - run: cargo xtask test-doc
+      # Drains the upload queue and prints the hit rate. Has to run even when the job fails, or
+      # nothing is stored for later runs.
+      - name: Stop HTTP cache proxy
+        continue-on-error: true
+        if: ${{ always() && runner.os != 'Windows' }}
+        uses: aviramha/cicache/cleanup@88c715f19ca5f152fc77a6305689df2f9b143ead # v0.1.2

--- a/.github/workflows/check-rust-docs.yaml
+++ b/.github/workflows/check-rust-docs.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Start HTTP cache proxy
         continue-on-error: true
         if: ${{ runner.os != 'Windows' }}
-        uses: aviramha/cicache@cb12b27235839cafd30183b4395629169f5824bd # v0.2.3
+        uses: aviramha/cicache@e2ce39ac4f3f8bee46a48fa3db0113737dd12099 # v0.3.0
         with:
           # Only genuinely large artifacts. The cache service is rate limited per job, so the
           # floor has to keep the number of stored objects in the tens rather than the thousands;
@@ -58,4 +58,4 @@ jobs:
       - name: Stop HTTP cache proxy
         continue-on-error: true
         if: ${{ always() && runner.os != 'Windows' }}
-        uses: aviramha/cicache/cleanup@cb12b27235839cafd30183b4395629169f5824bd # v0.2.3
+        uses: aviramha/cicache/cleanup@e2ce39ac4f3f8bee46a48fa3db0113737dd12099 # v0.3.0

--- a/.github/workflows/check-rust-docs.yaml
+++ b/.github/workflows/check-rust-docs.yaml
@@ -24,11 +24,19 @@ jobs:
       - name: Start HTTP cache proxy
         continue-on-error: true
         if: ${{ runner.os != 'Windows' }}
-        uses: aviramha/cicache@88c715f19ca5f152fc77a6305689df2f9b143ead # v0.1.2
+        uses: aviramha/cicache@01ec6277924fdf25c1ada5be0874a65b9469db39 # v0.1.3
         with:
           # Large artifacts are the win here; a high floor keeps the entry count down so this
           # competes less with the Rust caches for the repository's cache budget.
           min-size: "131072"
+      # frida's build script fetches its devkit with a TLS stack carrying its own root store, so
+      # it ignores SSL_CERT_FILE and cannot be talked through an intercepting proxy over HTTPS.
+      # Requesting the same artifact over plain HTTP keeps that hop on localhost; the proxy then
+      # fetches it over HTTPS upstream and caches it. Harmless without a proxy, where GitHub just
+      # redirects back to HTTPS.
+      - name: Fetch the frida devkit through the cache proxy
+        if: ${{ runner.os != 'Windows' }}
+        run: echo "FRIDA_DOWNLOAD_CDN=http://github.com/frida/frida/releases/download" >> "$GITHUB_ENV"
       - uses: metalbear-co/setup-protoc@770e54d44679c8e1d8fdc06d1d9268fa79fbefb4
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -46,4 +54,4 @@ jobs:
       - name: Stop HTTP cache proxy
         continue-on-error: true
         if: ${{ always() && runner.os != 'Windows' }}
-        uses: aviramha/cicache/cleanup@88c715f19ca5f152fc77a6305689df2f9b143ead # v0.1.2
+        uses: aviramha/cicache/cleanup@01ec6277924fdf25c1ada5be0874a65b9469db39 # v0.1.3

--- a/.github/workflows/check-rust-docs.yaml
+++ b/.github/workflows/check-rust-docs.yaml
@@ -26,10 +26,11 @@ jobs:
         if: ${{ runner.os != 'Windows' }}
         uses: aviramha/cicache@2dac7392897df52ee1f9c11166e5e8a91b01ab55 # v0.3.1
         with:
-          # Covers about 85% of the bytes this job downloads across ~150 objects. Lower floors
-          # add little: most of what is left is small crates, and objects are what cost calls to
-          # the rate limited cache API.
-          min-size: "131072"
+          # Covers about 70% of the bytes this job downloads across ~17 objects. The floor is
+          # set by the cache API's rate limit rather than by what is worth caching: every stored
+          # object costs two calls, the limit is shared across the jobs running at once, and a
+          # 128 KiB floor put ~150 objects per job over it.
+          min-size: "1048576"
           # Bumped past the keys an earlier version of the proxy left reserved but never
           # committed; the service reports those as existing while serving nothing for them.
           key-prefix: "cicache-v2"

--- a/.github/workflows/check-rust-docs.yaml
+++ b/.github/workflows/check-rust-docs.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Start HTTP cache proxy
         continue-on-error: true
         if: ${{ runner.os != 'Windows' }}
-        uses: aviramha/cicache@01ec6277924fdf25c1ada5be0874a65b9469db39 # v0.1.3
+        uses: aviramha/cicache@4a25bfdb846911d73d40200fd7d97f4c74ddc4cd # v0.1.4
         with:
           # Large artifacts are the win here; a high floor keeps the entry count down so this
           # competes less with the Rust caches for the repository's cache budget.
@@ -54,4 +54,4 @@ jobs:
       - name: Stop HTTP cache proxy
         continue-on-error: true
         if: ${{ always() && runner.os != 'Windows' }}
-        uses: aviramha/cicache/cleanup@01ec6277924fdf25c1ada5be0874a65b9469db39 # v0.1.3
+        uses: aviramha/cicache/cleanup@4a25bfdb846911d73d40200fd7d97f4c74ddc4cd # v0.1.4

--- a/.github/workflows/check-rust-docs.yaml
+++ b/.github/workflows/check-rust-docs.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Start HTTP cache proxy
         continue-on-error: true
         if: ${{ runner.os != 'Windows' }}
-        uses: aviramha/cicache@d7a986e0f1fa67ba0abe97cc25abcd61a8c27f49 # v0.2.0
+        uses: aviramha/cicache@41c6b73e1200efc1eb4c6cfa641986ba12f354e8 # v0.2.1
         with:
           # Only genuinely large artifacts. The cache service is rate limited per job, so the
           # floor has to keep the number of stored objects in the tens rather than the thousands;
@@ -55,4 +55,4 @@ jobs:
       - name: Stop HTTP cache proxy
         continue-on-error: true
         if: ${{ always() && runner.os != 'Windows' }}
-        uses: aviramha/cicache/cleanup@d7a986e0f1fa67ba0abe97cc25abcd61a8c27f49 # v0.2.0
+        uses: aviramha/cicache/cleanup@41c6b73e1200efc1eb4c6cfa641986ba12f354e8 # v0.2.1

--- a/.github/workflows/check-rust-docs.yaml
+++ b/.github/workflows/check-rust-docs.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Start HTTP cache proxy
         continue-on-error: true
         if: ${{ runner.os != 'Windows' }}
-        uses: aviramha/cicache@53b9220da9a6d323a92d0a283df6d1cf0042d43f # v0.2.2
+        uses: aviramha/cicache@cb12b27235839cafd30183b4395629169f5824bd # v0.2.3
         with:
           # Only genuinely large artifacts. The cache service is rate limited per job, so the
           # floor has to keep the number of stored objects in the tens rather than the thousands;
@@ -58,4 +58,4 @@ jobs:
       - name: Stop HTTP cache proxy
         continue-on-error: true
         if: ${{ always() && runner.os != 'Windows' }}
-        uses: aviramha/cicache/cleanup@53b9220da9a6d323a92d0a283df6d1cf0042d43f # v0.2.2
+        uses: aviramha/cicache/cleanup@cb12b27235839cafd30183b4395629169f5824bd # v0.2.3

--- a/.github/workflows/check-rust-docs.yaml
+++ b/.github/workflows/check-rust-docs.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Start HTTP cache proxy
         continue-on-error: true
         if: ${{ runner.os != 'Windows' }}
-        uses: aviramha/cicache@e2ce39ac4f3f8bee46a48fa3db0113737dd12099 # v0.3.0
+        uses: aviramha/cicache@2dac7392897df52ee1f9c11166e5e8a91b01ab55 # v0.3.1
         with:
           # Only genuinely large artifacts. The cache service is rate limited per job, so the
           # floor has to keep the number of stored objects in the tens rather than the thousands;
@@ -58,4 +58,4 @@ jobs:
       - name: Stop HTTP cache proxy
         continue-on-error: true
         if: ${{ always() && runner.os != 'Windows' }}
-        uses: aviramha/cicache/cleanup@e2ce39ac4f3f8bee46a48fa3db0113737dd12099 # v0.3.0
+        uses: aviramha/cicache/cleanup@2dac7392897df52ee1f9c11166e5e8a91b01ab55 # v0.3.1

--- a/.github/workflows/check-rust-docs.yaml
+++ b/.github/workflows/check-rust-docs.yaml
@@ -26,10 +26,10 @@ jobs:
         if: ${{ runner.os != 'Windows' }}
         uses: aviramha/cicache@2dac7392897df52ee1f9c11166e5e8a91b01ab55 # v0.3.1
         with:
-          # Only genuinely large artifacts. The cache service is rate limited per job, so the
-          # floor has to keep the number of stored objects in the tens rather than the thousands;
-          # it also leaves more of the repository's cache budget to the Rust caches.
-          min-size: "4194304"
+          # Covers about 85% of the bytes this job downloads across ~150 objects. Lower floors
+          # add little: most of what is left is small crates, and objects are what cost calls to
+          # the rate limited cache API.
+          min-size: "131072"
           # Bumped past the keys an earlier version of the proxy left reserved but never
           # committed; the service reports those as existing while serving nothing for them.
           key-prefix: "cicache-v2"

--- a/.github/workflows/check-rust-docs.yaml
+++ b/.github/workflows/check-rust-docs.yaml
@@ -24,12 +24,15 @@ jobs:
       - name: Start HTTP cache proxy
         continue-on-error: true
         if: ${{ runner.os != 'Windows' }}
-        uses: aviramha/cicache@41c6b73e1200efc1eb4c6cfa641986ba12f354e8 # v0.2.1
+        uses: aviramha/cicache@53b9220da9a6d323a92d0a283df6d1cf0042d43f # v0.2.2
         with:
           # Only genuinely large artifacts. The cache service is rate limited per job, so the
           # floor has to keep the number of stored objects in the tens rather than the thousands;
           # it also leaves more of the repository's cache budget to the Rust caches.
           min-size: "4194304"
+          # Bumped past the keys an earlier version of the proxy left reserved but never
+          # committed; the service reports those as existing while serving nothing for them.
+          key-prefix: "cicache-v2"
       # frida's build script fetches its devkit with a TLS stack carrying its own root store, so
       # it ignores SSL_CERT_FILE and cannot be talked through an intercepting proxy over HTTPS.
       # Requesting the same artifact over plain HTTP keeps that hop on localhost; the proxy then
@@ -55,4 +58,4 @@ jobs:
       - name: Stop HTTP cache proxy
         continue-on-error: true
         if: ${{ always() && runner.os != 'Windows' }}
-        uses: aviramha/cicache/cleanup@41c6b73e1200efc1eb4c6cfa641986ba12f354e8 # v0.2.1
+        uses: aviramha/cicache/cleanup@53b9220da9a6d323a92d0a283df6d1cf0042d43f # v0.2.2

--- a/.github/workflows/check-rust-docs.yaml
+++ b/.github/workflows/check-rust-docs.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Start HTTP cache proxy
         continue-on-error: true
         if: ${{ runner.os != 'Windows' }}
-        uses: aviramha/cicache@7e295ea73e080960835b7dd2c2b6c4150294acc4 # v0.1.6
+        uses: aviramha/cicache@d7a986e0f1fa67ba0abe97cc25abcd61a8c27f49 # v0.2.0
         with:
           # Only genuinely large artifacts. The cache service is rate limited per job, so the
           # floor has to keep the number of stored objects in the tens rather than the thousands;
@@ -55,4 +55,4 @@ jobs:
       - name: Stop HTTP cache proxy
         continue-on-error: true
         if: ${{ always() && runner.os != 'Windows' }}
-        uses: aviramha/cicache/cleanup@7e295ea73e080960835b7dd2c2b6c4150294acc4 # v0.1.6
+        uses: aviramha/cicache/cleanup@d7a986e0f1fa67ba0abe97cc25abcd61a8c27f49 # v0.2.0

--- a/.github/workflows/check-rust-docs.yaml
+++ b/.github/workflows/check-rust-docs.yaml
@@ -24,13 +24,14 @@ jobs:
       - name: Start HTTP cache proxy
         continue-on-error: true
         if: ${{ runner.os != 'Windows' }}
-        uses: aviramha/cicache@2dac7392897df52ee1f9c11166e5e8a91b01ab55 # v0.3.1
+        uses: aviramha/cicache@37dffe6651493698a2eb079e9bdca5da22fc013f # v0.4.2
         with:
-          # Covers about 70% of the bytes this job downloads across ~17 objects. The floor is
-          # set by the cache API's rate limit rather than by what is worth caching: every stored
-          # object costs two calls, the limit is shared across the jobs running at once, and a
-          # 128 KiB floor put ~150 objects per job over it.
-          min-size: "1048576"
+          # Objects of 1 MiB and up get entries of their own, where they deduplicate across jobs
+          # and runs. Everything smaller shares one packed entry: the cache API charges per entry
+          # against a limit shared by the whole run, so ~1300 small crates stored individually
+          # exhaust it, while packed they cost two calls.
+          min-size: "32768"
+          pack-threshold: "1048576"
           # Bumped past the keys an earlier version of the proxy left reserved but never
           # committed; the service reports those as existing while serving nothing for them.
           key-prefix: "cicache-v2"
@@ -59,4 +60,4 @@ jobs:
       - name: Stop HTTP cache proxy
         continue-on-error: true
         if: ${{ always() && runner.os != 'Windows' }}
-        uses: aviramha/cicache/cleanup@2dac7392897df52ee1f9c11166e5e8a91b01ab55 # v0.3.1
+        uses: aviramha/cicache/cleanup@37dffe6651493698a2eb079e9bdca5da22fc013f # v0.4.2

--- a/.github/workflows/check-rust-docs.yaml
+++ b/.github/workflows/check-rust-docs.yaml
@@ -24,11 +24,12 @@ jobs:
       - name: Start HTTP cache proxy
         continue-on-error: true
         if: ${{ runner.os != 'Windows' }}
-        uses: aviramha/cicache@f432b5a08611d79ff8a589312d1497cfd7dd4050 # v0.1.5
+        uses: aviramha/cicache@7e295ea73e080960835b7dd2c2b6c4150294acc4 # v0.1.6
         with:
-          # Large artifacts are the win here; a high floor keeps the entry count down so this
-          # competes less with the Rust caches for the repository's cache budget.
-          min-size: "131072"
+          # Only genuinely large artifacts. The cache service is rate limited per job, so the
+          # floor has to keep the number of stored objects in the tens rather than the thousands;
+          # it also leaves more of the repository's cache budget to the Rust caches.
+          min-size: "4194304"
       # frida's build script fetches its devkit with a TLS stack carrying its own root store, so
       # it ignores SSL_CERT_FILE and cannot be talked through an intercepting proxy over HTTPS.
       # Requesting the same artifact over plain HTTP keeps that hop on localhost; the proxy then
@@ -54,4 +55,4 @@ jobs:
       - name: Stop HTTP cache proxy
         continue-on-error: true
         if: ${{ always() && runner.os != 'Windows' }}
-        uses: aviramha/cicache/cleanup@f432b5a08611d79ff8a589312d1497cfd7dd4050 # v0.1.5
+        uses: aviramha/cicache/cleanup@7e295ea73e080960835b7dd2c2b6c4150294acc4 # v0.1.6

--- a/.github/workflows/check-rust-docs.yaml
+++ b/.github/workflows/check-rust-docs.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Start HTTP cache proxy
         continue-on-error: true
         if: ${{ runner.os != 'Windows' }}
-        uses: aviramha/cicache@37dffe6651493698a2eb079e9bdca5da22fc013f # v0.4.2
+        uses: aviramha/cicache@fa5c0c8d5c75a3f5a1b2e1a5d14d90b0ff63660d # v0.4.3
         with:
           # Objects of 1 MiB and up get entries of their own, where they deduplicate across jobs
           # and runs. Everything smaller shares one packed entry: the cache API charges per entry
@@ -60,4 +60,4 @@ jobs:
       - name: Stop HTTP cache proxy
         continue-on-error: true
         if: ${{ always() && runner.os != 'Windows' }}
-        uses: aviramha/cicache/cleanup@37dffe6651493698a2eb079e9bdca5da22fc013f # v0.4.2
+        uses: aviramha/cicache/cleanup@fa5c0c8d5c75a3f5a1b2e1a5d14d90b0ff63660d # v0.4.3

--- a/.github/workflows/check-rust-docs.yaml
+++ b/.github/workflows/check-rust-docs.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Start HTTP cache proxy
         continue-on-error: true
         if: ${{ runner.os != 'Windows' }}
-        uses: aviramha/cicache@4a25bfdb846911d73d40200fd7d97f4c74ddc4cd # v0.1.4
+        uses: aviramha/cicache@f432b5a08611d79ff8a589312d1497cfd7dd4050 # v0.1.5
         with:
           # Large artifacts are the win here; a high floor keeps the entry count down so this
           # competes less with the Rust caches for the repository's cache budget.
@@ -54,4 +54,4 @@ jobs:
       - name: Stop HTTP cache proxy
         continue-on-error: true
         if: ${{ always() && runner.os != 'Windows' }}
-        uses: aviramha/cicache/cleanup@4a25bfdb846911d73d40200fd7d97f4c74ddc4cd # v0.1.4
+        uses: aviramha/cicache/cleanup@f432b5a08611d79ff8a589312d1497cfd7dd4050 # v0.1.5

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -339,7 +339,7 @@ jobs:
       - name: Start HTTP cache proxy
         continue-on-error: true
         if: ${{ runner.os != 'Windows' }}
-        uses: aviramha/cicache@4a25bfdb846911d73d40200fd7d97f4c74ddc4cd # v0.1.4
+        uses: aviramha/cicache@f432b5a08611d79ff8a589312d1497cfd7dd4050 # v0.1.5
         with:
           # Large artifacts are the win here; a high floor keeps the entry count down so this
           # competes less with the Rust caches for the repository's cache budget.
@@ -375,7 +375,7 @@ jobs:
       - name: Stop HTTP cache proxy
         continue-on-error: true
         if: ${{ always() && runner.os != 'Windows' }}
-        uses: aviramha/cicache/cleanup@4a25bfdb846911d73d40200fd7d97f4c74ddc4cd # v0.1.4
+        uses: aviramha/cicache/cleanup@f432b5a08611d79ff8a589312d1497cfd7dd4050 # v0.1.5
 
   integration_tests:
     needs: [plan, build-ci-runner]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -339,7 +339,7 @@ jobs:
       - name: Start HTTP cache proxy
         continue-on-error: true
         if: ${{ runner.os != 'Windows' }}
-        uses: aviramha/cicache@e2ce39ac4f3f8bee46a48fa3db0113737dd12099 # v0.3.0
+        uses: aviramha/cicache@2dac7392897df52ee1f9c11166e5e8a91b01ab55 # v0.3.1
         with:
           # Only genuinely large artifacts. The cache service is rate limited per job, so the
           # floor has to keep the number of stored objects in the tens rather than the thousands;
@@ -379,7 +379,7 @@ jobs:
       - name: Stop HTTP cache proxy
         continue-on-error: true
         if: ${{ always() && runner.os != 'Windows' }}
-        uses: aviramha/cicache/cleanup@e2ce39ac4f3f8bee46a48fa3db0113737dd12099 # v0.3.0
+        uses: aviramha/cicache/cleanup@2dac7392897df52ee1f9c11166e5e8a91b01ab55 # v0.3.1
 
   integration_tests:
     needs: [plan, build-ci-runner]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -339,11 +339,12 @@ jobs:
       - name: Start HTTP cache proxy
         continue-on-error: true
         if: ${{ runner.os != 'Windows' }}
-        uses: aviramha/cicache@f432b5a08611d79ff8a589312d1497cfd7dd4050 # v0.1.5
+        uses: aviramha/cicache@7e295ea73e080960835b7dd2c2b6c4150294acc4 # v0.1.6
         with:
-          # Large artifacts are the win here; a high floor keeps the entry count down so this
-          # competes less with the Rust caches for the repository's cache budget.
-          min-size: "131072"
+          # Only genuinely large artifacts. The cache service is rate limited per job, so the
+          # floor has to keep the number of stored objects in the tens rather than the thousands;
+          # it also leaves more of the repository's cache budget to the Rust caches.
+          min-size: "4194304"
       # frida's build script fetches its devkit with a TLS stack carrying its own root store, so
       # it ignores SSL_CERT_FILE and cannot be talked through an intercepting proxy over HTTPS.
       # Requesting the same artifact over plain HTTP keeps that hop on localhost; the proxy then
@@ -375,7 +376,7 @@ jobs:
       - name: Stop HTTP cache proxy
         continue-on-error: true
         if: ${{ always() && runner.os != 'Windows' }}
-        uses: aviramha/cicache/cleanup@f432b5a08611d79ff8a589312d1497cfd7dd4050 # v0.1.5
+        uses: aviramha/cicache/cleanup@7e295ea73e080960835b7dd2c2b6c4150294acc4 # v0.1.6
 
   integration_tests:
     needs: [plan, build-ci-runner]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -339,12 +339,15 @@ jobs:
       - name: Start HTTP cache proxy
         continue-on-error: true
         if: ${{ runner.os != 'Windows' }}
-        uses: aviramha/cicache@41c6b73e1200efc1eb4c6cfa641986ba12f354e8 # v0.2.1
+        uses: aviramha/cicache@53b9220da9a6d323a92d0a283df6d1cf0042d43f # v0.2.2
         with:
           # Only genuinely large artifacts. The cache service is rate limited per job, so the
           # floor has to keep the number of stored objects in the tens rather than the thousands;
           # it also leaves more of the repository's cache budget to the Rust caches.
           min-size: "4194304"
+          # Bumped past the keys an earlier version of the proxy left reserved but never
+          # committed; the service reports those as existing while serving nothing for them.
+          key-prefix: "cicache-v2"
       # frida's build script fetches its devkit with a TLS stack carrying its own root store, so
       # it ignores SSL_CERT_FILE and cannot be talked through an intercepting proxy over HTTPS.
       # Requesting the same artifact over plain HTTP keeps that hop on localhost; the proxy then
@@ -376,7 +379,7 @@ jobs:
       - name: Stop HTTP cache proxy
         continue-on-error: true
         if: ${{ always() && runner.os != 'Windows' }}
-        uses: aviramha/cicache/cleanup@41c6b73e1200efc1eb4c6cfa641986ba12f354e8 # v0.2.1
+        uses: aviramha/cicache/cleanup@53b9220da9a6d323a92d0a283df6d1cf0042d43f # v0.2.2
 
   integration_tests:
     needs: [plan, build-ci-runner]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -341,10 +341,10 @@ jobs:
         if: ${{ runner.os != 'Windows' }}
         uses: aviramha/cicache@2dac7392897df52ee1f9c11166e5e8a91b01ab55 # v0.3.1
         with:
-          # Only genuinely large artifacts. The cache service is rate limited per job, so the
-          # floor has to keep the number of stored objects in the tens rather than the thousands;
-          # it also leaves more of the repository's cache budget to the Rust caches.
-          min-size: "4194304"
+          # Covers about 85% of the bytes this job downloads across ~150 objects. Lower floors
+          # add little: most of what is left is small crates, and objects are what cost calls to
+          # the rate limited cache API.
+          min-size: "131072"
           # Bumped past the keys an earlier version of the proxy left reserved but never
           # committed; the service reports those as existing while serving nothing for them.
           key-prefix: "cicache-v2"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -339,7 +339,7 @@ jobs:
       - name: Start HTTP cache proxy
         continue-on-error: true
         if: ${{ runner.os != 'Windows' }}
-        uses: aviramha/cicache@53b9220da9a6d323a92d0a283df6d1cf0042d43f # v0.2.2
+        uses: aviramha/cicache@cb12b27235839cafd30183b4395629169f5824bd # v0.2.3
         with:
           # Only genuinely large artifacts. The cache service is rate limited per job, so the
           # floor has to keep the number of stored objects in the tens rather than the thousands;
@@ -379,7 +379,7 @@ jobs:
       - name: Stop HTTP cache proxy
         continue-on-error: true
         if: ${{ always() && runner.os != 'Windows' }}
-        uses: aviramha/cicache/cleanup@53b9220da9a6d323a92d0a283df6d1cf0042d43f # v0.2.2
+        uses: aviramha/cicache/cleanup@cb12b27235839cafd30183b4395629169f5824bd # v0.2.3
 
   integration_tests:
     needs: [plan, build-ci-runner]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -339,7 +339,7 @@ jobs:
       - name: Start HTTP cache proxy
         continue-on-error: true
         if: ${{ runner.os != 'Windows' }}
-        uses: aviramha/cicache@7e295ea73e080960835b7dd2c2b6c4150294acc4 # v0.1.6
+        uses: aviramha/cicache@d7a986e0f1fa67ba0abe97cc25abcd61a8c27f49 # v0.2.0
         with:
           # Only genuinely large artifacts. The cache service is rate limited per job, so the
           # floor has to keep the number of stored objects in the tens rather than the thousands;
@@ -376,7 +376,7 @@ jobs:
       - name: Stop HTTP cache proxy
         continue-on-error: true
         if: ${{ always() && runner.os != 'Windows' }}
-        uses: aviramha/cicache/cleanup@7e295ea73e080960835b7dd2c2b6c4150294acc4 # v0.1.6
+        uses: aviramha/cicache/cleanup@d7a986e0f1fa67ba0abe97cc25abcd61a8c27f49 # v0.2.0
 
   integration_tests:
     needs: [plan, build-ci-runner]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -339,11 +339,19 @@ jobs:
       - name: Start HTTP cache proxy
         continue-on-error: true
         if: ${{ runner.os != 'Windows' }}
-        uses: aviramha/cicache@88c715f19ca5f152fc77a6305689df2f9b143ead # v0.1.2
+        uses: aviramha/cicache@01ec6277924fdf25c1ada5be0874a65b9469db39 # v0.1.3
         with:
           # Large artifacts are the win here; a high floor keeps the entry count down so this
           # competes less with the Rust caches for the repository's cache budget.
           min-size: "131072"
+      # frida's build script fetches its devkit with a TLS stack carrying its own root store, so
+      # it ignores SSL_CERT_FILE and cannot be talked through an intercepting proxy over HTTPS.
+      # Requesting the same artifact over plain HTTP keeps that hop on localhost; the proxy then
+      # fetches it over HTTPS upstream and caches it. Harmless without a proxy, where GitHub just
+      # redirects back to HTTPS.
+      - name: Fetch the frida devkit through the cache proxy
+        if: ${{ runner.os != 'Windows' }}
+        run: echo "FRIDA_DOWNLOAD_CDN=http://github.com/frida/frida/releases/download" >> "$GITHUB_ENV"
       - uses: metalbear-co/setup-protoc@770e54d44679c8e1d8fdc06d1d9268fa79fbefb4
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -367,7 +375,7 @@ jobs:
       - name: Stop HTTP cache proxy
         continue-on-error: true
         if: ${{ always() && runner.os != 'Windows' }}
-        uses: aviramha/cicache/cleanup@88c715f19ca5f152fc77a6305689df2f9b143ead # v0.1.2
+        uses: aviramha/cicache/cleanup@01ec6277924fdf25c1ada5be0874a65b9469db39 # v0.1.3
 
   integration_tests:
     needs: [plan, build-ci-runner]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -339,7 +339,7 @@ jobs:
       - name: Start HTTP cache proxy
         continue-on-error: true
         if: ${{ runner.os != 'Windows' }}
-        uses: aviramha/cicache@37dffe6651493698a2eb079e9bdca5da22fc013f # v0.4.2
+        uses: aviramha/cicache@fa5c0c8d5c75a3f5a1b2e1a5d14d90b0ff63660d # v0.4.3
         with:
           # Objects of 1 MiB and up get entries of their own, where they deduplicate across jobs
           # and runs. Everything smaller shares one packed entry: the cache API charges per entry
@@ -381,7 +381,7 @@ jobs:
       - name: Stop HTTP cache proxy
         continue-on-error: true
         if: ${{ always() && runner.os != 'Windows' }}
-        uses: aviramha/cicache/cleanup@37dffe6651493698a2eb079e9bdca5da22fc013f # v0.4.2
+        uses: aviramha/cicache/cleanup@fa5c0c8d5c75a3f5a1b2e1a5d14d90b0ff63660d # v0.4.3
 
   integration_tests:
     needs: [plan, build-ci-runner]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -339,7 +339,7 @@ jobs:
       - name: Start HTTP cache proxy
         continue-on-error: true
         if: ${{ runner.os != 'Windows' }}
-        uses: aviramha/cicache@01ec6277924fdf25c1ada5be0874a65b9469db39 # v0.1.3
+        uses: aviramha/cicache@4a25bfdb846911d73d40200fd7d97f4c74ddc4cd # v0.1.4
         with:
           # Large artifacts are the win here; a high floor keeps the entry count down so this
           # competes less with the Rust caches for the repository's cache budget.
@@ -375,7 +375,7 @@ jobs:
       - name: Stop HTTP cache proxy
         continue-on-error: true
         if: ${{ always() && runner.os != 'Windows' }}
-        uses: aviramha/cicache/cleanup@01ec6277924fdf25c1ada5be0874a65b9469db39 # v0.1.3
+        uses: aviramha/cicache/cleanup@4a25bfdb846911d73d40200fd7d97f4c74ddc4cd # v0.1.4
 
   integration_tests:
     needs: [plan, build-ci-runner]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -334,6 +334,16 @@ jobs:
       image: ghcr.io/metalbear-co/ci-agent-build:54901618bd7bdc9b4975fb7e5439e519f6469ac0
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      # Routes this job's downloads through a local caching proxy backed by the Actions cache.
+      # Never fatal: if it does not start, the job just downloads the way it did before.
+      - name: Start HTTP cache proxy
+        continue-on-error: true
+        if: ${{ runner.os != 'Windows' }}
+        uses: aviramha/cicache@88c715f19ca5f152fc77a6305689df2f9b143ead # v0.1.2
+        with:
+          # Large artifacts are the win here; a high floor keeps the entry count down so this
+          # competes less with the Rust caches for the repository's cache budget.
+          min-size: "131072"
       - uses: metalbear-co/setup-protoc@770e54d44679c8e1d8fdc06d1d9268fa79fbefb4
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -352,6 +362,12 @@ jobs:
         run: cargo nextest run --target x86_64-unknown-linux-gnu -p mirrord-agent-env
       - name: mirrord-agent-iptables UT
         run: cargo nextest run --target x86_64-unknown-linux-gnu -p mirrord-agent-iptables
+      # Drains the upload queue and prints the hit rate. Has to run even when the job fails, or
+      # nothing is stored for later runs.
+      - name: Stop HTTP cache proxy
+        continue-on-error: true
+        if: ${{ always() && runner.os != 'Windows' }}
+        uses: aviramha/cicache/cleanup@88c715f19ca5f152fc77a6305689df2f9b143ead # v0.1.2
 
   integration_tests:
     needs: [plan, build-ci-runner]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -339,7 +339,7 @@ jobs:
       - name: Start HTTP cache proxy
         continue-on-error: true
         if: ${{ runner.os != 'Windows' }}
-        uses: aviramha/cicache@cb12b27235839cafd30183b4395629169f5824bd # v0.2.3
+        uses: aviramha/cicache@e2ce39ac4f3f8bee46a48fa3db0113737dd12099 # v0.3.0
         with:
           # Only genuinely large artifacts. The cache service is rate limited per job, so the
           # floor has to keep the number of stored objects in the tens rather than the thousands;
@@ -379,7 +379,7 @@ jobs:
       - name: Stop HTTP cache proxy
         continue-on-error: true
         if: ${{ always() && runner.os != 'Windows' }}
-        uses: aviramha/cicache/cleanup@cb12b27235839cafd30183b4395629169f5824bd # v0.2.3
+        uses: aviramha/cicache/cleanup@e2ce39ac4f3f8bee46a48fa3db0113737dd12099 # v0.3.0
 
   integration_tests:
     needs: [plan, build-ci-runner]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -339,13 +339,14 @@ jobs:
       - name: Start HTTP cache proxy
         continue-on-error: true
         if: ${{ runner.os != 'Windows' }}
-        uses: aviramha/cicache@2dac7392897df52ee1f9c11166e5e8a91b01ab55 # v0.3.1
+        uses: aviramha/cicache@37dffe6651493698a2eb079e9bdca5da22fc013f # v0.4.2
         with:
-          # Covers about 70% of the bytes this job downloads across ~17 objects. The floor is
-          # set by the cache API's rate limit rather than by what is worth caching: every stored
-          # object costs two calls, the limit is shared across the jobs running at once, and a
-          # 128 KiB floor put ~150 objects per job over it.
-          min-size: "1048576"
+          # Objects of 1 MiB and up get entries of their own, where they deduplicate across jobs
+          # and runs. Everything smaller shares one packed entry: the cache API charges per entry
+          # against a limit shared by the whole run, so ~1300 small crates stored individually
+          # exhaust it, while packed they cost two calls.
+          min-size: "32768"
+          pack-threshold: "1048576"
           # Bumped past the keys an earlier version of the proxy left reserved but never
           # committed; the service reports those as existing while serving nothing for them.
           key-prefix: "cicache-v2"
@@ -380,7 +381,7 @@ jobs:
       - name: Stop HTTP cache proxy
         continue-on-error: true
         if: ${{ always() && runner.os != 'Windows' }}
-        uses: aviramha/cicache/cleanup@2dac7392897df52ee1f9c11166e5e8a91b01ab55 # v0.3.1
+        uses: aviramha/cicache/cleanup@37dffe6651493698a2eb079e9bdca5da22fc013f # v0.4.2
 
   integration_tests:
     needs: [plan, build-ci-runner]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -339,7 +339,7 @@ jobs:
       - name: Start HTTP cache proxy
         continue-on-error: true
         if: ${{ runner.os != 'Windows' }}
-        uses: aviramha/cicache@d7a986e0f1fa67ba0abe97cc25abcd61a8c27f49 # v0.2.0
+        uses: aviramha/cicache@41c6b73e1200efc1eb4c6cfa641986ba12f354e8 # v0.2.1
         with:
           # Only genuinely large artifacts. The cache service is rate limited per job, so the
           # floor has to keep the number of stored objects in the tens rather than the thousands;
@@ -376,7 +376,7 @@ jobs:
       - name: Stop HTTP cache proxy
         continue-on-error: true
         if: ${{ always() && runner.os != 'Windows' }}
-        uses: aviramha/cicache/cleanup@d7a986e0f1fa67ba0abe97cc25abcd61a8c27f49 # v0.2.0
+        uses: aviramha/cicache/cleanup@41c6b73e1200efc1eb4c6cfa641986ba12f354e8 # v0.2.1
 
   integration_tests:
     needs: [plan, build-ci-runner]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -341,10 +341,11 @@ jobs:
         if: ${{ runner.os != 'Windows' }}
         uses: aviramha/cicache@2dac7392897df52ee1f9c11166e5e8a91b01ab55 # v0.3.1
         with:
-          # Covers about 85% of the bytes this job downloads across ~150 objects. Lower floors
-          # add little: most of what is left is small crates, and objects are what cost calls to
-          # the rate limited cache API.
-          min-size: "131072"
+          # Covers about 70% of the bytes this job downloads across ~17 objects. The floor is
+          # set by the cache API's rate limit rather than by what is worth caching: every stored
+          # object costs two calls, the limit is shared across the jobs running at once, and a
+          # 128 KiB floor put ~150 objects per job over it.
+          min-size: "1048576"
           # Bumped past the keys an earlier version of the proxy left reserved but never
           # committed; the service reports those as existing while serving nothing for them.
           key-prefix: "cicache-v2"

--- a/.github/workflows/test-macos.yaml
+++ b/.github/workflows/test-macos.yaml
@@ -30,11 +30,19 @@ jobs:
       - name: Start HTTP cache proxy
         continue-on-error: true
         if: ${{ runner.os != 'Windows' }}
-        uses: aviramha/cicache@88c715f19ca5f152fc77a6305689df2f9b143ead # v0.1.2
+        uses: aviramha/cicache@01ec6277924fdf25c1ada5be0874a65b9469db39 # v0.1.3
         with:
           # Large artifacts are the win here; a high floor keeps the entry count down so this
           # competes less with the Rust caches for the repository's cache budget.
           min-size: "131072"
+      # frida's build script fetches its devkit with a TLS stack carrying its own root store, so
+      # it ignores SSL_CERT_FILE and cannot be talked through an intercepting proxy over HTTPS.
+      # Requesting the same artifact over plain HTTP keeps that hop on localhost; the proxy then
+      # fetches it over HTTPS upstream and caches it. Harmless without a proxy, where GitHub just
+      # redirects back to HTTPS.
+      - name: Fetch the frida devkit through the cache proxy
+        if: ${{ runner.os != 'Windows' }}
+        run: echo "FRIDA_DOWNLOAD_CDN=http://github.com/frida/frida/releases/download" >> "$GITHUB_ENV"
       - run: rm rust-toolchain.toml
       - uses: metalbear-co/setup-rust-toolchain@a8d42d5aa259519dac1faeee20e37c1fb43453a3
         with:
@@ -175,4 +183,4 @@ jobs:
       - name: Stop HTTP cache proxy
         continue-on-error: true
         if: ${{ always() && runner.os != 'Windows' }}
-        uses: aviramha/cicache/cleanup@88c715f19ca5f152fc77a6305689df2f9b143ead # v0.1.2
+        uses: aviramha/cicache/cleanup@01ec6277924fdf25c1ada5be0874a65b9469db39 # v0.1.3

--- a/.github/workflows/test-macos.yaml
+++ b/.github/workflows/test-macos.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Start HTTP cache proxy
         continue-on-error: true
         if: ${{ runner.os != 'Windows' }}
-        uses: aviramha/cicache@53b9220da9a6d323a92d0a283df6d1cf0042d43f # v0.2.2
+        uses: aviramha/cicache@cb12b27235839cafd30183b4395629169f5824bd # v0.2.3
         with:
           # Only genuinely large artifacts. The cache service is rate limited per job, so the
           # floor has to keep the number of stored objects in the tens rather than the thousands;
@@ -187,4 +187,4 @@ jobs:
       - name: Stop HTTP cache proxy
         continue-on-error: true
         if: ${{ always() && runner.os != 'Windows' }}
-        uses: aviramha/cicache/cleanup@53b9220da9a6d323a92d0a283df6d1cf0042d43f # v0.2.2
+        uses: aviramha/cicache/cleanup@cb12b27235839cafd30183b4395629169f5824bd # v0.2.3

--- a/.github/workflows/test-macos.yaml
+++ b/.github/workflows/test-macos.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Start HTTP cache proxy
         continue-on-error: true
         if: ${{ runner.os != 'Windows' }}
-        uses: aviramha/cicache@7e295ea73e080960835b7dd2c2b6c4150294acc4 # v0.1.6
+        uses: aviramha/cicache@d7a986e0f1fa67ba0abe97cc25abcd61a8c27f49 # v0.2.0
         with:
           # Only genuinely large artifacts. The cache service is rate limited per job, so the
           # floor has to keep the number of stored objects in the tens rather than the thousands;
@@ -184,4 +184,4 @@ jobs:
       - name: Stop HTTP cache proxy
         continue-on-error: true
         if: ${{ always() && runner.os != 'Windows' }}
-        uses: aviramha/cicache/cleanup@7e295ea73e080960835b7dd2c2b6c4150294acc4 # v0.1.6
+        uses: aviramha/cicache/cleanup@d7a986e0f1fa67ba0abe97cc25abcd61a8c27f49 # v0.2.0

--- a/.github/workflows/test-macos.yaml
+++ b/.github/workflows/test-macos.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Start HTTP cache proxy
         continue-on-error: true
         if: ${{ runner.os != 'Windows' }}
-        uses: aviramha/cicache@cb12b27235839cafd30183b4395629169f5824bd # v0.2.3
+        uses: aviramha/cicache@e2ce39ac4f3f8bee46a48fa3db0113737dd12099 # v0.3.0
         with:
           # Only genuinely large artifacts. The cache service is rate limited per job, so the
           # floor has to keep the number of stored objects in the tens rather than the thousands;
@@ -187,4 +187,4 @@ jobs:
       - name: Stop HTTP cache proxy
         continue-on-error: true
         if: ${{ always() && runner.os != 'Windows' }}
-        uses: aviramha/cicache/cleanup@cb12b27235839cafd30183b4395629169f5824bd # v0.2.3
+        uses: aviramha/cicache/cleanup@e2ce39ac4f3f8bee46a48fa3db0113737dd12099 # v0.3.0

--- a/.github/workflows/test-macos.yaml
+++ b/.github/workflows/test-macos.yaml
@@ -32,10 +32,10 @@ jobs:
         if: ${{ runner.os != 'Windows' }}
         uses: aviramha/cicache@2dac7392897df52ee1f9c11166e5e8a91b01ab55 # v0.3.1
         with:
-          # Only genuinely large artifacts. The cache service is rate limited per job, so the
-          # floor has to keep the number of stored objects in the tens rather than the thousands;
-          # it also leaves more of the repository's cache budget to the Rust caches.
-          min-size: "4194304"
+          # Covers about 85% of the bytes this job downloads across ~150 objects. Lower floors
+          # add little: most of what is left is small crates, and objects are what cost calls to
+          # the rate limited cache API.
+          min-size: "131072"
           # Bumped past the keys an earlier version of the proxy left reserved but never
           # committed; the service reports those as existing while serving nothing for them.
           key-prefix: "cicache-v2"

--- a/.github/workflows/test-macos.yaml
+++ b/.github/workflows/test-macos.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Start HTTP cache proxy
         continue-on-error: true
         if: ${{ runner.os != 'Windows' }}
-        uses: aviramha/cicache@37dffe6651493698a2eb079e9bdca5da22fc013f # v0.4.2
+        uses: aviramha/cicache@fa5c0c8d5c75a3f5a1b2e1a5d14d90b0ff63660d # v0.4.3
         with:
           # Objects of 1 MiB and up get entries of their own, where they deduplicate across jobs
           # and runs. Everything smaller shares one packed entry: the cache API charges per entry
@@ -189,4 +189,4 @@ jobs:
       - name: Stop HTTP cache proxy
         continue-on-error: true
         if: ${{ always() && runner.os != 'Windows' }}
-        uses: aviramha/cicache/cleanup@37dffe6651493698a2eb079e9bdca5da22fc013f # v0.4.2
+        uses: aviramha/cicache/cleanup@fa5c0c8d5c75a3f5a1b2e1a5d14d90b0ff63660d # v0.4.3

--- a/.github/workflows/test-macos.yaml
+++ b/.github/workflows/test-macos.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Start HTTP cache proxy
         continue-on-error: true
         if: ${{ runner.os != 'Windows' }}
-        uses: aviramha/cicache@d7a986e0f1fa67ba0abe97cc25abcd61a8c27f49 # v0.2.0
+        uses: aviramha/cicache@41c6b73e1200efc1eb4c6cfa641986ba12f354e8 # v0.2.1
         with:
           # Only genuinely large artifacts. The cache service is rate limited per job, so the
           # floor has to keep the number of stored objects in the tens rather than the thousands;
@@ -184,4 +184,4 @@ jobs:
       - name: Stop HTTP cache proxy
         continue-on-error: true
         if: ${{ always() && runner.os != 'Windows' }}
-        uses: aviramha/cicache/cleanup@d7a986e0f1fa67ba0abe97cc25abcd61a8c27f49 # v0.2.0
+        uses: aviramha/cicache/cleanup@41c6b73e1200efc1eb4c6cfa641986ba12f354e8 # v0.2.1

--- a/.github/workflows/test-macos.yaml
+++ b/.github/workflows/test-macos.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Start HTTP cache proxy
         continue-on-error: true
         if: ${{ runner.os != 'Windows' }}
-        uses: aviramha/cicache@01ec6277924fdf25c1ada5be0874a65b9469db39 # v0.1.3
+        uses: aviramha/cicache@4a25bfdb846911d73d40200fd7d97f4c74ddc4cd # v0.1.4
         with:
           # Large artifacts are the win here; a high floor keeps the entry count down so this
           # competes less with the Rust caches for the repository's cache budget.
@@ -183,4 +183,4 @@ jobs:
       - name: Stop HTTP cache proxy
         continue-on-error: true
         if: ${{ always() && runner.os != 'Windows' }}
-        uses: aviramha/cicache/cleanup@01ec6277924fdf25c1ada5be0874a65b9469db39 # v0.1.3
+        uses: aviramha/cicache/cleanup@4a25bfdb846911d73d40200fd7d97f4c74ddc4cd # v0.1.4

--- a/.github/workflows/test-macos.yaml
+++ b/.github/workflows/test-macos.yaml
@@ -30,11 +30,12 @@ jobs:
       - name: Start HTTP cache proxy
         continue-on-error: true
         if: ${{ runner.os != 'Windows' }}
-        uses: aviramha/cicache@f432b5a08611d79ff8a589312d1497cfd7dd4050 # v0.1.5
+        uses: aviramha/cicache@7e295ea73e080960835b7dd2c2b6c4150294acc4 # v0.1.6
         with:
-          # Large artifacts are the win here; a high floor keeps the entry count down so this
-          # competes less with the Rust caches for the repository's cache budget.
-          min-size: "131072"
+          # Only genuinely large artifacts. The cache service is rate limited per job, so the
+          # floor has to keep the number of stored objects in the tens rather than the thousands;
+          # it also leaves more of the repository's cache budget to the Rust caches.
+          min-size: "4194304"
       # frida's build script fetches its devkit with a TLS stack carrying its own root store, so
       # it ignores SSL_CERT_FILE and cannot be talked through an intercepting proxy over HTTPS.
       # Requesting the same artifact over plain HTTP keeps that hop on localhost; the proxy then
@@ -183,4 +184,4 @@ jobs:
       - name: Stop HTTP cache proxy
         continue-on-error: true
         if: ${{ always() && runner.os != 'Windows' }}
-        uses: aviramha/cicache/cleanup@f432b5a08611d79ff8a589312d1497cfd7dd4050 # v0.1.5
+        uses: aviramha/cicache/cleanup@7e295ea73e080960835b7dd2c2b6c4150294acc4 # v0.1.6

--- a/.github/workflows/test-macos.yaml
+++ b/.github/workflows/test-macos.yaml
@@ -25,6 +25,16 @@ jobs:
       MIRRORD_TESTS_USE_BINARY: ${{ github.workspace }}/target/universal-apple-darwin/debug/mirrord
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      # Routes this job's downloads through a local caching proxy backed by the Actions cache.
+      # Never fatal: if it does not start, the job just downloads the way it did before.
+      - name: Start HTTP cache proxy
+        continue-on-error: true
+        if: ${{ runner.os != 'Windows' }}
+        uses: aviramha/cicache@88c715f19ca5f152fc77a6305689df2f9b143ead # v0.1.2
+        with:
+          # Large artifacts are the win here; a high floor keeps the entry count down so this
+          # competes less with the Rust caches for the repository's cache budget.
+          min-size: "131072"
       - run: rm rust-toolchain.toml
       - uses: metalbear-co/setup-rust-toolchain@a8d42d5aa259519dac1faeee20e37c1fb43453a3
         with:
@@ -160,3 +170,9 @@ jobs:
           name: intproxy_logs_macos
           path: /tmp/intproxy_logs/macos
           retention-days: 2
+      # Drains the upload queue and prints the hit rate. Has to run even when the job fails, or
+      # nothing is stored for later runs.
+      - name: Stop HTTP cache proxy
+        continue-on-error: true
+        if: ${{ always() && runner.os != 'Windows' }}
+        uses: aviramha/cicache/cleanup@88c715f19ca5f152fc77a6305689df2f9b143ead # v0.1.2

--- a/.github/workflows/test-macos.yaml
+++ b/.github/workflows/test-macos.yaml
@@ -32,10 +32,11 @@ jobs:
         if: ${{ runner.os != 'Windows' }}
         uses: aviramha/cicache@2dac7392897df52ee1f9c11166e5e8a91b01ab55 # v0.3.1
         with:
-          # Covers about 85% of the bytes this job downloads across ~150 objects. Lower floors
-          # add little: most of what is left is small crates, and objects are what cost calls to
-          # the rate limited cache API.
-          min-size: "131072"
+          # Covers about 70% of the bytes this job downloads across ~17 objects. The floor is
+          # set by the cache API's rate limit rather than by what is worth caching: every stored
+          # object costs two calls, the limit is shared across the jobs running at once, and a
+          # 128 KiB floor put ~150 objects per job over it.
+          min-size: "1048576"
           # Bumped past the keys an earlier version of the proxy left reserved but never
           # committed; the service reports those as existing while serving nothing for them.
           key-prefix: "cicache-v2"

--- a/.github/workflows/test-macos.yaml
+++ b/.github/workflows/test-macos.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Start HTTP cache proxy
         continue-on-error: true
         if: ${{ runner.os != 'Windows' }}
-        uses: aviramha/cicache@4a25bfdb846911d73d40200fd7d97f4c74ddc4cd # v0.1.4
+        uses: aviramha/cicache@f432b5a08611d79ff8a589312d1497cfd7dd4050 # v0.1.5
         with:
           # Large artifacts are the win here; a high floor keeps the entry count down so this
           # competes less with the Rust caches for the repository's cache budget.
@@ -183,4 +183,4 @@ jobs:
       - name: Stop HTTP cache proxy
         continue-on-error: true
         if: ${{ always() && runner.os != 'Windows' }}
-        uses: aviramha/cicache/cleanup@4a25bfdb846911d73d40200fd7d97f4c74ddc4cd # v0.1.4
+        uses: aviramha/cicache/cleanup@f432b5a08611d79ff8a589312d1497cfd7dd4050 # v0.1.5

--- a/.github/workflows/test-macos.yaml
+++ b/.github/workflows/test-macos.yaml
@@ -30,12 +30,15 @@ jobs:
       - name: Start HTTP cache proxy
         continue-on-error: true
         if: ${{ runner.os != 'Windows' }}
-        uses: aviramha/cicache@41c6b73e1200efc1eb4c6cfa641986ba12f354e8 # v0.2.1
+        uses: aviramha/cicache@53b9220da9a6d323a92d0a283df6d1cf0042d43f # v0.2.2
         with:
           # Only genuinely large artifacts. The cache service is rate limited per job, so the
           # floor has to keep the number of stored objects in the tens rather than the thousands;
           # it also leaves more of the repository's cache budget to the Rust caches.
           min-size: "4194304"
+          # Bumped past the keys an earlier version of the proxy left reserved but never
+          # committed; the service reports those as existing while serving nothing for them.
+          key-prefix: "cicache-v2"
       # frida's build script fetches its devkit with a TLS stack carrying its own root store, so
       # it ignores SSL_CERT_FILE and cannot be talked through an intercepting proxy over HTTPS.
       # Requesting the same artifact over plain HTTP keeps that hop on localhost; the proxy then
@@ -184,4 +187,4 @@ jobs:
       - name: Stop HTTP cache proxy
         continue-on-error: true
         if: ${{ always() && runner.os != 'Windows' }}
-        uses: aviramha/cicache/cleanup@41c6b73e1200efc1eb4c6cfa641986ba12f354e8 # v0.2.1
+        uses: aviramha/cicache/cleanup@53b9220da9a6d323a92d0a283df6d1cf0042d43f # v0.2.2

--- a/.github/workflows/test-macos.yaml
+++ b/.github/workflows/test-macos.yaml
@@ -30,13 +30,14 @@ jobs:
       - name: Start HTTP cache proxy
         continue-on-error: true
         if: ${{ runner.os != 'Windows' }}
-        uses: aviramha/cicache@2dac7392897df52ee1f9c11166e5e8a91b01ab55 # v0.3.1
+        uses: aviramha/cicache@37dffe6651493698a2eb079e9bdca5da22fc013f # v0.4.2
         with:
-          # Covers about 70% of the bytes this job downloads across ~17 objects. The floor is
-          # set by the cache API's rate limit rather than by what is worth caching: every stored
-          # object costs two calls, the limit is shared across the jobs running at once, and a
-          # 128 KiB floor put ~150 objects per job over it.
-          min-size: "1048576"
+          # Objects of 1 MiB and up get entries of their own, where they deduplicate across jobs
+          # and runs. Everything smaller shares one packed entry: the cache API charges per entry
+          # against a limit shared by the whole run, so ~1300 small crates stored individually
+          # exhaust it, while packed they cost two calls.
+          min-size: "32768"
+          pack-threshold: "1048576"
           # Bumped past the keys an earlier version of the proxy left reserved but never
           # committed; the service reports those as existing while serving nothing for them.
           key-prefix: "cicache-v2"
@@ -188,4 +189,4 @@ jobs:
       - name: Stop HTTP cache proxy
         continue-on-error: true
         if: ${{ always() && runner.os != 'Windows' }}
-        uses: aviramha/cicache/cleanup@2dac7392897df52ee1f9c11166e5e8a91b01ab55 # v0.3.1
+        uses: aviramha/cicache/cleanup@37dffe6651493698a2eb079e9bdca5da22fc013f # v0.4.2

--- a/.github/workflows/test-macos.yaml
+++ b/.github/workflows/test-macos.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Start HTTP cache proxy
         continue-on-error: true
         if: ${{ runner.os != 'Windows' }}
-        uses: aviramha/cicache@e2ce39ac4f3f8bee46a48fa3db0113737dd12099 # v0.3.0
+        uses: aviramha/cicache@2dac7392897df52ee1f9c11166e5e8a91b01ab55 # v0.3.1
         with:
           # Only genuinely large artifacts. The cache service is rate limited per job, so the
           # floor has to keep the number of stored objects in the tens rather than the thousands;
@@ -187,4 +187,4 @@ jobs:
       - name: Stop HTTP cache proxy
         continue-on-error: true
         if: ${{ always() && runner.os != 'Windows' }}
-        uses: aviramha/cicache/cleanup@e2ce39ac4f3f8bee46a48fa3db0113737dd12099 # v0.3.0
+        uses: aviramha/cicache/cleanup@2dac7392897df52ee1f9c11166e5e8a91b01ab55 # v0.3.1

--- a/changelog.d/+ci-http-cache.internal.md
+++ b/changelog.d/+ci-http-cache.internal.md
@@ -1,0 +1,2 @@
+Route the mirrord CLI build job's downloads through a local caching HTTP proxy backed by the
+Actions cache, so repeat runs fetch toolchains and packages from cache instead of the network.

--- a/changelog.d/+ci-http-cache.internal.md
+++ b/changelog.d/+ci-http-cache.internal.md
@@ -1,2 +1,2 @@
 Route CI downloads through a local caching HTTP proxy backed by the Actions cache, so repeat runs
-fetch toolchains and packages from cache instead of the network.
+fetch build tools and packages from cache instead of the network.

--- a/changelog.d/+ci-http-cache.internal.md
+++ b/changelog.d/+ci-http-cache.internal.md
@@ -1,2 +1,2 @@
-Route the mirrord CLI build job's downloads through a local caching HTTP proxy backed by the
-Actions cache, so repeat runs fetch toolchains and packages from cache instead of the network.
+Route CI downloads through a local caching HTTP proxy backed by the Actions cache, so repeat runs
+fetch toolchains and packages from cache instead of the network.


### PR DESCRIPTION
Starts a caching HTTP(S) proxy at the top of the jobs that spend real time downloading, and points
their toolchains at it. Downloads that are safe to reuse are served from the Actions cache;
everything else is forwarded untouched. The teardown step prints the hit rate and bytes served.

The proxy is https://github.com/aviramha/cicache.

Measured on this branch, comparing a cold run against a warm one:

| job | before | after |
|---|---|---|
| `rust-docs` | 243.5 MB | 17.1 MB |
| `cargo-lint (linux)` | ~245 MB | 18.1 MB |
| `macos-tests` | 445 MB | 45.1 MB |

Objects of 1 MiB and up get their own cache entries, where they deduplicate across jobs and runs.
Everything smaller shares one packed entry, because the cache API charges per entry against a
limit shared by the whole run — storing ~1300 small crates individually exhausts it.

Worth a reviewer's opinion on:

- **Cache budget.** Entries land in the same 10 GB repository cache as the Rust caches and evict by
  LRU. A job's packed entry is ~70 MB and jobs keep separate caches, so the working set is a few
  hundred MB. If that starts evicting warm `target/` directories it is a net loss, and raising
  `min-size` is the lever.
- **TLS interception.** The proxy terminates TLS to see what it is caching, so each toolchain has
  to trust its CA. Anything that pins certificates or ships its own root store fails against it —
  frida needed `FRIDA_DOWNLOAD_CDN` for exactly this reason. Both proxy steps are
  `continue-on-error`, but a toolchain that refuses the CA fails its own download.

Windows jobs are excluded (no binary yet). The container-based jobs see nothing, since their work
runs inside `docker run`; wiring the proxy through `run-in-ci-runner` would cover those.

## Testing

Full CI green on this branch, twice: once cold to populate the cache and once warm to measure.
The proxy's own CI verifies the cache round trip across two jobs against the real service.
