### PR TITLE
Authenticate sessions-manager connections with a shared-secret header

### DIFF
--- a/changelog.d/+sessions-manager-auth-header.internal.md
+++ b/changelog.d/+sessions-manager-auth-header.internal.md
@@ -1,0 +1,5 @@
+Send an optional shared-secret header on sessions-manager control-plane and
+data-plane connections, so a deployment can put an authenticating proxy in front
+of sessions-manager. Set `MIRRORD_SESSIONS_MANAGER_AUTH_TOKEN` to enable it, and
+`MIRRORD_SESSIONS_MANAGER_AUTH_HEADER` to override the default `x-mirrord-sm-auth`
+header name.

--- a/mirrord/sessions-manager/client/src/connection.rs
+++ b/mirrord/sessions-manager/client/src/connection.rs
@@ -11,11 +11,19 @@ use rust_socketio::{
 };
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
-use tokio_tungstenite::connect_async;
+use tokio_tungstenite::{
+    connect_async,
+    tungstenite::{
+        client::IntoClientRequest,
+        handshake::client::Request,
+        http::{self, HeaderName, HeaderValue},
+    },
+};
 use tokio_util::sync::CancellationToken;
 
 use crate::{
-    envs::sessions_manager_namespace, error::SessionsManagerClientError,
+    envs::{sessions_manager_auth_header, sessions_manager_namespace},
+    error::SessionsManagerClientError,
     websocket::BinaryWebSocketConnection,
 };
 
@@ -44,6 +52,10 @@ pub struct SessionsManagerConnectInfo {
 
 pub struct SessionsManagerClient<R: ProtocolEndpoint> {
     manager_url: String,
+    /// Attached to the control-plane handshake and to every data-plane upgrade,
+    /// so a sessions-manager behind an authenticating proxy is reachable
+    /// without the proxy having to understand either protocol.
+    auth_header: Option<(String, String)>,
     registration: RegisterPayload,
     cancellation_token: CancellationToken,
     _marker: PhantomData<R>,
@@ -66,8 +78,14 @@ where
         let sessions_manager_url = std::env::var(SESSIONS_MANAGER_URL_ENV)
             .unwrap_or_else(|_| SESSIONS_MANAGER_URL_DEFAULT.to_owned());
         tracing::debug!(%sessions_manager_url, "Sessions Manager URL");
+        let auth_header = sessions_manager_auth_header();
+        if let Some((name, _)) = &auth_header {
+            tracing::debug!(header = %name, "Authenticating sessions-manager connections");
+        }
+
         Self {
             manager_url: sessions_manager_url,
+            auth_header,
             registration,
             cancellation_token: actual_token,
             _marker: PhantomData,
@@ -86,7 +104,12 @@ where
         let registration = self.registration.clone();
         let sm_controlplane_url = format!("{}/control", self.manager_url.trim_end_matches('/'));
 
-        let client = ClientBuilder::new(sm_controlplane_url)
+        let mut builder = ClientBuilder::new(sm_controlplane_url);
+        if let Some((name, value)) = self.auth_header.clone() {
+            builder = builder.opening_header(name, value);
+        }
+
+        let client = builder
             .namespace("/")
             .transport_type(TransportType::Websocket)
             .on(SocketIoEvent::Connect, move |_, client| {
@@ -182,6 +205,7 @@ impl SessionsManagerClient<Agent> {
     ) {
         let token = self.cancellation_token.clone();
         let sessions_manager_url = self.manager_url.clone();
+        let auth_header = self.auth_header.clone();
 
         tokio::spawn(async move {
             loop {
@@ -201,6 +225,13 @@ impl SessionsManagerClient<Agent> {
                         tracing::debug!(ws_path = %dataplane.ws_path, "Control plane intercepted new handoff request");
 
                         let target_ws_url = build_target_ws_url(&sessions_manager_url, &dataplane.ws_path);
+                        let request = match dataplane_request(&target_ws_url, auth_header.as_ref()) {
+                            Ok(request) => request,
+                            Err(err) => {
+                                tracing::error!(error = ?err, "Failed to build data plane upgrade request");
+                                continue;
+                            }
+                        };
                         let connection_out_tx_clone = connection_out_tx.clone();
                         let token_clone = token.clone();
 
@@ -209,7 +240,7 @@ impl SessionsManagerClient<Agent> {
                             _ = token_clone.cancelled() => {
                                 tracing::debug!("Aborting data-plane sub-session upgrade due to cancellation");
                             }
-                            connect_result = connect_async(&target_ws_url) => {
+                            connect_result = connect_async(request) => {
                                 match connect_result {
                                     Ok((ws_stream, _)) => {
                                         tracing::debug!("Data-plane sub-session established successfully");
@@ -291,12 +322,13 @@ impl SessionsManagerClient<Client> {
         };
 
         let target_ws_url = build_target_ws_url(&self.manager_url, &dataplane.ws_path);
+        let request = dataplane_request(&target_ws_url, self.auth_header.as_ref())?;
 
         tokio::select! {
             _ = self.cancellation_token.cancelled() => {
                 Err(SessionsManagerClientError::CancellationToken)
             }
-            connect_result = connect_async(&target_ws_url) => {
+            connect_result = connect_async(request) => {
                 let (ws_stream, _) = connect_result?;
                 tracing::debug!("Data-plane oneshot client established successfully");
                 let binary_conn = Connection::<Client>::from_channel(
@@ -338,4 +370,24 @@ fn build_target_ws_url(http_url: &str, ws_path: &str) -> String {
         http_url.to_owned()
     };
     format!("{base}{ws_path}")
+}
+
+/// Builds the data-plane upgrade request, carrying the auth header when one is
+/// configured.
+///
+/// [`connect_async`] accepts a bare URL, but that path offers nowhere to attach
+/// headers, so the request is constructed explicitly.
+fn dataplane_request(
+    url: &str,
+    auth_header: Option<&(String, String)>,
+) -> Result<Request, SessionsManagerClientError> {
+    let mut request = url.into_client_request()?;
+
+    if let Some((name, value)) = auth_header {
+        let name = HeaderName::try_from(name.as_str()).map_err(http::Error::from)?;
+        let value = HeaderValue::try_from(value.as_str()).map_err(http::Error::from)?;
+        request.headers_mut().insert(name, value);
+    }
+
+    Ok(request)
 }

--- a/mirrord/sessions-manager/client/src/envs.rs
+++ b/mirrord/sessions-manager/client/src/envs.rs
@@ -17,6 +17,17 @@ pub const REMOTE_SERVICE_REPLICA: &str = "MIRRORD_REMOTE_SERVICE_REPLICA";
 /// `TargetConfig.namespace`
 pub const REMOTE_TARGET_NAMESPACE: &str = "MIRRORD_TARGET_NAMESPACE";
 
+/// Names the header carrying [`SESSIONS_MANAGER_AUTH_TOKEN`].
+/// Only needed when the deployment expects something other than
+/// [`DEFAULT_AUTH_HEADER_NAME`].
+pub const SESSIONS_MANAGER_AUTH_HEADER: &str = "MIRRORD_SESSIONS_MANAGER_AUTH_HEADER";
+
+/// Shared secret expected by whatever fronts sessions-manager. Setting it is
+/// what turns the header on.
+pub const SESSIONS_MANAGER_AUTH_TOKEN: &str = "MIRRORD_SESSIONS_MANAGER_AUTH_TOKEN";
+
+const DEFAULT_AUTH_HEADER_NAME: &str = "x-mirrord-sm-auth";
+
 fn read_env(name: &str) -> Result<String, SessionsManagerClientError> {
     std::env::var(name)
         .inspect_err(|_| {
@@ -35,4 +46,17 @@ pub fn sessions_manager_replica_id() -> Result<String, SessionsManagerClientErro
 
 pub fn sessions_manager_namespace() -> Option<String> {
     read_env(REMOTE_TARGET_NAMESPACE).ok()
+}
+
+/// Header to attach to every sessions-manager connection, for deployments that
+/// put an authenticating proxy or load balancer in front of it.
+///
+/// [`None`] when no token is set, which is the case for a directly reachable
+/// sessions-manager.
+pub fn sessions_manager_auth_header() -> Option<(String, String)> {
+    let token = read_env(SESSIONS_MANAGER_AUTH_TOKEN).ok()?;
+    let name = read_env(SESSIONS_MANAGER_AUTH_HEADER)
+        .unwrap_or_else(|_| DEFAULT_AUTH_HEADER_NAME.to_owned());
+
+    Some((name, token))
 }

--- a/mirrord/sessions-manager/client/src/error.rs
+++ b/mirrord/sessions-manager/client/src/error.rs
@@ -18,6 +18,9 @@ pub enum SessionsManagerClientError {
     #[error("Cancellation token was signaled")]
     CancellationToken,
 
+    #[error("Invalid sessions-manager auth header: {0}")]
+    InvalidAuthHeader(#[from] tokio_tungstenite::tungstenite::http::Error),
+
     #[error("Missing required env var: {0}")]
     VarError(#[from] std::env::VarError),
 }


### PR DESCRIPTION
Prerequisite for exposing sessions-manager over the internet — metalbear-co/infra#467 puts it behind a load balancer that refuses requests without a shared secret, and the client currently has no way to send one.

Neither the Socket.IO control-plane handshake nor the `connect_async` data-plane upgrade sent any headers a proxy could key on, so turning on that check would have locked mirrord itself out. Both now attach an optional header, which lets a proxy make the decision without understanding either protocol.

Off unless `MIRRORD_SESSIONS_MANAGER_AUTH_TOKEN` is set, so nothing changes for a directly reachable sessions-manager. `MIRRORD_SESSIONS_MANAGER_AUTH_HEADER` overrides the default `x-mirrord-sm-auth` name.

**On the base branch:** this belongs to Graf's demo work, which lives on `danielg/demo-snapshot-260804` on his fork — that branch isn't on origin, so this targets the packaging branch instead, where the sessions-manager client files are identical. Happy to retarget if the snapshot lands on origin.

The demo-side companion changes (a slim image stage carrying just the bootstrap library, for deployments that mount it from an init container, plus the ECS README) only apply to files that exist on the snapshot branch, so they're held back rather than included here.

Verified with `cargo clippy --deny warnings` on this base. Not exercised against a live proxy yet.