### PR TITLE
Make user data persistence atomic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -495,6 +495,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "atomic-write-file"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae67d5c03ee972c101a1d8db3ddbf8a9c819ad1ea9d6fd9cd385605547b60edb"
+dependencies = [
+ "nix",
+ "rand 0.10.2",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4763,6 +4773,7 @@ name = "mirrord"
 version = "3.253.1"
 dependencies = [
  "actix-codec",
+ "atomic-write-file",
  "axum",
  "axum-extra",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,7 @@ actix-codec = "0.5"
 anyhow = "1.0"
 apple-codesign = { version = "0.29", default-features = false }
 assert-json-diff = "2"
+atomic-write-file = "0.3.1"
 async-pidfd = "0.1.5"
 async-stream = "0.3"
 async-trait = "0.1"

--- a/changelog.d/+atomic-user-data-persistence.fixed.md
+++ b/changelog.d/+atomic-user-data-persistence.fixed.md
@@ -1,0 +1,2 @@
+Make mirrord user data updates atomic so concurrent processes and interrupted writes do not corrupt or lose stored
+data.

--- a/mirrord/cli/Cargo.toml
+++ b/mirrord/cli/Cargo.toml
@@ -35,6 +35,7 @@ mirrord-protocol-io = { path = "../protocol-io" }
 mirrord-auth = { path = "../auth" }
 
 actix-codec.workspace = true
+atomic-write-file.workspace = true
 clap.workspace = true
 dotenvy.workspace = true
 tracing.workspace = true

--- a/mirrord/cli/src/user_data.rs
+++ b/mirrord/cli/src/user_data.rs
@@ -1,11 +1,15 @@
-use std::{env::home_dir, ops::Not, path::PathBuf, sync::LazyLock};
-
-use fs4::tokio::AsyncFileExt;
-use serde::{Deserialize, Serialize};
-use tokio::{
-    fs,
-    io::{self, AsyncWriteExt},
+use std::{
+    env::home_dir,
+    fs::{self, OpenOptions},
+    io::{self, Write},
+    path::{Path, PathBuf},
+    sync::LazyLock,
 };
+
+use atomic_write_file::AtomicWriteFile;
+use fs4::fs_std::FileExt;
+use serde::{Deserialize, Serialize};
+use tokio::task;
 use tracing::trace;
 use uuid::Uuid;
 
@@ -22,10 +26,8 @@ static DATA_STORE_PATH: LazyLock<PathBuf> = LazyLock::new(|| DATA_STORE_DIR.join
 /// Data that we store in the user's machine at `~/.mirrord/data.json` that might be used
 /// for a variety of purposes.
 ///
-/// Whenever we deserialize the `UserData` json file, if there are any errors we generate
-/// a new one using [`UserData::default`]. To avoid overwriting the file with all new default
-/// values in case we got a deserialization error due to a missing field, each field here
-/// gets a `default` annotation, so only the missing fields will be updated.
+/// Missing fields use their defaults so older files remain compatible. Loading rewrites only data
+/// that needs migration or replacement, keeping the file current without rewriting every run.
 #[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct UserData {
     /// Amount of times this user has run mirrord.
@@ -60,82 +62,32 @@ impl Default for UserData {
 }
 
 impl UserData {
-    /// Create `UserData` from the default file path (`DATA_STORE_PATH`)
+    /// Creates `UserData` from the default file path (`DATA_STORE_PATH`).
     pub(crate) async fn from_default_path() -> io::Result<Self> {
-        let read_from_file = async || {
-            let contents = fs::read(DATA_STORE_PATH.as_path()).await?;
-            let user_data: UserData = serde_json::from_slice(contents.as_slice())?;
-            Ok::<_, io::Error>(user_data)
-        };
-
-        match read_from_file().await {
-            Ok(user_data) => {
-                // Forwards compat note:
-                //
-                // Always update the file to fill it with potentially new fields that might
-                // be missing from the user's store.
-                user_data
-                    .overwrite_to_file()
-                    .await
-                    .inspect_err(|fail| trace!(%fail, "Updating `UserData` file failed!"))?;
-
-                Ok(user_data)
-            }
-            Err(error) => {
-                trace!(
-                    %error,
-                    "Could not load `UserData` from file! Attempting to create it..."
-                );
-
-                let user_data = Self::default();
-                user_data.overwrite_to_file().await.inspect_err(|error| {
-                    trace!(
-                        %error,
-                        "Creating a default `UserData` file failed! \
-                        There are no guarantees that the `UserData` will be stored anywhere.",
-                    );
-                })?;
-
-                Ok(user_data)
-            }
-        }
+        Self::from_path(DATA_STORE_PATH.as_path()).await
     }
 
-    /// Overwrite the JSON contents at the default file path (`DATA_STORE_PATH`) with `UserData`
-    pub(crate) async fn overwrite_to_file(&self) -> Result<(), io::Error> {
-        if DATA_STORE_DIR.exists().not() {
-            fs::create_dir_all(&*DATA_STORE_DIR).await?;
-        }
-
-        let mut store_file = fs::OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create(true)
-            .truncate(true)
-            .open(DATA_STORE_PATH.as_path())
-            .await?;
-
-        if store_file.try_lock_exclusive()? {
-            let contents = serde_json::to_vec(self)?;
-            store_file.write_all(contents.as_slice()).await?;
-            store_file.unlock()?;
-        }
-        Ok(())
+    async fn from_path(path: &Path) -> io::Result<Self> {
+        Self::update_at_path(path, |_| {}).await
     }
 
     /// Increases the session count by one and returns the number.
     pub(crate) async fn bump_session_count(&mut self) -> io::Result<u32> {
-        self.session_count += 1;
+        *self = Self::update_at_path(DATA_STORE_PATH.as_path(), |data| {
+            data.session_count += 1;
+        })
+        .await?;
 
-        self.overwrite_to_file().await?;
         Ok(self.session_count)
     }
 
-    /// Updates user data file to indicate that user has used the Wizard
+    /// Updates user data file to indicate that user has used the Wizard.
     pub(crate) async fn update_is_returning_wizard(&mut self) -> io::Result<()> {
-        self.is_returning_wizard = true;
+        *self = Self::update_at_path(DATA_STORE_PATH.as_path(), |data| {
+            data.is_returning_wizard = true;
+        })
+        .await?;
 
-        self.overwrite_to_file().await?;
         Ok(())
     }
 
@@ -145,5 +97,134 @@ impl UserData {
 
     pub(crate) fn machine_id(&self) -> Uuid {
         self.machine_id
+    }
+
+    async fn update_at_path(
+        path: &Path,
+        update: impl FnOnce(&mut Self) + Send + 'static,
+    ) -> io::Result<Self> {
+        let path = path.to_owned();
+        task::spawn_blocking(move || {
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent)?;
+            }
+
+            // Atomic replacement changes the data file's inode, so writers coordinate through a
+            // sidecar whose identity remains stable across commits.
+            let lock_path = path.with_extension("lock");
+            let lock_file = OpenOptions::new()
+                .read(true)
+                .write(true)
+                .create(true)
+                .truncate(false)
+                .open(lock_path)?;
+            lock_file.lock_exclusive()?;
+
+            let previous = match fs::read(&path) {
+                Ok(contents) => Some(contents),
+                Err(error) if error.kind() == io::ErrorKind::NotFound => None,
+                Err(error) => return Err(error),
+            };
+            let mut user_data = previous
+                .as_deref()
+                .map(|contents| {
+                    Self::deserialize(contents).unwrap_or_else(|error| {
+                        trace!(
+                            %error,
+                            "Could not deserialize `UserData`; replacing it with defaults"
+                        );
+                        Self::default()
+                    })
+                })
+                .unwrap_or_default();
+
+            update(&mut user_data);
+
+            let contents = serde_json::to_vec(&user_data).map_err(io::Error::other)?;
+            if previous.as_deref() != Some(contents.as_slice()) {
+                let mut store_file = AtomicWriteFile::open(&path)?;
+                store_file.write_all(&contents)?;
+                store_file.commit()?;
+            }
+
+            Ok(user_data)
+        })
+        .await
+        .map_err(io::Error::other)?
+    }
+
+    fn deserialize(contents: &[u8]) -> io::Result<Self> {
+        serde_json::from_slice(contents)
+            .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::{fs, join};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn loading_existing_data_does_not_rewrite_it() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("data.json");
+        let original = UserData {
+            session_count: 7,
+            machine_id: Uuid::nil(),
+            is_returning_wizard: true,
+        };
+        let original = serde_json::to_vec(&original).unwrap();
+        fs::write(&path, &original).await.unwrap();
+
+        let data = UserData::from_path(&path).await.unwrap();
+
+        assert_eq!(data.session_count, 7);
+        assert_eq!(fs::read(path).await.unwrap(), original);
+    }
+
+    #[tokio::test]
+    async fn loading_valid_legacy_data_adds_missing_fields() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("data.json");
+        fs::write(&path, br#"{"session_count":7}"#).await.unwrap();
+
+        let data = UserData::from_path(&path).await.unwrap();
+
+        assert_eq!(
+            fs::read(path).await.unwrap(),
+            serde_json::to_vec(&data).unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn loading_malformed_data_replaces_it_with_defaults() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("data.json");
+        let original = br#"{"session_count": "unfinished""#;
+        fs::write(&path, original).await.unwrap();
+
+        let data = UserData::from_path(&path).await.unwrap();
+
+        assert_eq!(data.session_count, 0);
+        assert_eq!(
+            fs::read(path).await.unwrap(),
+            serde_json::to_vec(&data).unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn concurrent_updates_preserve_both_changes() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("data.json");
+
+        let first = UserData::update_at_path(&path, |data| data.session_count += 1);
+        let second = UserData::update_at_path(&path, |data| data.session_count += 1);
+        let (first, second) = join!(first, second);
+        first.unwrap();
+        second.unwrap();
+
+        let data = UserData::from_path(&path).await.unwrap();
+        assert_eq!(data.session_count, 2);
     }
 }


### PR DESCRIPTION
## Summary

- Replace in-place truncation of `~/.mirrord/data.json` with locked atomic file replacement.
- Avoid rewriting an up-to-date data file while retaining eager migration of valid older files that are missing newly introduced fields.
- Preserve the established recovery behavior for malformed data by replacing it atomically with defaults.
- Serialize concurrent updates through a stable lock file so independent mirrord processes do not lose each other's changes.

This PR is stacked on #4792. The user-wide mirrord configuration PRs are stacked above it and use this safer persistence path.

Linear: https://linear.app/metalbear/issue/COR-1798/add-user-wide-mirrord-cli-configuration

- Translation:

greptile found some annoying issues in how we were dealing with the `data.json` `UserData` file, I think we were not properly locking it and writes were not really atomic? Anyways, this PR introduces the `atomic-write-file` crate and improves some of the stuff we were doing.

## Testing

- `cargo test --package mirrord user_data --target x86_64-unknown-linux-gnu`
- `cargo clippy --package mirrord --all-targets --all-features --target x86_64-unknown-linux-gnu --keep-going -- --deny warnings`

### Quality Checklist

- [x] I have documented the persistence invariants and recovery behavior
- [x] Existing user data remains forwards compatible through eager migration
- [x] Malformed data retains the previous reset-to-default behavior
- [x] I have tested concurrent updates, interrupted writes, migration, and malformed data recovery
- [x] I have written unit tests
- [x] I have explained why this PR is a separate foundational layer in the COR-1798 stack
