### PR TITLE
Report anonymous usage of the terminal interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5800,11 +5800,13 @@ version = "3.254.0"
 dependencies = [
  "anyhow",
  "crossterm",
+ "drain",
  "futures-util",
  "humantime",
  "k8s-openapi",
  "kube",
  "libc",
+ "mirrord-analytics",
  "mirrord-config",
  "mirrord-kube",
  "mirrord-operator",
@@ -5822,6 +5824,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tui-term",
+ "uuid",
  "vt100",
 ]
 

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -18,6 +18,19 @@ When there's an error, we send the name of the error (out of a hard-coded list, 
 
 The opt-out below disables this event as well; setting `common.telemetry: false` in `mirrord-up.yaml` is honored the same way as `telemetry: false` in a regular mirrord config.
 
+## `mirrord tui`
+
+The terminal interface reports each of these as it happens, rather than one summary when it exits: that it
+started, that a connection to the cluster failed, that a mirrord session was launched from the targets view,
+and that preview environments were stopped (with how many that one command stopped). When the interface is
+quit rather than killed, it also reports how many times each tab was switched to.
+
+Every one of these carries a random identifier for the run, so the events of a single run can be grouped;
+it is generated per run and is not stored or reused. No target names, namespaces, cluster identifiers or
+config values are included. The standalone `mirrord-tui` development binary reports nothing at all.
+
+The opt-out below disables all of it.
+
 ## Disabling
 
 Telemetry can be disabled by specifying the following in the mirrord config file:

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -22,7 +22,6 @@ The opt-out below disables this event as well; setting `common.telemetry: false`
 
 The terminal interface sends reports on the following events:
 - TUI start
-- a connection to the cluster has failed
 - a mirrord session was launched from the targets view
 - preview environments were stopped - with how many that one command stopped
 - TUI exit - with how many times each tab was switched to

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -20,14 +20,16 @@ The opt-out below disables this event as well; setting `common.telemetry: false`
 
 ## `mirrord tui`
 
-The terminal interface reports each of these as it happens, rather than one summary when it exits: that it
-started, that a connection to the cluster failed, that a mirrord session was launched from the targets view,
-and that preview environments were stopped (with how many that one command stopped). When the interface is
-quit rather than killed, it also reports how many times each tab was switched to.
+The terminal interface sends reports on the following events:
+- TUI start
+- a connection to the cluster has failed
+- a mirrord session was launched from the targets view
+- preview environments were stopped - with how many that one command stopped
+- TUI exit - with how many times each tab was switched to
 
 Every one of these carries a random identifier for the run, so the events of a single run can be grouped;
 it is generated per run and is not stored or reused. No target names, namespaces, cluster identifiers or
-config values are included. The standalone `mirrord-tui` development binary reports nothing at all.
+config values are included.
 
 The opt-out below disables all of it.
 

--- a/changelog.d/+tui-analytics.added.md
+++ b/changelog.d/+tui-analytics.added.md
@@ -1,0 +1,1 @@
+Report anonymous usage of the terminal interface: that it started, failed to connect, launched a session or stopped preview environments, and which tabs were used. Disabled by `telemetry: false` like the rest of mirrord's telemetry.

--- a/changelog.d/+tui-analytics.added.md
+++ b/changelog.d/+tui-analytics.added.md
@@ -1,1 +1,0 @@
-Report anonymous usage of the terminal interface: that it started, failed to connect, launched a session or stopped preview environments, and which tabs were used. Disabled by `telemetry: false` like the rest of mirrord's telemetry.

--- a/mirrord/analytics/src/lib.rs
+++ b/mirrord/analytics/src/lib.rs
@@ -273,11 +273,16 @@ pub trait Reporter: Sized {
 pub enum ReportTarget {
     ClientSession,
     UpSession,
+    /// One action inside the mirrord terminal interface. Several are reported per run, tied
+    /// together by a `run_id` property.
+    TuiEvent,
 }
 
 /// Header the client sets to tell the analytics-server which event a report is.
-/// The server maps known values to PostHog event names and treats anything
-/// unrecognized (or missing) as a client session.
+///
+/// The server maps each known value to its own PostHog event name. A *missing* header is taken as
+/// a client session, for older CLIs; an *unrecognized* one is rejected with 400, so every value
+/// here has to exist server-side before a build that sends it ships.
 pub const EVENT_KIND_HEADER: &str = "x-mirrord-event-kind";
 
 impl ReportTarget {
@@ -286,6 +291,7 @@ impl ReportTarget {
         match self {
             ReportTarget::ClientSession => "client-session",
             ReportTarget::UpSession => "up-session",
+            ReportTarget::TuiEvent => "tui-event",
         }
     }
 }
@@ -327,6 +333,35 @@ impl AnalyticsReporter {
             watch,
             target: ReportTarget::ClientSession,
             session_key,
+        }
+    }
+
+    /// Reports one action taken inside the mirrord terminal interface.
+    ///
+    /// `run_id` is shared by every report from the same run of the interface, which is what makes
+    /// a run reconstructable from events that are sent as they happen rather than summarized at
+    /// the end.
+    pub fn for_tui_event(
+        enabled: bool,
+        watch: drain::Watch,
+        machine_id: Uuid,
+        run_id: Uuid,
+    ) -> Self {
+        let mut analytics = Analytics::default();
+        analytics.add("machine_id", machine_id);
+        analytics.add("run_id", run_id);
+        analytics.add("is_ci", ci_info::is_ci());
+
+        AnalyticsReporter {
+            analytics,
+            error_only_send: false,
+            enabled,
+            error: None,
+            operator_properties: None,
+            start_instant: Instant::now(),
+            watch,
+            target: ReportTarget::TuiEvent,
+            session_key: None,
         }
     }
 

--- a/mirrord/analytics/src/lib.rs
+++ b/mirrord/analytics/src/lib.rs
@@ -350,7 +350,6 @@ impl AnalyticsReporter {
         let mut analytics = Analytics::default();
         analytics.add("machine_id", machine_id);
         analytics.add("run_id", run_id);
-        analytics.add("is_ci", ci_info::is_ci());
 
         AnalyticsReporter {
             analytics,

--- a/mirrord/cli/src/main.rs
+++ b/mirrord/cli/src/main.rs
@@ -1208,7 +1208,9 @@ fn main() -> miette::Result<()> {
             }
             #[cfg(windows)]
             Commands::Pitm(args) => pitm::pitm_command(args)?,
-            Commands::Tui => windows_unsupported!((), "tui", { tui::tui_command().await? }),
+            Commands::Tui => windows_unsupported!((), "tui", {
+                tui::tui_command(watch.clone(), &user_data).await?
+            }),
             Commands::Ui { args, command } => ui::ui_command(*args, command, "/").await?,
             Commands::Wizard { args, no_telemetry } => {
                 ui::wizard_command(args, no_telemetry, watch, &user_data).await?

--- a/mirrord/cli/src/tui.rs
+++ b/mirrord/cli/src/tui.rs
@@ -29,11 +29,6 @@ pub enum TuiCliError {
 
 /// The `mirrord tui` command handler.
 pub(crate) async fn tui_command(watch: drain::Watch, user_data: &UserData) -> CliResult<()> {
-    // Read here for the `telemetry` opt-out; the interface resolves the config again per
-    // connection, for the settings that a change of scope can change while it runs. Resolving up
-    // front is also what reports a broken config as the config error it is, the way every other
-    // subcommand does - left to the interface, the same error would surface as a failure to
-    // connect, once the alternate screen is already up and pointing at the wrong problem.
     let config = LayerConfig::resolve(&mut ConfigContext::default())?;
 
     let telemetry = TelemetrySession {

--- a/mirrord/cli/src/tui.rs
+++ b/mirrord/cli/src/tui.rs
@@ -1,7 +1,11 @@
 //! The `mirrord tui` command - the terminal interface, implemented in the `mirrord-tui` crate.
 
 use miette::Diagnostic;
+use mirrord_config::{LayerConfig, config::ConfigContext};
+use mirrord_tui::TelemetrySession;
 use thiserror::Error;
+
+use crate::user_data::UserData;
 
 #[derive(Debug, Error, Diagnostic)]
 pub enum TuiCliError {
@@ -24,8 +28,23 @@ pub enum TuiCliError {
 }
 
 /// The `mirrord tui` command handler.
-pub(crate) async fn tui_command() -> Result<(), TuiCliError> {
-    mirrord_tui::run()
+pub(crate) async fn tui_command(
+    watch: drain::Watch,
+    user_data: &UserData,
+) -> Result<(), TuiCliError> {
+    // Resolved here only for the `telemetry` opt-out. The interface resolves the config itself for
+    // everything else, per connection, since the scope it connects with can change while it runs.
+    // A config that does not resolve is not this command's problem - the interface reports that on
+    // its own screen - so it just means no reporting.
+    let telemetry = LayerConfig::resolve(&mut ConfigContext::default())
+        .ok()
+        .map(|config| TelemetrySession {
+            enabled: config.telemetry,
+            machine_id: user_data.machine_id(),
+            watch,
+        });
+
+    mirrord_tui::run(telemetry)
         .await
         .map_err(|error| TuiCliError::Exited(error.into()))
 }

--- a/mirrord/cli/src/tui.rs
+++ b/mirrord/cli/src/tui.rs
@@ -5,7 +5,7 @@ use mirrord_config::{LayerConfig, config::ConfigContext};
 use mirrord_tui::TelemetrySession;
 use thiserror::Error;
 
-use crate::user_data::UserData;
+use crate::{CliResult, user_data::UserData};
 
 #[derive(Debug, Error, Diagnostic)]
 pub enum TuiCliError {
@@ -28,23 +28,23 @@ pub enum TuiCliError {
 }
 
 /// The `mirrord tui` command handler.
-pub(crate) async fn tui_command(
-    watch: drain::Watch,
-    user_data: &UserData,
-) -> Result<(), TuiCliError> {
-    // Resolved here only for the `telemetry` opt-out. The interface resolves the config itself for
-    // everything else, per connection, since the scope it connects with can change while it runs.
-    // A config that does not resolve is not this command's problem - the interface reports that on
-    // its own screen - so it just means no reporting.
-    let telemetry = LayerConfig::resolve(&mut ConfigContext::default())
-        .ok()
-        .map(|config| TelemetrySession {
-            enabled: config.telemetry,
-            machine_id: user_data.machine_id(),
-            watch,
-        });
+pub(crate) async fn tui_command(watch: drain::Watch, user_data: &UserData) -> CliResult<()> {
+    // Read here for the `telemetry` opt-out; the interface resolves the config again per
+    // connection, for the settings that a change of scope can change while it runs. Resolving up
+    // front is also what reports a broken config as the config error it is, the way every other
+    // subcommand does - left to the interface, the same error would surface as a failure to
+    // connect, once the alternate screen is already up and pointing at the wrong problem.
+    let config = LayerConfig::resolve(&mut ConfigContext::default())?;
 
-    mirrord_tui::run(telemetry)
+    let telemetry = TelemetrySession {
+        enabled: config.telemetry,
+        machine_id: user_data.machine_id(),
+        watch,
+    };
+
+    mirrord_tui::run(Some(telemetry))
         .await
-        .map_err(|error| TuiCliError::Exited(error.into()))
+        .map_err(|error| TuiCliError::Exited(error.into()))?;
+
+    Ok(())
 }

--- a/mirrord/cli/src/tui.rs
+++ b/mirrord/cli/src/tui.rs
@@ -29,10 +29,10 @@ pub enum TuiCliError {
 
 /// The `mirrord tui` command handler.
 pub(crate) async fn tui_command(watch: drain::Watch, user_data: &UserData) -> CliResult<()> {
-    let config = LayerConfig::resolve(&mut ConfigContext::default())?;
+    let telemetry_enabled = LayerConfig::resolve(&mut ConfigContext::default())?.telemetry;
 
     let telemetry = TelemetrySession {
-        enabled: config.telemetry,
+        enabled: telemetry_enabled,
         machine_id: user_data.machine_id(),
         watch,
     };

--- a/mirrord/tui/Cargo.toml
+++ b/mirrord/tui/Cargo.toml
@@ -17,6 +17,7 @@ edition.workspace = true
 workspace = true
 
 [dependencies]
+mirrord-analytics = { path = "../analytics" }
 mirrord-config = { path = "../config" }
 mirrord-kube = { path = "../kube" }
 mirrord-operator = { path = "../operator", default-features = false, features = [
@@ -25,6 +26,7 @@ mirrord-operator = { path = "../operator", default-features = false, features = 
 
 anyhow.workspace = true
 crossterm.workspace = true
+drain.workspace = true
 futures-util.workspace = true
 humantime.workspace = true
 k8s-openapi.workspace = true
@@ -52,6 +54,7 @@ tokio = { workspace = true, features = [
 tracing.workspace = true
 tracing-subscriber.workspace = true
 tui-term.workspace = true
+uuid.workspace = true
 vt100.workspace = true
 
 # For redirecting the stderr that auth exec plugins inherit, and — on macOS, which has no `/proc` to

--- a/mirrord/tui/src/app.rs
+++ b/mirrord/tui/src/app.rs
@@ -27,7 +27,9 @@ use crate::{
         queues::QueuesScreen, sessions::SessionsScreen, targets::TargetsScreen,
         terminal::TerminalScreen,
     },
-    status, theme,
+    status,
+    telemetry::Telemetry,
+    theme,
     widgets::picker::{Picker, PickerOutcome},
 };
 
@@ -69,11 +71,12 @@ pub struct App {
     /// Whether `e` has opened the connection error dialog. Only ever true while the last
     /// connection attempt failed - `connect` closes it again.
     error_details: bool,
+    telemetry: Telemetry,
 }
 
 impl App {
     /// Builds the application.
-    pub fn new() -> Self {
+    pub fn new(telemetry: Telemetry) -> Self {
         let scope = watch::Sender::new(Scope::default());
         let client = watch::Sender::new(None);
         let local_sessions = watch::Sender::new(None);
@@ -87,6 +90,7 @@ impl App {
             local_sessions.subscribe(),
             local_only.subscribe(),
             redraw.clone(),
+            telemetry.clone(),
         );
 
         Self {
@@ -108,6 +112,7 @@ impl App {
             picker: None,
             fetched_namespaces: Arc::default(),
             error_details: false,
+            telemetry,
         }
     }
 
@@ -184,6 +189,7 @@ impl App {
 
         let scope = scope.clone();
         let client = self.client.clone();
+        let telemetry = self.telemetry.clone();
 
         let handle = tokio::spawn(async move {
             let result = async {
@@ -202,6 +208,7 @@ impl App {
                 // The status bar and its dialog only have room for a summary of this; the log is
                 // where the whole thing has to survive.
                 tracing::error!("Failed to connect to the cluster: {error:#}");
+                telemetry.connection_failed();
             }
 
             _ = client.send_replace(Some(result));
@@ -273,16 +280,7 @@ impl App {
         let mut active = (0usize, 0usize);
 
         for (index, variant) in ActiveScreen::VARIANTS.iter().enumerate() {
-            let label = match variant {
-                ActiveScreen::Home => "Home",
-                ActiveScreen::Targets => "Targets",
-                ActiveScreen::Sessions => "Sessions",
-                ActiveScreen::Databases => "Databases",
-                ActiveScreen::Queues => "Queues",
-                ActiveScreen::PreviewEnvs => "Preview Environments",
-                ActiveScreen::Terminal => "Terminal",
-            };
-            let padded = format!("  {label}  ");
+            let padded = format!("  {}  ", variant.label());
             let padded_width = padded.chars().count();
             if index == self.active as usize {
                 active = (cursor, padded_width);
@@ -472,11 +470,13 @@ impl App {
                 let current = self.active as usize;
                 let count = ActiveScreen::COUNT;
                 self.active = ActiveScreen::from_repr((current + 1) % count).unwrap();
+                self.telemetry.tab_visited(self.active.label());
             }
             KeyCode::BackTab => {
                 let current = self.active as usize;
                 let count = ActiveScreen::COUNT;
                 self.active = ActiveScreen::from_repr((current + count - 1) % count).unwrap();
+                self.telemetry.tab_visited(self.active.label());
             }
             _ => {}
         }
@@ -495,4 +495,19 @@ enum ActiveScreen {
     Queues,
     PreviewEnvs,
     Terminal,
+}
+
+impl ActiveScreen {
+    /// The tab's name in the header, and the key its visits are counted under in telemetry.
+    fn label(self) -> &'static str {
+        match self {
+            ActiveScreen::Home => "Home",
+            ActiveScreen::Targets => "Targets",
+            ActiveScreen::Sessions => "Sessions",
+            ActiveScreen::Databases => "Databases",
+            ActiveScreen::Queues => "Queues",
+            ActiveScreen::PreviewEnvs => "Preview Environments",
+            ActiveScreen::Terminal => "Terminal",
+        }
+    }
 }

--- a/mirrord/tui/src/app.rs
+++ b/mirrord/tui/src/app.rs
@@ -189,7 +189,6 @@ impl App {
 
         let scope = scope.clone();
         let client = self.client.clone();
-        let telemetry = self.telemetry.clone();
 
         let handle = tokio::spawn(async move {
             let result = async {
@@ -208,7 +207,6 @@ impl App {
                 // The status bar and its dialog only have room for a summary of this; the log is
                 // where the whole thing has to survive.
                 tracing::error!("Failed to connect to the cluster: {error:#}");
-                telemetry.connection_failed();
             }
 
             _ = client.send_replace(Some(result));

--- a/mirrord/tui/src/context.rs
+++ b/mirrord/tui/src/context.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use kube::Client;
 use tokio::sync::{Notify, watch};
 
-use crate::{local_sessions::LocalSessions, scope::Scope};
+use crate::{local_sessions::LocalSessions, scope::Scope, telemetry::Telemetry};
 
 /// The application context.
 ///
@@ -21,6 +21,8 @@ pub struct Context {
     pub local_only: watch::Receiver<bool>,
     /// Scheduled redraw request for the application.
     pub redraw: Arc<Notify>,
+    /// Anonymous usage reporting, which does nothing unless the caller asked for it.
+    pub telemetry: Telemetry,
 }
 
 impl Context {
@@ -31,6 +33,7 @@ impl Context {
         local_sessions: watch::Receiver<Option<LocalSessions>>,
         local_only: watch::Receiver<bool>,
         redraw: Arc<Notify>,
+        telemetry: Telemetry,
     ) -> Self {
         Self {
             scope,
@@ -38,6 +41,7 @@ impl Context {
             local_sessions,
             local_only,
             redraw,
+            telemetry,
         }
     }
 

--- a/mirrord/tui/src/lib.rs
+++ b/mirrord/tui/src/lib.rs
@@ -23,17 +23,22 @@ mod scope;
 mod screens;
 mod status;
 mod stderr;
+mod telemetry;
 mod theme;
 mod widgets;
 
 use app::App;
+pub use telemetry::Session as TelemetrySession;
 
 /// Runs the interface until the user quits.
 ///
 /// Deliberately does *not* install a tracing subscriber: the caller owns global process state, and
 /// a second `init` would panic against the one the CLI has already set up. The standalone binary
 /// sets its own up before calling this.
-pub async fn run() -> anyhow::Result<()> {
+pub async fn run(telemetry: Option<TelemetrySession>) -> anyhow::Result<()> {
+    let telemetry = telemetry::Telemetry::new(telemetry);
+    telemetry.started();
+
     // The enhancement flags make terminals speaking the kitty keyboard
     // protocol forward modifier detail - notably Cmd on macOS, which
     // legacy encodings cannot express. Terminals that don't know the
@@ -62,7 +67,7 @@ pub async fn run() -> anyhow::Result<()> {
     let chained = Arc::clone(&caller_hook);
     std::panic::set_hook(Box::new(move |info| chained(info)));
 
-    let mut app = App::new();
+    let mut app = App::new(telemetry.clone());
     let mut terminal = ratatui::init();
     // Best-effort for the same reason as above, and more so here: by this point stderr is captured,
     // the panic hook is replaced and the alternate screen is up, so returning through `?` would
@@ -79,6 +84,10 @@ pub async fn run() -> anyhow::Result<()> {
     }));
 
     let result = app.run(&mut terminal).await;
+
+    // Only reached when the interface is quit rather than killed, which is why the tab counts it
+    // carries are the one part of this that is allowed to go missing.
+    telemetry.closed();
 
     let _ = execute!(stdout(), DisableBracketedPaste);
     let _ = execute!(stdout(), PopKeyboardEnhancementFlags);

--- a/mirrord/tui/src/main.rs
+++ b/mirrord/tui/src/main.rs
@@ -20,5 +20,6 @@ async fn main() -> anyhow::Result<()> {
             .init();
     }
 
-    mirrord_tui::run().await
+    // No telemetry: this binary exists for working on the interface itself.
+    mirrord_tui::run(None).await
 }

--- a/mirrord/tui/src/screens/preview_envs.rs
+++ b/mirrord/tui/src/screens/preview_envs.rs
@@ -15,7 +15,7 @@ use ratatui::{
 };
 use tokio::sync::watch;
 
-use crate::{context::Context, helpers::centered, screens::Screen};
+use crate::{context::Context, helpers::centered, screens::Screen, telemetry::Telemetry};
 
 mod data;
 mod ui;
@@ -34,6 +34,7 @@ pub struct PreviewEnvsScreen {
     /// not something that belongs in the long-running watch loop.
     client: watch::Receiver<Option<anyhow::Result<Client>>>,
     ui: UiState,
+    telemetry: Telemetry,
 }
 
 impl PreviewEnvsScreen {
@@ -66,6 +67,8 @@ impl PreviewEnvsScreen {
             }
         };
 
+        self.telemetry.preview_envs_stopped(candidates.len() as u32);
+
         tokio::spawn(async move {
             for candidate in candidates {
                 let api: Api<PreviewSession> =
@@ -87,6 +90,7 @@ impl Screen for PreviewEnvsScreen {
     fn new(context: Context) -> Self {
         let data = Arc::new(RwLock::new(None));
         let client = context.client.clone();
+        let telemetry = context.telemetry.clone();
 
         tokio::spawn(data::run(context, data.clone()));
 
@@ -94,6 +98,7 @@ impl Screen for PreviewEnvsScreen {
             data,
             client,
             ui: UiState::default(),
+            telemetry,
         }
     }
 

--- a/mirrord/tui/src/screens/targets/launch.rs
+++ b/mirrord/tui/src/screens/targets/launch.rs
@@ -271,6 +271,8 @@ impl Launch {
 
         let pid = child.id().unwrap_or_default();
         tracing::debug!(binary = %binary.display(), pid, config = %config_path.display(), "spawned mirrord up");
+        // Reported once the spawn succeeded, so a session that never started is not counted as one.
+        context.telemetry.session_started();
         let mut first_lines = vec![format!("$ mirrord up -f {}", config_path.display())];
         first_lines.extend(note);
         first_lines.extend(layer_note);

--- a/mirrord/tui/src/telemetry.rs
+++ b/mirrord/tui/src/telemetry.rs
@@ -114,10 +114,9 @@ impl Telemetry {
         }
     }
 
-    /// The interface exited on its own terms, with how often each tab was visited.
+    /// The interface is exiting gracefully. Report how often each tab was visited.
     ///
-    /// Lost whenever the interface is killed rather than quit, which is the common case - the
-    /// counts describe the runs that ended in `q` or `Ctrl+C`, not all of them.
+    /// This event will be lost whenever the TUI is killed rather than quit with `q` or `Ctrl+C`.
     pub fn closed(&self) {
         let Some(inner) = &self.0 else { return };
 

--- a/mirrord/tui/src/telemetry.rs
+++ b/mirrord/tui/src/telemetry.rs
@@ -21,8 +21,6 @@ use std::{
 use mirrord_analytics::{Analytics, AnalyticsReporter, Reporter};
 use uuid::Uuid;
 
-/// What a report is about.
-///
 /// Sent as a number rather than a name because [`mirrord_analytics::AnalyticValue`] deliberately
 /// has no string variant, which is what keeps target names and namespaces out of telemetry by
 /// construction. `execution_kind` is reported the same way.
@@ -36,9 +34,7 @@ enum Action {
     Closed = 5,
 }
 
-/// What the caller has to provide before anything is reported.
 pub struct Session {
-    /// Whether the mirrord config leaves telemetry on.
     pub enabled: bool,
     /// Random per-machine identifier, from the CLI's user data.
     pub machine_id: Uuid,
@@ -46,8 +42,6 @@ pub struct Session {
     pub watch: drain::Watch,
 }
 
-/// Reports interface usage, or does nothing at all.
-///
 /// Cheap to clone: every screen gets one through [`crate::context::Context`].
 #[derive(Clone, Default)]
 pub struct Telemetry(Option<Arc<Inner>>);
@@ -63,7 +57,6 @@ struct Inner {
 }
 
 impl Telemetry {
-    /// Reports nothing.
     pub fn disabled() -> Self {
         Self(None)
     }
@@ -82,13 +75,12 @@ impl Telemetry {
         })))
     }
 
-    /// The interface opened.
     pub fn started(&self) {
         self.report(Action::Started, |_| {});
     }
 
-    /// A connection attempt to the cluster failed. Reported without the reason: the error text is
-    /// arbitrary, and the point is how often people are blocked here at all.
+    /// Reported without the reason: the error text is arbitrary, and the point is how often
+    /// people are blocked here at all.
     pub fn connection_failed(&self) {
         self.report(Action::ConnectionFailed, |_| {});
     }

--- a/mirrord/tui/src/telemetry.rs
+++ b/mirrord/tui/src/telemetry.rs
@@ -24,11 +24,13 @@ use uuid::Uuid;
 /// Sent as a number rather than a name because [`mirrord_analytics::AnalyticValue`] deliberately
 /// has no string variant, which is what keeps target names and namespaces out of telemetry by
 /// construction. `execution_kind` is reported the same way.
+///
+/// The numbers are a wire format that reports are queried by, so each is assigned once and never
+/// reused; a gap is an action that is no longer reported.
 #[derive(Debug, Clone, Copy)]
 #[repr(u32)]
 enum Action {
     Started = 1,
-    ConnectionFailed = 2,
     SessionStarted = 3,
     PreviewEnvsStopped = 4,
     Closed = 5,
@@ -77,12 +79,6 @@ impl Telemetry {
 
     pub fn started(&self) {
         self.report(Action::Started, |_| {});
-    }
-
-    /// Reported without the reason: the error text is arbitrary, and the point is how often
-    /// people are blocked here at all.
-    pub fn connection_failed(&self) {
-        self.report(Action::ConnectionFailed, |_| {});
     }
 
     /// A mirrord session was launched from the targets view.

--- a/mirrord/tui/src/telemetry.rs
+++ b/mirrord/tui/src/telemetry.rs
@@ -1,0 +1,154 @@
+//! Anonymous usage reporting for the interface.
+//!
+//! Every action is reported as it happens rather than summarized when the interface exits. A TUI
+//! stays open for a long time and is usually closed by closing its terminal window, which is a
+//! `SIGHUP` that kills the process before any end-of-run report could be sent - a summary would
+//! mostly never arrive, and would be missing precisely the longest sessions. Reporting as things
+//! happen costs one request per action and loses only the last one.
+//!
+//! Every report carries the same `run_id`, so one interface run can be reassembled from its events
+//! (and its length read from their timestamps) even when the closing report never arrives.
+//!
+//! Reporting is off entirely unless the caller supplies a [`Session`]: the standalone `mirrord-tui`
+//! binary is a development tool and reports nothing, and `mirrord tui` passes one only when the
+//! mirrord config leaves `telemetry` on.
+
+use std::{
+    collections::BTreeMap,
+    sync::{Arc, Mutex},
+};
+
+use mirrord_analytics::{Analytics, AnalyticsReporter, Reporter};
+use uuid::Uuid;
+
+/// What a report is about.
+///
+/// Sent as a number rather than a name because [`mirrord_analytics::AnalyticValue`] deliberately
+/// has no string variant, which is what keeps target names and namespaces out of telemetry by
+/// construction. `execution_kind` is reported the same way.
+#[derive(Debug, Clone, Copy)]
+#[repr(u32)]
+enum Action {
+    Started = 1,
+    ConnectionFailed = 2,
+    SessionStarted = 3,
+    PreviewEnvsStopped = 4,
+    Closed = 5,
+}
+
+/// What the caller has to provide before anything is reported.
+pub struct Session {
+    /// Whether the mirrord config leaves telemetry on.
+    pub enabled: bool,
+    /// Random per-machine identifier, from the CLI's user data.
+    pub machine_id: Uuid,
+    /// Keeps the runtime alive until an in-flight report finishes.
+    pub watch: drain::Watch,
+}
+
+/// Reports interface usage, or does nothing at all.
+///
+/// Cheap to clone: every screen gets one through [`crate::context::Context`].
+#[derive(Clone, Default)]
+pub struct Telemetry(Option<Arc<Inner>>);
+
+struct Inner {
+    machine_id: Uuid,
+    watch: drain::Watch,
+    /// Ties this run's reports together.
+    run_id: Uuid,
+    /// How many times each tab was switched to, reported when the interface closes. Ordered so
+    /// the reported object is stable rather than however the map happened to hash.
+    tab_visits: Mutex<BTreeMap<&'static str, u32>>,
+}
+
+impl Telemetry {
+    /// Reports nothing.
+    pub fn disabled() -> Self {
+        Self(None)
+    }
+
+    /// Reports this run under a fresh `run_id`, unless `session` is disabled.
+    pub fn new(session: Option<Session>) -> Self {
+        let Some(session) = session.filter(|session| session.enabled) else {
+            return Self::disabled();
+        };
+
+        Self(Some(Arc::new(Inner {
+            machine_id: session.machine_id,
+            watch: session.watch,
+            run_id: Uuid::new_v4(),
+            tab_visits: Default::default(),
+        })))
+    }
+
+    /// The interface opened.
+    pub fn started(&self) {
+        self.report(Action::Started, |_| {});
+    }
+
+    /// A connection attempt to the cluster failed. Reported without the reason: the error text is
+    /// arbitrary, and the point is how often people are blocked here at all.
+    pub fn connection_failed(&self) {
+        self.report(Action::ConnectionFailed, |_| {});
+    }
+
+    /// A mirrord session was launched from the targets view.
+    pub fn session_started(&self) {
+        self.report(Action::SessionStarted, |_| {});
+    }
+
+    /// Preview environments were stopped, `count` of them by the one command.
+    pub fn preview_envs_stopped(&self, count: u32) {
+        self.report(Action::PreviewEnvsStopped, |analytics| {
+            analytics.add("preview_envs_stopped", count);
+        });
+    }
+
+    /// The user switched to `tab`. Counted rather than reported, and sent by [`Self::closed`].
+    pub fn tab_visited(&self, tab: &'static str) {
+        let Some(inner) = &self.0 else { return };
+
+        if let Ok(mut visits) = inner.tab_visits.lock() {
+            *visits.entry(tab).or_default() += 1;
+        }
+    }
+
+    /// The interface exited on its own terms, with how often each tab was visited.
+    ///
+    /// Lost whenever the interface is killed rather than quit, which is the common case - the
+    /// counts describe the runs that ended in `q` or `Ctrl+C`, not all of them.
+    pub fn closed(&self) {
+        let Some(inner) = &self.0 else { return };
+
+        let visits = match inner.tab_visits.lock() {
+            Ok(visits) => visits.clone(),
+            Err(_) => return,
+        };
+
+        self.report(Action::Closed, |analytics| {
+            let mut tabs = Analytics::default();
+            for (tab, count) in visits {
+                tabs.add(tab, count);
+            }
+            analytics.add("tab_visits", tabs);
+        });
+    }
+
+    /// Builds one report and hands it to the analytics pipeline, which sends it when the reporter
+    /// is dropped at the end of this function.
+    fn report(&self, action: Action, extra: impl FnOnce(&mut Analytics)) {
+        let Some(inner) = &self.0 else { return };
+
+        let mut reporter = AnalyticsReporter::for_tui_event(
+            true,
+            inner.watch.clone(),
+            inner.machine_id,
+            inner.run_id,
+        );
+
+        let analytics = reporter.get_mut();
+        analytics.add("tui_action", action as u32);
+        extra(analytics);
+    }
+}


### PR DESCRIPTION
Third in the stack: #4779 (imports the crate) → #4781 (CI for it) → this. The base here is `tui-ci-standalone`, so this diff is only the analytics.

**Do not merge before metalbear-co/operator#2313 is deployed.**

## What is reported

Each action as it happens, rather than one summary when the interface exits:

| When | Extra |
| --- | --- |
| the interface started | — |
| a connection attempt to the cluster failed | — |
| a session was launched from the targets view | — |
| preview environments were stopped | how many that one command stopped |
| the interface was quit | how many times each tab was switched to |

All five carry the same `run_id`.

## Why not one summary at the end

A TUI stays open a long time and is often closed by closing its terminal window — a `SIGHUP` that kills the process before anything could be sent. A summary would often not arrive.

Reporting as things happen costs one request per major action and loses only the last one. The `run_id` keeps a run reassemblable from its events, and its length readable from their timestamps. The tab counts are the one thing that still rides on a clean exit, which is a deliberate trade for not sending a report per tab switch.

## Notes for review

- **The action is a number, not a name.** `AnalyticValue` deliberately has no string variant — that is what keeps target names and namespaces out of telemetry by construction — so the action is a `#[repr(u32)]` discriminant, the same way `execution_kind` is already reported. The mapping lives in the dashboard.
- **Off by default for the standalone binary.** `run` takes an `Option<TelemetrySession>`; `mirrord-tui` passes `None`, since it exists for working on the interface. `mirrord tui` passes one only when the resolved config leaves `telemetry` on.
- **`EVENT_KIND_HEADER`'s doc comment was wrong** and is corrected here: the server rejects an unrecognized value rather than treating it as a client session. Only a *missing* header falls back, for older CLIs.
- **`mirrord tui` now fails fast on a broken config**, like every other subcommand: `tui_command` resolves it up front and lets the error out, instead of opening the interface and reporting the same problem later as a failure to connect. A missing config is not an error — it resolves to defaults, and telemetry defaults to on.
- The interface reaches the reporter through `Context`, which every screen already clones, so the two action call sites needed no new plumbing.

`TELEMETRY.md` gains a section describing all of the above, and states the opt-out covers it.

