### PR TITLE
ci: only trigger Release on pull requests that touch CHANGELOG.md

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,13 @@ on:
       - main
     types:
       - closed
+    # Release PRs are the only ones that rewrite CHANGELOG.md: towncrier builds it into
+    # the release branch, while every other PR only adds changelog.d fragments. GitHub
+    # offers no head-branch filter for pull_request, so this path filter is what keeps a
+    # Release run from being created on every closed PR. Whether a run that does start
+    # publishes is still decided by the releases/* check in validate_release_request.
+    paths:
+      - CHANGELOG.md
   # Running from workflow dispatch (AKA manual) will not publish anything.
   # This is intended for testing changes to this flow.
   workflow_dispatch:

--- a/changelog.d/+release-trigger-path-filter.internal.md
+++ b/changelog.d/+release-trigger-path-filter.internal.md
@@ -1,0 +1,1 @@
+Release CI now runs only on pull requests that touch `CHANGELOG.md`, instead of starting a run that immediately exits for every closed pull request.


### PR DESCRIPTION
The Release workflow triggers on closed pull requests against `main` and then checks inside the job whether the head branch was `releases/*`. GitHub has no head-branch filter for `pull_request`, so every closed PR started a run that validated and exited.

Release PRs are the only ones that rewrite `CHANGELOG.md` — towncrier builds it when the release branch is cut, while every other PR only adds `changelog.d` fragments. A `paths` filter on that file gives the trigger the head-branch filter GitHub does not offer. The `releases/*` check stays in place and still decides whether a run that does start publishes.

Tested by parsing each workflow and confirming the trigger resolves to `{branches: [main], types: [closed], paths: [CHANGELOG.md]}`. Verifying the filter end to end needs a merge to `main`, so the next release PR is the real check — the in-job guard is unchanged, so a miss fails closed (no release) rather than publishing something unintended.