### PR TITLE
Keep docs of items that carry no docs of their own

### DIFF
--- a/changelog.d/3460.fixed.md
+++ b/changelog.d/3460.fixed.md
@@ -1,0 +1,1 @@
+Fixed `medschool` dropping items that carry no documentation of their own, which kept documented enum variants and struct fields out of the generated configuration reference.

--- a/medschool/src/main.rs
+++ b/medschool/src/main.rs
@@ -282,6 +282,50 @@ mod test {
     "#,
     ];
 
+    /// An enum that carries no docs of its own, but whose variants are documented.
+    ///
+    /// This mirrors `TlsDeliveryProtocol` in `mirrord-config`, where the heading lives on the
+    /// referencing field and the enum itself is left undocumented.
+    const UNDOCUMENTED_ENUM_EXPECTED: &str =
+        "# Root\n\n## Root - mode\n\n### Root - mode - local\n\n### Root - mode - remote\n\n";
+
+    const UNDOCUMENTED_ENUM_FILES: [&str; 1] = [r#"
+    /// # Root
+    struct UndocumentedEnumRoot {
+        /// ## Root - mode
+        mode: UndocumentedEnum,
+    }
+
+    enum UndocumentedEnum {
+        /// ### Root - mode - local
+        Local,
+
+        /// ### Root - mode - remote
+        Remote,
+    }
+"#];
+
+    /// An enum marked as internal must stay hidden, docs on its variants notwithstanding.
+    const INTERNAL_ENUM_EXPECTED: &str = "# Root\n\n## Root - mode\n\n";
+
+    const INTERNAL_ENUM_FILES: [&str; 1] = [r#"
+    /// # Root
+    struct InternalEnumRoot {
+        /// ## Root - mode
+        mode: InternalEnum,
+    }
+
+    /// <!--${internal}-->
+    /// # Should not show up
+    enum InternalEnum {
+        /// ### Should not show up either
+        Local,
+
+        /// ### Nor this one
+        Remote,
+    }
+"#];
+
     fn parse_string_files(files: Vec<String>) -> Vec<syn::File> {
         files
             .into_iter()
@@ -333,5 +377,33 @@ mod test {
         let root_type = resolve_references(type_docs.clone()).unwrap();
         let final_docs = root_type.produce_docs();
         assert_eq!(final_docs, UNORDERED_EXPECTED);
+    }
+
+    /// Regression test for [#3460](https://github.com/metalbear-co/mirrord/issues/3460).
+    ///
+    /// An item with no docs of its own is still worth keeping: dropping it would take the docs
+    /// on its variants out of `configuration.md` along with it.
+    #[test]
+    fn undocumented_enum_keeps_variant_docs() {
+        let files = parse_string_files(UNDOCUMENTED_ENUM_FILES.map(ToOwned::to_owned).to_vec());
+
+        let type_docs = super::parse_docs_into_set(files).unwrap();
+        let root_type = resolve_references(type_docs).unwrap();
+        let final_docs = root_type.produce_docs();
+
+        assert_eq!(final_docs, UNDOCUMENTED_ENUM_EXPECTED);
+    }
+
+    /// Counterpart to [`undocumented_enum_keeps_variant_docs`]: `<!--${internal}-->` is the one
+    /// thing that does drop the whole item.
+    #[test]
+    fn internal_enum_is_still_hidden() {
+        let files = parse_string_files(INTERNAL_ENUM_FILES.map(ToOwned::to_owned).to_vec());
+
+        let type_docs = super::parse_docs_into_set(files).unwrap();
+        let root_type = resolve_references(type_docs).unwrap();
+        let final_docs = root_type.produce_docs();
+
+        assert_eq!(final_docs, INTERNAL_ENUM_EXPECTED);
     }
 }

--- a/medschool/src/parse.rs
+++ b/medschool/src/parse.rs
@@ -10,6 +10,12 @@ use crate::{
 };
 
 /// Look into the [`syn::Attribute`]s of whatever item we're handling, and extract its doc strings.
+///
+/// [`None`] keeps the item out of `configuration.md` entirely, which only the
+/// `<!--${internal}-->` tag asks for. An item that simply carries no docs of its own yields an
+/// empty [`Vec`], so that whatever _is_ documented about it -- the fields of a struct, the
+/// variants of an enum -- still reaches the reference. Collapsing the two cases into [`None`]
+/// drops the item wholesale, taking those docs with it.
 #[tracing::instrument(level = "trace", ret)]
 pub fn docs_from_attributes(attributes: Vec<Attribute>) -> Option<Vec<String>> {
     // + 1 when a field appends in `resolve_references`
@@ -64,12 +70,11 @@ pub fn docs_from_attributes(attributes: Vec<Attribute>) -> Option<Vec<String>> {
         }
     }
 
-    if docs.is_empty() {
-        return None;
+    if !docs.is_empty() {
+        // New line to separate this types' docs from the next types' docs.
+        docs.push("\n".to_owned());
     }
 
-    // New line to separate this types' docs from the next types' docs.
-    docs.push("\n".to_owned());
     Some(docs)
 }
 
@@ -126,8 +131,8 @@ impl TryFrom<syn::ItemMod> for PartialType<'_> {
     }
 }
 
-/// Converts a [`syn::ItemEnum`] into a [`PartialType`].
-/// Currently, we don't handle enum variants as fields, we just use its top-level docs.
+/// Converts a [`syn::ItemEnum`] into a [`PartialType`], keeping the docs of both the enum itself
+/// and of each of its variants.
 impl TryFrom<syn::ItemEnum> for PartialType<'_> {
     type Error = ();
 


### PR DESCRIPTION
Closes #3460.

### Quality Checklist:

- [x] I have documented new code sufficiently
- [x] I have checked and updated the relevant existing docs in code, including removing outdated material
- [ ] ~I have written user-facing website docs for new features, or opened a (sub)issue to do so~
- [x] I have checked and updated existing website docs for changed features
- [x] I have tested this change and know it succeeds and fails as expected
- [x] I have written unit tests or purposefully omitted them
- [ ] ~I have written e2e tests or purposefully omitted them~
- [x] I have explained what this PR introduces and why, and linked to relevant context
- [x] I have introduced a short, clear and well-formatted changelog entry

## What

`docs_from_attributes` returns `None` for two unrelated situations: an item explicitly hidden with `<!--${internal}-->`, and an item that simply carries no doc comment of its own. The `TryFrom<syn::Item*>` impls turn that `None` into an `Err` via `.ok_or(())?` and drop the item, so an **undocumented enum or struct is discarded together with the docs on its variants and fields**.

That is the behaviour behind this issue. `FsModeConfig` has an enum-level doc comment, so its variants survive; an enum without one disappears completely. It also explains why the repro suggested in the issue works — editing the enum's own docs is what toggles whether its variants show up at all.

Only `<!--${internal}-->` yields `None` now. An item with no docs of its own yields an empty `Vec` and keeps whatever is documented beneath it.

## Effect on `configuration.md`

Regenerated with `cargo run -p medschool -- --input ./mirrord/config/src --output configuration.md`, the diff is **+280 lines, -0**. Nothing that was previously documented is lost; two config areas that were silently missing come back:

- **`InnerFilter`** (`feature/network/incoming/http_filter.rs`) — an enum with no doc comment of its own, whose variants document `body_filter`, `body_filter.json`, `header_filter`, `header_filter_jq` and `path_filter`. All of it was absent from the reference.
- **`PreviewLabelsConfig`** (`feature/preview.rs`) — a struct with no doc comment of its own, documenting `feature.preview.labels.include` and `feature.preview.labels.exclude`.

## One thing worth flagging

Restoring `InnerFilter` adds 5 duplicate anchors, because `HttpFilterConfig` references it from both `all_of` and `any_of`, and medschool inlines a referenced type's subtree once per reference. The anchors in those doc comments are hardcoded, so both copies claim `{#feature-network-incoming-inner-body-filter}` and friends.

This is pre-existing behaviour rather than something introduced here — `LocalTlsDelivery` is duplicated the same way today via `https_delivery`/`tls_delivery`, and the generated file already contains 7 duplicate anchors on `main`. I left it alone to keep this PR on the issue, and I'd argue documenting the inner filters twice beats not documenting them at all, but happy to follow up separately if you'd like the inlining deduplicated.

I also asked in the issue about the `{#feature-fs-mode}` duplication (the `mode` field in `feature/fs/advanced.rs` and the `FsModeConfig` enum both carry a heading with that anchor) and about three copy-paste anchor typos in the config docs. Those are source-doc fixes rather than medschool ones, so they're not in this PR — tell me which way you want them and I'll open another.

## Tests

Two regression tests in `medschool/src/main.rs`, alongside the existing fixture-based ones:

- `undocumented_enum_keeps_variant_docs` — fails on `main` with `"# Root\n\n## Root - mode\n\n"` against the expected output that includes both variants.
- `internal_enum_is_still_hidden` — pins the other half of the contract, so `<!--${internal}-->` keeps dropping the whole item.

The three pre-existing tests are unchanged and still pass. Verified with the pinned `nightly-2026-08-13` toolchain:

```
cargo test -p medschool                  # 5 passed
cargo clippy -p medschool --all-targets --all-features -- -Wclippy::indexing_slicing -D warnings
cargo fmt -p medschool -- --check
```
