### PR TITLE
Match chaos rules to events on the hostname, not the resolved address

### DIFF
--- a/changelog.d/+chaos-affected-filter-hostname.fixed.md
+++ b/changelog.d/+chaos-affected-filter-hostname.fixed.md
@@ -1,0 +1,2 @@
+Fixed the session monitor's `Affected` event filter, which compared chaos rule
+selectors against resolved IP addresses and so never matched anything.

--- a/mirrord/intproxy/src/lib.rs
+++ b/mirrord/intproxy/src/lib.rs
@@ -704,6 +704,7 @@ impl IntProxy {
                     self.monitor_tx.emit(MonitorEvent::OutgoingConnection {
                         address: format!("{}", connect_req.remote_address),
                         port,
+                        hostname: connect_req.hostname().cloned(),
                     });
                 }
                 self.task_txs

--- a/mirrord/intproxy/src/session_monitor.rs
+++ b/mirrord/intproxy/src/session_monitor.rs
@@ -36,6 +36,13 @@ pub enum MonitorEvent {
     OutgoingConnection {
         address: String,
         port: u16,
+        /// Hostname the app originally asked for, before it was resolved to `address`.
+        ///
+        /// Chaos rule selectors are written as hostnames, so this is what the session
+        /// monitor matches a rule against. `None` when the app connected to a literal
+        /// address and no name was ever involved.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        hostname: Option<String>,
     },
     PortSubscription {
         port: u16,

--- a/packages/monitor/src/components/EventStream.tsx
+++ b/packages/monitor/src/components/EventStream.tsx
@@ -147,7 +147,12 @@ export default function EventStream({
     .map((e) => {
       const matched =
         chaosRules && e.event.type === EventType.OutgoingConnection
-          ? matchChaosRule(chaosRules, e.event.address, e.event.port)
+          ? matchChaosRule(
+              chaosRules,
+              e.event.address,
+              e.event.port,
+              e.event.hostname,
+            )
           : null
       return { ...e, matched }
     })

--- a/packages/monitor/src/components/chaos/chaosMatch.ts
+++ b/packages/monitor/src/components/chaos/chaosMatch.ts
@@ -15,17 +15,24 @@ export function splitUpstream(upstream: string): {
 // The backend doesn't say which individual connections a rule affected (only the
 // aggregate hit counter), so the stream tags every outgoing event a rule *targets*:
 // the highest-priority armed rule whose host (and port, when given) matches.
+//
+// Selectors are written as hostnames, so the match runs against the hostname the
+// event carries. `address` holds the resolved IP and only works as a fallback for
+// a rule whose selector was itself written as a literal address.
 export function matchChaosRule(
   rules: ClientChaosRule[],
   address: string,
   port: number,
+  hostname?: string | null,
 ): ClientChaosRule | null {
-  const host = stripPortSuffix(address, port)
+  const candidates = [hostname, stripPortSuffix(address, port)].filter(
+    (value): value is string => Boolean(value),
+  )
   let best: ClientChaosRule | null = null
   for (const rule of rules) {
     if (!rule.armed) continue
     const target = splitUpstream(rule.upstream.trim())
-    if (target.host !== host) continue
+    if (!candidates.includes(target.host)) continue
     if (target.port !== null && target.port !== port) continue
     if (!best || rule.priority > best.priority) best = rule
   }

--- a/packages/monitor/src/components/chaos/chaosMatch.ts
+++ b/packages/monitor/src/components/chaos/chaosMatch.ts
@@ -16,23 +16,23 @@ export function splitUpstream(upstream: string): {
 // aggregate hit counter), so the stream tags every outgoing event a rule *targets*:
 // the highest-priority armed rule whose host (and port, when given) matches.
 //
-// Selectors are written as hostnames, so the match runs against the hostname the
-// event carries. `address` holds the resolved IP and only works as a fallback for
-// a rule whose selector was itself written as a literal address.
+// The two ways a selector can match mirror how the proxy itself decides. A name
+// selector matches as a substring of the hostname the app resolved, so a bare
+// service name also matches its fully qualified form. An address selector is
+// compared exactly, against the resolved address.
 export function matchChaosRule(
   rules: ClientChaosRule[],
   address: string,
   port: number,
   hostname?: string | null,
 ): ClientChaosRule | null {
-  const candidates = [hostname, stripPortSuffix(address, port)].filter(
-    (value): value is string => Boolean(value),
-  )
+  const resolved = stripPortSuffix(address, port)
   let best: ClientChaosRule | null = null
   for (const rule of rules) {
     if (!rule.armed) continue
     const target = splitUpstream(rule.upstream.trim())
-    if (!candidates.includes(target.host)) continue
+    const byName = hostname ? hostname.includes(target.host) : false
+    if (!byName && target.host !== resolved) continue
     if (target.port !== null && target.port !== port) continue
     if (!best || rule.priority > best.priority) best = rule
   }

--- a/packages/monitor/src/types.ts
+++ b/packages/monitor/src/types.ts
@@ -42,7 +42,12 @@ export type MonitorEvent =
   | { type: 'file_op'; path: string | null; operation: string }
   | { type: 'dns_query'; host: string }
   | { type: 'incoming_request'; method: string; path: string; host: string }
-  | { type: 'outgoing_connection'; address: string; port: number }
+  | {
+      type: 'outgoing_connection'
+      address: string
+      port: number
+      hostname?: string | null
+    }
   | { type: 'port_subscription'; port: number; mode: string }
   | { type: 'env_var'; vars: string[] }
   | { type: 'layer_connected'; pid: number; process_name: string }


### PR DESCRIPTION
## Problem

The session monitor's `Affected` event filter never selects anything, for any rule. With a latency rule armed and firing, its card showed 22 hits while `Affected` showed `0 events`.

Chaos rule selectors are written as hostnames, but the only destination an `outgoing_connection` event carried was `address`, which by then is a resolved IP. So the comparison in `matchChaosRule` comes down to:

```
"fraud-check-service.loan-demo.svc.cluster.local" === "10.96.27.156"
```

which is false for every rule. Nothing else in the stream can bridge it either: `dns_query` carries the short service name with no resolved address, and no event carries a chaos marker.

## Fix

The name is already available where the event is emitted. The connect request the layer sends carries the hostname the app originally asked for, and the proxy uses exactly that to decide whether a rule applies (`chaos_effect_for_address` → `applies_to_address`). This carries it on the event too and matches against it, keeping the resolved address as a fallback so a selector written as a literal address still works.

## Scope

This preserves the targeting semantics the existing comment describes, rather than changing them: a rule with a `percentage` still marks every connection it targets, not the subset actually faulted. Reporting only rules that genuinely fired would mean stamping the matched rule id on the event from the point where the effect is applied, which is a larger change and not attempted here.

## Verification

- `cargo check -p mirrord-intproxy` clean
- `pnpm typecheck` and `pnpm format:check` clean in `packages/monitor`
- `pnpm lint` reports one pre-existing error in `App.tsx:272`, identical before and after this change

COR-1821