### PR TITLE
CI: verify mirrord-tui on CI

### DIFF
--- a/.github/workflows/check-lint.yaml
+++ b/.github/workflows/check-lint.yaml
@@ -201,38 +201,6 @@ jobs:
         with:
           tool: cargo-shear@1.13.1
       - run: cargo shear --deny-warnings
-  tui-standalone:
-    if: ${{ inputs.run_rust }}
-    name: 'mirrord-tui builds on its own'
-    timeout-minutes: 20
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-      - run: rm rust-toolchain.toml
-      - uses: metalbear-co/setup-rust-toolchain@a8d42d5aa259519dac1faeee20e37c1fb43453a3
-        with:
-          cache: false
-          toolchain: ${{ inputs.rust_toolchain }}
-      - name: Rust cache
-        uses: metalbear-co/rust-cache@d49d62d59c5755dd81754c833186b84a82f895fe # v2.9.1+1
-        with:
-          shared-key: mirrord
-      - uses: metalbear-co/setup-protoc@770e54d44679c8e1d8fdc06d1d9268fa79fbefb4
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-      # What `cargo run` in this directory has to do first, and the only part of it a runner can
-      # do: there is no terminal to take over here, so the interface itself panics on startup and
-      # cannot be launched. That it launches and quits cleanly is covered by the pty smoke tests.
-      #
-      # Building from the crate's own directory rather than with `-p` from the root is the point:
-      # it is the command someone working on the interface actually types, and it selects this
-      # package alone only because the root manifest is virtual.
-      - name: cargo run, as far as a runner can take it
-        run: |
-          cd mirrord/tui
-          cargo build
   lint-success:
     if: '!cancelled()'
     needs:
@@ -244,8 +212,7 @@ jobs:
         ui-frontend-lint,
         vale,
         cargo-lint,
-        shear,
-        tui-standalone
+        shear
       ]
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/check-lint.yaml
+++ b/.github/workflows/check-lint.yaml
@@ -201,6 +201,44 @@ jobs:
         with:
           tool: cargo-shear@1.13.1
       - run: cargo shear --deny-warnings
+  tui-standalone:
+    if: ${{ inputs.run_rust }}
+    name: 'mirrord-tui stands alone'
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Rust cache
+        uses: metalbear-co/rust-cache@d49d62d59c5755dd81754c833186b84a82f895fe # v2.9.1+1
+        with:
+          shared-key: mirrord
+      # `mirrord` depends on `mirrord-tui`, and nothing may make that point the other way: the whole
+      # reason the interface is its own crate is that working on it does not mean building the CLI,
+      # the layer and the agent. Nothing else in CI notices if that stops being true - the workspace
+      # would simply keep building, only slower.
+      - name: the interface must not depend on the rest of mirrord
+        run: |
+          status=0
+          for crate in mirrord mirrord-layer mirrord-agent mirrord-intproxy; do
+            if cargo tree --quiet -p mirrord-tui -i "$crate" >/dev/null 2>&1; then
+              echo "::error file=mirrord/tui/Cargo.toml::mirrord-tui depends on $crate; the dependency has to point the other way round."
+              status=1
+            fi
+          done
+          exit $status
+      # And `cargo run` inside the crate has to keep selecting only the crate. That follows from the
+      # root manifest being virtual - `default-members` applies there, not in a member directory -
+      # so it is a property of the workspace layout that a future change could quietly take away.
+      - name: cargo must select only the interface from its own directory
+        run: |
+          selected=$(cd mirrord/tui && cargo tree --depth 0 --prefix none --quiet |
+            awk 'NF && $1 !~ /^\[/ {print $1}' | sort -u)
+          if [ "$selected" != "mirrord-tui" ]; then
+            echo "::error file=Cargo.toml::a bare cargo command in mirrord/tui selects [$(echo $selected)], not mirrord-tui alone."
+            exit 1
+          fi
   lint-success:
     if: '!cancelled()'
     needs:
@@ -212,7 +250,8 @@ jobs:
         ui-frontend-lint,
         vale,
         cargo-lint,
-        shear
+        shear,
+        tui-standalone
       ]
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/check-lint.yaml
+++ b/.github/workflows/check-lint.yaml
@@ -203,42 +203,36 @@ jobs:
       - run: cargo shear --deny-warnings
   tui-standalone:
     if: ${{ inputs.run_rust }}
-    name: 'mirrord-tui stands alone'
-    timeout-minutes: 10
+    name: 'mirrord-tui builds on its own'
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+      - run: rm rust-toolchain.toml
+      - uses: metalbear-co/setup-rust-toolchain@a8d42d5aa259519dac1faeee20e37c1fb43453a3
+        with:
+          cache: false
+          toolchain: ${{ inputs.rust_toolchain }}
       - name: Rust cache
         uses: metalbear-co/rust-cache@d49d62d59c5755dd81754c833186b84a82f895fe # v2.9.1+1
         with:
           shared-key: mirrord
-      # `mirrord` depends on `mirrord-tui`, and nothing may make that point the other way: the whole
-      # reason the interface is its own crate is that working on it does not mean building the CLI,
-      # the layer and the agent. Nothing else in CI notices if that stops being true - the workspace
-      # would simply keep building, only slower.
-      - name: the interface must not depend on the rest of mirrord
+      - uses: metalbear-co/setup-protoc@770e54d44679c8e1d8fdc06d1d9268fa79fbefb4
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      # What `cargo run` in this directory has to do first, and the only part of it a runner can
+      # do: there is no terminal to take over here, so the interface itself panics on startup and
+      # cannot be launched. That it launches and quits cleanly is covered by the pty smoke tests.
+      #
+      # Building from the crate's own directory rather than with `-p` from the root is the point:
+      # it is the command someone working on the interface actually types, and it selects this
+      # package alone only because the root manifest is virtual.
+      - name: cargo run, as far as a runner can take it
         run: |
-          status=0
-          for crate in mirrord mirrord-layer mirrord-agent mirrord-intproxy; do
-            if cargo tree --quiet -p mirrord-tui -i "$crate" >/dev/null 2>&1; then
-              echo "::error file=mirrord/tui/Cargo.toml::mirrord-tui depends on $crate; the dependency has to point the other way round."
-              status=1
-            fi
-          done
-          exit $status
-      # And `cargo run` inside the crate has to keep selecting only the crate. That follows from the
-      # root manifest being virtual - `default-members` applies there, not in a member directory -
-      # so it is a property of the workspace layout that a future change could quietly take away.
-      - name: cargo must select only the interface from its own directory
-        run: |
-          selected=$(cd mirrord/tui && cargo tree --depth 0 --prefix none --quiet |
-            awk 'NF && $1 !~ /^\[/ {print $1}' | sort -u)
-          if [ "$selected" != "mirrord-tui" ]; then
-            echo "::error file=Cargo.toml::a bare cargo command in mirrord/tui selects [$(echo $selected)], not mirrord-tui alone."
-            exit 1
-          fi
+          cd mirrord/tui
+          cargo build
   lint-success:
     if: '!cancelled()'
     needs:

--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -126,11 +126,7 @@ jobs:
         with:
           command: |
             cargo nextest run --target x86_64-unknown-linux-gnu -p mirrord-vpn
-      # The command someone working on the interface actually types, rather than reaching it with
-      # `-p` from the root: from here cargo selects this package alone, and only because the root
-      # manifest is virtual. `cargo run` itself cannot finish on a runner - there is no terminal for
-      # the interface to take over - and the smoke tests below cover launching the built binary.
-      - name: mirrord tui builds from its own directory
+      - name: verify mirrord tui builds as its own binary
         uses: ./.github/actions/run-in-ci-runner
         with:
           command: |

--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -126,6 +126,15 @@ jobs:
         with:
           command: |
             cargo nextest run --target x86_64-unknown-linux-gnu -p mirrord-vpn
+      # The command someone working on the interface actually types, rather than reaching it with
+      # `-p` from the root: from here cargo selects this package alone, and only because the root
+      # manifest is virtual. `cargo run` itself cannot finish on a runner - there is no terminal for
+      # the interface to take over - and the smoke tests below cover launching the built binary.
+      - name: mirrord tui builds from its own directory
+        uses: ./.github/actions/run-in-ci-runner
+        with:
+          command: |
+            cd mirrord/tui && cargo build --target x86_64-unknown-linux-gnu
       - name: mirrord tui UT
         uses: ./.github/actions/run-in-ci-runner
         with:

--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -126,15 +126,15 @@ jobs:
         with:
           command: |
             cargo nextest run --target x86_64-unknown-linux-gnu -p mirrord-vpn
-      - name: verify mirrord tui builds as its own binary
+      - name: mirrord tui build and UT
         uses: ./.github/actions/run-in-ci-runner
         with:
           command: |
-            cd mirrord/tui && cargo build --target x86_64-unknown-linux-gnu
-      - name: mirrord tui UT
-        uses: ./.github/actions/run-in-ci-runner
-        with:
-          command: |
+            set -e
+            # Built from its own directory, so that the crate is checked the way someone working
+            # only on it builds it, rather than with whatever features the rest of the workspace
+            # happens to turn on.
+            (cd mirrord/tui && cargo build --target x86_64-unknown-linux-gnu)
             cargo nextest run --target x86_64-unknown-linux-gnu -p mirrord-tui
       - name: save intproxy logs
         continue-on-error: true

--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -126,6 +126,11 @@ jobs:
         with:
           command: |
             cargo nextest run --target x86_64-unknown-linux-gnu -p mirrord-vpn
+      - name: mirrord tui UT
+        uses: ./.github/actions/run-in-ci-runner
+        with:
+          command: |
+            cargo nextest run --target x86_64-unknown-linux-gnu -p mirrord-tui
       - name: save intproxy logs
         continue-on-error: true
         if: ${{ always() }}

--- a/.github/workflows/test-macos.yaml
+++ b/.github/workflows/test-macos.yaml
@@ -56,6 +56,11 @@ jobs:
         run: cargo nextest run -p mirrord-sip
       - name: mirrord-intproxy UT
         run: cargo nextest run -p mirrord-intproxy
+      # The only place the interface's tests run on macOS, and so the only place its macOS-specific
+      # process lookup (`proc_pidinfo`, where Linux reads `/proc`) is executed rather than merely
+      # compiled. The pty tests need a real terminal-capable `/bin/sh`, which the runner has.
+      - name: mirrord-tui UT
+        run: cargo nextest run -p mirrord-tui
       - run: |
           cd mirrord/layer-tests/tests/apps/issue1123
           rustc issue1123.rs --out-dir target

--- a/changelog.d/+tui-ci-standalone.internal.md
+++ b/changelog.d/+tui-ci-standalone.internal.md
@@ -1,0 +1,1 @@
+Run the terminal interface's tests on macOS, and guard in CI that its crate stays buildable without the CLI, layer and agent.

--- a/changelog.d/+tui-ci-standalone.internal.md
+++ b/changelog.d/+tui-ci-standalone.internal.md
@@ -1,1 +1,1 @@
-Run the terminal interface's tests on macOS, and guard in CI that its crate stays buildable without the CLI, layer and agent.
+Run the terminal interface's tests on macOS, and build it from its own crate directory in CI.

--- a/mirrord/tui/tests/smoke.rs
+++ b/mirrord/tui/tests/smoke.rs
@@ -157,6 +157,17 @@ fn shell_is_constrained_to_the_pane_and_the_prefix_takes_the_keyboard_back() {
         "the session panel should not be drawn without sessions; screen was:\n{screen}",
     );
 
+    // A prompt long enough to fill the pane wraps what is typed after it onto the next line, and a
+    // wrapped line matches no needle that spans the break. `PS1` in the environment does not settle
+    // that: the shell is started as a login shell, and where `/bin/sh` is bash its system rc files
+    // replace the prompt with one built from the hostname - long enough on a CI runner to wrap a
+    // six-character command on its own. Asking for the prompt from inside the shell does settle it,
+    // because nothing runs afterwards to override it. Written split so that the command's own echo
+    // cannot be mistaken for the prompt it asks for.
+    writer.write_all(b"PS1=mt'> '\r").unwrap();
+    writer.flush().unwrap();
+    wait_for(&rx, &mut parser, "mt> ");
+
     // The shell's own view has to agree: the pane's inner rectangle, not the 30x100 outer pty.
     writer.write_all(b"stty size\r").unwrap();
     writer.flush().unwrap();
@@ -173,10 +184,11 @@ fn shell_is_constrained_to_the_pane_and_the_prefix_takes_the_keyboard_back() {
     wait_for(&rx, &mut parser, "18 78");
 
     // `q` belongs to the shell while it has the keyboard, so it has to reach the shell as a
-    // keystroke rather than quitting the application.
+    // keystroke rather than quitting the application. Matched together with the prompt it is typed
+    // at, which is what makes it this shell's echo rather than any other `echo q` on the screen.
     writer.write_all(b"echo q").unwrap();
     writer.flush().unwrap();
-    wait_for(&rx, &mut parser, "$ echo q");
+    wait_for(&rx, &mut parser, "mt> echo q");
 
     // C-b is held back from the shell, and only then is `q` taken as the global quit key.
     writer.write_all(&[0x02]).unwrap();


### PR DESCRIPTION
Stacked on #4779 `import-mirrord-tui` this diff is only the CI change.

Three additions, no new jobs:

```yaml
# test-integration.yaml, next to the tests it belongs with
- cd mirrord/tui && cargo build --target x86_64-unknown-linux-gnu
- cargo nextest run --target x86_64-unknown-linux-gnu -p mirrord-tui

# test-macos.yaml
- cargo nextest run -p mirrord-tui
```

## Already covered by existing checks:

- **clippy** — `--all-targets --all-features -- "-Wclippy::indexing_slicing" -D warnings` reaches it on all five targets: `--workspace` on linux, and via the `mirrord/*` `default-members` glob on the other four.
- **rustfmt, cargo shear, typos, cargo deny, rust-docs** — all workspace-wide.

## UT fix

`shell_is_constrained_to_the_pane_and_the_prefix_takes_the_keyboard_back` types `echo q` at the pane's shell and waits for it on screen, which assumed both the character the prompt prints and that it leaves six columns on the line. Neither holds in CI:

- `sh` running as root prompts with `#`, not `$`.
- On macOS `/bin/sh` is bash, started as a login shell, and its system rc files rebuild the prompt out of the hostname. A runner's hostname is 61 characters, so in the 78-column pane the echoed command wrapped onto the next line and no needle spanning the break could match it.

The `PS1` the test puts in the environment settles neither, because those rc files run after it is inherited. It now asks for a short prompt from inside the shell, where nothing runs afterwards to override it, and matches the echo together with that prompt — a stronger assertion than the bare command.