### PR TITLE
COR-1818 read JB_IDE_PORT when ignoring debugger ports

### DIFF
--- a/changelog.d/+jetbrains-ide-port.fixed.md
+++ b/changelog.d/+jetbrains-ide-port.fixed.md
@@ -1,0 +1,1 @@
+Added `JB_IDE_PORT` to the ignored debugger ports.

--- a/mirrord/layer-lib/src/debugger_ports.rs
+++ b/mirrord/layer-lib/src/debugger_ports.rs
@@ -25,6 +25,19 @@ pub const MIRRORD_DETECT_DEBUGGER_PORT_ENV: &str = "MIRRORD_DETECT_DEBUGGER_PORT
 /// like '12233-13000' or multiple individual ports like '12233,13344,14455'
 pub const MIRRORD_IGNORE_DEBUGGER_PORTS_ENV: &str = "MIRRORD_IGNORE_DEBUGGER_PORTS";
 
+/// Environment variable set by JetBrains IDEs, holding the port the IDE itself listens on for the
+/// debugger handshake. The debugged process connects *out* to it, so that connection must stay
+/// local rather than being routed to the cluster.
+///
+/// Read directly because guessing does not work. The IntelliJ plugin passes a hardcoded
+/// `MIRRORD_IGNORE_DEBUGGER_PORTS=35000-65535`, but this is an ephemeral port, and the Linux
+/// ephemeral range starts at 32768 -- so roughly 8% of runs picked a port below the range and the
+/// debugger silently failed to attach with `ECONNRESET`. Detection through
+/// [`MIRRORD_DETECT_DEBUGGER_PORT_ENV`] does not cover it either: for Node the IDE sets
+/// `NODE_OPTIONS=--require .../debugConnector.js` rather than `--inspect`, and the port it would
+/// find is the *inspector* port, not this one.
+pub const JB_IDE_PORT_ENV: &str = "JB_IDE_PORT";
+
 /// The default port used by node's --inspect debugger from the
 /// [node documentation](https://nodejs.org/en/learn/getting-started/debugging#enable-inspector)
 pub const NODE_INSPECTOR_DEFAULT_PORT: u16 = 9229;
@@ -472,6 +485,13 @@ impl DebuggerPorts {
     ///
     /// Log errors (like malformed env variables) but do not panic.
     pub fn from_env() -> Self {
+        // Applies to both paths below: a JetBrains IDE port is always worth ignoring, whether or
+        // not a debugger type was detected.
+        let jetbrains = env::var(JB_IDE_PORT_ENV)
+            .ok()
+            .and_then(|value| value.trim().parse::<u16>().ok())
+            .map(Self::Single);
+
         let (detected, next) = match env::var(MIRRORD_DETECT_DEBUGGER_PORT_ENV)
             .ok()
             .and_then(|s| {
@@ -504,6 +524,7 @@ impl DebuggerPorts {
             if let Ok(existing) = env::var(MIRRORD_IGNORE_DEBUGGER_PORTS_ENV) {
                 dbg_ports.push(DebuggerPorts::from_str(&existing).ok());
             }
+            dbg_ports.push(jetbrains);
             let dbg_ports = dbg_ports.into_iter().flatten().collect::<Vec<_>>();
             let dbg_port = Self::Combination(dbg_ports);
             // TODO: Audit that the environment access only happens in single-threaded code.
@@ -521,10 +542,24 @@ impl DebuggerPorts {
 
         // IGNORE_DEBUGGER_PORTS may have a combination of single, multiple or ranges of ports
         // separated by a comma they need to be parsed individually
-        env::var(MIRRORD_IGNORE_DEBUGGER_PORTS_ENV)
+        let configured = env::var(MIRRORD_IGNORE_DEBUGGER_PORTS_ENV)
             .ok()
-            .and_then(|s| Self::from_str(&s).ok())
-            .unwrap_or(Self::None)
+            .and_then(|s| Self::from_str(&s).ok());
+
+        Self::combine(jetbrains, configured)
+    }
+
+    /// Merges the JetBrains IDE port with whatever was configured explicitly.
+    ///
+    /// Separate from [`Self::from_env`] so the rule can be tested without touching process
+    /// environment variables, which are global and race across parallel tests.
+    fn combine(jetbrains: Option<Self>, configured: Option<Self>) -> Self {
+        match (jetbrains, configured) {
+            (Some(jb), Some(configured)) => Self::Combination(vec![jb, configured]),
+            (Some(jb), None) => jb,
+            (None, Some(configured)) => configured,
+            (None, None) => Self::None,
+        }
     }
 
     /// Return whether the given [SocketAddr] is used by the debugger.
@@ -548,6 +583,8 @@ impl DebuggerPorts {
 
 #[cfg(test)]
 mod test {
+    use std::net::{Ipv4Addr, SocketAddr};
+
     use rstest::rstest;
 
     use super::*;
@@ -801,5 +838,70 @@ mod test {
         assert!(!DebuggerPorts::Combination(ports).contains(&"127.0.0.1:1340".parse().unwrap()));
 
         assert!(!DebuggerPorts::None.contains(&"127.0.0.1:1337".parse().unwrap()));
+    }
+
+    /// The plugin's hardcoded range. Kept here verbatim so these cases describe the real setup.
+    fn plugin_range() -> DebuggerPorts {
+        DebuggerPorts::FixedRange(35000..=65535)
+    }
+
+    fn local(port: u16) -> SocketAddr {
+        SocketAddr::new(Ipv4Addr::LOCALHOST.into(), port)
+    }
+
+    /// The regression this fix exists for.
+    ///
+    /// `JB_IDE_PORT` is an ephemeral port, and the Linux ephemeral range starts at 32768, so the
+    /// plugin's `35000-65535` misses about 8% of it. Both values below were observed in real
+    /// sessions where the debugger failed to attach with `ECONNRESET`.
+    #[rstest]
+    #[case(33055)]
+    #[case(34085)]
+    fn jetbrains_port_below_the_configured_range_is_ignored(#[case] ide_port: u16) {
+        let ports =
+            DebuggerPorts::combine(Some(DebuggerPorts::Single(ide_port)), Some(plugin_range()));
+
+        assert!(
+            ports.contains(&local(ide_port)),
+            "JB_IDE_PORT {ide_port} must be treated as a debugger port even though it is \
+             below the configured range"
+        );
+    }
+
+    #[test]
+    fn the_configured_range_still_applies_when_a_jetbrains_port_is_present() {
+        let ports =
+            DebuggerPorts::combine(Some(DebuggerPorts::Single(33055)), Some(plugin_range()));
+
+        assert!(ports.contains(&local(40000)), "range must not be lost");
+        assert!(
+            !ports.contains(&local(1234)),
+            "unrelated port must not match"
+        );
+    }
+
+    #[test]
+    fn a_jetbrains_port_alone_is_enough() {
+        let ports = DebuggerPorts::combine(Some(DebuggerPorts::Single(33055)), None);
+
+        assert!(ports.contains(&local(33055)));
+        assert!(!ports.contains(&local(33056)));
+    }
+
+    #[test]
+    fn nothing_configured_matches_nothing() {
+        let ports = DebuggerPorts::combine(None, None);
+
+        assert!(!ports.contains(&local(33055)));
+    }
+
+    /// Documents an existing limit rather than a new one: only loopback addresses are considered.
+    /// It holds for JetBrains because the IDE sets `JB_IDE_HOST=localhost`.
+    #[test]
+    fn a_non_loopback_address_is_never_a_debugger_port() {
+        let ports = DebuggerPorts::combine(Some(DebuggerPorts::Single(33055)), None);
+        let remote = SocketAddr::new(Ipv4Addr::new(10, 0, 0, 5).into(), 33055);
+
+        assert!(!ports.contains(&remote));
     }
 }


### PR DESCRIPTION
## Linear

https://linear.app/metalbear/issue/COR-1818/mirrord-ignore-debugger-ports-range-is-too-small-misses-8percent-of

## Hatsune Miku

<details>

```
⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣤⣀⣀⠀⠀⣀⡠⠴⠒⠚⠉⠉⠓⠒⠦⣄⣶⠒⣷⡀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠘⡷⢬⣉⠉⠁⠀⠀⠀⠀⠀⠀⠀⠀⠠⡌⠻⣧⢻⣧⣤⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣖⠗⡋⢹⠀⠀⢰⡄⠀⠀⢸⣷⡀⠀⣠⠽⣆⢼⣇⢻⣸⡄⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⡜⣡⣶⢋⡏⠙⢢⣏⣇⠀⠀⠈⣇⡵⡏⠀⠀⢹⡏⢾⣿⠃⢿⡆⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣾⢿⢻⣏⣿⡇⡄⣾⠀⠹⡄⠄⠀⡇⠀⠹⣤⠈⠹⣿⣾⢸⠀⢘⣷⣄⣀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢠⣴⣯⣿⣽⣿⣷⢸⡗⠦⣄⡹⣼⣄⣿⣴⠛⠹⡄⡇⣿⣿⠾⠚⢹⢿⢽⣽⡇⠀⠀⠀⠀⠀⠀⠀⠀⠀
⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣸⣿⣞⣾⣿⢿⣯⢻⢻⡴⠞⠁⠈⠻⣿⣌⡉⠓⣿⣰⡿⠀⠀⠀⠸⡜⡾⣿⡇⠀⠀⠀⠀⠀⠀⠀⠀⠀
⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⡴⣡⠊⢸⣹⠁⠈⠙⣾⡄⠁⠀⢰⠛⠉⠉⠉⢳⣀⣿⣿⠃⠀⠀⣀⣀⣧⣿⡞⣷⡀⠀⠀⠀⠀⠀⠀⠀⠀
⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣠⠋⡴⠁⠀⠸⢿⣤⣤⣤⣹⣿⣷⣶⣾⣷⣶⣶⣺⣋⣽⣿⣷⠶⠟⠛⠋⢧⠀⠀⠸⡜⣷⠀⠀⠀⠀⠀⠀⠀⠀
⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⡜⠁⡰⠁⠀⠀⢠⡿⠀⠀⠀⠉⠉⠉⠙⢻⡟⣹⣿⠃⣿⠋⠁⠀⠀⠀⠀⠀⠸⡄⠀⠀⢣⠹⣧⠀⠀⠀⠀⠀⠀⠀
⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢠⠏⡀⢠⠇⠀⠀⢠⡿⠁⠀⠀⠀⠀⣤⣶⡴⠚⢻⠡⣸⠀⢹⣆⠀⠀⠀⠀⠀⠀⠀⡇⠀⠀⠸⡄⢻⣇⠀⠀⠀⠀⠀⠀
⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⡏⣼⠁⢸⠀⠀⠀⣾⠃⠀⠀⠀⠀⠀⢻⣿⣧⣀⣬⠋⠁⠀⣠⣿⣶⣆⠀⠀⠀⠀⠀⡇⠀⠀⠀⡇⠈⣿⡀⠀⠀⠀⠀⠀
⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣸⣸⣿⠀⡇⠀⢰⣸⡟⠀⠀⠀⣀⣠⠴⠚⣟⣻⣧⣯⣗⣤⣾⣿⣿⡿⠋⠀⠀⠀⠀⣸⣤⠀⠀⠀⡇⡆⢻⠃⠀⠀⠀⠀⠀
⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣿⡿⢸⡀⣇⠀⣸⣿⡁⠀⣾⣻⡁⣀⣤⣶⠟⠋⠉⠛⢿⣋⣻⡏⠉⠀⠀⠀⠀⠀⢰⣿⡇⠀⠀⠀⣷⡇⣸⡄⠀⠀⠀⠀⠀
⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠿⠇⠀⢧⢸⠀⣿⡿⠇⠀⠈⠛⠛⠋⠉⠀⠀⠀⠀⠀⡟⠀⣿⠇⠀⠀⠀⠀⠀⢠⣿⣿⡇⠀⠀⣰⡿⣧⣿⠃⠀⠀⠀⠀⠀
⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢿⣄⣹⡇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢰⡇⠀⣿⠀⠀⠀⠀⠀⠀⣸⡿⢸⠁⢠⣾⠋⢰⣿⡏⠀⠀⠀⠀⠀⠀
⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠉⠛⠛⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣼⣶⣶⡿⠀⠀⠀⠀⠀⠀⠉⠁⢸⣶⡟⠁⠀⠾⠟⠀⠀⠀⠀⠀⠀⠀
⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠈⠉⠉⠀⠀⠀⠀⠀⠀⠀⠀⠀⠈⠉⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
```

</details>

## Summary

![this is fine](https://raw.githubusercontent.com/cristeigabriela/pr-assets/main/cor-1818-this-is-fine.png)

![JB_IDE_PORT=33065 in the target process environment](https://raw.githubusercontent.com/cristeigabriela/pr-assets/main/cor-1818-jb-ide-port.png)

A JetBrains debugger intermittently failed to attach when running under mirrord, with the debug connector reporting `ECONNRESET`.

The IntelliJ plugin passes a hardcoded `MIRRORD_IGNORE_DEBUGGER_PORTS` of `35000-65535` (`MirrordExecManager.kt:256` and `:318`). The debugged process connects *out* to the IDE at `JB_IDE_HOST:JB_IDE_PORT` to publish the inspector port it just opened. `JB_IDE_PORT` is an ephemeral port, and on Linux the ephemeral range starts at 32768, so any value below 35000 fell outside the ignore range. `DebuggerPorts::contains` then returned false, the layer routed the handshake to the cluster, and the pod reset it.

The address side was never the problem: the IDE sets `JB_IDE_HOST=localhost`, so the loopback requirement in `contains` was satisfied. Only the port was missed.

Detection through `MIRRORD_DETECT_DEBUGGER_PORT` does not cover this. `NodeInspector` reads `NODE_OPTIONS` for `--inspect`/`--inspect-brk`/`--inspect-wait`, but for Node the IDE sets `NODE_OPTIONS=--require /tmp/<random>/debugConnector.js`, so the detector finds nothing. Even when it does find a port, that is the *inspector* port the debugger listens on — not the IDE port the publisher dials. The Node path in the plugin also sets no `MIRRORD_DETECT_DEBUGGER_PORT` at all, unlike the IDEA, PyCharm, Rider and Tomcat paths.

This reads `JB_IDE_PORT` directly in `DebuggerPorts::from_env` and merges it with whatever was configured, on both the detected-debugger path and the fallback path. It is a JetBrains standard variable and is already present in the target process environment, so no plugin change is required and older plugin builds benefit too. It is exact, where any hardcoded range is a guess.


### Quality Checklist:

- [x] I have documented new code sufficiently
- [x] I have checked and updated the relevant existing docs in code, including removing outdated material
- [x] I have tested this change and know it succeeds and fails as expected
- [x] I have written unit tests or purposefully omitted them
- [x] I have written e2e tests or purposefully omitted them
- [x] I have explained what this PR introduces and why, and linked to relevant context (e.g. linear issues, related PRs,
  documentation)
- [x] I have introduced a short, clear and well-formatted changelog entry
