### PR TITLE
Make install.sh POSIX sh compatible

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,6 +72,7 @@ jobs:
       config_schema_changed: ${{ steps.changed-config-schema.outputs.any_changed }}
       dockerfile_changed: ${{ steps.changed-dockerfile.outputs.any_changed }}
       runner_image_changed: ${{ steps.changed-runner-image.outputs.any_changed }}
+      install_script_changed: ${{ steps.changed-install-script.outputs.any_changed }}
       frontend_changed: ${{ steps.changed-wizard-frontend.outputs.any_changed }}
       release_branch: ${{ steps.release-branch.outputs.branch }}
       runner_4: ${{ steps.runners.outputs.runner_4 }}
@@ -151,6 +152,13 @@ jobs:
           files_ignore: |
             tests/src/**
             tests/README.md
+      - name: get install script changes
+        id: changed-install-script
+        uses: metalbear-co/changed-files@db1aaf2ad42e3c3035f04afd76630172ef6743eb
+        with:
+          files: |
+            scripts/install.sh
+            .github/workflows/test-install-script.yaml
       - name: get vale changes
         id: changed-vale
         uses: metalbear-co/changed-files@db1aaf2ad42e3c3035f04afd76630172ef6743eb
@@ -246,6 +254,7 @@ jobs:
           echo ${{ steps.changed-dockerfile.outputs.any_changed }};
           echo ${{ steps.changed-config-schema.outputs.any_changed }};
           echo ${{ steps.changed-wizard-frontend.outputs.any_changed }};
+          echo ${{ steps.changed-install-script.outputs.any_changed }};
           echo ${{ steps.release-branch.outputs.branch }};
 
   # ── checks (no build deps) ─────────────────────────────────────────
@@ -291,6 +300,11 @@ jobs:
     with:
       rust_toolchain: ${{ needs.plan.outputs.rust_toolchain }}
     secrets: inherit
+
+  install_script:
+    needs: [plan]
+    if: ${{ needs.plan.outputs.install_script_changed == 'true' || needs.plan.outputs.ci_changed == 'true' }}
+    uses: ./.github/workflows/test-install-script.yaml
 
   # ── builds ──────────────────────────────────────────────────────────
 
@@ -442,6 +456,7 @@ jobs:
         check-rust-docs,
         cargo-deny,
         windows_tests,
+        install_script,
       ]
     runs-on: ubuntu-24.04
     permissions:

--- a/.github/workflows/test-install-script.yaml
+++ b/.github/workflows/test-install-script.yaml
@@ -1,0 +1,102 @@
+# Verifies `scripts/install.sh` against every platform it claims to support, under
+# every shell a user might pipe it into.
+#
+# The documented invocation is `curl ... | sh`, so the script has to be POSIX sh:
+# on Debian/Ubuntu `/bin/sh` is dash, and a bashism there breaks the install with a
+# syntax error rather than anything actionable. See #4762.
+#
+# The install jobs pipe the script into the shell from stdin, the same way the
+# documented command does, and then run the binary that comes out.
+name: Test install script
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: scripts/install.sh
+          sparse-checkout-cone-mode: false
+
+      # `-s sh` uses the POSIX dialect regardless of the shebang.
+      - name: shellcheck, POSIX sh dialect
+        run: shellcheck -s sh scripts/install.sh
+
+      - name: parse under dash
+        run: dash -n scripts/install.sh
+
+  install:
+    name: install (${{ matrix.name }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      # The full set of shells runs on one arch per platform and the second arch runs
+      # a single sanity test. `sh` is listed separately from the shell it points at to test
+      # the indirection specifically.
+      matrix:
+        include:
+          - { name: "linux x86_64 / sh", os: ubuntu-24.04, sh: "sh" }
+          - { name: "linux x86_64 / bash", os: ubuntu-24.04, sh: "bash" }
+          - { name: "linux x86_64 / dash", os: ubuntu-24.04, sh: "dash" }
+          - { name: "linux x86_64 / zsh", os: ubuntu-24.04, sh: "zsh" }
+          - { name: "linux x86_64 / busybox ash", os: ubuntu-24.04, sh: "busybox sh" }
+          - { name: "linux aarch64 / sh", os: ubuntu-24.04-arm, sh: "sh" }
+          - { name: "mac aarch64 / sh", os: macos-latest, sh: "sh" }
+          - { name: "mac aarch64 / bash", os: macos-latest, sh: "bash" }
+          - { name: "mac aarch64 / zsh", os: macos-latest, sh: "zsh" }
+          - { name: "mac x86_64 / sh", os: macos-15-intel, sh: "sh" }
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: scripts/install.sh
+          sparse-checkout-cone-mode: false
+
+      - name: Install the shell under test
+        if: ${{ runner.os == 'Linux' && (matrix.sh == 'zsh' || matrix.sh == 'busybox sh') }}
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq zsh busybox-static
+
+      # $SH is deliberately unquoted, so that "busybox sh" splits into a command
+      # and its argument.
+      - name: Install, piped into the shell the same way the docs pipe it
+        env:
+          SH: ${{ matrix.sh }}
+        run: |
+          set -euo pipefail
+          $SH --version 2>&1 | head -n 1 || true
+          cat scripts/install.sh | $SH
+          command -v mirrord
+          mirrord --version
+
+      - name: Check version selection (one platform/ shell only)
+        if: ${{ matrix.os == 'ubuntu-24.04' && matrix.sh == 'sh' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # Specify a non-latest release
+          pinned=$(gh release list --repo "$GITHUB_REPOSITORY" --limit 2 --json tagName --jq '.[1].tagName')
+          echo "Pinning to $pinned"
+
+          uninstall() { sudo rm -f "$(command -v mirrord)"; }
+
+          uninstall
+          sh scripts/install.sh "$pinned"
+          [ "$(mirrord --version)" = "mirrord $pinned" ]
+
+          # use `-s --` to pass the argument to the script when using pipes
+          uninstall
+          cat scripts/install.sh | sh -s -- "$pinned"
+          [ "$(mirrord --version)" = "mirrord $pinned" ]
+
+          # VERSION outranks the argument.
+          uninstall
+          cat scripts/install.sh | VERSION="$pinned" sh -s -- 0.0.0-should-be-ignored
+          [ "$(mirrord --version)" = "mirrord $pinned" ]

--- a/changelog.d/+install-script-ci.internal.md
+++ b/changelog.d/+install-script-ci.internal.md
@@ -1,0 +1,1 @@
+Add CI coverage for `install.sh`, running it on every platform it supports under every shell it might be piped into.

--- a/changelog.d/4762.fixed.md
+++ b/changelog.d/4762.fixed.md
@@ -1,0 +1,1 @@
+Make the `install.sh` script POSIX sh compatible, so that piping it into `sh` works on systems where `/bin/sh` is dash (e.g. Ubuntu).

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # mirrord installer
 #             _                        _ 
 #   _ __ ___ (_)_ __ _ __ ___  _ __ __| |
@@ -8,6 +8,9 @@
 #
 # Usage:
 #   curl -fsSL https://github.com/metalbear-co/mirrord/raw/latest/scripts/install.sh | sh
+#
+# Written for POSIX sh so it runs under any /bin/sh, including dash on
+# Debian/Ubuntu. Avoid bashisms ([[ ]], function, $OSTYPE, arrays, local).
 set -e
 
 file_issue_prompt() {
@@ -17,65 +20,69 @@ file_issue_prompt() {
 }
 
 get_latest_version() {
-  local res=$(curl -fsSL https://github.com/metalbear-co/mirrord/raw/latest/Cargo.toml | grep version | head -n 1 | cut -d' ' -f3 | tr -d '\"')
-  echo $res
+  curl -fsSL https://github.com/metalbear-co/mirrord/raw/latest/Cargo.toml | grep version | head -n 1 | cut -d' ' -f3 | tr -d '"'
 }
 
 copy() {
-  if [[ ":$PATH:" == *":$HOME/.local/bin:"* ]]; then
+  case ":$PATH:" in
+    *":$HOME/.local/bin:"*)
       if [ ! -d "$HOME/.local/bin" ]; then
         mkdir -p "$HOME/.local/bin"
       fi
       mv /tmp/mirrord/mirrord "$HOME/.local/bin/mirrord"
-  else
+      ;;
+    *)
       # Try without sudo first, run with sudo only if mv failed without it.
       mv /tmp/mirrord/mirrord /usr/local/bin/mirrord || (
         echo "Cannot write to installation target directory as current user, writing as root."
         sudo mv /tmp/mirrord/mirrord /usr/local/bin/mirrord
       )
-  fi
+      ;;
+  esac
 }
 
 # This function decides what version will be installed based on the following priority:
 # 1. Environment variable `VERSION` is set.
 # 2. Command line argument is passed.
 # 3. Latest available on GitHub
-function get_version() {
-  if [[ -z "$VERSION" ]]; then
-      if [[ -n "$1" ]]; then
+get_version() {
+  if [ -z "$VERSION" ]; then
+      if [ -n "$1" ]; then
           VERSION="$1"
       else
           VERSION=$(get_latest_version)
       fi
   fi
-  echo $VERSION
+  echo "$VERSION"
 }
 
-function install() {
-  local version=$(get_version $1);
+install() {
+  version=$(get_version "$1")
   echo "Installing version $version"
-  if [[ "$OSTYPE" == "linux"* ]]; then
-      ARCH=$(uname -m);
-      OS="linux";
-      if [[ "$ARCH" != "x86_64" && "$ARCH" != "aarch64" ]]; then
+  case "$(uname -s)" in
+    Linux)
+      ARCH=$(uname -m)
+      OS="linux"
+      if [ "$ARCH" != "x86_64" ] && [ "$ARCH" != "aarch64" ]; then
           echo "mirrord is only available for linux x86_64/aarch64 architecture"
           file_issue_prompt
-          exit 1
       fi
-  elif [[ "$OSTYPE" == "darwin"* ]]; then
-      ARCH="universal";
-      OS="mac";
-  else
-      echo "mirrord isn't supported for your platform - $OSTYPE"
+      ;;
+    Darwin)
+      ARCH="universal"
+      OS="mac"
+      ;;
+    *)
+      echo "mirrord isn't supported for your platform - $(uname -s)"
       file_issue_prompt
-      exit 1
-  fi
+      ;;
+  esac
   mkdir -p /tmp/mirrord
-  curl -o /tmp/mirrord/mirrord -fsSL https://github.com/metalbear-co/mirrord/releases/download/$version/mirrord_$OS\_$ARCH
+  curl -o /tmp/mirrord/mirrord -fsSL "https://github.com/metalbear-co/mirrord/releases/download/$version/mirrord_${OS}_${ARCH}"
   chmod +x /tmp/mirrord/mirrord
   copy
   echo "mirrord installed! Have fun! For feedback and support, join our Slack: https://metalbear.co/slack , open an issue or discussion on our GitHub: https://github.com/metalbear-co/mirrord/ or send us an email at hi@metalbear.co"
-  }
+}
 
 
-install $1
+install "$1"


### PR DESCRIPTION
The installer is documented as `curl ... | sh` but was written in bash. On distros where `/bin/sh` is dash (Ubuntu, Debian) the bashisms break it — most importantly `$OSTYPE`, which is bash-only, so platform detection falls through to the "unsupported platform" branch.

Rewrote it in POSIX sh: `case` instead of `[[ ]]` pattern matching, `uname -s` instead of `$OSTYPE`, plain `[ ]` tests, and no `function` keyword. Behaviour is otherwise unchanged.

Second commit adds CI for this, gated on `scripts/install.sh` (or the workflow) changing. It pipes the script into each shell on each platform we support — sh/bash/dash/zsh/busybox ash on linux x86_64 and aarch64, sh/bash/zsh on mac aarch64 and x86_64 — and runs the resulting binary. Plus a shellcheck `-s sh` and `dash -n` job for the branches the install jobs never reach, and one cell covering version-selection precedence.

Confirmed the new job would have caught this: the pre-fix script piped into dash dies with `Syntax error: "(" unexpected`.

Closes #4762