### PR TITLE
Authenticate sessions-manager connections with a shared-secret header

### DIFF
--- a/changelog.d/+sessions-manager-auth-header.internal.md
+++ b/changelog.d/+sessions-manager-auth-header.internal.md
@@ -1,0 +1,5 @@
+Send an optional shared-secret header on sessions-manager control-plane and
+data-plane connections, so a deployment can put an authenticating proxy in front
+of sessions-manager. Set `MIRRORD_SESSIONS_MANAGER_AUTH_TOKEN` to enable it, and
+`MIRRORD_SESSIONS_MANAGER_AUTH_HEADER` to override the default `x-mirrord-sm-auth`
+header name.

--- a/mirrord/sessions-manager/client/src/client/agent.rs
+++ b/mirrord/sessions-manager/client/src/client/agent.rs
@@ -15,7 +15,7 @@ use crate::{
     client::ClientBuilder,
     config::SessionsManagerConfig,
     control_plane::HttpControlPlaneClient,
-    credentials::{CredentialProvider, NoCredentials},
+    credentials::{CredentialProvider, credentials_from_env},
     data_plane::{DataPlaneConnectRequest, DataPlaneTransport, WebSocketDataPlaneTransport},
     environment::sessions_manager_environment,
     error::SessionsManagerClientError,
@@ -46,7 +46,7 @@ impl AgentClient<WebSocketDataPlaneTransport> {
                     service.into(),
                     SessionsManagerConfig::base_url_from_env()?,
                 )?,
-                credentials: Arc::new(NoCredentials),
+                credentials: credentials_from_env()?,
                 cancellation: cancellation.into().unwrap_or_default(),
                 transport: WebSocketDataPlaneTransport,
             },
@@ -69,16 +69,37 @@ impl<T: DataPlaneTransport> AgentClient<T> {
     }
 
     pub fn start_control_plane(self) -> Result<AgentControlPlane, SessionsManagerClientError> {
+        let data_plane = DataPlaneContext {
+            base_url: self.builder.config.base_url.clone(),
+            transport: self.builder.transport,
+            credentials: self.builder.credentials.clone(),
+        };
         let client = HttpControlPlaneClient::new(&self.builder.config, self.builder.credentials)?;
 
         Ok(AgentControlPlane::start(
             client,
             self.replica_id,
             self.agent_instance_id,
-            self.builder.config.base_url,
             self.builder.cancellation,
-            self.builder.transport,
+            data_plane,
         ))
+    }
+}
+
+/// What a data-plane upgrade needs regardless of which assignment triggers it.
+struct DataPlaneContext<T> {
+    base_url: Url,
+    transport: T,
+    credentials: Arc<dyn CredentialProvider>,
+}
+
+impl<T: Clone> Clone for DataPlaneContext<T> {
+    fn clone(&self) -> Self {
+        Self {
+            base_url: self.base_url.clone(),
+            transport: self.transport.clone(),
+            credentials: self.credentials.clone(),
+        }
     }
 }
 
@@ -93,9 +114,8 @@ impl AgentControlPlane {
         client: HttpControlPlaneClient,
         replica_id: String,
         agent_instance_id: String,
-        data_plane_base_url: Url,
         cancellation: CancellationToken,
-        transport: T,
+        data_plane: DataPlaneContext<T>,
     ) -> Self {
         let (sender, receiver) = mpsc::channel(CONNECTIONS_QUEUE_CAPACITY);
         let queue = QueueSender { sender };
@@ -104,10 +124,9 @@ impl AgentControlPlane {
             client,
             replica_id,
             agent_instance_id,
-            data_plane_base_url,
             queue,
             cancellation.clone(),
-            transport,
+            data_plane,
         ));
 
         Self {
@@ -121,10 +140,9 @@ impl AgentControlPlane {
         client: HttpControlPlaneClient,
         replica_id: String,
         agent_instance_id: String,
-        data_plane_base_url: Url,
         queue: QueueSender,
         cancellation: CancellationToken,
-        transport: T,
+        data_plane: DataPlaneContext<T>,
     ) -> Result<(), SessionsManagerClientError> {
         let mut dataplane_upgrades = JoinSet::new();
         let mut assignments_subscriber = AgentAssignmentSubscriber::new(
@@ -140,9 +158,8 @@ impl AgentControlPlane {
                 assignment = assignments_subscriber.next() => match assignment {
                     Some(Ok(assignment)) => Self::spawn_upgrade_task(
                         &mut dataplane_upgrades,
-                        &data_plane_base_url,
                         &cancellation,
-                        transport.clone(),
+                        data_plane.clone(),
                         assignment,
                     ),
                     Some(Err(error)) => break Err(error),
@@ -211,12 +228,15 @@ impl AgentControlPlane {
             AssignmentId,
             Result<Connection<Agent>, SessionsManagerClientError>,
         )>,
-        data_plane_base_url: &Url,
         cancellation: &CancellationToken,
-        transport: T,
+        data_plane: DataPlaneContext<T>,
         assignment: ConnectionAssignment,
     ) {
-        let base_url = data_plane_base_url.clone();
+        let DataPlaneContext {
+            base_url,
+            transport,
+            credentials,
+        } = data_plane;
         let cancellation = cancellation.clone();
         let assignment_id = assignment.assignment_id.clone();
         dataplane_upgrades.spawn(async move {
@@ -227,6 +247,7 @@ impl AgentControlPlane {
                 transport.connect(DataPlaneConnectRequest {
                     control_plane_url: base_url,
                     assignment,
+                    credentials,
                 }),
             )
             .await

--- a/mirrord/sessions-manager/client/src/client/intproxy.rs
+++ b/mirrord/sessions-manager/client/src/client/intproxy.rs
@@ -11,7 +11,7 @@ use crate::{
     client::ClientBuilder,
     config::SessionsManagerConfig,
     control_plane::{HttpControlPlaneClient, subscriber::ControlPlaneSubscriber},
-    credentials::{CredentialProvider, NoCredentials},
+    credentials::{CredentialProvider, credentials_from_env},
     data_plane::{DataPlaneTransport, WebSocketDataPlaneTransport},
     error::SessionsManagerClientError,
     retry::{init_retry_policy, run_interruptible, wait_next_retry_delay},
@@ -49,7 +49,7 @@ impl IntproxyClient<WebSocketDataPlaneTransport> {
                     connect_info.service,
                     SessionsManagerConfig::base_url_from_env()?,
                 )?,
-                credentials: Arc::new(NoCredentials),
+                credentials: credentials_from_env()?,
                 cancellation: cancellation.into().unwrap_or_default(),
                 transport: WebSocketDataPlaneTransport,
             },
@@ -136,6 +136,7 @@ impl<T: DataPlaneTransport> IntproxyClient<T> {
                 .connect(crate::data_plane::DataPlaneConnectRequest {
                     control_plane_url: self.builder.config.base_url.clone(),
                     assignment,
+                    credentials: self.builder.credentials.clone(),
                 }),
         )
         .await?

--- a/mirrord/sessions-manager/client/src/credentials.rs
+++ b/mirrord/sessions-manager/client/src/credentials.rs
@@ -27,6 +27,26 @@ pub const SESSIONS_MANAGER_AUTH_HEADER_ENV: &str = "MIRRORD_SESSIONS_MANAGER_AUT
 
 const DEFAULT_AUTH_HEADER_NAME: &str = "x-mirrord-sm-auth";
 
+/// Header names the client sets for itself, which the shared secret may not take over.
+///
+/// Every one of these is applied after the credential headers, so a shared secret sent under
+/// one of these names is either replaced or duplicated rather than delivered: `authorization`
+/// carries the per-assignment token on the data plane, `accept` selects the control-plane
+/// event stream, and the rest are part of the WebSocket handshake. The failure would other-
+/// wise be near-invisible — the control plane authenticating while every data-plane upgrade
+/// is rejected by the fronting proxy — so a name from this list is refused up front.
+const RESERVED_HEADER_NAMES: &[&str] = &[
+    "authorization",
+    "accept",
+    "host",
+    "connection",
+    "upgrade",
+    "sec-websocket-key",
+    "sec-websocket-version",
+    "sec-websocket-protocol",
+    "sec-websocket-extensions",
+];
+
 /// Sends a fixed shared secret on every sessions-manager request, for deployments that put
 /// an authenticating proxy or load balancer in front of it.
 ///
@@ -60,6 +80,12 @@ impl SharedSecretCredentials {
         let name = HeaderName::try_from(name).map_err(|_| {
             SessionsManagerClientError::InvalidConfig(format!("invalid auth header name: {name}"))
         })?;
+        // `HeaderName` parsing lowercases, so this comparison needs no normalizing of its own.
+        if RESERVED_HEADER_NAMES.contains(&name.as_str()) {
+            return Err(SessionsManagerClientError::InvalidConfig(format!(
+                "auth header name {name} is reserved by the sessions-manager client"
+            )));
+        }
         let mut value = HeaderValue::from_str(token).map_err(|_| {
             SessionsManagerClientError::InvalidConfig(
                 "auth token is not a valid header value".to_owned(),
@@ -92,5 +118,71 @@ pub(crate) fn credentials_from_env()
             Ok(Arc::new(credentials))
         }
         None => Ok(Arc::new(NoCredentials)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Exercises `new` rather than `from_env`, so the cases do not race each other over
+    /// process environment.
+    fn header_of(name: &str, token: &str) -> Result<HeaderMap, SessionsManagerClientError> {
+        SharedSecretCredentials::new(name, token)?.headers()
+    }
+
+    #[test]
+    fn sends_the_token_under_the_configured_name() {
+        let headers = header_of("x-custom-auth", "shhh").unwrap();
+        assert_eq!(headers.get("x-custom-auth").unwrap(), "shhh");
+    }
+
+    #[test]
+    fn header_name_is_case_insensitive() {
+        let headers = header_of("X-Custom-Auth", "shhh").unwrap();
+        assert_eq!(headers.get("x-custom-auth").unwrap(), "shhh");
+    }
+
+    #[test]
+    fn token_is_marked_sensitive_so_it_stays_out_of_logs() {
+        let headers = header_of("x-custom-auth", "shhh").unwrap();
+        assert!(headers.get("x-custom-auth").unwrap().is_sensitive());
+    }
+
+    /// A reserved name is refused outright: the client overwrites each of these after
+    /// applying credentials, so the secret would never reach the proxy.
+    #[test]
+    fn reserved_header_names_are_refused() {
+        for name in RESERVED_HEADER_NAMES {
+            // `SharedSecretCredentials` holds a secret and deliberately has no `Debug`, so
+            // the result is matched rather than unwrapped.
+            let Err(error) = SharedSecretCredentials::new(name, "shhh") else {
+                panic!("{name} should be refused as an auth header name");
+            };
+            assert!(
+                matches!(error, SessionsManagerClientError::InvalidConfig(_)),
+                "{name} produced {error:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn reserved_check_ignores_case() {
+        assert!(
+            SharedSecretCredentials::new("Authorization", "shhh").is_err(),
+            "reserved names should be refused whatever their case"
+        );
+    }
+
+    #[test]
+    fn malformed_names_and_tokens_are_refused() {
+        assert!(
+            SharedSecretCredentials::new("no spaces allowed", "shhh").is_err(),
+            "an invalid header name should be refused"
+        );
+        assert!(
+            SharedSecretCredentials::new("x-custom-auth", "new\nline").is_err(),
+            "a token that cannot be a header value should be refused"
+        );
     }
 }

--- a/mirrord/sessions-manager/client/src/credentials.rs
+++ b/mirrord/sessions-manager/client/src/credentials.rs
@@ -1,4 +1,6 @@
-use reqwest::header::HeaderMap;
+use std::{env::VarError, sync::Arc};
+
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 
 use crate::error::SessionsManagerClientError;
 
@@ -12,5 +14,83 @@ pub(crate) struct NoCredentials;
 impl CredentialProvider for NoCredentials {
     fn headers(&self) -> Result<HeaderMap, SessionsManagerClientError> {
         Ok(HeaderMap::new())
+    }
+}
+
+/// Shared secret expected by whatever fronts sessions-manager. Setting it is what
+/// turns [`SharedSecretCredentials`] on.
+pub const SESSIONS_MANAGER_AUTH_TOKEN_ENV: &str = "MIRRORD_SESSIONS_MANAGER_AUTH_TOKEN";
+
+/// Names the header carrying [`SESSIONS_MANAGER_AUTH_TOKEN_ENV`]. Only needed when the
+/// deployment expects something other than [`DEFAULT_AUTH_HEADER_NAME`].
+pub const SESSIONS_MANAGER_AUTH_HEADER_ENV: &str = "MIRRORD_SESSIONS_MANAGER_AUTH_HEADER";
+
+const DEFAULT_AUTH_HEADER_NAME: &str = "x-mirrord-sm-auth";
+
+/// Sends a fixed shared secret on every sessions-manager request, for deployments that put
+/// an authenticating proxy or load balancer in front of it.
+///
+/// This is distinct from the per-assignment authorization the control plane hands out: the
+/// proxy decides whether a request reaches sessions-manager at all, and has to make that
+/// call without understanding the control-plane or data-plane protocol.
+pub struct SharedSecretCredentials {
+    name: HeaderName,
+    value: HeaderValue,
+}
+
+impl SharedSecretCredentials {
+    /// Reads the shared secret from the environment.
+    ///
+    /// [`None`] when no token is set, which is the case for a directly reachable
+    /// sessions-manager.
+    pub fn from_env() -> Result<Option<Self>, SessionsManagerClientError> {
+        let token = match std::env::var(SESSIONS_MANAGER_AUTH_TOKEN_ENV) {
+            Ok(token) => token,
+            Err(VarError::NotPresent) => return Ok(None),
+            Err(error) => return Err(error.into()),
+        };
+
+        let name = std::env::var(SESSIONS_MANAGER_AUTH_HEADER_ENV)
+            .unwrap_or_else(|_| DEFAULT_AUTH_HEADER_NAME.to_owned());
+
+        Self::new(&name, &token).map(Some)
+    }
+
+    pub fn new(name: &str, token: &str) -> Result<Self, SessionsManagerClientError> {
+        let name = HeaderName::try_from(name).map_err(|_| {
+            SessionsManagerClientError::InvalidConfig(format!("invalid auth header name: {name}"))
+        })?;
+        let mut value = HeaderValue::from_str(token).map_err(|_| {
+            SessionsManagerClientError::InvalidConfig(
+                "auth token is not a valid header value".to_owned(),
+            )
+        })?;
+        value.set_sensitive(true);
+
+        Ok(Self { name, value })
+    }
+}
+
+impl CredentialProvider for SharedSecretCredentials {
+    fn headers(&self) -> Result<HeaderMap, SessionsManagerClientError> {
+        let mut headers = HeaderMap::new();
+        headers.insert(self.name.clone(), self.value.clone());
+        Ok(headers)
+    }
+}
+
+/// The credentials a client uses unless the caller supplies its own: the shared secret when
+/// the environment configures one, and nothing otherwise.
+pub(crate) fn credentials_from_env()
+-> Result<Arc<dyn CredentialProvider>, SessionsManagerClientError> {
+    match SharedSecretCredentials::from_env()? {
+        Some(credentials) => {
+            tracing::debug!(
+                header = %credentials.name,
+                "authenticating sessions-manager connections with a shared secret"
+            );
+            Ok(Arc::new(credentials))
+        }
+        None => Ok(Arc::new(NoCredentials)),
     }
 }

--- a/mirrord/sessions-manager/client/src/data_plane.rs
+++ b/mirrord/sessions-manager/client/src/data_plane.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
 use futures::future::BoxFuture;
 use mirrord_protocol_io::{Connection, ProtocolEndpoint};
@@ -7,11 +7,15 @@ use url::Url;
 
 mod websocket;
 
-use crate::error::SessionsManagerClientError;
+use crate::{credentials::CredentialProvider, error::SessionsManagerClientError};
 
 pub struct DataPlaneConnectRequest {
     pub control_plane_url: Url,
     pub assignment: ConnectionAssignment,
+    /// Carried so the upgrade passes whatever fronts sessions-manager. The
+    /// per-assignment authorization proves which session this is; these prove the
+    /// request may reach sessions-manager at all.
+    pub credentials: Arc<dyn CredentialProvider>,
 }
 
 /// Establishes a data-plane connection for either protocol endpoint.

--- a/mirrord/sessions-manager/client/src/data_plane/websocket.rs
+++ b/mirrord/sessions-manager/client/src/data_plane/websocket.rs
@@ -24,6 +24,7 @@ pub(crate) async fn connect_data_plane<E: ProtocolEndpoint + Send + Unpin + 'sta
     let DataPlaneConnectRequest {
         control_plane_url: base_url,
         assignment,
+        credentials,
     } = request;
     let scheme = match base_url.scheme() {
         "http" => "ws",
@@ -38,6 +39,7 @@ pub(crate) async fn connect_data_plane<E: ProtocolEndpoint + Send + Unpin + 'sta
     .to_owned();
     let url = assignment.data_plane_endpoint.resolve(&base_url, &scheme)?;
     let mut request = url.as_str().into_client_request()?;
+    request.headers_mut().extend(credentials.headers()?);
     let mut authorization = HeaderValue::from_str(assignment.authorization.expose_secret())
         .map_err(|_| SessionsManagerClientError::InvalidAuthorization)?;
     authorization.set_sensitive(true);

--- a/mirrord/sessions-manager/client/src/lib.rs
+++ b/mirrord/sessions-manager/client/src/lib.rs
@@ -9,7 +9,7 @@ mod error;
 mod retry;
 
 pub use client::{AgentClient, AgentControlPlane, IntproxyClient, SessionsManagerConnectInfo};
-pub use credentials::CredentialProvider;
+pub use credentials::{CredentialProvider, SharedSecretCredentials};
 pub use data_plane::{DataPlaneConnectRequest, DataPlaneTransport, WebSocketDataPlaneTransport};
 pub use environment::{
     sessions_manager_environment, sessions_manager_replica_id, sessions_manager_service,


### PR DESCRIPTION
Prerequisite for exposing sessions-manager over the internet — it sits behind a load balancer that refuses requests without a shared secret, and the client has no way to send one.

Both planes have to carry the header, because the proxy decides whether a request reaches sessions-manager at all and cannot do that by understanding the control-plane or data-plane protocol.

Off unless `MIRRORD_SESSIONS_MANAGER_AUTH_TOKEN` is set, so nothing changes for a directly reachable sessions-manager. `MIRRORD_SESSIONS_MANAGER_AUTH_HEADER` overrides the default `x-mirrord-sm-auth` name.

**Relationship to #4774.** This replaces it. That one targeted #4542 and was written against the older client, where the control plane was Socket.IO and the data-plane upgrade took a bare URL — it needed its own `auth_header` field and a hand-built upgrade request. On this branch neither applies: the control plane is HTTP/SSE and already routes every request through `CredentialProvider`, and the upgrade already builds an explicit request. So this is a port rather than a rebase, and it lands one level lower in the stack, on the branch that introduces the client.

**What that changes.** The header arrives as a `SharedSecretCredentials` implementation of the existing trait, so the control plane needed no new plumbing at all. Only the data plane did: `connect_data_plane` consults nothing today, and the per-assignment `Authorization` it sends answers a different question — which session a connection belongs to, not whether the caller may reach sessions-manager. Both are now sent.

The default for both client builders moves from `NoCredentials` to reading the environment, which is what keeps the feature env-driven; callers passing their own `with_credentials` are unaffected.

Threading credentials into the agent's upgrade path pushed `run` to eight arguments, over the `too_many_arguments` limit. Rather than allow the lint, the data-plane parameters are grouped into a `DataPlaneContext`, which also shortens `spawn_upgrade_task`.

## Testing

`cargo clippy --all-targets --deny warnings`, `cargo fmt --check`, and `cargo test` (26 passing) on this crate, plus `cargo check` on `mirrord-agent` and `mirrord-intproxy`, since `DataPlaneConnectRequest` gained a required field. Not yet exercised against a live proxy.