### PR TITLE
Stop chaos latency from deferring the connect response

### DIFF
--- a/changelog.d/+chaos-connect-latency.fixed.md
+++ b/changelog.d/+chaos-connect-latency.fixed.md
@@ -1,0 +1,7 @@
+Chaos latency rules no longer delay the response to a connect request. Applying a
+latency effect previously held that response back, which blocked the calling
+thread while the connection was set up and stopped client-side timeouts in
+single-threaded runtimes from firing during the fault. Latency is now applied to
+reads and writes only, so it no longer prevents an application from reacting to
+the delay it is being asked to survive. As a side effect, a `read_ms` value is no
+longer charged a second time when a connection is opened.

--- a/changelog.d/+chaos-connect-latency.fixed.md
+++ b/changelog.d/+chaos-connect-latency.fixed.md
@@ -1,7 +1,5 @@
-Chaos latency rules no longer delay the response to a connect request. Applying a
-latency effect previously held that response back, which blocked the calling
-thread while the connection was set up and stopped client-side timeouts in
-single-threaded runtimes from firing during the fault. Latency is now applied to
-reads and writes only, so it no longer prevents an application from reacting to
-the delay it is being asked to survive. As a side effect, a `read_ms` value is no
-longer charged a second time when a connection is opened.
+Chaos latency rules no longer delay the response to a connect request. Holding
+that response back blocked the calling thread, which stopped client-side timeouts
+from firing during the fault. Latency now affects reads and writes only, so your
+app can react to the delay. A `read_ms` value also costs its delay once per
+operation, rather than twice on a new connection.

--- a/mirrord/intproxy/src/background_tasks.rs
+++ b/mirrord/intproxy/src/background_tasks.rs
@@ -29,8 +29,7 @@ pub struct MessageBusInner<MessageIn, MessageOut> {
     /// [`WeakSender`] channel so you can send `MessageIn` messages to the [`MessageBus`] itself.
     ///
     /// Useful for when you want to do something in a spawned task, and need to send another
-    /// `MessageIn` (i.e. some `OutgoingProxyMessage` like `OutgoingProxyMessage::DeferredConnect`)
-    /// that should be handled by the proxy task responsible for `MessageIn`.
+    /// `MessageIn` back to the proxy task responsible for handling it.
     ///
     /// See [`MessageBus::clone_self_tx`].
     self_tx: WeakSender<MessageIn>,

--- a/mirrord/intproxy/src/background_tasks.rs
+++ b/mirrord/intproxy/src/background_tasks.rs
@@ -12,7 +12,7 @@ use mirrord_protocol::ClientMessage;
 use mirrord_protocol_io::{Client, TxHandle};
 use thiserror::Error;
 use tokio::{
-    sync::mpsc::{self, Receiver, Sender, WeakSender},
+    sync::mpsc::{self, Receiver, Sender},
     task::JoinHandle,
 };
 use tokio_stream::{StreamExt, StreamMap, StreamNotifyClose, wrappers::ReceiverStream};
@@ -25,14 +25,6 @@ pub type MessageBus<T> =
 /// parents. It allows the tasks to send and receive messages.
 pub struct MessageBusInner<MessageIn, MessageOut> {
     tx: Sender<MessageOut>,
-
-    /// [`WeakSender`] channel so you can send `MessageIn` messages to the [`MessageBus`] itself.
-    ///
-    /// Useful for when you want to do something in a spawned task, and need to send another
-    /// `MessageIn` back to the proxy task responsible for handling it.
-    ///
-    /// See [`MessageBus::clone_self_tx`].
-    self_tx: WeakSender<MessageIn>,
 
     rx: Receiver<MessageIn>,
     agent_tx: TxHandle<Client>,
@@ -80,13 +72,6 @@ impl<MessageIn, MessageOut> MessageBusInner<MessageIn, MessageOut> {
     /// Creates a clone of the agent tx handle
     pub fn clone_layer_tx(&self) -> Sender<MessageOut> {
         self.tx.clone()
-    }
-
-    /// Creates a clone of this task's input sender.
-    ///
-    /// With this, you can send messages to the [`MessageBus`] itself.
-    pub fn clone_self_tx(&self) -> Option<Sender<MessageIn>> {
-        self.self_tx.upgrade()
     }
 }
 
@@ -234,7 +219,6 @@ where
 
         let mut message_bus = MessageBus::<T> {
             tx: out_msg_tx,
-            self_tx: in_msg_tx.downgrade(),
             rx: in_msg_rx,
             token: token.clone(),
             agent_tx: self.agent_tx.another(),

--- a/mirrord/intproxy/src/proxies/outgoing.rs
+++ b/mirrord/intproxy/src/proxies/outgoing.rs
@@ -892,7 +892,7 @@ impl BackgroundTask for OutgoingProxy {
 
 #[cfg(test)]
 mod test {
-    use std::net::SocketAddr;
+    use std::{net::SocketAddr, time::Duration};
 
     use mirrord_intproxy_protocol::{
         LayerId, NetProtocol, OutgoingConnectRequest, OutgoingConnectRequestMetadata,
@@ -912,7 +912,10 @@ mod test {
         background_tasks::{BackgroundTasks, TaskUpdate},
         main_tasks::{ConnectionRefresh, ProxyMessage, ToLayer},
         proxies::outgoing::{OutgoingProxy, OutgoingProxyError, OutgoingProxyMessage},
-        session_monitor::chaos::ChaosWatcherRx,
+        session_monitor::chaos::{
+            ChaosRuleList, ChaosWatcherRx,
+            rules::{ChaosRule, ChaosRuleRequest},
+        },
     };
 
     /// Verifies that the outgoing proxy can handle operator reconnect
@@ -995,5 +998,67 @@ mod test {
             ((), TaskUpdate::Finished(Ok(()))) => {}
             other => panic!("unexpected update from the outgoing proxy: {other:?}"),
         }
+    }
+
+    /// A latency effect must never delay the connect handshake.
+    ///
+    /// The layer waits for [`OutgoingResponse::Connect`] in a blocking call, so holding that
+    /// response back stalls the calling thread for the length of the delay. In a single-threaded
+    /// runtime that stalls the event loop, and a client-side timeout implemented as a timer
+    /// cannot fire while it does, which is normally the code a latency fault exists to exercise.
+    /// Latency belongs on reads and writes, which travel over the interceptor socket the
+    /// application polls, and so leave it free to react.
+    #[tokio::test]
+    async fn latency_rule_does_not_delay_connect() {
+        // Far longer than any wait below, so a reintroduced delay cannot pass by being quick.
+        let rule: ChaosRule = serde_json::from_str::<ChaosRuleRequest>(
+            r#"{
+                "name": "latency far beyond the test's patience",
+                "selector": { "upstream": "1.1.1.1:80", "percentage": 100 },
+                "effect": { "latency": { "read_ms": 600000, "write_ms": 600000 } }
+            }"#,
+        )
+        .expect("rule should deserialize")
+        .try_into()
+        .expect("rule should validate");
+
+        let peer_addr = "1.1.1.1:80".parse::<SocketAddr>().unwrap();
+        let (connection, _, out) = Connection::dummy();
+        let (_chaos_tx, chaos_rx) = watch::channel(ChaosRuleList::from_iter([rule]));
+
+        let mut background_tasks: BackgroundTasks<(), ProxyMessage, OutgoingProxyError> =
+            BackgroundTasks::new(connection.tx_handle());
+
+        let outgoing = background_tasks.register(
+            OutgoingProxy::new(false, 0, 0, ChaosWatcherRx::new(chaos_rx)),
+            (),
+            8,
+        );
+
+        // The deferral this guards against only ran when the agent supported connect v2.
+        outgoing
+            .send(OutgoingProxyMessage::AgentProtocolVersion(
+                "1.22.0".parse().unwrap(),
+            ))
+            .await;
+
+        outgoing
+            .send(OutgoingProxyMessage::Layer(
+                OutgoingRequest::Connect(OutgoingConnectRequest {
+                    remote_address: SocketAddress::Ip(peer_addr),
+                    protocol: NetProtocol::Stream,
+                    metadata: OutgoingConnectRequestMetadata::default(),
+                }),
+                0,
+                LayerId(0),
+            ))
+            .await;
+
+        // Asserted on the agent-bound message rather than the wire format, so the test keeps
+        // meaning if the connect encoding changes.
+        tokio::time::timeout(Duration::from_secs(5), out.next())
+            .await
+            .expect("latency rule delayed the connect request to the agent")
+            .expect("outgoing proxy closed its agent connection");
     }
 }

--- a/mirrord/intproxy/src/proxies/outgoing.rs
+++ b/mirrord/intproxy/src/proxies/outgoing.rs
@@ -4,7 +4,7 @@ use std::{
     collections::{HashMap, HashSet},
     fmt, io,
     net::{Ipv4Addr, Ipv6Addr, SocketAddr},
-    ops::{ControlFlow, Not},
+    ops::Not,
     sync::Arc,
     time::{Duration, Instant},
 };
@@ -122,12 +122,6 @@ struct ConnectInProgress {
     layer_id: LayerId,
     message_id: MessageId,
     id: u128,
-}
-
-pub struct DeferredConnection {
-    request: OutgoingConnectRequest,
-    message_id: MessageId,
-    layer_id: LayerId,
 }
 
 /// Original connection metadata requested by the layer.
@@ -726,7 +720,6 @@ pub enum OutgoingProxyMessage {
     AgentSeqpacket(DaemonSeqpacket),
     AgentProtocolVersion(Version),
     Layer(OutgoingRequest, MessageId, LayerId),
-    DeferredConnect(DeferredConnection),
     ConnectionRefresh(ConnectionRefresh),
     LayerForked(LayerForked),
     LayerClosed(LayerClosed),
@@ -812,28 +805,12 @@ impl BackgroundTask for OutgoingProxy {
                                 continue;
                             }
 
-                            let connect = if self.supports_connect_v2() {
-                                match self.chaos_effect_for_connect_latency(connect, message_id, layer_id, message_bus).await {
-                                    ControlFlow::Continue(connect) => connect,
-                                    ControlFlow::Break(()) => continue,
-                                }
-                            } else {
-                                connect
-                            };
-
                             self.handle_connect_request(message_id, layer_id, connect, message_bus).await?;
                         }
                         request => {
                             self.handle_layer_request(request, layer_id, message_id, message_bus).await?;
                         }
                     },
-                    Some(OutgoingProxyMessage::DeferredConnect(DeferredConnection {
-                        request,
-                        message_id,
-                        layer_id,
-                    })) => {
-                        self.handle_connect_request(message_id, layer_id, request, message_bus).await?;
-                    }
                     Some(OutgoingProxyMessage::LayerForked(forked)) => {
                         self.connections_in_layers.clone_all(forked.parent, forked.child);
                     }

--- a/mirrord/intproxy/src/proxies/outgoing/chaos.rs
+++ b/mirrord/intproxy/src/proxies/outgoing/chaos.rs
@@ -16,7 +16,7 @@ use tracing::Level;
 use crate::{
     background_tasks::MessageBus,
     main_tasks::ToLayer,
-    proxies::outgoing::{DeferredConnection, InterceptorId, OutgoingProxy, OutgoingProxyMessage},
+    proxies::outgoing::{InterceptorId, OutgoingProxy},
     session_monitor::chaos::rules::{
         ChaosEffectConnectionError, ChaosSelector, ConnectionErrorType, TcpChaosEffect,
     },
@@ -131,55 +131,6 @@ impl OutgoingProxy {
         }
     }
 
-    #[tracing::instrument(level = Level::DEBUG, skip(self, message_bus), ret)]
-    pub(super) async fn chaos_effect_for_connect_latency(
-        &self,
-        request: OutgoingConnectRequest,
-        message_id: MessageId,
-        layer_id: LayerId,
-        message_bus: &mut MessageBus<OutgoingProxy>,
-    ) -> ControlFlow<(), OutgoingConnectRequest> {
-        let effect = self.chaos_effect_for_address(
-            &request.remote_address,
-            request.protocol,
-            request.hostname(),
-            |selector| match selector {
-                ChaosSelector::Tcp {
-                    effect: TcpChaosEffect::Latency(effect),
-                    ..
-                } => effect.connection_latency_duration(),
-                _ => None,
-            },
-        );
-
-        match effect {
-            Some(wait_for) if let Some(outgoing_tx) = message_bus.clone_self_tx() => {
-                let deferred = DeferredConnection {
-                    request,
-                    message_id,
-                    layer_id,
-                };
-
-                tokio::spawn(async move {
-                    sleep(wait_for).await;
-
-                    let _ = outgoing_tx
-                        .send(OutgoingProxyMessage::DeferredConnect(deferred))
-                        .await
-                        .inspect_err(|fail| {
-                            tracing::warn!(?fail, "Failed sending deferred connect!")
-                        });
-                });
-
-                ControlFlow::Break(())
-            }
-            Some(_) => {
-                tracing::debug!("Connection should be delayed, but outgoing_tx is closed.");
-                ControlFlow::Continue(request)
-            }
-            None => ControlFlow::Continue(request),
-        }
-    }
 
     /// Latency to apply to an intercepted connection's data messages, if a `ChaosRule` with a
     /// *read* latency effect matches this connection.

--- a/mirrord/intproxy/src/proxies/outgoing/chaos.rs
+++ b/mirrord/intproxy/src/proxies/outgoing/chaos.rs
@@ -131,7 +131,6 @@ impl OutgoingProxy {
         }
     }
 
-
     /// Latency to apply to an intercepted connection's data messages, if a `ChaosRule` with a
     /// *read* latency effect matches this connection.
     pub(super) fn chaos_read_latency_for_connection(

--- a/mirrord/intproxy/src/session_monitor/chaos/rules.rs
+++ b/mirrord/intproxy/src/session_monitor/chaos/rules.rs
@@ -592,13 +592,6 @@ impl ChaosEffectLatency {
         self.add_latency_jitter(self.write)
     }
 
-    /// Returns the duration of read+write latency applied by the effect to simulate connection
-    /// latency, plus random jitter (if set). Will always return `Some(_)` because either read or
-    /// write latency must be non-zero in a valid effect, but returns an `Option` for convenience.
-    pub fn connection_latency_duration(&self) -> Option<Duration> {
-        self.add_latency_jitter(self.write + self.read)
-    }
-
     /// Calculates a final latency to be applied by the effect by adding jitter to the given
     /// `Duration`. Will not add jitter to a `Duration` of 0, which may occur when either read
     /// or write latency is 0.


### PR DESCRIPTION
Closes COR-1817.

### What

A chaos `latency` effect deferred the response to an outgoing connect request until the delay elapsed. The layer waits for that response inside `make_proxy_request_with_response`, which blocks the calling thread, so the delay stalled that thread for its full duration. In a single-threaded runtime that stalls the whole event loop, and a client-side timeout implemented as a timer cannot fire while it is stalled. That timeout is usually the exact code a latency fault is meant to exercise.

It also bypassed non-blocking connect. `handle_connect_request` answers the layer immediately from a locally bound `TcpListener` and performs the remote connect in the background, specifically so a slow remote never blocks the application. `chaos_effect_for_connect_latency` ran ahead of that function, so the mechanism never got the chance. A genuinely slow dependency behaved correctly; only an injected one did not.

### How

Removes the connect-latency deferral: `chaos_effect_for_connect_latency`, `DeferredConnection` and its message variant, and `ChaosEffectLatency::connection_latency_duration`.

Latency now applies to reads and writes only. That path already exists and runs through the interceptor's delay queues, which do not block the layer. Net 81 deletions, 2 insertions.

Two consequences worth calling out for review:

- **Behavior change.** `connection_latency_duration` was `read + write` charged at connect, on top of the per-read charge, so `read_ms` was effectively paid twice on a new connection. It is now paid once. Anyone who calibrated a rule against the old numbers will see roughly half the delay.
- **Slow connect establishment can no longer be simulated.** Under non-blocking connect the app's `connect()` is decoupled from the real one anyway, so a slow remote surfaces as a delay before the first byte, which is what per-read latency already produces. If an explicit knob is wanted later, it belongs on the first data exchange or agent-side, not on the layer's connect response.

### Testing

Verified against a live cluster. Same version on both legs, same command, same rule, same target. A Node service run with `mirrord exec -- npm run dev`, calling a downstream HTTP service, bounding each call with `AbortSignal.timeout(2000)` and retrying twice before degrading.

Rule: `latency.read_ms = 8000`, `percentage = 100`.

| | no fault | 8000ms latency |
|---|---|---|
| stock | ~0.2s | 17.60s / 16.46s / 17.14s |
| patched | ~0.2s | 4.04s / 4.16s / 4.17s |

Stock does two attempts of ~8s and the timeout never fires. Patched does two attempts of ~2s, so it fires as written.

Controls, to check the effect was fixed rather than disabled:

- `read_ms = 1000`, under the client's bound: 1.52s / 1.18s / 1.18s, request succeeds. Still slowed by about the configured amount, and about 1x rather than 2x, which confirms the doubled charge is gone.
- `write_ms = 3000` only, no read latency: 4.22s / 4.25s. Write-only rules still apply, and the timeout still fires.
- Rule hit counters still increment.

`cargo test -p mirrord-intproxy` passes, 72 tests.

### Gaps, stated plainly

- A regression test is included (see the follow-up comment for the full matrix). Note that no test previously covered the removed path.
- Exercised over TCP on macOS only. UDP and non-IP address families are untested.
- `connection_error` with `after_ms > 0` defers the response the same way and still blocks. Not addressed here.
- Removing the connect-time roll means one fewer `percentage` roll per connection, so the effective hit rate for a given percentage shifts slightly. Not measured.

### Quality Checklist:

- [x] I have documented new code sufficiently
- [x] I have checked and updated the relevant existing docs in code, including removing outdated material
- [ ] I have written user-facing website docs for new features, or opened a (sub)issue to do so
- [ ] I have checked and updated existing website docs for changed features — the docs do not describe connect-time latency, but the halved effective delay may warrant a note
- [x] I have tested this change and know it succeeds and fails as expected
- [x] I have written unit tests or purposefully omitted them
- [ ] I have written e2e tests or purposefully omitted them — omitted; the unit test covers the invariant, and the behavior matrix in the follow-up comment was run manually against a cluster
- [x] I have explained what this PR introduces and why, and linked to relevant context
- [x] I have introduced a short, clear and well-formatted changelog entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)