### PR TITLE
Adds support for JSON output for `db-branches connections` command.


### DIFF
--- a/changelog.d/+cor-1794-json-format-db-branch-connections.changed.md
+++ b/changelog.d/+cor-1794-json-format-db-branch-connections.changed.md
@@ -1,0 +1,1 @@
+Adds support for JSON output for `db-branches connections` command.

--- a/mirrord/cli/src/config.rs
+++ b/mirrord/cli/src/config.rs
@@ -1204,7 +1204,11 @@ pub(super) enum DbBranchesCommand {
         names: Vec<String>,
     },
     /// Show active portforward connections for database branches
-    Connections,
+    Connections {
+        /// Format output for terminal display or scripting.
+        #[arg(long, default_value_t)]
+        format: DbBranchesConnectionsFormat,
+    },
     /// Destroy database branches
     Destroy {
         /// Destroy all branches
@@ -1214,6 +1218,14 @@ pub(super) enum DbBranchesCommand {
         #[arg(required_unless_present = "all")]
         names: Vec<String>,
     },
+}
+
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, ValueEnum, Display)]
+#[strum(serialize_all = "lowercase")]
+pub(super) enum DbBranchesConnectionsFormat {
+    #[default]
+    Pretty,
+    Json,
 }
 
 #[derive(Args, Debug)]

--- a/mirrord/cli/src/db_branches.rs
+++ b/mirrord/cli/src/db_branches.rs
@@ -19,7 +19,7 @@ use strum::IntoDiscriminant;
 
 use crate::{
     CliResult,
-    config::{DbBranchesArgs, DbBranchesCommand},
+    config::{DbBranchesArgs, DbBranchesCommand, DbBranchesConnectionsFormat},
     kube::{kube_client_from_layer_config, list_resource_if_defined},
     util::is_pid_alive,
 };
@@ -35,6 +35,14 @@ pub struct PortforwardSession {
     pub portforwards: Vec<Portforward>,
     pub key: String,
     pub session_id: u64,
+}
+
+#[derive(Debug, Serialize)]
+struct PortforwardConnection {
+    db_id: String,
+    connection_string: String,
+    key: String,
+    session_id: u64,
 }
 
 /// Directory where portforward session files are stored (`~/.mirrord/db_branch_portforwards/`).
@@ -194,30 +202,28 @@ impl From<MongodbBranchDatabase> for BranchInfo {
 pub async fn db_branches_command(args: DbBranchesArgs) -> CliResult<()> {
     match &args.command {
         DbBranchesCommand::Status { names } => status_command(&args, names.as_slice()).await,
-        DbBranchesCommand::Connections => connections_command().await,
+        DbBranchesCommand::Connections { format } => connections_command(*format).await,
         DbBranchesCommand::Destroy { all, names } => destroy_command(&args, *all, names).await,
     }
 }
 
-async fn connections_command() -> CliResult<()> {
+async fn connections_command(format: DbBranchesConnectionsFormat) -> CliResult<()> {
     let pf_dir = portforward_session_dir();
 
     let mut entries = match tokio::fs::read_dir(&pf_dir).await {
         Ok(entries) => entries,
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
-            println!("No active portforward sessions.");
+            print_no_active_portforwards(format);
             return Ok(());
         }
         Err(err) => {
             tracing::warn!(?err, "failed to read portforward session directory");
-            println!("No active portforward sessions.");
+            print_no_active_portforwards(format);
             return Ok(());
         }
     };
 
-    let mut table = Table::new();
-    table.add_row(row!["DB ID", "ADDRESS", "KEY", "SESSION ID"]);
-    let mut has_rows = false;
+    let mut connections = Vec::new();
 
     while let Ok(Some(entry)) = entries.next_entry().await {
         let path = entry.path();
@@ -247,24 +253,49 @@ async fn connections_command() -> CliResult<()> {
             Err(_) => continue,
         };
 
-        for pf in &session.portforwards {
-            table.add_row(row![
-                pf.db_id,
-                pf.connection_string,
-                session.key,
-                format!("{:X}", session.session_id)
-            ]);
-            has_rows = true;
-        }
+        connections.extend(session.portforwards.into_iter().map(|portforward| {
+            PortforwardConnection {
+                db_id: portforward.db_id,
+                connection_string: portforward.connection_string,
+                key: session.key.clone(),
+                session_id: session.session_id,
+            }
+        }));
     }
 
-    if has_rows {
-        table.printstd();
-    } else {
-        println!("No active portforward sessions.");
+    match format {
+        DbBranchesConnectionsFormat::Pretty if connections.is_empty() => {
+            print_no_active_portforwards(format)
+        }
+        DbBranchesConnectionsFormat::Pretty => build_connections_table(connections).printstd(),
+        DbBranchesConnectionsFormat::Json => println!("{}", serde_json::to_string(&connections)?),
     }
 
     Ok(())
+}
+
+fn print_no_active_portforwards(format: DbBranchesConnectionsFormat) {
+    if format == DbBranchesConnectionsFormat::Pretty {
+        println!("No active portforward sessions.");
+    } else {
+        println!("[]");
+    }
+}
+
+fn build_connections_table(connections: Vec<PortforwardConnection>) -> Table {
+    let mut table = Table::new();
+    table.add_row(row!["DB ID", "ADDRESS", "KEY", "SESSION ID"]);
+
+    for connection in connections {
+        table.add_row(row![
+            connection.db_id,
+            connection.connection_string,
+            connection.key,
+            format!("{:X}", connection.session_id)
+        ]);
+    }
+
+    table
 }
 
 fn get_api<T: Resource<DynamicType = (), Scope = NamespaceResourceScope>>(
@@ -596,8 +627,12 @@ async fn destroy_command(args: &DbBranchesArgs, all: bool, names: &[String]) -> 
 #[cfg(test)]
 mod tests {
     use prettytable::Row;
+    use serde_json::json;
 
-    use super::{BranchInfo, HashSet, Table, build_status_table, row};
+    use super::{
+        BranchInfo, HashSet, PortforwardConnection, Table, build_connections_table,
+        build_status_table, row,
+    };
 
     fn branch_info(name: &str, db_type: &'static str) -> BranchInfo {
         BranchInfo {
@@ -682,5 +717,37 @@ mod tests {
             "\n\nexpected:\n{}got:\n{}",
             expected, table
         );
+    }
+
+    #[test]
+    fn connections_output_is_serializable_and_matches_table() {
+        let connections = vec![PortforwardConnection {
+            db_id: "postgres".to_owned(),
+            connection_string: "postgresql://localhost:5432/app".to_owned(),
+            key: "feature-branch".to_owned(),
+            session_id: 0xCAFE,
+        }];
+
+        assert_eq!(
+            serde_json::to_value(&connections).unwrap(),
+            json!([{
+                "db_id": "postgres",
+                "connection_string": "postgresql://localhost:5432/app",
+                "key": "feature-branch",
+                "session_id": 51966,
+            }])
+        );
+
+        let table = build_connections_table(connections);
+        let expected = Table::from_iter([
+            row!["DB ID", "ADDRESS", "KEY", "SESSION ID"],
+            row![
+                "postgres",
+                "postgresql://localhost:5432/app",
+                "feature-branch",
+                "CAFE"
+            ],
+        ]);
+        assert_eq!(expected, table);
     }
 }


### PR DESCRIPTION
<!-- Thank you for contributing to mirrord! -->
<!-- Please use the checklist below as a guide for docs, tests and admin tasks for your PR -->
<!-- Feel free to ~strikethrough~ any items that you don't think apply -->
- Issue: https://linear.app/metalbear/issue/COR-1794/add-json-output-to-mirrord-db-branches-connections

### Quality Checklist:

- [ ] I have documented new code sufficiently
- [ ] I have checked and updated the relevant existing docs in code, including removing outdated material
- [ ] I have written user-facing website docs for new features, or opened a (sub)issue to do so
- [ ] I have checked and updated existing website docs for changed features
- [ ] I have tested this change and know it succeeds and fails as expected
- [ ] I have written unit tests or purposefully omitted them
- [ ] I have written e2e tests or purposefully omitted them
- [ ] I have explained what this PR introduces and why, and linked to relevant context (e.g. linear issues, related PRs,
  documentation)
- [x] I have introduced a short, clear and well-formatted changelog entry

<!-- need help with the changelog? see ../CONTRIBUTING.md#submitting-a-pull-request -->
<!-- Add more details of your changes below if needed -->

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>