### PR TITLE
feat(monitor): report unhandled errors as user-facing failures

### DIFF
--- a/changelog.d/+monitor-reclassify-unhandled-error.internal.md
+++ b/changelog.d/+monitor-reclassify-unhandled-error.internal.md
@@ -1,0 +1,3 @@
+Report unhandled errors in the local UI as user-facing failures rather than background
+health signals, so they sit alongside the error-boundary crash they are a variant of, and
+drop the event-kind property that no longer distinguishes anything.

--- a/changelog.d/monitor-reclassify-unhandled-error.internal.md
+++ b/changelog.d/monitor-reclassify-unhandled-error.internal.md
@@ -1,0 +1,2 @@
+Report unhandled errors in the local UI as user-facing failures rather than background
+health signals, so they sit alongside the error-boundary crash they are a variant of.

--- a/changelog.d/monitor-reclassify-unhandled-error.internal.md
+++ b/changelog.d/monitor-reclassify-unhandled-error.internal.md
@@ -1,2 +1,0 @@
-Report unhandled errors in the local UI as user-facing failures rather than background
-health signals, so they sit alongside the error-boundary crash they are a variant of.

--- a/packages/monitor/src/App.tsx
+++ b/packages/monitor/src/App.tsx
@@ -280,9 +280,9 @@ export default function App({
         ...prev,
         joinedKey: result.joinedKey ?? key,
       }))
-      emitUserSucceeded('operator_session_joined', 'user_action', { key })
+      emitUserSucceeded('operator_session_joined', { key })
     } else {
-      emitUserBlocked('operator_session_join_failed', 'user_action', {
+      emitUserBlocked('operator_session_join_failed', {
         key,
         ...(result.error && { error: result.error }),
       })

--- a/packages/monitor/src/analytics.ts
+++ b/packages/monitor/src/analytics.ts
@@ -98,7 +98,12 @@ export function trackEvent(
   posthog.capture(event, { source: 'session-monitor', ...properties })
 }
 
-export type EventKind = 'user_action' | 'health'
+// Every emitted event describes something a person was trying to do, including a crash,
+// which stops them mid-task just as surely as a failed request does. Background liveness
+// signals are deliberately not reported through here: they track how long a tab stayed
+// open rather than whether anyone was affected, so mixing them in makes the
+// blocked-versus-succeeded ratio unreadable.
+export type EventKind = 'user_action'
 
 export function emitUserBlocked(
   reason: string,

--- a/packages/monitor/src/analytics.ts
+++ b/packages/monitor/src/analytics.ts
@@ -98,29 +98,24 @@ export function trackEvent(
   posthog.capture(event, { source: 'session-monitor', ...properties })
 }
 
-// Every emitted event describes something a person was trying to do, including a crash,
-// which stops them mid-task just as surely as a failed request does. Background liveness
-// signals are deliberately not reported through here: they track how long a tab stayed
-// open rather than whether anyone was affected, so mixing them in makes the
-// blocked-versus-succeeded ratio unreadable.
-export type EventKind = 'user_action'
-
+// Every event these two emit describes something a person was trying to do, including a
+// crash, which stops them mid-task just as surely as a failed request does. Background
+// liveness signals are deliberately not reported through here: they track how long a tab
+// stayed open rather than whether anyone was affected, so mixing them in makes the
+// blocked-versus-succeeded ratio unreadable. `reason` is the only axis a breakdown needs.
 export function emitUserBlocked(
   reason: string,
-  kind: EventKind,
   properties: Record<string, unknown> = {},
   error?: unknown,
 ): void {
   trackEvent('monitor_user_blocked', {
     reason,
-    kind,
     surface: 'monitor',
     ...properties,
   })
   if (error !== undefined && initialized) {
     posthog.captureException(error, {
       reason,
-      kind,
       surface: 'monitor',
       ...properties,
     })
@@ -129,12 +124,10 @@ export function emitUserBlocked(
 
 export function emitUserSucceeded(
   reason: string,
-  kind: EventKind,
   properties: Record<string, unknown> = {},
 ): void {
   trackEvent('monitor_user_succeeded', {
     reason,
-    kind,
     surface: 'monitor',
     ...properties,
   })

--- a/packages/monitor/src/api.ts
+++ b/packages/monitor/src/api.ts
@@ -66,7 +66,7 @@ export const api = {
     )
     if (!r.ok) {
       if (r.status !== HTTP_NOT_FOUND) {
-        emitUserBlocked('session_fetch_failed', 'user_action', {
+        emitUserBlocked('session_fetch_failed', {
           session_id: sessionId,
           status: r.status,
           error: r.statusText,
@@ -74,7 +74,7 @@ export const api = {
       }
       return null
     }
-    emitUserSucceeded('session_loaded', 'user_action', {
+    emitUserSucceeded('session_loaded', {
       session_id: sessionId,
     })
     const data = (await r.json()) as SessionInfo
@@ -92,20 +92,20 @@ export const api = {
         },
       )
     } catch (err) {
-      emitUserBlocked('session_kill_failed', 'user_action', {
+      emitUserBlocked('session_kill_failed', {
         session_id: sessionId,
         error: err instanceof Error ? err.message : String(err),
       })
       return
     }
     if (!r.ok) {
-      emitUserBlocked('session_kill_failed', 'user_action', {
+      emitUserBlocked('session_kill_failed', {
         session_id: sessionId,
         status: r.status,
         error: r.statusText,
       })
     } else {
-      emitUserSucceeded('session_killed', 'user_action', {
+      emitUserSucceeded('session_killed', {
         session_id: sessionId,
       })
     }
@@ -136,12 +136,12 @@ export const api = {
       body: JSON.stringify(rule),
     })
     if (!r.ok) {
-      emitUserBlocked('chaos_rule_create_failed', 'user_action', {
+      emitUserBlocked('chaos_rule_create_failed', {
         session_id: sessionId,
       })
       throw new Error(await chaosErrorMessage(r))
     }
-    emitUserSucceeded('chaos_rule_created', 'user_action', {
+    emitUserSucceeded('chaos_rule_created', {
       session_id: sessionId,
     })
     return (await r.json()) as ChaosRule
@@ -159,13 +159,13 @@ export const api = {
       body: JSON.stringify(rule),
     })
     if (!r.ok) {
-      emitUserBlocked('chaos_rule_update_failed', 'user_action', {
+      emitUserBlocked('chaos_rule_update_failed', {
         session_id: sessionId,
         rule_id: ruleId,
       })
       throw new Error(await chaosErrorMessage(r))
     }
-    emitUserSucceeded('chaos_rule_updated', 'user_action', {
+    emitUserSucceeded('chaos_rule_updated', {
       session_id: sessionId,
       rule_id: ruleId,
     })
@@ -178,13 +178,13 @@ export const api = {
       credentials: 'include',
     })
     if (!r.ok) {
-      emitUserBlocked('chaos_rule_delete_failed', 'user_action', {
+      emitUserBlocked('chaos_rule_delete_failed', {
         session_id: sessionId,
         rule_id: ruleId,
       })
       throw new Error(await chaosErrorMessage(r))
     }
-    emitUserSucceeded('chaos_rule_deleted', 'user_action', {
+    emitUserSucceeded('chaos_rule_deleted', {
       session_id: sessionId,
       rule_id: ruleId,
     })
@@ -261,14 +261,14 @@ export const api = {
       },
     )
     if (!r.ok) {
-      emitUserBlocked('me_fetch_failed', 'user_action', {
+      emitUserBlocked('me_fetch_failed', {
         status: r.status,
         error: r.statusText,
       })
       return { k8sUsername: null }
     }
     const data = (await r.json()) as { username?: string | null }
-    emitUserSucceeded('me_loaded', 'user_action')
+    emitUserSucceeded('me_loaded')
     return { k8sUsername: data.username ?? null }
   },
 }

--- a/packages/monitor/src/components/ErrorBoundary.tsx
+++ b/packages/monitor/src/components/ErrorBoundary.tsx
@@ -24,7 +24,6 @@ export class ErrorBoundary extends Component<Props, State> {
   override componentDidCatch(error: Error, info: ErrorInfo): void {
     emitUserBlocked(
       'ui_crashed',
-      'user_action',
       {
         error: error.message,
         component: this.props.component,

--- a/packages/monitor/src/components/SessionDetail.tsx
+++ b/packages/monitor/src/components/SessionDetail.tsx
@@ -84,7 +84,7 @@ export default function SessionDetail({
       } catch (err) {
         const error = err instanceof Error ? err.message : String(err)
         console.warn('Failed to fetch session snapshot', err)
-        emitUserBlocked('snapshot_fetch_failed', 'user_action', {
+        emitUserBlocked('snapshot_fetch_failed', {
           session_id: session.session_id,
           error,
         })

--- a/packages/monitor/src/extensionBridge.ts
+++ b/packages/monitor/src/extensionBridge.ts
@@ -107,14 +107,14 @@ export async function joinViaExtension(key: string): Promise<{
     key,
   })
   if (!response) {
-    emitUserBlocked('extension_bridge_failed', 'user_action', {
+    emitUserBlocked('extension_bridge_failed', {
       action: 'join',
       error: 'No response from extension',
     })
     return { ok: false, error: 'No response from extension' }
   }
   if (response.type !== 'join_result') {
-    emitUserBlocked('extension_bridge_failed', 'user_action', {
+    emitUserBlocked('extension_bridge_failed', {
       action: 'join',
       error: 'Unsupported response',
     })
@@ -135,14 +135,14 @@ export async function leaveViaExtension(): Promise<{
     type: 'leave',
   })
   if (!response) {
-    emitUserBlocked('extension_bridge_failed', 'user_action', {
+    emitUserBlocked('extension_bridge_failed', {
       action: 'leave',
       error: 'No response from extension',
     })
     return { ok: false, error: 'No response from extension' }
   }
   if (response.type !== 'leave_result') {
-    emitUserBlocked('extension_bridge_failed', 'user_action', {
+    emitUserBlocked('extension_bridge_failed', {
       action: 'leave',
       error: 'Unsupported response',
     })

--- a/packages/monitor/src/hooks/useChaosRules.ts
+++ b/packages/monitor/src/hooks/useChaosRules.ts
@@ -130,7 +130,6 @@ export function useChaosRules(sessionId: string): UseChaosRules {
         loadErrorRef.current = true
         emitUserBlocked(
           'chaos_rules_load_failed',
-          'user_action',
           {
             session_id: sessionId,
             error: err instanceof Error ? err.message : String(err),

--- a/packages/monitor/src/index.tsx
+++ b/packages/monitor/src/index.tsx
@@ -19,7 +19,6 @@ function bootstrapOnce(): void {
   window.addEventListener('error', (event: ErrorEvent) => {
     emitUserBlocked(
       'unhandled_error',
-      'user_action',
       {
         error: event.message,
         source: 'error',
@@ -40,7 +39,6 @@ function bootstrapOnce(): void {
             : 'unknown rejection'
       emitUserBlocked(
         'unhandled_error',
-        'user_action',
         {
           error,
           source: 'unhandledrejection',

--- a/packages/monitor/src/index.tsx
+++ b/packages/monitor/src/index.tsx
@@ -19,7 +19,7 @@ function bootstrapOnce(): void {
   window.addEventListener('error', (event: ErrorEvent) => {
     emitUserBlocked(
       'unhandled_error',
-      'health',
+      'user_action',
       {
         error: event.message,
         source: 'error',
@@ -40,7 +40,7 @@ function bootstrapOnce(): void {
             : 'unknown rejection'
       emitUserBlocked(
         'unhandled_error',
-        'health',
+        'user_action',
         {
           error,
           source: 'unhandledrejection',


### PR DESCRIPTION
Unhandled errors and promise rejections were emitted under a different event kind than the
error boundary's crash, so any breakdown by kind counted one and missed the other. Both
blank the UI for the person in front of it, so they're now reported the same way.

That left `kind` with exactly one legal value at every call site, so it's gone — the
parameter, the type, and the emitted property. `reason` already carries the distinction a
breakdown needs.

The part worth an opinion: events from here stop carrying `kind`, so a saved query
filtering on it matches only events recorded before this ships. I don't believe anything
worth keeping filters on it, but that should be a deliberate call rather than a side
effect — say so if you'd rather keep emitting it as a constant.

Second of three in the stack, based on #4763. `packages/monitor` has no test harness, so
verification is `tsc -b`, `eslint src`, and `prettier --check src`.
