### PR TITLE
Update nix and tun2 (now just tun).

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,7 +221,7 @@ dependencies = [
  "spki",
  "subtle",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tungstenite 0.24.0",
  "uuid",
@@ -249,7 +249,7 @@ dependencies = [
  "scroll 0.12.0",
  "serde",
  "serde-xml-rs",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -275,7 +275,7 @@ dependencies = [
  "sha1",
  "sha2 0.10.9",
  "signature",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "url",
  "x509-certificate",
  "xml-rs",
@@ -339,7 +339,7 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "time",
 ]
 
@@ -1249,7 +1249,7 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "serde_urlencoded",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-util",
  "tower-service",
@@ -1319,9 +1319,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "bytes-utils"
@@ -1418,9 +1418,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
@@ -2091,7 +2091,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
 dependencies = [
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -2353,7 +2353,7 @@ dependencies = [
  "shrinkwraprs",
  "stopwatch2",
  "sysinfo",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "widestring",
  "winapi",
 ]
@@ -2899,9 +2899,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2914,9 +2914,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2924,15 +2924,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -2941,9 +2941,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
 
 [[package]]
 name = "futures-lite"
@@ -2957,32 +2957,32 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.4",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -3253,7 +3253,7 @@ dependencies = [
  "ipnet",
  "jni",
  "rand 0.10.2",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tinyvec",
  "tokio",
  "tracing",
@@ -3275,7 +3275,7 @@ dependencies = [
  "rand 0.10.2",
  "ring",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tinyvec",
  "tracing",
  "url",
@@ -3303,7 +3303,7 @@ dependencies = [
  "serde",
  "smallvec",
  "system-configuration",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
 ]
@@ -4050,7 +4050,7 @@ dependencies = [
  "jni-sys",
  "log",
  "simd_cesu8",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "walkdir",
  "windows-link 0.2.1",
 ]
@@ -4117,7 +4117,7 @@ dependencies = [
  "jsonptr",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -4130,7 +4130,7 @@ dependencies = [
  "pest_derive",
  "regex",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -4287,7 +4287,7 @@ dependencies = [
  "serde",
  "serde-saphyr",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-tungstenite",
  "tokio-util",
@@ -4311,7 +4311,7 @@ dependencies = [
  "serde",
  "serde-value",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -4347,7 +4347,7 @@ dependencies = [
  "pin-project",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-util",
  "tracing",
@@ -4364,9 +4364,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libloading"
@@ -4595,7 +4595,7 @@ dependencies = [
  "glob",
  "rand 0.10.2",
  "syn 2.0.118",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tracing",
  "tracing-subscriber",
 ]
@@ -4686,7 +4686,7 @@ version = "0.2.1"
 source = "git+https://github.com/metalbear-co/minhook-detours-rs.git?rev=4bfbf5717c6829f91b527180a038ec591b8265ca#4bfbf5717c6829f91b527180a038ec591b8265ca"
 dependencies = [
  "minhook-detours-sys",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "winapi",
 ]
 
@@ -4815,7 +4815,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-retry",
  "tokio-rustls",
@@ -4884,7 +4884,7 @@ dependencies = [
  "serde_json_path",
  "socket2 0.5.10",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-retry",
  "tokio-rustls",
@@ -4908,7 +4908,7 @@ dependencies = [
  "schemars 1.2.1",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tracing",
 ]
 
@@ -4964,7 +4964,7 @@ dependencies = [
  "serde",
  "serde-saphyr",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tower-test",
  "tracing",
@@ -5008,7 +5008,7 @@ dependencies = [
  "strum_macros",
  "tempfile",
  "tera",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "toml 1.1.2+spec-1.1.0",
  "tracing",
 ]
@@ -5033,7 +5033,7 @@ dependencies = [
  "log",
  "miette",
  "mirrord-intproxy-protocol",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-util",
  "tracing",
@@ -5078,7 +5078,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-retry",
  "tokio-rustls",
@@ -5099,7 +5099,7 @@ dependencies = [
  "bytes",
  "futures",
  "mirrord-protocol",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-util",
 ]
@@ -5113,7 +5113,7 @@ dependencies = [
  "jaq-std",
  "mirrord-test-macros",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
 ]
 
@@ -5135,7 +5135,7 @@ dependencies = [
  "serde",
  "serde_json",
  "shellexpand",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-retry",
  "tower",
@@ -5219,7 +5219,7 @@ dependencies = [
  "socket2 0.5.10",
  "str-win",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tracing",
  "tracing-subscriber",
  "utils-win",
@@ -5330,7 +5330,7 @@ dependencies = [
  "strum_macros",
  "tar",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-tungstenite",
  "tower",
@@ -5376,7 +5376,7 @@ dependencies = [
  "socket2 0.5.10",
  "strum",
  "strum_macros",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tracing",
  "uuid",
 ]
@@ -5398,7 +5398,7 @@ dependencies = [
  "smallvec",
  "strum",
  "strum_macros",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-retry",
  "tokio-stream",
@@ -5416,7 +5416,7 @@ dependencies = [
  "mirrord-protocol",
  "rand 0.10.2",
  "rstest",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
 ]
@@ -5435,7 +5435,7 @@ dependencies = [
  "mirrord-session-monitor-protocol",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "winapi",
@@ -5464,7 +5464,7 @@ dependencies = [
  "rstest",
  "tar",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tracing",
  "which",
 ]
@@ -5526,7 +5526,7 @@ dependencies = [
  "rustls",
  "rustls-pemfile",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-rustls",
  "tracing",
@@ -5557,7 +5557,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "tera",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "uuid",
  "yamlpatch",
@@ -5577,10 +5577,10 @@ dependencies = [
  "pnet_packet",
  "rust-yaml",
  "semver 1.0.28",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
- "tun2",
+ "tun",
 ]
 
 [[package]]
@@ -5669,9 +5669,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.29.0"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags 2.13.0",
  "cfg-if",
@@ -5985,7 +5985,7 @@ dependencies = [
  "serde_json",
  "strum",
  "strum_macros",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -6666,7 +6666,7 @@ dependencies = [
  "parking_lot",
  "procfs",
  "protobuf",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -6766,7 +6766,7 @@ dependencies = [
  "prost-reflect",
  "prost-types",
  "protox-parse",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -6778,7 +6778,7 @@ dependencies = [
  "logos 0.15.1",
  "miette",
  "prost-types",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -6824,7 +6824,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2 0.5.10",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "web-time",
@@ -6847,7 +6847,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tinyvec",
  "tracing",
  "web-time",
@@ -7130,7 +7130,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -7893,9 +7893,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "indexmap 2.14.0",
  "itoa",
@@ -7918,7 +7918,7 @@ dependencies = [
  "serde_json",
  "serde_json_path_core",
  "serde_json_path_macros",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -7930,7 +7930,7 @@ dependencies = [
  "inventory",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -8419,6 +8419,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8607,11 +8618,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "thiserror-impl 2.0.18",
+ "thiserror-impl 2.0.20",
 ]
 
 [[package]]
@@ -8627,13 +8638,13 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -8711,9 +8722,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -9181,10 +9192,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
-name = "tun2"
-version = "4.0.0"
+name = "tun"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21afe73d3d42581a7400fbf5aec057a646ffe3f8bb5ae3f61d88c7e7f4ac77be"
+checksum = "8bb55e468c585e02ef89ba7a1a9848871ac942dfc64547ad4d1166b0f61a98be"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -9194,10 +9205,11 @@ dependencies = [
  "libc",
  "log",
  "nix",
- "thiserror 1.0.69",
+ "serde_json",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-util",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
  "wintun-bindings",
 ]
 
@@ -9235,7 +9247,7 @@ dependencies = [
  "log",
  "rand 0.9.4",
  "sha1",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -9413,7 +9425,7 @@ dependencies = [
  "mirrord-config",
  "rand 0.10.2",
  "str-win",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tracing",
  "winapi",
  "windows-sys 0.59.0",
@@ -10135,7 +10147,7 @@ dependencies = [
  "futures",
  "libloading 0.9.0",
  "log",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "windows-sys 0.61.2",
 ]
 
@@ -10203,7 +10215,7 @@ dependencies = [
  "oid-registry 0.8.1",
  "ring",
  "rusticata-macros",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "time",
 ]
 
@@ -10281,7 +10293,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "subfeature",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "yamlpath",
 ]
 
@@ -10294,7 +10306,7 @@ dependencies = [
  "line-index",
  "self_cell",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tree-sitter",
  "tree-sitter-iter",
  "tree-sitter-yaml",
@@ -10458,7 +10470,7 @@ dependencies = [
  "flate2",
  "indexmap 2.14.0",
  "memchr",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "zopfli",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -178,7 +178,7 @@ mirrord-session-monitor-client = { path = "mirrord/session-monitor-client" }
 mirrord-session-monitor-protocol = { path = "mirrord/session-monitor-protocol" }
 mirrord-test-macros = { path = "mirrord/test-macros" }
 mockall = "0.13"
-nix = { version = "0.29", features = ["net"] }
+nix = { version = "0.31", features = ["net"] }
 nom = "7.1"
 notify = { version = "8", features = ["macos_fsevent"] }
 null-terminated = { git = "https://github.com/metalbear-co/null-terminated.rs", default-features = false }
@@ -256,7 +256,7 @@ tower-http = { version = "0.6.6", features = ["fs", "set-header", "trace"] }
 tower-test = "0.4"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
-tun2 = { version = "4", features = ["async"] }
+tun = { version = "0.8.14", features = ["async"] }
 url = "2.5.8"
 uuid = { version = "1.18", features = ["v4", "serde"] }
 walkdir = "2"

--- a/changelog.d/+cor-1801-update-nix-tun.internal.md
+++ b/changelog.d/+cor-1801-update-nix-tun.internal.md
@@ -1,0 +1,1 @@
+Update nix and tun.

--- a/mirrord/agent/src/file.rs
+++ b/mirrord/agent/src/file.rs
@@ -7,7 +7,7 @@ use std::{
     iter::{Enumerate, Peekable},
     ops::RangeInclusive,
     os::{
-        fd::{AsRawFd, RawFd},
+        fd::AsRawFd,
         unix::{ffi::OsStrExt, fs::MetadataExt, prelude::FileExt},
     },
     path::{Path, PathBuf, StripPrefixError},
@@ -17,7 +17,7 @@ use std::{
 use faccess::{AccessMode, PathExt as _};
 use libc::DT_DIR;
 use mirrord_protocol::{FileRequest, FileResponse, RemoteResult, ResponseError, file::*};
-use nix::unistd::UnlinkatFlags;
+use nix::{fcntl::AT_FDCWD, unistd::UnlinkatFlags};
 use tracing::{Level, error, trace};
 
 use crate::{
@@ -549,9 +549,12 @@ impl FileManager {
             }
         };
 
-        let fd: Option<RawFd> = dirfd.map(|fd| fd as RawFd);
-
-        nix::unistd::unlinkat(fd, path.as_ref(), flags)
+        // `path` is already resolved against `dirfd`, so we can just use it with `AT_FDCWD`.
+        //
+        // TODO(alex): clanker says that what we're doing here is not really equivalent to
+        // `unlinkat`, renaming a dir or replacing the original path could cause issues, also
+        // potential issues with symlinks and permissions.
+        nix::unistd::unlinkat(AT_FDCWD, path.as_ref(), flags)
             .map_err(|error| ResponseError::from(std::io::Error::from_raw_os_error(error as i32)))
     }
 

--- a/mirrord/agent/src/steal/test/utils.rs
+++ b/mirrord/agent/src/steal/test/utils.rs
@@ -1022,7 +1022,7 @@ where
     }
 
     fn size_hint(&self) -> SizeHint {
-        self.size.clone().unwrap_or_default()
+        self.size.unwrap_or_default()
     }
 
     fn is_end_stream(&self) -> bool {

--- a/mirrord/layer-tests/tests/apps/dup_listen/src/main.rs
+++ b/mirrord/layer-tests/tests/apps/dup_listen/src/main.rs
@@ -2,7 +2,7 @@
 use std::{
     io::Read,
     net::{Ipv4Addr, Shutdown, SocketAddr, TcpListener},
-    os::fd::AsRawFd,
+    os::fd::AsFd,
 };
 
 #[cfg(target_family = "unix")]
@@ -10,7 +10,7 @@ fn main() {
     let listener = TcpListener::bind(SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), 80)).unwrap();
 
     // Duplicate the listener's descriptor and close it.
-    let fd = listener.as_raw_fd();
+    let fd = listener.as_fd();
     let fd_2 = nix::unistd::dup(fd).unwrap();
     nix::unistd::close(fd_2).unwrap();
     // Test code waits for this message.

--- a/mirrord/layer/src/lib.rs
+++ b/mirrord/layer/src/lib.rs
@@ -73,7 +73,7 @@ use std::{
     fs::File,
     io::Read,
     net::SocketAddr,
-    os::unix::process::parent_id,
+    os::{fd::IntoRawFd, unix::process::parent_id},
     panic,
     sync::{Arc, OnceLock},
     time::Duration,
@@ -110,7 +110,7 @@ use mirrord_layer_macro::{hook_fn, hook_guard_fn};
 use mirrord_protocol::{EnvVars, GetEnvVarsRequest};
 use nix::{
     errno::Errno,
-    fcntl::{FcntlArg, OFlag, fcntl, open},
+    fcntl::{OFlag, open},
     sys::stat::Mode,
 };
 use socket::SOCKETS;
@@ -281,10 +281,13 @@ fn layer_pre_initialization() -> Result<(), LayerError> {
 /// [`ExperimentalConfig::guard_std_fds`](mirrord_config::experimental::ExperimentalConfig). See [#4622](https://github.com/metalbear-co/mirrord/issues/4622).
 fn guard_std_fds() {
     for fd in 0..=2 {
-        if fcntl(fd, FcntlArg::F_GETFD).is_err() {
+        // SAFETY: `F_GETFD` accepts arbitrary descriptor numbers and reports closed ones with
+        // `EBADF`, so probing does not require a valid borrowed descriptor.
+        if unsafe { libc::fcntl(fd, libc::F_GETFD) } == -1 {
             // `open` returns the lowest free fd, which is exactly `fd`:
             // lower fds were verified or opened in previous iterations.
-            let _ = open("/dev/null", OFlag::O_RDWR, Mode::empty());
+            // Converting to a raw descriptor keeps it open for the rest of the process lifetime.
+            let _ = open("/dev/null", OFlag::O_RDWR, Mode::empty()).map(IntoRawFd::into_raw_fd);
         }
     }
 }
@@ -838,12 +841,10 @@ pub(crate) unsafe extern "C" fn fork_detour() -> pid_t {
 pub(crate) unsafe extern "C" fn vfork_detour() -> pid_t {
     #[cfg(target_os = "macos")]
     let pipe_result = {
-        use std::os::fd::AsRawFd;
-
         use nix::fcntl::{FcntlArg, FdFlag};
 
         nix::unistd::pipe().and_then(|pipe| {
-            nix::fcntl::fcntl(pipe.1.as_raw_fd(), FcntlArg::F_SETFD(FdFlag::FD_CLOEXEC))?;
+            nix::fcntl::fcntl(&pipe.1, FcntlArg::F_SETFD(FdFlag::FD_CLOEXEC))?;
             Ok(pipe)
         })
     };

--- a/mirrord/vpn/Cargo.toml
+++ b/mirrord/vpn/Cargo.toml
@@ -29,7 +29,7 @@ semver.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["fs", "process"] }
 tracing.workspace = true
-tun2 = { workspace = true, features = ["async"] }
+tun = { workspace = true, features = ["async"] }
 rust-yaml.workspace = true
 
 [lib]

--- a/mirrord/vpn/src/socket.rs
+++ b/mirrord/vpn/src/socket.rs
@@ -7,7 +7,7 @@ use crate::packet::patch_packet_checksum;
 pub fn create_vpn_socket(
     network: &NetworkConfiguration,
 ) -> impl Stream<Item = io::Result<Vec<u8>>> + Sink<Vec<u8>, Error = io::Error> + use<> {
-    let mut config = tun2::Configuration::default();
+    let mut config = tun::Configuration::default();
     config
         .address(network.ip)
         .netmask(network.net_mask)
@@ -19,7 +19,7 @@ pub fn create_vpn_socket(
         config.ensure_root_privileges(true);
     });
 
-    let dev = tun2::create_as_async(&config).unwrap();
+    let dev = tun::create_as_async(&config).unwrap();
 
     dev.into_framed().with(|mut packet: Vec<u8>| {
         patch_packet_checksum(&mut packet);


### PR DESCRIPTION
<!-- Thank you for contributing to mirrord! -->
<!-- Please use the checklist below as a guide for docs, tests and admin tasks for your PR -->
<!-- Feel free to ~strikethrough~ any items that you don't think apply -->

- Issue: https://linear.app/metalbear/issue/COR-1801/investigate-future-rust-incompatibility-warnings

Drop `tun2` now that `tun` is updated again.
Update `nix`. Had to change 1 nix usage in the layer to `unsafe libc` as it's not really possible to do it without `unsafe` even with `nix` (and using rust primitives would also be kinda wrong there due to what's expected of `OwnedFd` and `BorrowedFd`).

The clanker found a (minor) potential issue in the agent.

### Quality Checklist:

- [x] I have documented new code sufficiently
- [ ] I have checked and updated the relevant existing docs in code, including removing outdated material
- [ ] I have written user-facing website docs for new features, or opened a (sub)issue to do so
- [ ] I have checked and updated existing website docs for changed features
- [ ] I have tested this change and know it succeeds and fails as expected
- [ ] I have written unit tests or purposefully omitted them
- [ ] I have written e2e tests or purposefully omitted them
- [ ] I have explained what this PR introduces and why, and linked to relevant context (e.g. linear issues, related PRs,
  documentation)
- [x] I have introduced a short, clear and well-formatted changelog entry

<!-- need help with the changelog? see ../CONTRIBUTING.md#submitting-a-pull-request -->
<!-- Add more details of your changes below if needed -->