### PR TITLE
INT-661 Support PostgreSQL connection parameter overrides in DB branch configuration (e.g., sslmode)

### DIFF
--- a/changelog.d/+pg-branch-query-params.added.md
+++ b/changelog.d/+pg-branch-query-params.added.md
@@ -1,0 +1,1 @@
+Added `query_params` to pg db branches for branch connection overrides like `sslmode`.

--- a/mirrord-schema.json
+++ b/mirrord-schema.json
@@ -2132,6 +2132,14 @@
                 "null"
               ]
             },
+            "query_params": {
+              "title": "feature.db_branches[].query_params (type: pg) {#feature-db_branches-pg-query_params}",
+              "description": "Query parameters applied to the branch connection handed to your application - the\nreconstructed connection URL and, in params mode, the matching environment variables.\nValues win over mirrord's own defaults. They only affect the branch connection; the\nsource database connection used for the copy is not changed.\n\nThe common use is `sslmode`: a source like GCP Cloud SQL may require\n`?sslmode=require`, while the branch pod mirrord creates serves no TLS, so the branch\nconnection needs `{ \"sslmode\": \"disable\" }` (this is also mirrord's default for\nnon-TLS branch pods).\n\n```json\n{\n  \"feature\": {\n    \"db_branches\": [\n      {\n        \"type\": \"pg\",\n        \"query_params\": { \"sslmode\": \"disable\" }\n      }\n    ]\n  }\n}\n```",
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
             "ttl_mins": {
               "description": "Branch TTL in minutes, counted from when the branch is last used. Mutually exclusive\nwith `ttl_secs`.",
               "type": [

--- a/mirrord/cli/src/internal_proxy/db_portforwards.rs
+++ b/mirrord/cli/src/internal_proxy/db_portforwards.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     fmt::Write as _,
     net::{IpAddr, Ipv6Addr, SocketAddr},
     sync::Arc,
@@ -68,17 +68,25 @@ enum Envs {
 struct Pf {
     envs: Envs,
     db_id: String,
+    /// User-configured `query_params` overriding the connection string's query pairs (pg only).
+    /// Needed because [`ConnInfo::ReplaceInUrl`] keeps the source URL's query verbatim, so a
+    /// source-only param like `sslmode=require` would be demanded from the branch too.
+    query_overrides: BTreeMap<String, String>,
 }
 
 enum ConnInfo {
     /// The original URL with host:port to be replaced with local address.
-    ReplaceInUrl(Url),
+    ReplaceInUrl {
+        url: Url,
+        query_overrides: BTreeMap<String, String>,
+    },
     /// All params available to build a URL from scratch.
     BuildUrl {
         scheme: &'static str,
         user: String,
         password: String,
         database: Option<String>,
+        query_overrides: BTreeMap<String, String>,
     },
     /// ADO.NET-style connection string for MSSQL.
     BuildMssql {
@@ -95,16 +103,48 @@ struct PortMapping {
     conn_info: ConnInfo,
 }
 
+/// Replaces the URL's query pairs named in `overrides` with the override values, appending
+/// the ones the URL does not carry yet. Existing occurrences of an overridden key are dropped
+/// so a driver reading either the first or the last occurrence sees the override. A no-op on
+/// an empty map, keeping untouched URLs byte-identical.
+fn apply_query_overrides(url: &mut Url, overrides: &BTreeMap<String, String>) {
+    if overrides.is_empty() {
+        return;
+    }
+    let kept: Vec<(String, String)> = url
+        .query_pairs()
+        .filter(|(key, _)| !overrides.contains_key(key.as_ref()))
+        .map(|(key, value)| (key.into_owned(), value.into_owned()))
+        .collect();
+    let mut pairs = url.query_pairs_mut();
+    pairs.clear();
+    for (key, value) in kept
+        .iter()
+        .map(|(key, value)| (key.as_str(), value.as_str()))
+        .chain(
+            overrides
+                .iter()
+                .map(|(key, value)| (key.as_str(), value.as_str())),
+        )
+    {
+        pairs.append_pair(key, value);
+    }
+}
+
 impl ConnInfo {
     fn connection_string(&self, local: SocketAddr) -> String {
         match self {
-            ConnInfo::ReplaceInUrl(url) => {
+            ConnInfo::ReplaceInUrl {
+                url,
+                query_overrides,
+            } => {
                 let mut url = url.clone();
                 let host = match local.ip() {
                     IpAddr::V4(v4) => v4.to_string(),
                     IpAddr::V6(v6) => format!("[{v6}]"),
                 };
                 if url.set_host(Some(&host)).is_ok() && url.set_port(Some(local.port())).is_ok() {
+                    apply_query_overrides(&mut url, query_overrides);
                     url.to_string()
                 } else {
                     local.to_string()
@@ -115,6 +155,7 @@ impl ConnInfo {
                 user,
                 password,
                 database,
+                query_overrides,
             } => {
                 let mut url = Url::parse(&format!("{scheme}://localhost")).unwrap();
                 let host = match local.ip() {
@@ -131,6 +172,7 @@ impl ConnInfo {
                 if *scheme == "mongodb" {
                     url.query_pairs_mut().append_pair("authSource", "admin");
                 }
+                apply_query_overrides(&mut url, query_overrides);
                 url.to_string()
             }
             ConnInfo::BuildMssql {
@@ -177,6 +219,7 @@ fn extract_portforward_configs(config: &DatabaseBranchesConfig, key: &str) -> Ha
                     scheme: None,
                 },
                 db_id,
+                query_overrides: BTreeMap::new(),
             });
             continue;
         }
@@ -266,7 +309,15 @@ fn extract_portforward_configs(config: &DatabaseBranchesConfig, key: &str) -> Ha
             }
         };
         let db_id = resolve_branch_id(&base.id, key, &NullProgress).into();
-        portforwards.insert(Pf { envs, db_id });
+        let query_overrides = match branch {
+            DatabaseBranchConfig::Pg(db) => db.query_params.clone(),
+            _ => BTreeMap::new(),
+        };
+        portforwards.insert(Pf {
+            envs,
+            db_id,
+            query_overrides,
+        });
     }
 
     portforwards
@@ -279,7 +330,12 @@ fn resolve_port_mappings(
     portforwards
         .into_iter()
         .filter_map(|pf| -> Option<_> {
-            let (host, port, conn_info) = match pf.envs {
+            let Pf {
+                envs,
+                db_id,
+                query_overrides,
+            } = pf;
+            let (host, port, conn_info) = match envs {
                 Envs::Url(url_var) => {
                     let url = vars
                         .get(&url_var)?
@@ -303,7 +359,14 @@ fn resolve_port_mappings(
 
                     let port = url.port()?;
 
-                    (host, port, ConnInfo::ReplaceInUrl(url))
+                    (
+                        host,
+                        port,
+                        ConnInfo::ReplaceInUrl {
+                            url,
+                            query_overrides,
+                        },
+                    )
                 }
                 Envs::Params {
                     host: host_var,
@@ -377,6 +440,7 @@ fn resolve_port_mappings(
                                     user,
                                     password,
                                     database,
+                                    query_overrides,
                                 }
                             })
                         })
@@ -385,13 +449,7 @@ fn resolve_port_mappings(
                     (remote_host, port_val, conn_info)
                 }
             };
-            Some((
-                (host, port),
-                PortMapping {
-                    db_id: pf.db_id,
-                    conn_info,
-                },
-            ))
+            Some(((host, port), PortMapping { db_id, conn_info }))
         })
         .collect()
 }
@@ -551,7 +609,7 @@ mod tests {
     use mirrord_config::feature::database_branches::{
         CockroachdbBranchConfig, ConnectionParamsConfig, ConnectionParamsVars, ConnectionSource,
         DatabaseBranchBaseConfig, DatabaseBranchConfig, DatabaseBranchesConfig, MysqlBranchConfig,
-        ParamSource, TargetEnvironmentVariableSource,
+        ParamSource, PgBranchConfig, TargetEnvironmentVariableSource,
     };
 
     use super::*;
@@ -695,6 +753,7 @@ mod tests {
         let pf = Pf {
             envs: Envs::Url("DB_URL".to_owned()),
             db_id: "branch-1".to_owned(),
+            query_overrides: BTreeMap::new(),
         };
         let vars = HashMap::from([(
             "DB_URL".to_owned(),
@@ -707,7 +766,7 @@ mod tests {
         let key = (RemoteAddr::Hostname("db.example.com".to_owned()), 5432);
         let mapping = result.get(&key).unwrap();
         assert_eq!(mapping.db_id, "branch-1");
-        assert!(matches!(mapping.conn_info, ConnInfo::ReplaceInUrl(_)));
+        assert!(matches!(mapping.conn_info, ConnInfo::ReplaceInUrl { .. }));
     }
 
     #[test]
@@ -722,6 +781,7 @@ mod tests {
                 scheme: Some("postgresql"),
             },
             db_id: "branch-2".to_owned(),
+            query_overrides: BTreeMap::new(),
         };
         let vars = HashMap::from([
             ("H".to_owned(), "db.host.com".to_owned()),
@@ -758,6 +818,7 @@ mod tests {
                 scheme: Some("mssql"),
             },
             db_id: "mssql-branch".to_owned(),
+            query_overrides: BTreeMap::new(),
         };
         let vars = HashMap::from([
             ("H".to_owned(), "10.0.0.5".to_owned()),
@@ -785,6 +846,7 @@ mod tests {
                 scheme: None,
             },
             db_id: "spanner-branch".to_owned(),
+            query_overrides: BTreeMap::new(),
         };
         let vars = HashMap::from([(
             "SPANNER_EMULATOR_HOST".to_owned(),
@@ -797,5 +859,98 @@ mod tests {
         let mapping = result.get(&key).unwrap();
         assert_eq!(mapping.db_id, "spanner-branch");
         assert!(matches!(mapping.conn_info, ConnInfo::HostPort));
+    }
+
+    // --- query param overrides ---
+
+    fn pg(id: Option<&str>, conn: ConnectionSource) -> DatabaseBranchConfig {
+        DatabaseBranchConfig::Pg(Box::new(PgBranchConfig {
+            base: base(id, conn),
+            copy: Default::default(),
+            connection_settings: Default::default(),
+            query_params: BTreeMap::from([("sslmode".to_owned(), "disable".to_owned())]),
+            iam_auth: None,
+            migrations: None,
+        }))
+    }
+
+    #[test]
+    fn extract_pg_captures_query_params() {
+        let config = DatabaseBranchesConfig(vec![pg(Some("db1"), url_env("DB_URL"))]);
+        let result = extract_portforward_configs(&config, "key");
+
+        let pf = result.into_iter().next().unwrap();
+        assert_eq!(
+            pf.query_overrides,
+            BTreeMap::from([("sslmode".to_owned(), "disable".to_owned())])
+        );
+    }
+
+    /// The source URL's own `sslmode=require` describes the source's TLS setup; the branch
+    /// pod serves no TLS, so the user's override must replace it in the local string.
+    #[test]
+    fn replace_in_url_applies_query_override() {
+        let conn_info = ConnInfo::ReplaceInUrl {
+            url: "postgresql://user:pass@db.example.com:5432/mydb?sslmode=require&app=x"
+                .parse()
+                .unwrap(),
+            query_overrides: BTreeMap::from([("sslmode".to_owned(), "disable".to_owned())]),
+        };
+        let local: SocketAddr = "127.0.0.1:5555".parse().unwrap();
+
+        assert_eq!(
+            conn_info.connection_string(local),
+            "postgresql://user:pass@127.0.0.1:5555/mydb?app=x&sslmode=disable"
+        );
+    }
+
+    #[test]
+    fn replace_in_url_without_overrides_keeps_query_verbatim() {
+        let conn_info = ConnInfo::ReplaceInUrl {
+            url: "postgresql://user:pass@db.example.com:5432/mydb?sslmode=require"
+                .parse()
+                .unwrap(),
+            query_overrides: BTreeMap::new(),
+        };
+        let local: SocketAddr = "127.0.0.1:5555".parse().unwrap();
+
+        assert_eq!(
+            conn_info.connection_string(local),
+            "postgresql://user:pass@127.0.0.1:5555/mydb?sslmode=require"
+        );
+    }
+
+    #[test]
+    fn build_url_appends_query_overrides() {
+        let conn_info = ConnInfo::BuildUrl {
+            scheme: "postgresql",
+            user: "admin".to_owned(),
+            password: "secret".to_owned(),
+            database: Some("mydb".to_owned()),
+            query_overrides: BTreeMap::from([("sslmode".to_owned(), "disable".to_owned())]),
+        };
+        let local: SocketAddr = "127.0.0.1:5555".parse().unwrap();
+
+        assert_eq!(
+            conn_info.connection_string(local),
+            "postgresql://admin:secret@127.0.0.1:5555/mydb?sslmode=disable"
+        );
+    }
+
+    #[test]
+    fn build_url_mongodb_auth_source_survives_overrides() {
+        let conn_info = ConnInfo::BuildUrl {
+            scheme: "mongodb",
+            user: "admin".to_owned(),
+            password: "secret".to_owned(),
+            database: None,
+            query_overrides: BTreeMap::from([("retryWrites".to_owned(), "false".to_owned())]),
+        };
+        let local: SocketAddr = "127.0.0.1:5555".parse().unwrap();
+
+        assert_eq!(
+            conn_info.connection_string(local),
+            "mongodb://admin:secret@127.0.0.1:5555?authSource=admin&retryWrites=false"
+        );
     }
 }

--- a/mirrord/config/src/feature/database_branches.rs
+++ b/mirrord/config/src/feature/database_branches.rs
@@ -1133,12 +1133,16 @@ pub struct ConnectionParamsVars {
     /// Engine-specific connection parameters that have no universal slot above, keyed by a name
     /// the engine recognizes. They are written flat alongside the fixed slots, so a Spanner
     /// `params` block reads `{ "project": ..., "instance": ..., "database_id": ... }` with no
-    /// nesting. Unlike the fixed slots, these are read-only source locators: the operator resolves
-    /// each from the target pod and hands it to the branch init sidecar, and never overrides it on
-    /// the local app.
+    /// nesting. The operator resolves each from the target pod and hands it to the branch init
+    /// sidecar. A param with a branch-side equivalent (PostgreSQL's and CockroachDB's `sslmode`)
+    /// also gets its env var rewritten on the local app to the branch's own value; the rest are
+    /// read-only source locators the local app keeps untouched.
     ///
-    /// Google Cloud Spanner is the only engine that uses this. Each key names the env var on the
-    /// target pod that holds one of Spanner's three separate source identifiers:
+    /// PostgreSQL and CockroachDB accept `sslmode`: the TLS mode of the source connection,
+    /// which params mode has no URL to carry.
+    ///
+    /// Google Cloud Spanner keys name the env vars on the target pod that hold its three
+    /// separate source identifiers:
     /// - `project`: the GCP project id the source Spanner instance lives in.
     /// - `instance`: the source Spanner instance id within that project.
     /// - `database_id`: the source database id to recreate in the emulator (and, for the `schema`
@@ -1608,6 +1612,27 @@ mod tests {
     }
 
     #[test]
+    fn deserialize_pg_query_params_roundtrip() {
+        let json = serde_json::json!({
+            "type": "pg",
+            "connection": { "url": "DB_URL" },
+            "query_params": { "sslmode": "disable" }
+        });
+        let branch: DatabaseBranchConfig = serde_json::from_value(json).unwrap();
+        let DatabaseBranchConfig::Pg(pg) = &branch else {
+            panic!("expected a pg branch, got {branch:?}");
+        };
+        assert_eq!(
+            pg.query_params,
+            BTreeMap::from([("sslmode".to_owned(), "disable".to_owned())])
+        );
+
+        let serialized = serde_json::to_value(&branch).unwrap();
+        let roundtripped: DatabaseBranchConfig = serde_json::from_value(serialized).unwrap();
+        assert_eq!(branch, roundtripped);
+    }
+
+    #[test]
     fn serialize_roundtrip_url_gcp_secret_manager() {
         let source = ConnectionSource::Url {
             url: TargetEnvironmentVariableSource::GcpSecretManager {
@@ -2016,6 +2041,7 @@ mod tests {
             },
             copy: Default::default(),
             connection_settings: Default::default(),
+            query_params: Default::default(),
             iam_auth: None,
             migrations: None,
         }))

--- a/mirrord/config/src/feature/database_branches/pg.rs
+++ b/mirrord/config/src/feature/database_branches/pg.rs
@@ -31,6 +31,33 @@ pub struct PgBranchConfig {
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub connection_settings: BTreeMap<String, String>,
 
+    /// #### feature.db_branches[].query_params (type: pg) {#feature-db_branches-pg-query_params}
+    ///
+    /// Query parameters applied to the branch connection handed to your application - the
+    /// reconstructed connection URL and, in params mode, the matching environment variables.
+    /// Values win over mirrord's own defaults. They only affect the branch connection; the
+    /// source database connection used for the copy is not changed.
+    ///
+    /// The common use is `sslmode`: a source like GCP Cloud SQL may require
+    /// `?sslmode=require`, while the branch pod mirrord creates serves no TLS, so the branch
+    /// connection needs `{ "sslmode": "disable" }` (this is also mirrord's default for
+    /// non-TLS branch pods).
+    ///
+    /// ```json
+    /// {
+    ///   "feature": {
+    ///     "db_branches": [
+    ///       {
+    ///         "type": "pg",
+    ///         "query_params": { "sslmode": "disable" }
+    ///       }
+    ///     ]
+    ///   }
+    /// }
+    /// ```
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub query_params: BTreeMap<String, String>,
+
     /// #### feature.db_branches[].iam_auth (type: pg) {#feature-db_branches-pg-iam_auth}
     ///
     /// IAM authentication for the source database.

--- a/mirrord/operator/src/client.rs
+++ b/mirrord/operator/src/client.rs
@@ -809,6 +809,32 @@ where
                 .require_feature(NewOperatorFeature::DbBranchProfiles)?;
         }
 
+        // Same fail-fast for pg `query_params` and the pg `sslmode` connection param: an older
+        // operator's CRD schema prunes `queryParams` (the override silently never applies), and
+        // its validation rejects a pg `sslmode` extra, failing the branch after creation instead
+        // of before.
+        if layer_config
+            .feature
+            .db_branches
+            .iter()
+            .any(|branch_config| match branch_config {
+                mirrord_config::feature::database_branches::DatabaseBranchConfig::Pg(pg_config) => {
+                    !pg_config.query_params.is_empty()
+                        || matches!(
+                            &pg_config.base.connection,
+                            mirrord_config::feature::database_branches::ConnectionSource::Params(
+                                params_config,
+                            ) if params_config.params.extra.contains_key("sslmode")
+                        )
+                }
+                _ => false,
+            })
+        {
+            self.operator
+                .spec
+                .require_feature(NewOperatorFeature::PgBranchQueryParams)?;
+        }
+
         let use_unified_crd = self
             .operator
             .spec

--- a/mirrord/operator/src/client/database_branches.rs
+++ b/mirrord/operator/src/client/database_branches.rs
@@ -1743,6 +1743,7 @@ impl UnifiedBranchParams {
                 copy: SqlBranchCopyConfig::from(config.copy.clone()),
                 iam_auth,
                 connection_settings: config.connection_settings.clone(),
+                query_params: config.query_params.clone(),
             }),
             mysql_options: None,
             mariadb_options: None,

--- a/mirrord/operator/src/crd.rs
+++ b/mirrord/operator/src/crd.rs
@@ -717,6 +717,12 @@ pub enum NewOperatorFeature {
     /// and stealing nothing.
     KafkaQueueSplittingWithProtobufDecoding,
 
+    /// This operator honors `queryParams` on `postgresOptions` and accepts the pg `sslmode`
+    /// extra connection param. Gated so the CLI fails fast on older operators: their CRD
+    /// schema silently prunes `queryParams` (the branch would ignore the override), and
+    /// their validation marks a branch declaring a pg `sslmode` param `Failed`.
+    PgBranchQueryParams,
+
     /// This variant is what a client sees when the operator includes a feature the client is not
     /// yet aware of, because it was introduced in a version newer than the client's.
     #[schemars(skip)]
@@ -774,6 +780,7 @@ impl Display for NewOperatorFeature {
             NewOperatorFeature::KafkaQueueSplittingWithProtobufDecoding => {
                 "Splitting Kafka topics with protobuf payload decoding"
             }
+            NewOperatorFeature::PgBranchQueryParams => "pg branch query params",
             NewOperatorFeature::Unknown => "unknown feature",
         };
         f.write_str(name)

--- a/mirrord/operator/src/crd/db_branching/branch_database.rs
+++ b/mirrord/operator/src/crd/db_branching/branch_database.rs
@@ -262,6 +262,12 @@ pub struct PostgresOptions {
     /// sent via `PGOPTIONS`. Used for things an RLS policy reads (a tenant variable) or `role`.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub connection_settings: BTreeMap<String, String>,
+    /// Query params for the branch-side connection the operator hands to the app (URL query
+    /// string and matching env var rewrites). Values win over the engine's own defaults.
+    /// The common use is `sslmode` when the branch pod's TLS setup differs from what the
+    /// source connection demands.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub query_params: BTreeMap<String, String>,
 }
 
 /// MySQL-specific branch options.
@@ -461,6 +467,37 @@ impl ExtraParamSet for SpannerParam {
     }
 }
 
+/// Extra connection params PostgreSQL branches accept in params mode.
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    PartialEq,
+    Eq,
+    strum_macros::Display,
+    strum_macros::EnumString,
+    strum_macros::EnumIter,
+    strum_macros::VariantNames,
+)]
+#[strum(serialize_all = "camelCase")]
+pub enum PgParam {
+    /// TLS mode of the source connection (`require`/`verify-ca`/`verify-full`/...),
+    /// forwarded to the dump's source URL. Params mode has no URL to carry it. The branch
+    /// side rewrites the param's env var to the branch pod's own TLS mode, so an app that
+    /// mirrors `require` from the source does not demand TLS from a plaintext branch.
+    Sslmode,
+}
+
+impl ExtraParamSet for PgParam {
+    fn parse(key: &str) -> Option<Self> {
+        key.parse().ok()
+    }
+
+    fn valid_names() -> &'static [&'static str] {
+        Self::VARIANTS
+    }
+}
+
 /// Extra connection params CockroachDB branches accept in params mode.
 #[derive(
     Clone,
@@ -585,6 +622,7 @@ impl BranchDatabaseSpec {
             DialectConfig::Cockroachdb(_) => {
                 check::<CockroachdbParam>(DatabaseDialect::Cockroachdb, extra)
             }
+            DialectConfig::Postgres(_) => check::<PgParam>(DatabaseDialect::Postgres, extra),
             other => match extra.keys().next() {
                 Some(key) => Err(DialectValidationError::UnknownConnectionParam {
                     dialect: other.discriminant(),
@@ -1076,6 +1114,32 @@ mod tests {
             err,
             DialectValidationError::UnknownConnectionParam {
                 dialect: DatabaseDialect::Cockroachdb,
+                ..
+            }
+        ));
+    }
+
+    /// Params mode has no URL to carry `sslmode`, so it is an extra param; unknown keys
+    /// still fail so a typo cannot silently connect with the wrong TLS mode.
+    #[test]
+    fn validate_extra_params_postgres_accepts_sslmode_and_rejects_unknown() {
+        let options = PostgresOptions {
+            copy: SqlBranchCopyConfig::default(),
+            iam_auth: None,
+            connection_settings: BTreeMap::new(),
+            query_params: BTreeMap::new(),
+        };
+        let config = DialectConfig::Postgres(&options);
+
+        let good = BTreeMap::from([("sslmode".to_owned(), env_source("PGSSLMODE"))]);
+        assert!(BranchDatabaseSpec::validate_extra_params(&config, &good).is_ok());
+
+        let bad = BTreeMap::from([("sslrootcert".to_owned(), env_source("X"))]);
+        let err = BranchDatabaseSpec::validate_extra_params(&config, &bad).unwrap_err();
+        assert!(matches!(
+            err,
+            DialectValidationError::UnknownConnectionParam {
+                dialect: DatabaseDialect::Postgres,
                 ..
             }
         ));

--- a/tests/go-e2e-pg-branching/main.go
+++ b/tests/go-e2e-pg-branching/main.go
@@ -24,6 +24,17 @@ func requireEnv(name string) string {
 	return val
 }
 
+// sslmode returns DB_SSLMODE, defaulting to disable: the test source and branch pods serve
+// no TLS. Scenarios exercising mirrord's branch-side sslmode rewrite set DB_SSLMODE on the
+// target pod and declare it as an `sslmode` connection param; the printed conn string then
+// shows whether the session rewrote it or the mirrored pod value leaked through.
+func sslmode() string {
+	if mode := os.Getenv("DB_SSLMODE"); mode != "" {
+		return mode
+	}
+	return "disable"
+}
+
 func buildConnStringFromParams() string {
 	host := requireEnv("DB_HOST")
 	port := requireEnv("DB_PORT")
@@ -31,8 +42,8 @@ func buildConnStringFromParams() string {
 	password := requireEnv("DB_PASSWORD")
 	dbname := requireEnv("DB_NAME")
 
-	return fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s sslmode=disable",
-		host, port, user, password, dbname)
+	return fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s sslmode=%s",
+		host, port, user, password, dbname, sslmode())
 }
 
 // buildConnStringFromServer parses a composite env var and combines the
@@ -62,8 +73,8 @@ func buildConnStringFromServer(envName string) string {
 	user := requireEnv("DB_USER")
 	password := requireEnv("DB_PASSWORD")
 	dbname := requireEnv("DB_NAME")
-	connStr := fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s sslmode=disable",
-		host, port, user, password, dbname)
+	connStr := fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s sslmode=%s",
+		host, port, user, password, dbname, sslmode())
 	log.Printf("Using %s mode: %s", envName, connStr)
 	return connStr
 }


### PR DESCRIPTION
## Support PostgreSQL branch connection query-param overrides (sslmode)

Sources like GCP Cloud SQL mandate `?sslmode=require`, but the branch pod mirrord creates
serves no TLS, so an app that keeps requesting SSL against the branch fails with
`SSL connection requested. No SSL enabled connection from this host is configured.`
Closes the reported issue by reusing the machinery CockroachDB already has for exactly
this, instead of inventing a new mechanism.

### What changed

- `type: pg` branches accept an `sslmode` connection param in params mode (new `PgParam`
  set mirroring `CockroachdbParam`); it names the source TLS mode for the dump, and its
  env var is rewritten to the branch-side value like the fixed slots.
- New `query_params` field on pg branch config, e.g. `{ "sslmode": "disable" }`: query
  params applied to the branch connection handed to the app. Values win over mirrord's
  defaults; the source/copy connection is never changed.
- CRD: `PostgresOptions.queryParams` (additive, `BTreeMap`, skip-if-empty), gated by
  `NewOperatorFeature::PgBranchQueryParams` so the CLI fails fast on older operators
  (their schema silently prunes the field, and their validation rejects a pg `sslmode`
  param).
- DB port-forward connection strings apply the overrides too: `ReplaceInUrl` used to keep
  the source URL's query verbatim, so `?sslmode=require` leaked into the local string.
- Go pg-branching test app: params-mode `sslmode` is now `DB_SSLMODE` with a `disable`
  default, so operator e2e can exercise the rewrite.

| | Before | After |
| --- | --- | --- |
| pg `sslmode` connection param | rejected by validation | accepted, forwarded to dump, rewritten branch-side |
| Port-forward string from a URL source | keeps `?sslmode=require` | applies configured `query_params` |
| Branch connection query control | none | `query_params` per branch entry |

### Testing

Unit tests for config roundtrip, CRD validation, and port-forward reconstruction;
`mirrord-schema.json` regenerated. Operator-side behavior and e2e live in the companion
operator PR.