### PR TITLE
Make chaos connect latency non-blocking instead of removing it

### DIFF
--- a/changelog.d/+chaos-connect-latency.fixed.md
+++ b/changelog.d/+chaos-connect-latency.fixed.md
@@ -1,0 +1,7 @@
+Chaos latency rules no longer delay the response to a connect request. Applying a
+latency effect previously held that response back, which blocked the calling
+thread while the connection was set up and stopped client-side timeouts in
+single-threaded runtimes from firing during the fault. Latency is now applied to
+reads and writes only, so it no longer prevents an application from reacting to
+the delay it is being asked to survive. As a side effect, a `read_ms` value is no
+longer charged a second time when a connection is opened.

--- a/changelog.d/+chaos-connect-latency.fixed.md
+++ b/changelog.d/+chaos-connect-latency.fixed.md
@@ -1,6 +1,6 @@
 Chaos latency rules no longer hold back the response to a connect request.
 Holding it back blocked the calling thread, which in a single-threaded runtime
-stalled the event loop, so a client-side timeout could not fire during the
-fault it was written for. A connection now waits for its delay before it
-carries data, on whichever of the first read or write comes first, which leaves
-the application free to act on it. The total delay a request sees is unchanged.
+stalled the event loop, so a client-side timeout could not fire during the fault
+it was written for. A connection now waits for its delay before it carries data,
+on whichever of the first read or write comes first, which leaves the
+application free to act on it.

--- a/changelog.d/+chaos-connect-latency.fixed.md
+++ b/changelog.d/+chaos-connect-latency.fixed.md
@@ -1,5 +1,6 @@
-Chaos latency rules no longer delay the response to a connect request. Holding
-that response back blocked the calling thread, which stopped client-side timeouts
-from firing during the fault. Latency now affects reads and writes only, so your
-app can react to the delay. A `read_ms` value also costs its delay once per
-operation, rather than twice on a new connection.
+Chaos latency rules no longer hold back the response to a connect request.
+Holding it back blocked the calling thread, which in a single-threaded runtime
+stalled the event loop, so a client-side timeout could not fire during the
+fault it was written for. A connection now waits for its delay before it
+carries data, on whichever of the first read or write comes first, which leaves
+the application free to act on it. The total delay a request sees is unchanged.

--- a/changelog.d/+chaos-connect-latency.fixed.md
+++ b/changelog.d/+chaos-connect-latency.fixed.md
@@ -3,4 +3,4 @@ Holding it back blocked the calling thread, which in a single-threaded runtime
 stalled the event loop, so a client-side timeout could not fire during the fault
 it was written for. A connection now waits for its delay before it carries data,
 on whichever of the first read or write comes first, which leaves the
-application free to act on it.
+application free to act on it. The total delay a request sees is unchanged.

--- a/changelog.d/+chaos-connect-latency.fixed.md
+++ b/changelog.d/+chaos-connect-latency.fixed.md
@@ -1,7 +1,5 @@
-Chaos latency rules no longer delay the response to a connect request. Applying a
-latency effect previously held that response back, which blocked the calling
-thread while the connection was set up and stopped client-side timeouts in
-single-threaded runtimes from firing during the fault. Latency is now applied to
-reads and writes only, so it no longer prevents an application from reacting to
-the delay it is being asked to survive. As a side effect, a `read_ms` value is no
-longer charged a second time when a connection is opened.
+Chaos latency rules no longer delay the response to a connect request. Holding
+that response back blocked the calling thread, which stopped client-side timeouts
+from firing during the fault. Latency now affects reads and writes only, so your
+app can react to the delay. A `read_ms` value also costs its delay once per
+operation, rather than twice on a new connection.

--- a/mirrord/intproxy/src/background_tasks.rs
+++ b/mirrord/intproxy/src/background_tasks.rs
@@ -29,8 +29,7 @@ pub struct MessageBusInner<MessageIn, MessageOut> {
     /// [`WeakSender`] channel so you can send `MessageIn` messages to the [`MessageBus`] itself.
     ///
     /// Useful for when you want to do something in a spawned task, and need to send another
-    /// `MessageIn` (i.e. some `OutgoingProxyMessage` like `OutgoingProxyMessage::DeferredConnect`)
-    /// that should be handled by the proxy task responsible for `MessageIn`.
+    /// `MessageIn` back to the proxy task responsible for handling it.
     ///
     /// See [`MessageBus::clone_self_tx`].
     self_tx: WeakSender<MessageIn>,

--- a/mirrord/intproxy/src/background_tasks.rs
+++ b/mirrord/intproxy/src/background_tasks.rs
@@ -12,7 +12,7 @@ use mirrord_protocol::ClientMessage;
 use mirrord_protocol_io::{Client, TxHandle};
 use thiserror::Error;
 use tokio::{
-    sync::mpsc::{self, Receiver, Sender, WeakSender},
+    sync::mpsc::{self, Receiver, Sender},
     task::JoinHandle,
 };
 use tokio_stream::{StreamExt, StreamMap, StreamNotifyClose, wrappers::ReceiverStream};
@@ -25,14 +25,6 @@ pub type MessageBus<T> =
 /// parents. It allows the tasks to send and receive messages.
 pub struct MessageBusInner<MessageIn, MessageOut> {
     tx: Sender<MessageOut>,
-
-    /// [`WeakSender`] channel so you can send `MessageIn` messages to the [`MessageBus`] itself.
-    ///
-    /// Useful for when you want to do something in a spawned task, and need to send another
-    /// `MessageIn` back to the proxy task responsible for handling it.
-    ///
-    /// See [`MessageBus::clone_self_tx`].
-    self_tx: WeakSender<MessageIn>,
 
     rx: Receiver<MessageIn>,
     agent_tx: TxHandle<Client>,
@@ -80,13 +72,6 @@ impl<MessageIn, MessageOut> MessageBusInner<MessageIn, MessageOut> {
     /// Creates a clone of the agent tx handle
     pub fn clone_layer_tx(&self) -> Sender<MessageOut> {
         self.tx.clone()
-    }
-
-    /// Creates a clone of this task's input sender.
-    ///
-    /// With this, you can send messages to the [`MessageBus`] itself.
-    pub fn clone_self_tx(&self) -> Option<Sender<MessageIn>> {
-        self.self_tx.upgrade()
     }
 }
 
@@ -234,7 +219,6 @@ where
 
         let mut message_bus = MessageBus::<T> {
             tx: out_msg_tx,
-            self_tx: in_msg_tx.downgrade(),
             rx: in_msg_rx,
             token: token.clone(),
             agent_tx: self.agent_tx.another(),

--- a/mirrord/intproxy/src/proxies/outgoing.rs
+++ b/mirrord/intproxy/src/proxies/outgoing.rs
@@ -118,6 +118,8 @@ struct ConnectInProgress {
     prepared_listener: Option<TcpListener>,
     remote_address: SocketAddress,
     hostname: Option<String>,
+    /// Delay owed by this connection before it carries data, from a chaos latency rule.
+    connect_latency: Option<Duration>,
     requested_at: Instant,
     layer_id: LayerId,
     message_id: MessageId,
@@ -134,6 +136,12 @@ struct InterceptorConnectionInfo {
     remote_address: SocketAddress,
     /// Hostname of this connection, if any (as originally requested).
     hostname: Option<String>,
+    /// Delay owed before this connection carries data, from a chaos latency rule.
+    ///
+    /// Charged once, to whichever of the first read or write comes first, and cleared when it
+    /// is taken. Server-speaks-first protocols read before they write, so neither direction can
+    /// be assumed to be the one that pays it.
+    connect_latency: Option<Duration>,
 }
 
 /// Handles logic and state of the `outgoing` feature.
@@ -270,6 +278,17 @@ impl OutgoingProxy {
         self.interceptor_connection_info.get(&interceptor_id)
     }
 
+    /// Takes the delay a connection owes before it carries data, leaving zero behind.
+    ///
+    /// Charged to whichever of the first read or write comes first, so a connection pays it once
+    /// however it is used.
+    fn take_connect_latency(&mut self, interceptor_id: InterceptorId) -> Duration {
+        self.interceptor_connection_info
+            .get_mut(&interceptor_id)
+            .and_then(|info| info.connect_latency.take())
+            .unwrap_or_default()
+    }
+
     fn supports_connect_v2(&self) -> bool {
         self.protocol_version
             .as_ref()
@@ -344,7 +363,8 @@ impl OutgoingProxy {
 
         let delay = self
             .chaos_read_latency_for_connection(id)
-            .unwrap_or_else(|| Duration::from_millis(self.receive_delay_ms));
+            .unwrap_or_else(|| Duration::from_millis(self.receive_delay_ms))
+            + self.take_connect_latency(id);
         if self
             .queue_interceptor_command(id, InterceptorCommand::Data(bytes.0), delay)
             .await
@@ -495,6 +515,7 @@ impl OutgoingProxy {
             InterceptorConnectionInfo {
                 remote_address: in_progress.remote_address,
                 hostname: in_progress.hostname,
+                connect_latency: in_progress.connect_latency,
             },
         );
         self.agent_write_queues.insert(id, agent_write_queue);
@@ -570,6 +591,15 @@ impl OutgoingProxy {
             None
         };
 
+        // Looked up here rather than on the way in, so the connect response still goes back to
+        // the layer immediately. The layer blocks on that response, so delaying it would stall
+        // the calling thread and stop client-side timers from firing.
+        let connect_latency = self.chaos_connect_latency_for_address(
+            &request.remote_address,
+            request.protocol,
+            request.hostname(),
+        );
+
         let uid = if supports_connect_v2 {
             let request_uid = Uid::new_v4();
             self.v2_reqs.insert(
@@ -578,6 +608,7 @@ impl OutgoingProxy {
                     prepared_listener: prepared_stream,
                     remote_address: request.remote_address.clone(),
                     hostname: request.hostname().cloned(),
+                    connect_latency,
                     requested_at: Instant::now(),
                     layer_id: session_id,
                     message_id,
@@ -594,6 +625,7 @@ impl OutgoingProxy {
                     prepared_listener: prepared_stream,
                     remote_address: request.remote_address.clone(),
                     hostname: request.hostname().cloned(),
+                    connect_latency,
                     requested_at: Instant::now(),
                     layer_id: session_id,
                     message_id,
@@ -858,7 +890,8 @@ impl BackgroundTask for OutgoingProxy {
 
                         let delay = self
                             .chaos_write_latency_for_connection(id)
-                            .unwrap_or_else(|| Duration::from_millis(self.transmit_delay_ms));
+                            .unwrap_or_else(|| Duration::from_millis(self.transmit_delay_ms))
+                            + self.take_connect_latency(id);
                         let msg = id.protocol.wrap_agent_write(id.connection_id, bytes);
                         self.queue_agent_message(id, msg, delay, Some(permit)).await;
                     }
@@ -1002,15 +1035,12 @@ mod test {
 
     /// A latency effect must never delay the connect handshake.
     ///
-    /// The layer waits for [`OutgoingResponse::Connect`] in a blocking call, so holding that
-    /// response back stalls the calling thread for the length of the delay. In a single-threaded
-    /// runtime that stalls the event loop, and a client-side timeout implemented as a timer
-    /// cannot fire while it does, which is normally the code a latency fault exists to exercise.
-    /// Latency belongs on reads and writes, which travel over the interceptor socket the
-    /// application polls, and so leave it free to react.
+    /// The layer waits for [`OutgoingResponse::Connect`] in a blocking call, so a client-side
+    /// timeout based on active time instead of actual time passed will never trigger. The delay
+    /// is owed by the connection instead, and paid before it carries data.
     #[tokio::test]
     async fn latency_rule_does_not_delay_connect() {
-        // Far longer than any wait below, so a reintroduced delay cannot pass by being quick.
+        // Far longer than any wait below, so a delay here cannot pass by being quick.
         let rule: ChaosRule = serde_json::from_str::<ChaosRuleRequest>(
             r#"{
                 "name": "latency far beyond the test's patience",
@@ -1035,7 +1065,7 @@ mod test {
             8,
         );
 
-        // The deferral this guards against only ran when the agent supported connect v2.
+        // agent needs to support connect v2
         outgoing
             .send(OutgoingProxyMessage::AgentProtocolVersion(
                 "1.22.0".parse().unwrap(),
@@ -1054,8 +1084,6 @@ mod test {
             ))
             .await;
 
-        // Asserted on the agent-bound message rather than the wire format, so the test keeps
-        // meaning if the connect encoding changes.
         tokio::time::timeout(Duration::from_secs(5), out.next())
             .await
             .expect("latency rule delayed the connect request to the agent")

--- a/mirrord/intproxy/src/proxies/outgoing.rs
+++ b/mirrord/intproxy/src/proxies/outgoing.rs
@@ -892,7 +892,7 @@ impl BackgroundTask for OutgoingProxy {
 
 #[cfg(test)]
 mod test {
-    use std::net::SocketAddr;
+    use std::{net::SocketAddr, time::Duration};
 
     use mirrord_intproxy_protocol::{
         LayerId, NetProtocol, OutgoingConnectRequest, OutgoingConnectRequestMetadata,
@@ -912,7 +912,10 @@ mod test {
         background_tasks::{BackgroundTasks, TaskUpdate},
         main_tasks::{ConnectionRefresh, ProxyMessage, ToLayer},
         proxies::outgoing::{OutgoingProxy, OutgoingProxyError, OutgoingProxyMessage},
-        session_monitor::chaos::ChaosWatcherRx,
+        session_monitor::chaos::{
+            ChaosRuleList, ChaosWatcherRx,
+            rules::{ChaosRule, ChaosRuleRequest},
+        },
     };
 
     /// Verifies that the outgoing proxy can handle operator reconnect
@@ -995,5 +998,67 @@ mod test {
             ((), TaskUpdate::Finished(Ok(()))) => {}
             other => panic!("unexpected update from the outgoing proxy: {other:?}"),
         }
+    }
+
+    /// A latency effect must never delay the connect handshake.
+    ///
+    /// The layer waits for [`OutgoingResponse::Connect`] in a blocking call, so holding that
+    /// response back stalls the calling thread for the length of the delay. In a single-threaded
+    /// runtime that stalls the event loop, and a client-side timeout implemented as a timer
+    /// cannot fire while it does, which is normally the code a latency fault exists to exercise.
+    /// Latency belongs on reads and writes, which travel over the interceptor socket the
+    /// application polls, and so leave it free to react.
+    #[tokio::test]
+    async fn latency_rule_does_not_delay_connect() {
+        // Far longer than any wait below, so a reintroduced delay cannot pass by being quick.
+        let rule: ChaosRule = serde_json::from_str::<ChaosRuleRequest>(
+            r#"{
+                "name": "latency far beyond the test's patience",
+                "selector": { "upstream": "1.1.1.1:80", "percentage": 100 },
+                "effect": { "latency": { "read_ms": 600000, "write_ms": 600000 } }
+            }"#,
+        )
+        .expect("rule should deserialize")
+        .try_into()
+        .expect("rule should validate");
+
+        let peer_addr = "1.1.1.1:80".parse::<SocketAddr>().unwrap();
+        let (connection, _, out) = Connection::dummy();
+        let (_chaos_tx, chaos_rx) = watch::channel(ChaosRuleList::from_iter([rule]));
+
+        let mut background_tasks: BackgroundTasks<(), ProxyMessage, OutgoingProxyError> =
+            BackgroundTasks::new(connection.tx_handle());
+
+        let outgoing = background_tasks.register(
+            OutgoingProxy::new(false, 0, 0, ChaosWatcherRx::new(chaos_rx)),
+            (),
+            8,
+        );
+
+        // The deferral this guards against only ran when the agent supported connect v2.
+        outgoing
+            .send(OutgoingProxyMessage::AgentProtocolVersion(
+                "1.22.0".parse().unwrap(),
+            ))
+            .await;
+
+        outgoing
+            .send(OutgoingProxyMessage::Layer(
+                OutgoingRequest::Connect(OutgoingConnectRequest {
+                    remote_address: SocketAddress::Ip(peer_addr),
+                    protocol: NetProtocol::Stream,
+                    metadata: OutgoingConnectRequestMetadata::default(),
+                }),
+                0,
+                LayerId(0),
+            ))
+            .await;
+
+        // Asserted on the agent-bound message rather than the wire format, so the test keeps
+        // meaning if the connect encoding changes.
+        tokio::time::timeout(Duration::from_secs(5), out.next())
+            .await
+            .expect("latency rule delayed the connect request to the agent")
+            .expect("outgoing proxy closed its agent connection");
     }
 }

--- a/mirrord/intproxy/src/proxies/outgoing.rs
+++ b/mirrord/intproxy/src/proxies/outgoing.rs
@@ -4,7 +4,7 @@ use std::{
     collections::{HashMap, HashSet},
     fmt, io,
     net::{Ipv4Addr, Ipv6Addr, SocketAddr},
-    ops::{ControlFlow, Not},
+    ops::Not,
     sync::Arc,
     time::{Duration, Instant},
 };
@@ -122,12 +122,6 @@ struct ConnectInProgress {
     layer_id: LayerId,
     message_id: MessageId,
     id: u128,
-}
-
-pub struct DeferredConnection {
-    request: OutgoingConnectRequest,
-    message_id: MessageId,
-    layer_id: LayerId,
 }
 
 /// Original connection metadata requested by the layer.
@@ -726,7 +720,6 @@ pub enum OutgoingProxyMessage {
     AgentSeqpacket(DaemonSeqpacket),
     AgentProtocolVersion(Version),
     Layer(OutgoingRequest, MessageId, LayerId),
-    DeferredConnect(DeferredConnection),
     ConnectionRefresh(ConnectionRefresh),
     LayerForked(LayerForked),
     LayerClosed(LayerClosed),
@@ -812,28 +805,12 @@ impl BackgroundTask for OutgoingProxy {
                                 continue;
                             }
 
-                            let connect = if self.supports_connect_v2() {
-                                match self.chaos_effect_for_connect_latency(connect, message_id, layer_id, message_bus).await {
-                                    ControlFlow::Continue(connect) => connect,
-                                    ControlFlow::Break(()) => continue,
-                                }
-                            } else {
-                                connect
-                            };
-
                             self.handle_connect_request(message_id, layer_id, connect, message_bus).await?;
                         }
                         request => {
                             self.handle_layer_request(request, layer_id, message_id, message_bus).await?;
                         }
                     },
-                    Some(OutgoingProxyMessage::DeferredConnect(DeferredConnection {
-                        request,
-                        message_id,
-                        layer_id,
-                    })) => {
-                        self.handle_connect_request(message_id, layer_id, request, message_bus).await?;
-                    }
                     Some(OutgoingProxyMessage::LayerForked(forked)) => {
                         self.connections_in_layers.clone_all(forked.parent, forked.child);
                     }

--- a/mirrord/intproxy/src/proxies/outgoing/chaos.rs
+++ b/mirrord/intproxy/src/proxies/outgoing/chaos.rs
@@ -16,7 +16,7 @@ use tracing::Level;
 use crate::{
     background_tasks::MessageBus,
     main_tasks::ToLayer,
-    proxies::outgoing::{DeferredConnection, InterceptorId, OutgoingProxy, OutgoingProxyMessage},
+    proxies::outgoing::{InterceptorId, OutgoingProxy},
     session_monitor::chaos::rules::{
         ChaosEffectConnectionError, ChaosSelector, ConnectionErrorType, TcpChaosEffect,
     },
@@ -131,55 +131,6 @@ impl OutgoingProxy {
         }
     }
 
-    #[tracing::instrument(level = Level::DEBUG, skip(self, message_bus), ret)]
-    pub(super) async fn chaos_effect_for_connect_latency(
-        &self,
-        request: OutgoingConnectRequest,
-        message_id: MessageId,
-        layer_id: LayerId,
-        message_bus: &mut MessageBus<OutgoingProxy>,
-    ) -> ControlFlow<(), OutgoingConnectRequest> {
-        let effect = self.chaos_effect_for_address(
-            &request.remote_address,
-            request.protocol,
-            request.hostname(),
-            |selector| match selector {
-                ChaosSelector::Tcp {
-                    effect: TcpChaosEffect::Latency(effect),
-                    ..
-                } => effect.connection_latency_duration(),
-                _ => None,
-            },
-        );
-
-        match effect {
-            Some(wait_for) if let Some(outgoing_tx) = message_bus.clone_self_tx() => {
-                let deferred = DeferredConnection {
-                    request,
-                    message_id,
-                    layer_id,
-                };
-
-                tokio::spawn(async move {
-                    sleep(wait_for).await;
-
-                    let _ = outgoing_tx
-                        .send(OutgoingProxyMessage::DeferredConnect(deferred))
-                        .await
-                        .inspect_err(|fail| {
-                            tracing::warn!(?fail, "Failed sending deferred connect!")
-                        });
-                });
-
-                ControlFlow::Break(())
-            }
-            Some(_) => {
-                tracing::debug!("Connection should be delayed, but outgoing_tx is closed.");
-                ControlFlow::Continue(request)
-            }
-            None => ControlFlow::Continue(request),
-        }
-    }
 
     /// Latency to apply to an intercepted connection's data messages, if a `ChaosRule` with a
     /// *read* latency effect matches this connection.

--- a/mirrord/intproxy/src/proxies/outgoing/chaos.rs
+++ b/mirrord/intproxy/src/proxies/outgoing/chaos.rs
@@ -131,7 +131,6 @@ impl OutgoingProxy {
         }
     }
 
-
     /// Latency to apply to an intercepted connection's data messages, if a `ChaosRule` with a
     /// *read* latency effect matches this connection.
     pub(super) fn chaos_read_latency_for_connection(

--- a/mirrord/intproxy/src/proxies/outgoing/chaos.rs
+++ b/mirrord/intproxy/src/proxies/outgoing/chaos.rs
@@ -131,6 +131,30 @@ impl OutgoingProxy {
         }
     }
 
+    /// One-shot latency owed by a connection before it carries data, if a `ChaosRule` with a
+    /// latency effect matches the address being connected to.
+    ///
+    /// Looked up by address because the interceptor does not exist yet at connect time.
+    pub(super) fn chaos_connect_latency_for_address(
+        &self,
+        remote_address: &SocketAddress,
+        protocol: NetProtocol,
+        hostname: Option<&String>,
+    ) -> Option<Duration> {
+        self.chaos_effect_for_address(
+            remote_address,
+            protocol,
+            hostname,
+            |selector| match selector {
+                ChaosSelector::Tcp {
+                    effect: TcpChaosEffect::Latency(effect),
+                    ..
+                } => effect.connection_latency_duration(),
+                _ => None,
+            },
+        )
+    }
+
     /// Latency to apply to an intercepted connection's data messages, if a `ChaosRule` with a
     /// *read* latency effect matches this connection.
     pub(super) fn chaos_read_latency_for_connection(

--- a/mirrord/intproxy/src/session_monitor/chaos/rules.rs
+++ b/mirrord/intproxy/src/session_monitor/chaos/rules.rs
@@ -580,6 +580,13 @@ impl ChaosEffectLatency {
         })
     }
 
+    /// Returns the duration a connection waits before it carries any data, plus random jitter
+    /// (if set). Applied once, to whichever of the first read or write happens first, so the
+    /// delay lands on data the application is polling for rather than on the connect response.
+    pub fn connection_latency_duration(&self) -> Option<Duration> {
+        self.add_latency_jitter(self.write + self.read)
+    }
+
     /// Returns the duration of read latency applied by the effect, plus random jitter (if set).
     /// Returns `None` if duration is 0.
     pub fn read_latency_duration(&self) -> Option<Duration> {

--- a/mirrord/intproxy/src/session_monitor/chaos/rules.rs
+++ b/mirrord/intproxy/src/session_monitor/chaos/rules.rs
@@ -592,13 +592,6 @@ impl ChaosEffectLatency {
         self.add_latency_jitter(self.write)
     }
 
-    /// Returns the duration of read+write latency applied by the effect to simulate connection
-    /// latency, plus random jitter (if set). Will always return `Some(_)` because either read or
-    /// write latency must be non-zero in a valid effect, but returns an `Option` for convenience.
-    pub fn connection_latency_duration(&self) -> Option<Duration> {
-        self.add_latency_jitter(self.write + self.read)
-    }
-
     /// Calculates a final latency to be applied by the effect by adding jitter to the given
     /// `Duration`. Will not add jitter to a `Duration` of 0, which may occur when either read
     /// or write latency is 0.


### PR DESCRIPTION
Alternative to #4749, taking @gememma's suggestion there: keep connection latency as an effect, and stop the layer blocking on it.

Closes COR-1817.

### The problem, unchanged from #4749

A latency effect deferred the response to an outgoing connect request until the delay elapsed. The layer waits for that response inside `make_proxy_request_with_response`, which blocks the calling thread. In a single-threaded runtime that stalls the event loop, so a client-side timeout implemented as a timer cannot fire during the fault it was written for.

It also bypassed non-blocking connect, which answers the layer immediately from a locally bound listener precisely so a slow remote never blocks the application.

### What this does instead

The delay is now owed by the connection rather than held against its connect response. `handle_connect_request` looks it up by address, carries it on `ConnectInProgress`, and lands it on `InterceptorConnectionInfo`. It is then charged to whichever of the first read or write comes first, through the delay queues that already exist, and cleared when taken.

Charging whichever comes first matters: server-speaks-first protocols read before they write, so neither direction can be assumed to be the one that pays.

**The total delay a request sees is unchanged.** Previously a connection waited `read_ms + write_ms` before the connect returned, then paid `read_ms` again on the first read. Now it waits the same `read_ms + write_ms` before data flows, and still pays `read_ms` on that read. The elapsed time is identical. The only thing that changes is that the wait no longer happens inside a blocking call, so timers keep running.

That is why this stays a `fixed` changelog entry rather than a `changed` one. Nothing about the effect's strength or configuration moves.

### Difference from #4749

#4749 removes connection latency entirely. That halves the delay on new connections and drops the capability, which is the behaviour change @gememma objected to, and she is right that reintroducing it after launch would be awkward.

This keeps it. The two are mutually exclusive; pick one.

Worth being explicit about a consequence, though. Because non-blocking connect decouples the application's `connect()` from the real one, a connect delay and a first-read delay are observationally the same to the application: both surface as a late first byte. So connection latency here remains a second charge on the same round trip, which is the doubling behind the "as high as three times the configured value" warning that went out with 3.224.0. Making it non-blocking does not make it distinguishable from read latency.

If connection latency is a capability worth keeping in its own right, the coherent version is an explicit `connect_ms` field rather than `read_ms + write_ms` summed, and that is better decided before launch than after. Happy to follow up with it.

### Testing

`cargo test -p mirrord-intproxy --lib`: 63 passed, including the regression test from #4749, which still holds because the connect handshake is still never deferred.

Not yet re-verified end to end against a cluster. #4749 was, with before and after measurements, and I will post the same for this branch.

### Review comments from #4749

Carried over: the terser test doc comment and the three comment trims. The changelog category question is answered differently here, for the reason above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
