### PR TITLE
Report each flaky test once, on the run that flaked

### DIFF
--- a/.github/scripts/flaky-issue.sh
+++ b/.github/scripts/flaky-issue.sh
@@ -1,29 +1,47 @@
 #!/usr/bin/env bash
 #
-# Reports, files, or updates the Linear issue tracking a test that retries on `main`.
+# Files the Linear issue tracking a test that retries on `main`, or counts a repeat sighting on the
+# issue already tracking it.
 #
-# Keeps one issue per test, found by the attachment the report leaves on it rather than by its
-# title, so retitling an issue in Linear does not orphan it. With a <body-file> it files that issue
-# when none is open and comments on it when one is; without one it only looks the issue up, printing
-# nothing when none is open.
+# Keeps one issue per test, found by the attachment the report leaves on it rather than by its title
+# or its team, so neither retitling an issue nor moving it to another team orphans it. A test whose
+# issue is still open has its tally folded into that issue and a comment left on it, and is reported
+# as a repeat: the channel hears about first sightings, the issue's followers about every one.
 #
-# Usage: flaky-issue.sh <repo> <team-key> <test> [<body-file>]
+# A test already tracked by an open issue is counted on it however rarely it flaked, so <threshold>
+# gates filing a new issue and nothing else.
 #
-# Prints the issue identifier. Requires $LINEAR_APP_TOKEN, which `linear-token.sh` mints.
+# Usage: flaky-issue.sh <repo> <team-key> <package> <test> <retries> <threshold> <run-url>
+#
+# Prints `new\t<identifier>\t<url>`, `repeat\t<identifier>\t<url>`, or `below\t\t` for a test that
+# flaked too rarely to be worth an issue of its own. Requires $LINEAR_APP_TOKEN, which
+# `linear-token.sh` mints.
 
 set -euo pipefail
 
 repo=$1
 team_key=$2
-name=$3
-body_file=${4:-}
+package=$3
+name=$4
+retries=$5
+threshold=$6
+run_url=$7
 
-label=flake
-title="Flaky test in ${repo#*/}: $name"
+short=${repo#*/}
 
-# Doubles as the attachment's link and as the key the next run finds the issue by, so it has to be
-# derived from nothing but the test itself.
-key_url="https://github.com/$repo/search?q=$(jq -rn --arg q "$name" '$q | @uri')&type=code"
+# Trailing segments only. The qualified pair is unwieldy on a line and the tail is what a human
+# recognises a test by; the attachment keeps the whole of it. Package and test are formatted apart,
+# being two names rather than one path.
+display="\`${package##*::}\`/\`${name##*::}\`"
+title="Fix flaky test $display in $short"
+seen=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+repo_url="https://github.com/$repo"
+
+# The key the next run finds this issue by, and nothing else: it names the test in full so that two
+# tests sharing a trailing segment stay apart, and it stays put however the issue is retitled or
+# moved.
+key_url="flaky-test://$repo/$package/$name"
 
 # GraphQL reports failures in the body with HTTP 200, so the response has to be inspected rather
 # than left to curl's status handling.
@@ -43,40 +61,96 @@ api() {
   printf '%s' "$response"
 }
 
+# JUnit's `classname` is nextest's binary id, so the pair the report carries is exactly what a
+# filterset needs to select this test and nothing else. A binary id leads with the package that owns
+# it, which narrows the build from the whole workspace to the one crate.
+run_command="cargo nextest run -p ${package%%::*} -E 'binary_id(=$package) and test(=$name)'"
+
+# Rewritten on every sighting, which is what the note at the foot warns anyone editing it about.
+body() {
+  printf 'Failed %s× across all observed runs.\n\n### Running in isolation\n\n```\n%s\n```\n\n_This issue was generated automatically. Do not edit by hand, as it may be overridden._' \
+    "$1" "$run_command"
+}
+
+metadata() {
+  jq -n --arg repo "$repo" --arg package "$package" --arg test "$name" --arg seen "$seen" \
+    --argjson occurrences "$1" \
+    '{source: "flaky-test-report", repository: $repo, package: $package, test: $test,
+      occurrences: $occurrences, lastSeen: $seen}'
+}
+
+# Open states are listed rather than closed ones: Linear has a `duplicate` type alongside `completed`
+# and `canceled`, and counting sightings onto an issue somebody closed as a duplicate would leave the
+# surviving issue untouched.
 existing=$(api "$(jq -n --arg url "$key_url" '{
   query: "query($url: String!) {
     attachmentsForURL(url: $url) {
-      nodes { issue { id identifier state { type } team { key } } }
+      nodes { id metadata issue { id identifier url state { type } } }
     }
   }",
   variables: { url: $url }
-}')" | jq -r --arg key "$team_key" '
-  [.data.attachmentsForURL.nodes[]?.issue
-   | select(.team.key == $key)
-   | select(.state.type != "completed" and .state.type != "canceled")][0] // empty
+}')" | jq -r '
+  [.data.attachmentsForURL.nodes[]?
+   | select(.issue.state.type as $type
+            | ["triage", "backlog", "unstarted", "started"] | index($type))
+   | {attachment: .id, occurrences: (.metadata.occurrences // 1),
+      issue: .issue.id, identifier: .issue.identifier, url: .issue.url}][0] // empty
   | @json')
 
-if [ -z "$body_file" ]; then
-  printf '%s' "$existing" | jq -r '.identifier // empty'
-  exit 0
-fi
-
-body=$(cat "$body_file")
-
 if [ -n "$existing" ]; then
-  identifier=$(printf '%s' "$existing" | jq -r .identifier)
-  mutation=$(jq -n --arg id "$(printf '%s' "$existing" | jq -r .id)" --arg body "$body" '{
+  identifier=$(jq -r .identifier <<< "$existing")
+  occurrences=$(( $(jq -r .occurrences <<< "$existing") + retries ))
+
+  # The tally sits on top of an issue that already exists and already says what is wrong, so
+  # failing to refresh it is not worth failing the report over.
+  updated=$(api "$(jq -n \
+    --arg id "$(jq -r .issue <<< "$existing")" \
+    --arg body "$(body "$occurrences")" '{
+    query: "mutation($id: String!, $body: String!) {
+      issueUpdate(id: $id, input: { description: $body }) { success }
+    }",
+    variables: { id: $id, body: $body }
+  }')" | jq -r '.data.issueUpdate.success') || updated=false
+
+  if [ "$updated" != "true" ]; then
+    echo "::warning::could not refresh the tally on $identifier" >&2
+  fi
+
+  counted=$(api "$(jq -n \
+    --arg id "$(jq -r .attachment <<< "$existing")" \
+    --arg subtitle "$package/$name" \
+    --argjson metadata "$(metadata "$occurrences")" '{
+    query: "mutation($id: String!, $subtitle: String!, $metadata: JSONObject!) {
+      attachmentUpdate(id: $id, input: { subtitle: $subtitle, metadata: $metadata }) { success }
+    }",
+    variables: { id: $id, subtitle: $subtitle, metadata: $metadata }
+  }')" | jq -r '.data.attachmentUpdate.success') || counted=false
+
+  if [ "$counted" != "true" ]; then
+    echo "::warning::could not count this sighting on $identifier" >&2
+  fi
+
+  # Posted last, so that anyone following the issue arrives at a body already carrying this sighting.
+  # The channel stays quiet for repeats; this is how the people who care about a given test hear.
+  noted=$(api "$(jq -n --arg id "$(jq -r .issue <<< "$existing")" \
+    --arg body "$(printf 'Failed again in [this run](%s). Now %s× across all observed runs.' \
+      "$run_url" "$occurrences")" '{
     query: "mutation($id: String!, $body: String!) {
       commentCreate(input: { issueId: $id, body: $body }) { success }
     }",
     variables: { id: $id, body: $body }
-  }')
-  if [ "$(api "$mutation" | jq -r '.data.commentCreate.success')" != "true" ]; then
-    echo "Linear rejected the comment on $identifier" >&2
-    exit 1
+  }')" | jq -r '.data.commentCreate.success') || noted=false
+
+  if [ "$noted" != "true" ]; then
+    echo "::warning::could not note this sighting on $identifier" >&2
   fi
 
-  echo "$identifier"
+  printf 'repeat\t%s\t%s\n' "$identifier" "$(jq -r .url <<< "$existing")"
+  exit 0
+fi
+
+if [ "$retries" -lt "$threshold" ]; then
+  printf 'below\t\t\n'
   exit 0
 fi
 
@@ -90,37 +164,39 @@ if [ -z "$team_id" ]; then
   exit 1
 fi
 
-label_id=$(api "$(jq -n --arg name "$label" '{
-  query: "query($name: String!) {
-    issueLabels(filter: { name: { eq: $name } }) { nodes { id team { key } } }
-  }",
-  variables: { name: $name }
-}')" | jq -r --arg key "$team_key" '
-  [.data.issueLabels.nodes[]? | select(.team == null or .team.key == $key)][0].id // empty')
+label_ids='[]'
 
-if [ -z "$label_id" ]; then
-  echo "::warning::no Linear label named $label, filing $title without it" >&2
-fi
+for label in tech-debt flaky-test; do
+  label_id=$(api "$(jq -n --arg name "$label" '{
+    query: "query($name: String!) {
+      issueLabels(filter: { name: { eq: $name } }) { nodes { id team { key } } }
+    }",
+    variables: { name: $name }
+  }')" | jq -r --arg key "$team_key" '
+    [.data.issueLabels.nodes[]? | select(.team == null or .team.key == $key)][0].id // empty')
+
+  if [ -z "$label_id" ]; then
+    echo "::warning::no Linear label named $label, filing without it" >&2
+    continue
+  fi
+
+  label_ids=$(jq -c --arg id "$label_id" '. + [$id]' <<< "$label_ids")
+done
 
 created=$(api "$(jq -n \
   --arg team "$team_id" \
   --arg title "$title" \
-  --arg body "$body" \
-  --arg label "$label_id" '{
+  --arg body "$(body "$retries")" \
+  --argjson labels "$label_ids" '{
   query: "mutation($team: String!, $title: String!, $body: String!, $labels: [String!]) {
     issueCreate(input: {
-      teamId: $team, title: $title, description: $body, priority: 1, labelIds: $labels
+      teamId: $team, title: $title, description: $body, priority: 2, labelIds: $labels
     }) {
       success
-      issue { id identifier }
+      issue { id identifier url }
     }
   }",
-  variables: {
-    team: $team,
-    title: $title,
-    body: $body,
-    labels: (if $label == "" then [] else [$label] end)
-  }
+  variables: { team: $team, title: $title, body: $body, labels: $labels }
 }')" | jq -r '.data.issueCreate | select(.success == true) | .issue // empty')
 
 if [ -z "$created" ]; then
@@ -128,33 +204,43 @@ if [ -z "$created" ]; then
   exit 1
 fi
 
+issue_id=$(jq -r .id <<< "$created")
+
+# Context for whoever opens the issue. Linear cannot move an attachment's URL, so the run is the one
+# that first caught this test rather than the newest, and neither is touched again.
+for link in "Repository|$repo_url" "Run|$run_url"; do
+  linked=$(api "$(jq -n --arg id "$issue_id" --arg title "${link%%|*}" --arg url "${link#*|}" '{
+    query: "mutation($id: String!, $url: String!, $title: String!) {
+      attachmentCreate(input: { issueId: $id, url: $url, title: $title }) { success }
+    }",
+    variables: { id: $id, url: $url, title: $title }
+  }')" | jq -r '.data.attachmentCreate.success') || linked=false
+
+  if [ "$linked" != "true" ]; then
+    echo "::warning::could not attach ${link%%|*} to the issue" >&2
+  fi
+done
+
 attached=$(api "$(jq -n \
-  --arg id "$(printf '%s' "$created" | jq -r .id)" \
+  --arg id "$issue_id" \
   --arg url "$key_url" \
-  --arg title "Flaky test" \
-  --arg name "$name" \
-  --arg repo "$repo" '{
-  query: "mutation($id: String!, $url: String!, $title: String!, $name: String!, $metadata: JSONObject!) {
+  --arg title "Tracking key" \
+  --arg subtitle "$package/$name" \
+  --argjson metadata "$(metadata "$retries")" '{
+  query: "mutation($id: String!, $url: String!, $title: String!, $subtitle: String!, $metadata: JSONObject!) {
     attachmentCreate(input: {
-      issueId: $id, url: $url, title: $title, subtitle: $name, metadata: $metadata
+      issueId: $id, url: $url, title: $title, subtitle: $subtitle, metadata: $metadata
     }) { success }
   }",
-  variables: {
-    id: $id,
-    url: $url,
-    title: $title,
-    name: $name,
-    metadata: { source: "flaky-test-report", repository: $repo, test: $name }
-  }
+  variables: { id: $id, url: $url, title: $title, subtitle: $subtitle, metadata: $metadata }
 }')" | jq -r '.data.attachmentCreate.success')
 
-# The attachment is the only thing the next run finds this issue by, so an issue that failed to get
-# one is unreachable and would be filed again every day. Trash it, leaving the reason behind for
+# This attachment is the only thing the next run finds this issue by, so an issue that failed to get
+# one is unreachable and would be filed again every run. Trash it, leaving the reason behind for
 # whoever finds it there, rather than let it accumulate copies.
 if [ "$attached" != "true" ]; then
-  echo "Linear rejected the attachment keying $title, trashing the issue" >&2
+  echo "Linear rejected the attachment keying this issue, trashing it" >&2
 
-  issue_id=$(printf '%s' "$created" | jq -r .id)
   note='Filed by the flaky test report, which then failed to attach the key it finds this issue by.
 Trashed so the next report can file a clean one. The test is still flaky.'
 
@@ -171,10 +257,10 @@ Trashed so the next report can file a clean one. The test is still flaky.'
   }')" | jq -r '.data.issueDelete.success') || trashed=false
 
   if [ "$trashed" != "true" ]; then
-    echo "$title is left unkeyed in Linear and will be filed again tomorrow" >&2
+    echo "$title is left unkeyed in Linear and will be filed again on the next flake" >&2
   fi
 
   exit 1
 fi
 
-printf '%s' "$created" | jq -r .identifier
+printf 'new\t%s\t%s\n' "$(jq -r .identifier <<< "$created")" "$(jq -r .url <<< "$created")"

--- a/.github/scripts/flaky-notify.sh
+++ b/.github/scripts/flaky-notify.sh
@@ -1,52 +1,42 @@
 #!/usr/bin/env bash
 #
-# Builds the Slack payload announcing tests that retry on `main`.
+# Builds the Slack payload announcing tests that retried for the first time.
 #
-# Reads the `<retries>\t<test>` listing `flaky-tests.sh` produces on stdin and writes the webhook
-# payload to stdout. Every test is named in the message itself, annotated with the Linear issue
-# tracking it when one is open, so the channel needs no trip to the run to see what is flaking.
+# Reads `<package>\t<test>\t<issue>\t<issue-url>` lines on stdin, where the last two may be empty,
+# and writes the webhook payload to stdout. Each test is named by its trailing segments and linked to
+# the Linear issue filed for it, so the channel needs no trip to the run to see what is flaking.
 #
-# Usage: flaky-notify.sh <repo> <team-key> <notify-threshold> <runs-read>
-#
-# Annotates issues only when $LINEAR_APP_TOKEN is set.
+# Usage: flaky-notify.sh <repo> <run-url>
 
 set -euo pipefail
 
 repo=$1
-team_key=$2
-notify_threshold=$3
-runs=$4
+run_url=$2
 
-scripts=$(dirname "$0")
+short=${repo#*/}
+repo_url="https://github.com/$repo"
 bullets=()
 
-while IFS=$'\t' read -r retries name; do
+while IFS=$'\t' read -r package name issue issue_url; do
   [ -n "$name" ] || continue
 
-  issue=""
-  if [ -n "${LINEAR_APP_TOKEN:-}" ]; then
-    if ! issue=$("$scripts/flaky-issue.sh" "$repo" "$team_key" "$name" < /dev/null); then
-      echo "::warning::could not reach Linear for the issue tracking $name" >&2
-      issue=""
-    fi
+  bullet="•  \`${package##*::}\`/\`${name##*::}\`"
+
+  if [ -n "${issue:-}" ]; then
+    bullet="$bullet  ·  <$issue_url|$issue>"
   fi
 
-  if [ -n "$issue" ]; then
-    bullets+=("$(printf '•  *%s×*  `%s`  ·  %s' "$retries" "$name" "$issue")")
-  else
-    bullets+=("$(printf '•  *%s×*  `%s`' "$retries" "$name")")
-  fi
+  bullets+=("$bullet")
 done
 
-count=${#bullets[@]}
-if [ "$count" -eq 0 ]; then
+if [ "${#bullets[@]}" -eq 0 ]; then
   echo "nothing to report" >&2
   exit 1
 fi
 
 list=$(printf '%s\n' "${bullets[@]}")
 
-# A Slack section caps out at 3000 characters, which a thoroughly broken `main` can cross.
+# A Slack section caps out at 3000 characters, which a thoroughly broken run can cross.
 dropped=0
 while [ "${#list}" -gt 2900 ] && [ "${#bullets[@]}" -gt 1 ]; do
   unset 'bullets[-1]'
@@ -58,16 +48,10 @@ if [ "$dropped" -ne 0 ]; then
   list=$(printf '%s\n_…and %s more._' "$list" "$dropped")
 fi
 
-if [ "$count" -eq 1 ]; then
-  headline="1 flaky test on ${repo#*/} main"
-else
-  headline="$count flaky tests on ${repo#*/} main"
-fi
-
 jq -n \
-  --arg headline "$headline" \
+  --arg headline "Flaky tests detected on $short" \
   --arg list "$list" \
-  --arg footer "At least $notify_threshold retries across the last $runs \`main\` runs that published test reports." \
+  --arg footer "<$repo_url|Repository> • <$run_url|Run>" \
   '{
     text: $headline,
     blocks: [

--- a/.github/scripts/flaky-tests.sh
+++ b/.github/scripts/flaky-tests.sh
@@ -1,94 +1,64 @@
 #!/usr/bin/env bash
 #
-# Reports tests that nextest had to retry on `main`, which a green run hides entirely.
+# Reports the tests nextest had to retry in one `main` run, which a green run hides entirely.
 #
-# Reads the JUnit reports CI merges into one `nextest-junit` artifact per `main` run, counting a
-# test's `flakyFailure` elements (attempts that failed before it passed) and `rerunFailure` ones
-# (attempts of a test that failed for good). A run that failed publishes the reports of the jobs it
-# did get through, since a broken `main` retries tests like any other.
+# Reads the JUnit reports CI merges into that run's `nextest-junit` artifact, counting a test's
+# `flakyFailure` elements (attempts that failed before it passed) and `rerunFailure` ones (attempts
+# of a test that failed for good). A run that failed publishes the reports of the jobs it did get
+# through, since a broken `main` retries tests like any other.
 #
-# Sampling is by run that carried a report, never by run: a run that skipped the test matrix, or
-# whose artifact has expired, is not one of the <samples> and does not consume one. Since only a
-# `main` run publishes under that name, listing artifacts by it answers both questions at once, in a
-# single request.
+# Usage: flaky-tests.sh <repo> <run-id>
 #
-# Usage: flaky-tests.sh <repo> <samples> <notify-threshold> [issue-threshold]
+# Reports every test that was retried at all, leaving the threshold to whoever decides what is worth
+# filing: a test already tracked by an open issue is counted on it however rarely it flakes.
 #
-# Writes a markdown table to stdout. On $GITHUB_OUTPUT it sets `scanned`, `notify_count` and
-# `notify_tests` for the report, and `issue_count` / `issue_threshold` / `issue_tests` for tests at
-# or above <issue-threshold>, which are flaky enough to warrant their own issue. Both listings are
-# `<retries>\t<test>` lines, most retried first.
+# Writes a markdown table to stdout. On $GITHUB_OUTPUT it sets `count` and `tests`, the latter
+# `<retries>\t<package>\t<test>` lines, most retried first.
 
 set -euo pipefail
 
 repo=$1
-samples=$2
-notify_threshold=$3
-issue_threshold=${4:-10}
+run_id=$2
 
 readonly ARTIFACT=nextest-junit
-
-whole_number() {
-  case $2 in
-    '' | *[!0-9]*)
-      echo "$1 must be a whole number, got '$2'" >&2
-      exit 1
-      ;;
-  esac
-}
-
-whole_number 'the sample size' "$samples"
-whole_number 'the notify threshold' "$notify_threshold"
-whole_number 'the issue threshold' "$issue_threshold"
-
-# One page holds 100 artifacts, and asking for more would report on more runs than it read.
-if [ "$samples" -gt 100 ]; then
-  echo "::warning::sample size $samples exceeds the 100-artifact page limit, sampling 100" >&2
-  samples=100
-fi
 
 work=$(mktemp -d)
 trap 'rm -rf "$work"' EXIT
 
 mkdir -p "$work/reports"
 
-# Newest first, so taking the head of the listing takes the most recent runs. CI publishes this
-# artifact on `main` alone; the branch is checked anyway so that widening that never widens this
-# silently.
-# Trimmed with awk rather than head, which would close the pipe on `gh` mid-write and take the
-# script down with it under `pipefail`.
-gh api "repos/$repo/actions/artifacts?per_page=100&name=$ARTIFACT" \
-  --jq '.artifacts[]? | select(.expired == false) | select(.workflow_run.head_branch == "main")
-        | "\(.id)\t\(.workflow_run.id)"' |
-  awk -v samples="$samples" 'NR <= samples' > "$work/artifacts.tsv"
+artifacts=$(gh api "repos/$repo/actions/runs/$run_id/artifacts?per_page=100")
 
-selected=$(awk 'END {print NR}' "$work/artifacts.tsv")
+artifact=$(jq -r --arg name "$ARTIFACT" '.artifacts[]? | select(.expired == false)
+  | select(.name == $name) | .id' <<< "$artifacts" | awk 'NR == 1')
 
-if [ "$selected" -lt "$samples" ]; then
-  echo "::warning::asked for $samples runs, only $selected still carry a $ARTIFACT artifact" >&2
+# Reporting zero flakes is right for a run that had no tests to retry and wrong for one whose report
+# went missing, and the two are told apart by what is left behind: merging deletes the per-job
+# reports as it goes, so any still there mean the merge never happened.
+if [ -n "$artifact" ]; then
+  if ! gh api "repos/$repo/actions/artifacts/$artifact/zip" > "$work/artifact.zip" 2> /dev/null ||
+    ! unzip -qo "$work/artifact.zip" -d "$work/reports" 2> /dev/null; then
+    echo "::error::could not read the $ARTIFACT artifact of run $run_id" >&2
+    exit 1
+  fi
+else
+  unmerged=$(jq -r --arg name "$ARTIFACT" '[.artifacts[]? | select(.name | startswith($name + "-"))]
+    | length' <<< "$artifacts")
+
+  if [ "$unmerged" -ne 0 ]; then
+    echo "::error::run $run_id left $unmerged per-job report(s) unmerged" >&2
+    exit 1
+  fi
+
+  echo "::warning::run $run_id published no $ARTIFACT artifact" >&2
 fi
 
-# Counts the reports read, not the ones picked: one that fails to download or unpack takes its
-# run's retries with it, and counting it would overstate the sample the alert reports on.
-scanned=0
-
-while IFS=$'\t' read -r artifact run; do
-  [ -n "$artifact" ] || continue
-
-  if gh api "repos/$repo/actions/artifacts/$artifact/zip" > "$work/artifact.zip" 2>/dev/null &&
-    unzip -qo "$work/artifact.zip" -d "$work/reports/$run" 2>/dev/null; then
-    scanned=$((scanned + 1))
-  else
-    echo "::warning::could not read the report of run $run" >&2
-  fi
-done < "$work/artifacts.tsv"
-
-python3 - "$work/reports" "$notify_threshold" "$work/ranked.tsv" <<'PY'
+python3 - "$work/reports" "$work/ranked.tsv" <<'PY'
 import pathlib, sys
 from collections import Counter
 from xml.etree import ElementTree
 
-reports, threshold, out = pathlib.Path(sys.argv[1]), int(sys.argv[2]), pathlib.Path(sys.argv[3])
+reports, out = pathlib.Path(sys.argv[1]), pathlib.Path(sys.argv[2])
 retries = Counter()
 
 for report in reports.rglob("*.xml"):
@@ -100,30 +70,21 @@ for report in reports.rglob("*.xml"):
     for case in root.iter("testcase"):
         attempts = len(case.findall("flakyFailure")) + len(case.findall("rerunFailure"))
         if attempts:
-            retries[f"{case.get('classname', '?')} {case.get('name', '?')}"] += attempts
+            retries[(case.get("classname", "?"), case.get("name", "?"))] += attempts
 
 ranked = sorted(retries.items(), key=lambda kv: (-kv[1], kv[0]))
-out.write_text("".join(f"{count}\t{test}\n" for test, count in ranked))
+out.write_text("".join(f"{count}\t{pkg}\t{test}\n" for (pkg, test), count in ranked))
 PY
-
-awk -F'\t' -v t="$notify_threshold" '$1 >= t' "$work/ranked.tsv" > "$work/notify.tsv"
-awk -F'\t' -v t="$issue_threshold" '$1 >= t' "$work/ranked.tsv" > "$work/issue.tsv"
 
 echo "| retries | test |"
 echo "|---:|---|"
-awk -F'\t' '{printf "| %s | `%s` |\n", $1, $2}' "$work/notify.tsv"
+awk -F'\t' '{printf "| %s | `%s`/`%s` |\n", $1, $2, $3}' "$work/ranked.tsv"
 
 if [ -n "${GITHUB_OUTPUT:-}" ]; then
   {
-    echo "scanned=$scanned"
-    echo "notify_count=$(awk 'END {print NR}' "$work/notify.tsv")"
-    echo "issue_count=$(awk 'END {print NR}' "$work/issue.tsv")"
-    echo "issue_threshold=$issue_threshold"
-    echo "notify_tests<<EOF"
-    cat "$work/notify.tsv"
-    echo "EOF"
-    echo "issue_tests<<EOF"
-    cat "$work/issue.tsv"
+    echo "count=$(awk 'END {print NR}' "$work/ranked.tsv")"
+    echo "tests<<EOF"
+    cat "$work/ranked.tsv"
     echo "EOF"
   } >> "$GITHUB_OUTPUT"
 fi

--- a/.github/workflows/flaky-test-report.yaml
+++ b/.github/workflows/flaky-test-report.yaml
@@ -1,18 +1,17 @@
 name: Flaky Test Report
 
 on:
-  schedule:
-    - cron: "0 6 * * 1-5"
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: [main]
   workflow_dispatch:
     inputs:
-      samples:
-        description: "How many `main` runs with test reports to sample, overriding $CI_FLAKY_SAMPLES"
-        required: false
-      notify_threshold:
-        description: "Retries before a test is reported, overriding $CI_FLAKY_NOTIFY_THRESHOLD"
-        required: false
-      issue_threshold:
-        description: "Retries before a test gets its own issue, overriding $CI_FLAKY_ISSUE_THRESHOLD"
+      run_id:
+        description: "The `main` CI run to report on"
+        required: true
+      threshold:
+        description: "Retries before a test is reported, overriding $CI_FLAKY_THRESHOLD"
         required: false
 
 permissions:
@@ -21,77 +20,94 @@ permissions:
 
 jobs:
   report:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion != 'skipped' }}
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Collect retried tests
+      - name: "Collect retried tests"
         id: collect
         env:
-          CI_FLAKY_ISSUE_THRESHOLD: ${{ inputs.issue_threshold || vars.CI_FLAKY_ISSUE_THRESHOLD || '10' }}
-          CI_FLAKY_NOTIFY_THRESHOLD: ${{ inputs.notify_threshold || vars.CI_FLAKY_NOTIFY_THRESHOLD || '3' }}
-          CI_FLAKY_SAMPLES: ${{ inputs.samples || vars.CI_FLAKY_SAMPLES || '15' }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_ID: ${{ github.event.workflow_run.id || inputs.run_id }}
         run: |
           .github/scripts/flaky-tests.sh \
             "$GITHUB_REPOSITORY" \
-            "$CI_FLAKY_SAMPLES" \
-            "$CI_FLAKY_NOTIFY_THRESHOLD" \
-            "$CI_FLAKY_ISSUE_THRESHOLD" | tee -a "$GITHUB_STEP_SUMMARY"
-      - name: File a Linear issue per offending test
-        if: ${{ steps.collect.outputs.issue_count != '0' }}
+            "$RUN_ID" | tee -a "$GITHUB_STEP_SUMMARY"
+      - name: "File issues and notify #ci-alerts"
+        if: ${{ steps.collect.outputs.count != '0' }}
         env:
-          CI_FLAKY_ISSUE_THRESHOLD: ${{ steps.collect.outputs.issue_threshold }}
-          CI_FLAKY_SCANNED: ${{ steps.collect.outputs.scanned }}
+          CI_FLAKY_TESTS: ${{ steps.collect.outputs.tests }}
+          CI_FLAKY_THRESHOLD: ${{ inputs.threshold || vars.CI_FLAKY_THRESHOLD || '1' }}
           LINEAR_APP_CLIENT_ID: ${{ secrets.LINEAR_APP_CLIENT_ID }}
           LINEAR_APP_CLIENT_SECRET: ${{ secrets.LINEAR_APP_CLIENT_SECRET }}
-          CI_FLAKY_ISSUE_TESTS: ${{ steps.collect.outputs.issue_tests }}
-        run: |
-          set -euo pipefail
-
-          LINEAR_APP_TOKEN=$(.github/scripts/linear-token.sh)
-          echo "::add-mask::$LINEAR_APP_TOKEN"
-          export LINEAR_APP_TOKEN
-
-          report="https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
-
-          while IFS=$'\t' read -r retries test; do
-            [ -n "$test" ] || continue
-
-            printf '`%s` retried %s times across the last %s `main` runs that published test reports, at or over the threshold of %s.\n\n[Latest report](%s)\n' \
-              "$test" "$retries" "$CI_FLAKY_SCANNED" "$CI_FLAKY_ISSUE_THRESHOLD" "$report" > body.md
-
-            issue=$(.github/scripts/flaky-issue.sh "$GITHUB_REPOSITORY" MBE "$test" body.md)
-            echo "\`$test\` tracked in $issue" >> "$GITHUB_STEP_SUMMARY"
-          done <<< "$CI_FLAKY_ISSUE_TESTS"
-      - name: "Notify #ci-alerts"
-        # Runs on the collection alone, so that a Linear that fails the step above still leaves the
-        # channel with the report.
-        if: ${{ !cancelled() && steps.collect.outcome == 'success' && steps.collect.outputs.notify_count != '0' }}
-        env:
-          CI_FLAKY_NOTIFY_THRESHOLD: ${{ inputs.notify_threshold || vars.CI_FLAKY_NOTIFY_THRESHOLD || '3' }}
-          CI_FLAKY_SCANNED: ${{ steps.collect.outputs.scanned }}
-          CI_FLAKY_NOTIFY_COUNT: ${{ steps.collect.outputs.notify_count }}
-          LINEAR_APP_CLIENT_ID: ${{ secrets.LINEAR_APP_CLIENT_ID }}
-          LINEAR_APP_CLIENT_SECRET: ${{ secrets.LINEAR_APP_CLIENT_SECRET }}
+          RUN_ID: ${{ github.event.workflow_run.id || inputs.run_id }}
           SLACK_CI_ALERTS_WEBHOOK_URL: ${{ secrets.SLACK_CI_ALERTS_WEBHOOK_URL }}
-          CI_FLAKY_NOTIFY_TESTS: ${{ steps.collect.outputs.notify_tests }}
         run: |
           set -euo pipefail
 
-          if [ -z "$SLACK_CI_ALERTS_WEBHOOK_URL" ]; then
-            echo "::warning::$CI_FLAKY_NOTIFY_COUNT flaky test(s) but SLACK_CI_ALERTS_WEBHOOK_URL is not set"
-            exit 0
-          fi
+          # Ten digits or more overflows the comparisons it is about to be used in, which fail
+          # noisily and compare false rather than refusing to run.
+          case $CI_FLAKY_THRESHOLD in
+            '' | *[!0-9]* | ??????????*)
+              echo "::error::CI_FLAKY_THRESHOLD must be a whole number under ten digits, got '$CI_FLAKY_THRESHOLD'"
+              exit 1
+              ;;
+          esac
 
-          # Annotating the report is worth a warning at most: the tests it names are the point.
+          run_url="https://github.com/$GITHUB_REPOSITORY/actions/runs/$RUN_ID"
+
+          # Filing is what separates a first sighting from a repeat, so a Linear that cannot be
+          # reached leaves the run announcing every flake it found rather than none of them.
           if LINEAR_APP_TOKEN=$(.github/scripts/linear-token.sh); then
             echo "::add-mask::$LINEAR_APP_TOKEN"
             export LINEAR_APP_TOKEN
           else
-            echo "::warning::could not mint a Linear token; the report will carry no issue numbers"
+            echo "::warning::could not mint a Linear token; announcing every flake in this run"
           fi
 
-          payload=$(.github/scripts/flaky-notify.sh "$GITHUB_REPOSITORY" MBE "$CI_FLAKY_NOTIFY_THRESHOLD" "$CI_FLAKY_SCANNED" <<< "$CI_FLAKY_NOTIFY_TESTS")
+          : > new.tsv
+
+          while IFS=$'\t' read -r retries package test; do
+            [ -n "$test" ] || continue
+
+            if [ -z "${LINEAR_APP_TOKEN:-}" ]; then
+              if [ "$retries" -ge "$CI_FLAKY_THRESHOLD" ]; then
+                printf '%s\t%s\t\t\n' "$package" "$test" >> new.tsv
+              fi
+              continue
+            fi
+
+            if ! filed=$(.github/scripts/flaky-issue.sh \
+              "$GITHUB_REPOSITORY" MBE "$package" "$test" "$retries" "$CI_FLAKY_THRESHOLD" \
+              "$run_url"); then
+              echo "::warning::could not reach Linear for $package/$test"
+              if [ "$retries" -ge "$CI_FLAKY_THRESHOLD" ]; then
+                printf '%s\t%s\t\t\n' "$package" "$test" >> new.tsv
+              fi
+              continue
+            fi
+
+            IFS=$'\t' read -r state identifier issue_url <<< "$filed"
+
+            if [ "$state" = below ]; then
+              continue
+            elif [ "$state" = new ]; then
+              printf '%s\t%s\t%s\t%s\n' \
+                "$package" "$test" "$identifier" "$issue_url" >> new.tsv
+              echo "\`$package\`/\`$test\` filed as [$identifier]($issue_url)" >> "$GITHUB_STEP_SUMMARY"
+            else
+              echo "\`$package\`/\`$test\` already tracked in [$identifier]($issue_url)" >> "$GITHUB_STEP_SUMMARY"
+            fi
+          done <<< "$CI_FLAKY_TESTS"
+
+          [ -s new.tsv ] || exit 0
+
+          if [ -z "$SLACK_CI_ALERTS_WEBHOOK_URL" ]; then
+            echo "::warning::new flaky test(s) but SLACK_CI_ALERTS_WEBHOOK_URL is not set"
+            exit 0
+          fi
+
+          payload=$(.github/scripts/flaky-notify.sh "$GITHUB_REPOSITORY" "$run_url" < new.tsv)
 
           curl --fail-with-body --silent --show-error \
             -X POST \

--- a/changelog.d/+current-run-flakes.internal.md
+++ b/changelog.d/+current-run-flakes.internal.md
@@ -1,0 +1,1 @@
+Report a flaky test when it first flakes, instead of on a rolling window of runs.


### PR DESCRIPTION
Resolves INT-675.

Flaky tests are reported on the run that flaked, rather than sampled from a moving window. Slack notifications are only sent for unreported flakes.

## Slack alert

🎲 **Flaky tests detected on mirrord**

•  `http_mirroring`/`application_3_Application__NodeHTTP`  ·  [MBE-904](https://linear.app/metalbear/issue/MBE-904)

[Repository](https://github.com/metalbear-co/mirrord) • [Run](https://github.com/metalbear-co/mirrord/actions/runs/33000487600)

## Linear issue

**Fix flaky test `http_mirroring`/`application_3_Application__NodeHTTP` in mirrord**

Failed 1× across all observed runs.

### Running in isolation

    cargo nextest run -p mirrord-layer-tests -E 'binary_id(=mirrord-layer-tests::http_mirroring) and test(=mirroring_with_http::application_3_Application__NodeHTTP)'

_This issue was generated automatically. Do not edit by hand, as it may be overridden._