### PR TITLE
COR-1830 Delete conntrack with reply source port filter

### DIFF
--- a/changelog.d/+conntrack-delete.fixed.md
+++ b/changelog.d/+conntrack-delete.fixed.md
@@ -1,0 +1,1 @@
+Fixed an issue where `conntrack -D` flush entries of newly redirected incoming connections.

--- a/mirrord/agent/env/src/envs.rs
+++ b/mirrord/agent/env/src/envs.rs
@@ -28,15 +28,13 @@ pub const STEALER_FLUSH_CONNECTIONS: CheckedEnv<bool> =
 /// Controls whether the connection flush (see [`STEALER_FLUSH_CONNECTIONS`]) uses a `conntrack -D`
 /// command in addition to `ss -K`.
 ///
-/// The `conntrack -D --dport <port>` call also deletes the conntrack entries of connections that
-/// were just redirected to the agent but not yet accepted. When that happens, the agent can no
-/// longer resolve their original destination via `SO_ORIGINAL_DST` (the lookup fails with
-/// `ENOENT`) and has to drop them. On busy stolen ports this produces a burst of dropped
-/// connections every time stealing starts.
+/// The `conntrack -D` call is scoped with `--reply-port-src` so that it only deletes entries of
+/// connections that were not redirected to the agent. Without that filter it also deleted the
+/// entries of connections that had just been redirected but not yet accepted, leaving the agent
+/// unable to resolve their original destination via `SO_ORIGINAL_DST` (the lookup fails with
+/// `ENOENT`).
 ///
-/// Defaults to `true` (i.e. `conntrack -D` is used). Set to `false` to flush using only `ss -K`,
-/// avoiding the dropped-connection burst at the cost of not flushing connections that `ss` can't
-/// reach.
+/// Defaults to `true` (i.e. `conntrack -D` is used). Set to `false` to flush using only `ss -K`.
 pub const STEALER_FLUSH_CONNECTIONS_CONNTRACK: CheckedEnv<bool> =
     CheckedEnv::new("MIRRORD_AGENT_STEALER_FLUSH_CONNECTIONS_CONNTRACK");
 

--- a/mirrord/agent/iptables/src/flush_connections.rs
+++ b/mirrord/agent/iptables/src/flush_connections.rs
@@ -81,23 +81,34 @@ where
 
         // Update existing connections of specific port to be marked
         // so that they will be rejected by the rule we added in `create`.
-        //
-        // Skipped when disabled, because `conntrack -D` also deletes the conntrack entries of
-        // connections that were just redirected to the agent, making the agent drop them when it
-        // fails to resolve their original destination.
         if self.conntrack {
-            let conntrack_output = Command::new("conntrack")
-                .args([
-                    "-D",
-                    "-p",
-                    "tcp",
-                    "--dport",
-                    &redirected_port.to_string(),
-                    "--state",
-                    "ESTABLISHED",
-                ])
-                .output()
-                .await?;
+            let port = redirected_port.to_string();
+
+            // `--dport` alone matches both connections that existed before the redirect rule and
+            // connections the rule has just redirected to the agent.
+            // The two only differ in the reply tuple: an untouched connection still replies from
+            // `redirected_port`, while a redirected one replies from the agent's listener port.
+            // Filtering on `--reply-port-src` therefore deletes only the former.
+            let args = [
+                "-D",
+                "-p",
+                "tcp",
+                "--dport",
+                &port,
+                "--reply-port-src",
+                &port,
+                "--state",
+                "ESTABLISHED",
+            ];
+
+            let conntrack_output = Command::new("conntrack").args(args).output().await?;
+
+            tracing::trace!(
+                redirected_port,
+                status = ?conntrack_output.status,
+                stderr = %String::from_utf8_lossy(&conntrack_output.stderr).trim(),
+                "`conntrack -D` command finished",
+            );
 
             if conntrack_output.status.success().not()
                 && conntrack_output


### PR DESCRIPTION
<!-- Thank you for contributing to mirrord! -->
<!-- Please use the checklist below as a guide for docs, tests and admin tasks for your PR -->
<!-- Feel free to ~strikethrough~ any items that you don't think apply -->

When using `conntrack -D` for flushing pre-existing connections, the following could happen:
1. Agent receives port sub. Agent adds redirect rule for <target_port>.
2. Agent runs `conntrack -D --dport <target_port>`.
3. Before step 2 finishes, a new connection is already redirected to the agent. Agent is blocked on finishing `conntrack -D`, and the new connection is queued but not accepted yet.
4. Agent finish step 2 and handle the new redirected connection, and it fails to find the original source port, because conntrack entries is deleted by step 2.

To differentiate entries of existing connections from newly redirected connections, we filter by adding `--reply-port-src <target_port>` to the `conntrack -D` command.

```
#1 tcp      6 116 TIME_WAIT src=10.244.0.1 dst=10.244.0.98 sport=56728 dport=80 src=10.244.0.98 dst=10.244.0.1 sport=35015 dport=56728 [ASSURED] mark=0 use=1

#2 tcp      6 117 TIME_WAIT src=10.244.0.1 dst=10.244.0.98 sport=29598 dport=80 src=10.244.0.98 dst=10.244.0.1 sport=80 dport=29598 [ASSURED] mark=0 use=1
```

The first entry belongs to a redirected connection, note the reply `sport` is 35015 (agent redirect listener port).
The second entry belongs to an existing connection, the reply `sport` is 80 which is the <target_port>.

`conntrack -D --dport 80 --reply-port-src 80` allows us to delete entries like No.2 while keeping No.1. 

### Quality Checklist:

- [x] I have documented new code sufficiently
- [x] I have checked and updated the relevant existing docs in code, including removing outdated material
- [ ] ~~I have written user-facing website docs for new features, or opened a (sub)issue to do so~~
- [ ] ~~I have checked and updated existing website docs for changed features~~
- [x] I have tested this change and know it succeeds and fails as expected
- [ ] ~~I have written unit tests or purposefully omitted them~~
- [ ] ~~I have written e2e tests or purposefully omitted them~~
- [x] I have explained what this PR introduces and why, and linked to relevant context (e.g. linear issues, related PRs,
  documentation)
- [x] I have introduced a short, clear and well-formatted changelog entry

<!-- need help with the changelog? see ../CONTRIBUTING.md#submitting-a-pull-request -->
<!-- Add more details of your changes below if needed -->