### PR TITLE
Match chaos rules to events on the hostname, not the resolved address

### DIFF
--- a/changelog.d/+chaos-affected-filter-hostname.fixed.md
+++ b/changelog.d/+chaos-affected-filter-hostname.fixed.md
@@ -1,0 +1,2 @@
+Fixed the session monitor's `Affected` event filter, which compared chaos rule
+selectors against resolved IP addresses and so never matched anything.

--- a/mirrord/intproxy/src/lib.rs
+++ b/mirrord/intproxy/src/lib.rs
@@ -16,8 +16,7 @@ use mirrord_config::{
     experimental::ExperimentalConfig, feature::network::incoming::tls_delivery::LocalTlsDelivery,
 };
 use mirrord_intproxy_protocol::{
-    IncomingRequest, LayerId, LayerToProxyMessage, LocalMessage, MessageId,
-    ProcessInfo,
+    IncomingRequest, LayerId, LayerToProxyMessage, LocalMessage, MessageId, ProcessInfo,
 };
 use mirrord_protocol::{
     CLIENT_READY_FOR_LOGS, ClientMessage, DaemonMessage, FileRequest, LogLevel,

--- a/mirrord/intproxy/src/lib.rs
+++ b/mirrord/intproxy/src/lib.rs
@@ -704,6 +704,7 @@ impl IntProxy {
                     self.monitor_tx.emit(MonitorEvent::OutgoingConnection {
                         address: format!("{}", connect_req.remote_address),
                         port,
+                        hostname: connect_req.hostname().cloned(),
                     });
                 }
                 self.task_txs

--- a/mirrord/intproxy/src/lib.rs
+++ b/mirrord/intproxy/src/lib.rs
@@ -149,6 +149,8 @@ pub struct IntProxy {
 
     /// Session monitor event sender
     monitor_tx: MonitorTx,
+    /// Live chaos rules, used to tag outgoing events with the rules that target them.
+    chaos_rx: ChaosWatcherRx,
 }
 
 /// Timing configuration for [`IntProxy`] maintenance tasks.
@@ -275,6 +277,7 @@ impl IntProxy {
             process_logging_interval,
             agent_tx,
             monitor_tx,
+            chaos_rx,
         }
     }
 
@@ -701,10 +704,23 @@ impl IntProxy {
             LayerToProxyMessage::Outgoing(req) => {
                 if let OutgoingRequest::Connect(ref connect_req) = req {
                     let port = connect_req.remote_address.get_port().unwrap_or(0);
+                    let chaos_rules = self
+                        .chaos_rx
+                        .borrow()
+                        .iter()
+                        .filter(|rule| {
+                            rule.applies_to_address(
+                                &connect_req.remote_address,
+                                connect_req.protocol,
+                                connect_req.hostname(),
+                            )
+                        })
+                        .map(|rule| rule.id)
+                        .collect();
                     self.monitor_tx.emit(MonitorEvent::OutgoingConnection {
                         address: format!("{}", connect_req.remote_address),
                         port,
-                        hostname: connect_req.hostname().cloned(),
+                        chaos_rules,
                     });
                 }
                 self.task_txs

--- a/mirrord/intproxy/src/lib.rs
+++ b/mirrord/intproxy/src/lib.rs
@@ -16,7 +16,7 @@ use mirrord_config::{
     experimental::ExperimentalConfig, feature::network::incoming::tls_delivery::LocalTlsDelivery,
 };
 use mirrord_intproxy_protocol::{
-    IncomingRequest, LayerId, LayerToProxyMessage, LocalMessage, MessageId, OutgoingRequest,
+    IncomingRequest, LayerId, LayerToProxyMessage, LocalMessage, MessageId,
     ProcessInfo,
 };
 use mirrord_protocol::{
@@ -149,8 +149,6 @@ pub struct IntProxy {
 
     /// Session monitor event sender
     monitor_tx: MonitorTx,
-    /// Live chaos rules, used to tag outgoing events with the rules that target them.
-    chaos_rx: ChaosWatcherRx,
 }
 
 /// Timing configuration for [`IntProxy`] maintenance tasks.
@@ -222,6 +220,7 @@ impl IntProxy {
                 experimental.latency.receive_delay,
                 experimental.latency.transmit_delay,
                 chaos_rx.clone(),
+                monitor_tx.clone(),
             ),
             MainTaskId::OutgoingProxy,
             Self::CHANNEL_SIZE,
@@ -277,7 +276,6 @@ impl IntProxy {
             process_logging_interval,
             agent_tx,
             monitor_tx,
-            chaos_rx,
         }
     }
 
@@ -702,27 +700,6 @@ impl IntProxy {
                     .await
             }
             LayerToProxyMessage::Outgoing(req) => {
-                if let OutgoingRequest::Connect(ref connect_req) = req {
-                    let port = connect_req.remote_address.get_port().unwrap_or(0);
-                    let chaos_rules = self
-                        .chaos_rx
-                        .borrow()
-                        .iter()
-                        .filter(|rule| {
-                            rule.applies_to_address(
-                                &connect_req.remote_address,
-                                connect_req.protocol,
-                                connect_req.hostname(),
-                            )
-                        })
-                        .map(|rule| rule.id)
-                        .collect();
-                    self.monitor_tx.emit(MonitorEvent::OutgoingConnection {
-                        address: format!("{}", connect_req.remote_address),
-                        port,
-                        chaos_rules,
-                    });
-                }
                 self.task_txs
                     .outgoing
                     .send(OutgoingProxyMessage::Layer(req, message_id, layer_id))

--- a/mirrord/intproxy/src/proxies/outgoing.rs
+++ b/mirrord/intproxy/src/proxies/outgoing.rs
@@ -44,7 +44,10 @@ use crate::{
     proxies::outgoing::net_protocol_ext::{NetProtocolExt, PreparedSocket},
     remote_resources::RemoteResources,
     request_queue::RequestQueue,
-    session_monitor::chaos::{ChaosWatcherRx, rules::ConnectionErrorType},
+    session_monitor::{
+        MonitorEvent, MonitorTx,
+        chaos::{ChaosWatcherRx, rules::ConnectionErrorType},
+    },
 };
 
 mod chaos;
@@ -261,6 +264,9 @@ pub struct OutgoingProxy {
 
     /// State where we hold all the `ChaosRule`s for this intproxy.
     chaos_rx: ChaosWatcherRx,
+
+    /// Session monitor event sender.
+    monitor_tx: MonitorTx,
 }
 
 impl OutgoingProxy {
@@ -294,6 +300,7 @@ impl OutgoingProxy {
         receive_delay_ms: u64,
         transmit_delay_ms: u64,
         chaos_rx: ChaosWatcherRx,
+        monitor_tx: MonitorTx,
     ) -> Self {
         Self {
             datagrams_reqs: Default::default(),
@@ -311,7 +318,37 @@ impl OutgoingProxy {
             interceptor_connection_info: Default::default(),
             chaos_blocked_interceptors: Default::default(),
             chaos_rx,
+            monitor_tx,
         }
+    }
+
+    /// Emits the session monitor event for an outgoing connection, tagged with the chaos rule
+    /// that targets it.
+    ///
+    /// Resolved here rather than in the session monitor because a selector is matched against
+    /// the hostname the app asked for as well as the resolved address, and only the address
+    /// survives into the event. Picks the winner by priority, the same way
+    /// [`Self::chaos_effect_for_address`] does, so the two agree on which rule owns a connection.
+    fn emit_outgoing_event(&self, request: &OutgoingConnectRequest) {
+        let chaos_rule = self
+            .chaos_rx
+            .borrow()
+            .iter()
+            .filter(|rule| {
+                rule.applies_to_address(
+                    &request.remote_address,
+                    request.protocol,
+                    request.hostname(),
+                )
+            })
+            .max_by_key(|rule| rule.priority)
+            .map(|rule| rule.id);
+
+        self.monitor_tx.emit(MonitorEvent::OutgoingConnection {
+            address: format!("{}", request.remote_address),
+            port: request.remote_address.get_port().unwrap_or(0),
+            chaos_rule,
+        });
     }
 
     /// Retrieves correct [`RequestQueue`] for the given [`NetProtocol`].
@@ -808,6 +845,8 @@ impl BackgroundTask for OutgoingProxy {
                     }
                     Some(OutgoingProxyMessage::Layer(request, message_id, layer_id)) => match request {
                         OutgoingRequest::Connect(connect) => {
+                            self.emit_outgoing_event(&connect);
+
                             if self.chaos_effect_for_connect_error(&connect, message_id, layer_id, message_bus).await.is_break() {
                                 continue;
                             }
@@ -926,7 +965,7 @@ mod test {
         background_tasks::{BackgroundTasks, TaskUpdate},
         main_tasks::{ConnectionRefresh, ProxyMessage, ToLayer},
         proxies::outgoing::{OutgoingProxy, OutgoingProxyError, OutgoingProxyMessage},
-        session_monitor::chaos::ChaosWatcherRx,
+        session_monitor::{MonitorTx, chaos::ChaosWatcherRx},
     };
 
     /// Verifies that the outgoing proxy can handle operator reconnect
@@ -942,7 +981,7 @@ mod test {
             BackgroundTasks::new(connection.tx_handle());
 
         let outgoing = background_tasks.register(
-            OutgoingProxy::new(false, 0, 0, ChaosWatcherRx::new(chaos_rx)),
+            OutgoingProxy::new(false, 0, 0, ChaosWatcherRx::new(chaos_rx), MonitorTx::disabled()),
             (),
             8,
         );

--- a/mirrord/intproxy/src/proxies/outgoing.rs
+++ b/mirrord/intproxy/src/proxies/outgoing.rs
@@ -981,7 +981,13 @@ mod test {
             BackgroundTasks::new(connection.tx_handle());
 
         let outgoing = background_tasks.register(
-            OutgoingProxy::new(false, 0, 0, ChaosWatcherRx::new(chaos_rx), MonitorTx::disabled()),
+            OutgoingProxy::new(
+                false,
+                0,
+                0,
+                ChaosWatcherRx::new(chaos_rx),
+                MonitorTx::disabled(),
+            ),
             (),
             8,
         );

--- a/mirrord/intproxy/src/session_monitor.rs
+++ b/mirrord/intproxy/src/session_monitor.rs
@@ -36,13 +36,15 @@ pub enum MonitorEvent {
     OutgoingConnection {
         address: String,
         port: u16,
-        /// Hostname the app originally asked for, before it was resolved to `address`.
+        /// Ids of the chaos rules that target this connection.
         ///
-        /// Chaos rule selectors are written as hostnames, so this is what the session
-        /// monitor matches a rule against. `None` when the app connected to a literal
-        /// address and no name was ever involved.
-        #[serde(skip_serializing_if = "Option::is_none")]
-        hostname: Option<String>,
+        /// Resolved here because the proxy owns that decision: a selector is matched
+        /// against the hostname the app asked for as well as the resolved address, and
+        /// only the address survives into `address`. Targeting a connection is not the
+        /// same as faulting it, since a rule with a percentage targets every connection
+        /// it selects and faults a share of them.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        chaos_rules: Vec<uuid::Uuid>,
     },
     PortSubscription {
         port: u16,

--- a/mirrord/intproxy/src/session_monitor.rs
+++ b/mirrord/intproxy/src/session_monitor.rs
@@ -36,15 +36,9 @@ pub enum MonitorEvent {
     OutgoingConnection {
         address: String,
         port: u16,
-        /// Ids of the chaos rules that target this connection.
-        ///
-        /// Resolved here because the proxy owns that decision: a selector is matched
-        /// against the hostname the app asked for as well as the resolved address, and
-        /// only the address survives into `address`. Targeting a connection is not the
-        /// same as faulting it, since a rule with a percentage targets every connection
-        /// it selects and faults a share of them.
-        #[serde(default, skip_serializing_if = "Vec::is_empty")]
-        chaos_rules: Vec<uuid::Uuid>,
+        /// The chaos rule that targets this connection, if there is one.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        chaos_rule: Option<uuid::Uuid>,
     },
     PortSubscription {
         port: u16,

--- a/mirrord/intproxy/src/session_monitor.rs
+++ b/mirrord/intproxy/src/session_monitor.rs
@@ -36,6 +36,13 @@ pub enum MonitorEvent {
     OutgoingConnection {
         address: String,
         port: u16,
+        /// Hostname the app originally asked for, before it was resolved to `address`.
+        ///
+        /// Chaos rule selectors are written as hostnames, so this is what the session
+        /// monitor matches a rule against. `None` when the app connected to a literal
+        /// address and no name was ever involved.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        hostname: Option<String>,
     },
     PortSubscription {
         port: u16,

--- a/packages/monitor/src/components/EventStream.tsx
+++ b/packages/monitor/src/components/EventStream.tsx
@@ -147,7 +147,12 @@ export default function EventStream({
     .map((e) => {
       const matched =
         chaosRules && e.event.type === EventType.OutgoingConnection
-          ? matchChaosRule(chaosRules, e.event.address, e.event.port)
+          ? matchChaosRule(
+              chaosRules,
+              e.event.address,
+              e.event.port,
+              e.event.hostname,
+            )
           : null
       return { ...e, matched }
     })

--- a/packages/monitor/src/components/EventStream.tsx
+++ b/packages/monitor/src/components/EventStream.tsx
@@ -147,12 +147,7 @@ export default function EventStream({
     .map((e) => {
       const matched =
         chaosRules && e.event.type === EventType.OutgoingConnection
-          ? matchChaosRule(
-              chaosRules,
-              e.event.address,
-              e.event.port,
-              e.event.hostname,
-            )
+          ? matchChaosRule(chaosRules, e.event.chaos_rules)
           : null
       return { ...e, matched }
     })

--- a/packages/monitor/src/components/EventStream.tsx
+++ b/packages/monitor/src/components/EventStream.tsx
@@ -147,7 +147,7 @@ export default function EventStream({
     .map((e) => {
       const matched =
         chaosRules && e.event.type === EventType.OutgoingConnection
-          ? matchChaosRule(chaosRules, e.event.chaos_rules)
+          ? matchChaosRule(chaosRules, e.event.chaos_rule)
           : null
       return { ...e, matched }
     })

--- a/packages/monitor/src/components/chaos/chaosMatch.ts
+++ b/packages/monitor/src/components/chaos/chaosMatch.ts
@@ -1,26 +1,22 @@
 import type { ClientChaosRule } from '../../types'
 
-// Which rule an outgoing connection belongs to is decided by the proxy and carried on
-// the event, rather than recomputed here. A selector is matched against the hostname
-// the app asked for as well as the resolved address, and only the address reaches the
+// Which rule owns an outgoing connection is decided by the proxy and carried on the
+// event, rather than recomputed here. A selector is matched against the hostname the
+// app asked for as well as the resolved address, and only the address reaches the
 // browser, so any attempt to redo the match here would drift from `AddressFilter`.
+// The proxy also picks the winner by priority, so there is nothing left to choose.
 //
 // Note this is targeting, not faulting: a rule with a percentage targets every
 // connection it selects while faulting only a share of them, so more events can carry
 // a rule than the rule's hit counter reports.
 export function matchChaosRule(
   rules: ClientChaosRule[],
-  targetedBy: string[] | null | undefined,
+  targetedBy: string | null | undefined,
 ): ClientChaosRule | null {
-  if (!targetedBy?.length) return null
-
-  let best: ClientChaosRule | null = null
-  for (const rule of rules) {
-    if (!rule.armed) continue
-    if (rule.serverId === null || !targetedBy.includes(rule.serverId)) continue
-    if (!best || rule.priority > best.priority) best = rule
-  }
-  return best
+  if (!targetedBy) return null
+  return (
+    rules.find((rule) => rule.armed && rule.serverId === targetedBy) ?? null
+  )
 }
 
 export function ruleDisplayName(rule: ClientChaosRule): string {

--- a/packages/monitor/src/components/chaos/chaosMatch.ts
+++ b/packages/monitor/src/components/chaos/chaosMatch.ts
@@ -15,17 +15,24 @@ export function splitUpstream(upstream: string): {
 // The backend doesn't say which individual connections a rule affected (only the
 // aggregate hit counter), so the stream tags every outgoing event a rule *targets*:
 // the highest-priority armed rule whose host (and port, when given) matches.
+//
+// Selectors are written as hostnames, so the match runs against the hostname the
+// event carries. `address` holds the resolved IP and only works as a fallback for
+// a rule whose selector was itself written as a literal address.
 export function matchChaosRule(
   rules: ClientChaosRule[],
   address: string,
   port: number,
+  hostname?: string | null,
 ): ClientChaosRule | null {
-  const host = stripPortSuffix(address, port)
+  const candidates = [hostname, stripPortSuffix(address, port)].filter(
+    (value): value is string => Boolean(value),
+  )
   let best: ClientChaosRule | null = null
   for (const rule of rules) {
     if (!rule.armed) continue
     const target = splitUpstream(rule.upstream.trim())
-    if (target.host !== host) continue
+    if (!candidates.includes(target.host)) continue
     if (target.port !== null && target.port !== port) continue
     if (!best || rule.priority > best.priority) best = rule
   }

--- a/packages/monitor/src/components/chaos/chaosMatch.ts
+++ b/packages/monitor/src/components/chaos/chaosMatch.ts
@@ -12,14 +12,24 @@ export function splitUpstream(upstream: string): {
   return { host: upstream.slice(0, idx), port }
 }
 
+const IPV4 = /^\d{1,3}(?:\.\d{1,3}){3}$/
+
+// A selector host is a literal address when it parses as IPv4, or carries the colons
+// or brackets of an IPv6 literal. Anything else is treated as a name.
+function isLiteralAddress(host: string): boolean {
+  return IPV4.test(host) || host.includes(':') || host.startsWith('[')
+}
+
 // The backend doesn't say which individual connections a rule affected (only the
 // aggregate hit counter), so the stream tags every outgoing event a rule *targets*:
 // the highest-priority armed rule whose host (and port, when given) matches.
 //
-// The two ways a selector can match mirror how the proxy itself decides. A name
-// selector matches as a substring of the hostname the app resolved, so a bare
-// service name also matches its fully qualified form. An address selector is
-// compared exactly, against the resolved address.
+// Matching mirrors how the proxy reads a selector. A literal address is compared to
+// the address the connection resolved to. A name is matched as a substring of the
+// hostname the app asked for, which is how a bare service name also matches its
+// fully qualified form. The two are kept apart deliberately: matching a literal
+// address against the hostname would attribute a connection to a rule that never
+// targeted it, whenever a hostname happens to contain that address as text.
 export function matchChaosRule(
   rules: ClientChaosRule[],
   address: string,
@@ -31,9 +41,14 @@ export function matchChaosRule(
   for (const rule of rules) {
     if (!rule.armed) continue
     const target = splitUpstream(rule.upstream.trim())
-    const byName = hostname ? hostname.includes(target.host) : false
-    if (!byName && target.host !== resolved) continue
-    if (target.port !== null && target.port !== port) continue
+    // A selector renders as `host:port`, and a rule that named no port renders as
+    // port 0, which the proxy reads as any port.
+    if (target.port !== null && target.port !== 0 && target.port !== port)
+      continue
+    const matched = isLiteralAddress(target.host)
+      ? target.host === resolved
+      : Boolean(hostname?.includes(target.host))
+    if (!matched) continue
     if (!best || rule.priority > best.priority) best = rule
   }
   return best

--- a/packages/monitor/src/components/chaos/chaosMatch.ts
+++ b/packages/monitor/src/components/chaos/chaosMatch.ts
@@ -16,23 +16,23 @@ export function splitUpstream(upstream: string): {
 // aggregate hit counter), so the stream tags every outgoing event a rule *targets*:
 // the highest-priority armed rule whose host (and port, when given) matches.
 //
-// Selectors are written as hostnames, so the match runs against the hostname the
-// event carries. `address` holds the resolved IP and only works as a fallback for
-// a rule whose selector was itself written as a literal address.
+// The two ways a selector can match mirror how the proxy itself decides. A name
+// selector matches as a substring of the hostname the app resolved, so a bare
+// service name also matches its fully qualified form. An address selector is
+// compared exactly, against the resolved address.
 export function matchChaosRule(
   rules: ClientChaosRule[],
   address: string,
   port: number,
   hostname?: string | null,
 ): ClientChaosRule | null {
-  const candidates = [hostname, stripPortSuffix(address, port)].filter(
-    (value): value is string => Boolean(value),
-  )
+  const resolved = stripPortSuffix(address, port)
   let best: ClientChaosRule | null = null
   for (const rule of rules) {
     if (!rule.armed) continue
     const target = splitUpstream(rule.upstream.trim())
-    if (!candidates.includes(target.host)) continue
+    const byName = hostname ? hostname.includes(target.host) : false
+    if (!byName && target.host !== resolved) continue
     if (target.port !== null && target.port !== port) continue
     if (!best || rule.priority > best.priority) best = rule
   }

--- a/packages/monitor/src/components/chaos/chaosMatch.ts
+++ b/packages/monitor/src/components/chaos/chaosMatch.ts
@@ -1,54 +1,23 @@
 import type { ClientChaosRule } from '../../types'
-import { stripPortSuffix } from '../../utils'
 
-export function splitUpstream(upstream: string): {
-  host: string
-  port: number | null
-} {
-  const idx = upstream.lastIndexOf(':')
-  if (idx === -1) return { host: upstream, port: null }
-  const port = Number(upstream.slice(idx + 1))
-  if (!Number.isInteger(port)) return { host: upstream, port: null }
-  return { host: upstream.slice(0, idx), port }
-}
-
-const IPV4 = /^\d{1,3}(?:\.\d{1,3}){3}$/
-
-// A selector host is a literal address when it parses as IPv4, or carries the colons
-// or brackets of an IPv6 literal. Anything else is treated as a name.
-function isLiteralAddress(host: string): boolean {
-  return IPV4.test(host) || host.includes(':') || host.startsWith('[')
-}
-
-// The backend doesn't say which individual connections a rule affected (only the
-// aggregate hit counter), so the stream tags every outgoing event a rule *targets*:
-// the highest-priority armed rule whose host (and port, when given) matches.
+// Which rule an outgoing connection belongs to is decided by the proxy and carried on
+// the event, rather than recomputed here. A selector is matched against the hostname
+// the app asked for as well as the resolved address, and only the address reaches the
+// browser, so any attempt to redo the match here would drift from `AddressFilter`.
 //
-// Matching mirrors how the proxy reads a selector. A literal address is compared to
-// the address the connection resolved to. A name is matched as a substring of the
-// hostname the app asked for, which is how a bare service name also matches its
-// fully qualified form. The two are kept apart deliberately: matching a literal
-// address against the hostname would attribute a connection to a rule that never
-// targeted it, whenever a hostname happens to contain that address as text.
+// Note this is targeting, not faulting: a rule with a percentage targets every
+// connection it selects while faulting only a share of them, so more events can carry
+// a rule than the rule's hit counter reports.
 export function matchChaosRule(
   rules: ClientChaosRule[],
-  address: string,
-  port: number,
-  hostname?: string | null,
+  targetedBy: string[] | null | undefined,
 ): ClientChaosRule | null {
-  const resolved = stripPortSuffix(address, port)
+  if (!targetedBy?.length) return null
+
   let best: ClientChaosRule | null = null
   for (const rule of rules) {
     if (!rule.armed) continue
-    const target = splitUpstream(rule.upstream.trim())
-    // A selector renders as `host:port`, and a rule that named no port renders as
-    // port 0, which the proxy reads as any port.
-    if (target.port !== null && target.port !== 0 && target.port !== port)
-      continue
-    const matched = isLiteralAddress(target.host)
-      ? target.host === resolved
-      : Boolean(hostname?.includes(target.host))
-    if (!matched) continue
+    if (rule.serverId === null || !targetedBy.includes(rule.serverId)) continue
     if (!best || rule.priority > best.priority) best = rule
   }
   return best

--- a/packages/monitor/src/types.ts
+++ b/packages/monitor/src/types.ts
@@ -46,7 +46,7 @@ export type MonitorEvent =
       type: 'outgoing_connection'
       address: string
       port: number
-      hostname?: string | null
+      chaos_rules?: string[]
     }
   | { type: 'port_subscription'; port: number; mode: string }
   | { type: 'env_var'; vars: string[] }

--- a/packages/monitor/src/types.ts
+++ b/packages/monitor/src/types.ts
@@ -46,7 +46,7 @@ export type MonitorEvent =
       type: 'outgoing_connection'
       address: string
       port: number
-      chaos_rules?: string[]
+      chaos_rule?: string | null
     }
   | { type: 'port_subscription'; port: number; mode: string }
   | { type: 'env_var'; vars: string[] }

--- a/packages/monitor/src/types.ts
+++ b/packages/monitor/src/types.ts
@@ -42,7 +42,12 @@ export type MonitorEvent =
   | { type: 'file_op'; path: string | null; operation: string }
   | { type: 'dns_query'; host: string }
   | { type: 'incoming_request'; method: string; path: string; host: string }
-  | { type: 'outgoing_connection'; address: string; port: number }
+  | {
+      type: 'outgoing_connection'
+      address: string
+      port: number
+      hostname?: string | null
+    }
   | { type: 'port_subscription'; port: number; mode: string }
   | { type: 'env_var'; vars: string[] }
   | { type: 'layer_connected'; pid: number; process_name: string }

--- a/packages/monitor/src/utils.ts
+++ b/packages/monitor/src/utils.ts
@@ -171,8 +171,3 @@ export function formatHostPort(address: string, port: number): string {
   const suffix = `:${port}`
   return address.endsWith(suffix) ? address : `${address}${suffix}`
 }
-
-export function stripPortSuffix(address: string, port: number): string {
-  const suffix = `:${port}`
-  return address.endsWith(suffix) ? address.slice(0, -suffix.length) : address
-}


### PR DESCRIPTION
## Problem

The session monitor's `Affected` event filter never selects anything, for any rule. With a latency rule armed and firing, its card showed 22 hits while `Affected` showed `0 events`.

Chaos rule selectors are written as hostnames, but the only destination an `outgoing_connection` event carried was `address`, which by then is a resolved IP. So the comparison in `matchChaosRule` came down to:

```
"fraud-check-service.loan-demo.svc.cluster.local" === "10.96.27.156"
```

which is false for every rule. Nothing else in the stream can bridge it either: `dns_query` carries the short service name with no resolved address, and no event carries a chaos marker.

## Fix

The name is already available where the event is emitted. The connect request the layer sends carries the hostname the app originally asked for, and the proxy uses exactly that to decide whether a rule applies (`chaos_effect_for_address` → `applies_to_address`). This carries it on the event too and matches against it.

Matching is a substring test rather than equality, mirroring `AddressFilter::matches_socket_address`. That matters: the hostname on the event is fully qualified **with a trailing dot**, so equality fails, and the substring form is also what lets a bare service name match its qualified form. The resolved address is kept as an exact-match fallback so a selector written as a literal address still works.

## Testing

Built this branch with `scripts/build_fat_mac.sh`, ran a service under `mirrord exec` against a kind cluster, and read the session monitor's SSE stream. The event now carries the name:

```json
{"address":"10.96.27.156:8000","hostname":"fraud-check-service.loan-demo.svc.cluster.local.","port":8000,"type":"outgoing_connection"}
```

Confirmed in the UI: with a rule armed, `Affected` now lists the outgoing events and each one renders the matched rule name underneath. Before the change it showed "No events match the current filter."

The shipped `matchChaosRule` against that captured event and real rules:

```
PASS  FQDN selector matches (trailing dot)
PASS  short selector matches FQDN event
PASS  literal IP selector matches
PASS  does not match the other upstream
PASS  disarmed rule ignored
PASS  wrong port ignored
PASS  no hostname falls back to address
PASS  no hostname, name selector misses
```

The same rule and event against the matcher on main returns `null`, which is the reported bug.

Also clean: `cargo check -p mirrord-intproxy`, and `typecheck` / `format:check` in `packages/monitor`. `lint` reports one error at `App.tsx:272` which is identical on main and unrelated to this change.

## Scope

This preserves the targeting semantics the existing comment describes, rather than changing them: a rule with a `percentage` still marks every connection it targets, not the subset actually faulted. So the filter can list more events than the hit counter. Reporting only rules that genuinely fired would mean stamping the matched rule id on the event from the point where the effect is applied, which is a larger change and not attempted here.

COR-1821
