### PR TITLE
feat(monitor): record whether the local API answered on blocking events

### DIFF
--- a/changelog.d/+monitor-failure-classification.internal.md
+++ b/changelog.d/+monitor-failure-classification.internal.md
@@ -1,0 +1,1 @@
+Classify session monitor blocking telemetry by whether the local API answered, so a single unreachable API is distinguishable from a server-side error.

--- a/packages/monitor/src/analytics.ts
+++ b/packages/monitor/src/analytics.ts
@@ -1,4 +1,5 @@
 import posthog from 'posthog-js'
+import { ApiError } from './apiError'
 
 const POSTHOG_KEY = 'phc_wIZh92nyk4vu6HidiLFUzjW6piZlZszuWZZFBS7yHHe'
 const POSTHOG_HOST = 'https://hog.metalbear.com'
@@ -98,25 +99,47 @@ export function trackEvent(
   posthog.capture(event, { source: 'session-monitor', ...properties })
 }
 
+/**
+ * Whether the local API answered, which `reason` alone cannot say: one session ending under
+ * an open tab fails every poller and every pending action at once, so a single outage arrives
+ * as several unrelated-looking reasons. The message cannot separate them either — a `fetch`
+ * that never reached the server rejects with a `TypeError` phrased per browser ("Failed to
+ * fetch", "NetworkError when attempting to fetch resource.", "Load failed"), splitting one
+ * condition across three buckets, while a server that answered and refused can phrase its body
+ * to look like a network error. The status is the only reliable signal, so carry it as an axis.
+ */
+function apiFailure(
+  properties: Record<string, unknown>,
+  error: unknown,
+): string {
+  if (error instanceof ApiError || typeof properties['status'] === 'number')
+    return 'response'
+  if (error instanceof TypeError) return 'transport'
+  return 'unknown'
+}
+
 // Every event these two emit describes something a person was trying to do, including a
 // crash, which stops them mid-task just as surely as a failed request does. Background
 // liveness signals are deliberately not reported through here: they track how long a tab
 // stayed open rather than whether anyone was affected, so mixing them in makes the
-// blocked-versus-succeeded ratio unreadable. `reason` is the only axis a breakdown needs.
+// blocked-versus-succeeded ratio unreadable.
 export function emitUserBlocked(
   reason: string,
   properties: Record<string, unknown> = {},
   error?: unknown,
 ): void {
+  const failure = apiFailure(properties, error)
   trackEvent('monitor_user_blocked', {
     reason,
     surface: 'monitor',
+    failure,
     ...properties,
   })
   if (error !== undefined && initialized) {
     posthog.captureException(error, {
       reason,
       surface: 'monitor',
+      failure,
       ...properties,
     })
   }

--- a/packages/monitor/src/api.ts
+++ b/packages/monitor/src/api.ts
@@ -8,6 +8,7 @@ import type {
   SessionInfo,
 } from './types'
 import { emitUserBlocked, emitUserSucceeded } from './analytics'
+import { ApiError } from './apiError'
 
 const HTTP_NOT_FOUND = 404
 
@@ -51,7 +52,10 @@ export const api = {
       credentials: 'include',
     })
     if (!r.ok) {
-      throw new Error(`Failed to fetch sessions: ${r.status} ${r.statusText}`)
+      throw new ApiError(
+        r.status,
+        `Failed to fetch sessions: ${r.status} ${r.statusText}`,
+      )
     }
     const data = (await r.json()) as SessionInfo[]
     return data
@@ -92,10 +96,14 @@ export const api = {
         },
       )
     } catch (err) {
-      emitUserBlocked('session_kill_failed', {
-        session_id: sessionId,
-        error: err instanceof Error ? err.message : String(err),
-      })
+      emitUserBlocked(
+        'session_kill_failed',
+        {
+          session_id: sessionId,
+          error: err instanceof Error ? err.message : String(err),
+        },
+        err,
+      )
       return
     }
     if (!r.ok) {
@@ -120,7 +128,7 @@ export const api = {
     })
     if (!r.ok) {
       if (r.status === HTTP_NOT_FOUND) return []
-      throw new Error(await chaosErrorMessage(r))
+      throw new ApiError(r.status, await chaosErrorMessage(r))
     }
     return (await r.json()) as ChaosRule[]
   },
@@ -138,8 +146,9 @@ export const api = {
     if (!r.ok) {
       emitUserBlocked('chaos_rule_create_failed', {
         session_id: sessionId,
+        status: r.status,
       })
-      throw new Error(await chaosErrorMessage(r))
+      throw new ApiError(r.status, await chaosErrorMessage(r))
     }
     emitUserSucceeded('chaos_rule_created', {
       session_id: sessionId,
@@ -162,8 +171,9 @@ export const api = {
       emitUserBlocked('chaos_rule_update_failed', {
         session_id: sessionId,
         rule_id: ruleId,
+        status: r.status,
       })
-      throw new Error(await chaosErrorMessage(r))
+      throw new ApiError(r.status, await chaosErrorMessage(r))
     }
     emitUserSucceeded('chaos_rule_updated', {
       session_id: sessionId,
@@ -181,8 +191,9 @@ export const api = {
       emitUserBlocked('chaos_rule_delete_failed', {
         session_id: sessionId,
         rule_id: ruleId,
+        status: r.status,
       })
-      throw new Error(await chaosErrorMessage(r))
+      throw new ApiError(r.status, await chaosErrorMessage(r))
     }
     emitUserSucceeded('chaos_rule_deleted', {
       session_id: sessionId,
@@ -204,7 +215,8 @@ export const api = {
       : '/api/v2/operator/sessions'
     const r = await fetch(withToken(path), { credentials: 'include' })
     if (!r.ok) {
-      throw new Error(
+      throw new ApiError(
+        r.status,
         `Failed to fetch operator sessions: ${r.status} ${r.statusText}`,
       )
     }
@@ -231,7 +243,10 @@ export const api = {
       credentials: 'include',
     })
     if (!r.ok)
-      throw new Error(`Failed to fetch contexts: ${r.status} ${r.statusText}`)
+      throw new ApiError(
+        r.status,
+        `Failed to fetch contexts: ${r.status} ${r.statusText}`,
+      )
     const data = (await r.json()) as ContextsResponse
     return data
   },
@@ -246,7 +261,10 @@ export const api = {
       },
     )
     if (!r.ok)
-      throw new Error(`Failed to fetch namespaces: ${r.status} ${r.statusText}`)
+      throw new ApiError(
+        r.status,
+        `Failed to fetch namespaces: ${r.status} ${r.statusText}`,
+      )
     const data = (await r.json()) as NamespacesResponse
     return data
   },

--- a/packages/monitor/src/apiError.ts
+++ b/packages/monitor/src/apiError.ts
@@ -1,0 +1,13 @@
+/**
+ * A non-ok response from the local API. Distinguishes "the server answered and refused" from
+ * a `fetch` rejection, which means the browser never reached the server at all.
+ */
+export class ApiError extends Error {
+  readonly status: number
+
+  constructor(status: number, message: string) {
+    super(message)
+    this.name = 'ApiError'
+    this.status = status
+  }
+}

--- a/packages/monitor/src/components/SessionDetail.tsx
+++ b/packages/monitor/src/components/SessionDetail.tsx
@@ -84,10 +84,14 @@ export default function SessionDetail({
       } catch (err) {
         const error = err instanceof Error ? err.message : String(err)
         console.warn('Failed to fetch session snapshot', err)
-        emitUserBlocked('snapshot_fetch_failed', {
-          session_id: session.session_id,
-          error,
-        })
+        emitUserBlocked(
+          'snapshot_fetch_failed',
+          {
+            session_id: session.session_id,
+            error,
+          },
+          err,
+        )
       }
     }
     void hydrateFromSnapshot()


### PR DESCRIPTION
## Summary

The session monitor reports a blocked user with a `reason` and a free-text `error`. Neither says the thing that matters most when triaging: **did the local API answer at all?**

That gap has two consequences today.

**One outage looks like several bugs.** A mirrord session ending while a monitor tab is open fails the chaos-rule poller, the snapshot fetch, and any pending kill at the same moment. Each emits under its own reason, so a single connectivity event arrives as a handful of apparently unrelated feature failures. The top reason in a breakdown then reads as "the chaos pane is broken" when nothing about chaos rules is broken.

**The message cannot be used to separate them.** A `fetch` that never reached the server rejects with a `TypeError` whose text is browser-specific: `Failed to fetch` on Chromium, `NetworkError when attempting to fetch resource.` on Firefox, `Load failed` on Safari. One condition, three buckets, split by browser rather than by cause. String matching does not rescue this either, because the local API can answer with a body that reads like a network error, e.g. a 500 whose body is `Connection refused (os error 61)`, which is a server response and should not be counted as unreachable.

So carry the distinction as its own axis instead of inferring it:

- Non-ok responses from the local API throw an `ApiError` that holds the status. Previously they threw a bare `Error`, and the status was lost at the point where it was still known.
- `emitUserBlocked` derives `failure` as `transport` (the browser never reached the server), `response` (the server answered and refused), or `unknown` (not an API call, such as a render crash), and puts it on both the event and the captured exception.
- The three chaos-rule mutation events emitted with no failure information at all; they now carry `status`.

No user-visible behaviour changes. This is only what the events say about themselves.

## Test plan

Gates, in `packages/monitor` unless noted:

- `pnpm --filter session-monitor-frontend typecheck` — pass
- `pnpm --filter session-monitor-frontend lint` — pass
- `pnpm --filter session-monitor-frontend format:check` — pass
- `pnpm --filter mirrord-ui build` — pass

Behaviour, exercised in a real browser against the built `packages/ui/dist` bundle, with a stub local API and PostHog intercepted so the actual outgoing payloads could be decoded and read:

| local API behaviour | decoded `monitor_user_blocked` |
|---|---|
| answers `500` with body `Something went wrong: Connection refused (os error 61)` | `reason=chaos_rules_load_failed`, `failure=response` |
| socket destroyed mid-request | `reason=chaos_rules_load_failed`, `failure=transport` |

The first case is the one worth noting: the body names a connection refusal, and it is still correctly classified as a response rather than as unreachable.

Negative control on the same harness, with the branch stashed and the bundle rebuilt from `origin/main`: both cases emit `failure=undefined` and are separable only by the browser-specific error string. Restoring the branch and rebuilding reproduced the verified bundle hashes.

Not exercised: a real `mirrord ui` server (the API was stubbed), and Firefox/Safari, whose distinct rejection messages are quoted from telemetry rather than reproduced locally. The classification does not read the message, so it is insensitive to that wording by construction.
