### PR TITLE
Fixed outgoing iovec processing in the agent

### DIFF
--- a/changelog.d/+iovec-outgoing-agent.fixed.md
+++ b/changelog.d/+iovec-outgoing-agent.fixed.md
@@ -1,0 +1,1 @@
+Fixed a bug where the agent could scramble data in tunneled outgoing connections.

--- a/mirrord/agent/src/util/io/throttle.rs
+++ b/mirrord/agent/src/util/io/throttle.rs
@@ -9,7 +9,7 @@ use std::{
     task::{Context, Poll},
 };
 
-use bytes::Bytes;
+use bytes::{Buf, Bytes};
 use futures::{Sink, SinkExt, Stream};
 use pin_project_lite::pin_project;
 use tokio::{
@@ -267,7 +267,7 @@ where
                     if chunk.len() <= written {
                         return true;
                     }
-                    chunk.data = chunk.data.split_to(written);
+                    chunk.data.advance(written);
                     false
                 });
                 if let Some(popped) = popped {
@@ -312,5 +312,90 @@ where
     fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         std::task::ready!(self.as_mut().poll_flush_buffer_down_to(0, cx))?;
         self.project().writer.poll_shutdown(cx)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use futures::SinkExt;
+    use tokio::io::AsyncWrite;
+
+    use super::*;
+
+    /// Accepts at most a fixed number of bytes per
+    /// [`AsyncWrite::poll_write`]/[`AsyncWrite::poll_write_vectored`] call, forcing the
+    /// [`IoVecThrottledSink`] to handle partial writes.
+    struct ShortWriter {
+        max_per_write: usize,
+        written: Vec<u8>,
+    }
+
+    impl AsyncWrite for ShortWriter {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            _: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<io::Result<usize>> {
+            let this = self.get_mut();
+            let accepted = buf.get(..this.max_per_write).unwrap_or(buf);
+            this.written.extend_from_slice(accepted);
+            Poll::Ready(Ok(accepted.len()))
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_shutdown(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_write_vectored(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            bufs: &[io::IoSlice<'_>],
+        ) -> Poll<io::Result<usize>> {
+            let mut total = 0;
+            for buf in bufs {
+                let Poll::Ready(accepted) = self.as_mut().poll_write(cx, buf)? else {
+                    unreachable!()
+                };
+                total += accepted;
+                if accepted < buf.len() {
+                    break;
+                }
+            }
+            Poll::Ready(Ok(total))
+        }
+
+        fn is_write_vectored(&self) -> bool {
+            true
+        }
+    }
+
+    /// Data written through the sink must come out exactly once and in order,
+    /// also when the underlying writer keeps accepting only part of each write.
+    #[tokio::test]
+    async fn handles_partial_writes() {
+        let throttle = Throttle::new(1024 * 1024);
+        let mut sink = ThrottledSink::new(
+            IoVecThrottledSink::new(ShortWriter {
+                max_per_write: 7,
+                written: Vec::new(),
+            }),
+            throttle,
+        );
+
+        let mut expected = Vec::new();
+        for chunk_no in 0u8..10 {
+            let chunk = vec![chunk_no; 10];
+            expected.extend_from_slice(&chunk);
+            sink.feed(Bytes::from(chunk)).await.unwrap();
+        }
+        sink.flush().await.unwrap();
+
+        let written = &sink.sink.writer.written;
+        assert_eq!(written.len(), expected.len());
+        assert_eq!(*written, expected);
     }
 }


### PR DESCRIPTION
<!-- Thank you for contributing to mirrord! -->
<!-- Please use the checklist below as a guide for docs, tests and admin tasks for your PR -->
<!-- Feel free to ~strikethrough~ any items that you don't think apply -->

Simple bug in iovec handling. One line change and a UT.

### Quality Checklist:

- [x] I have documented new code sufficiently
- [x] I have checked and updated the relevant existing docs in code, including removing outdated material
- ~[ ] I have written user-facing website docs for new features, or opened a (sub)issue to do so~
- ~[ ] I have checked and updated existing website docs for changed features~
- [x] I have tested this change and know it succeeds and fails as expected
- [x] I have written unit tests or purposefully omitted them
- [x] I have written e2e tests or purposefully omitted them
- [x] I have explained what this PR introduces and why, and linked to relevant context (e.g. linear issues, related PRs,
  documentation)
- [x] I have introduced a short, clear and well-formatted changelog entry

<!-- need help with the changelog? see ../CONTRIBUTING.md#submitting-a-pull-request -->
<!-- Add more details of your changes below if needed -->