### PR TITLE
MBE-2084 publish remote bootstrap

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -841,6 +841,53 @@ jobs:
             -t ghcr.io/metalbear-co/mirrord:latest \
             ghcr.io/metalbear-co/mirrord@${{ steps.build_release.outputs.digest }}
 
+      - name: Build and push remote bootstrap (test)
+        id: build_remote_bootstrap_test
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          REMOTE_BOOTSTRAP_TAGS: "ghcr.io/metalbear-co/mirrord-remote-bootstrap-staging:${{ github.sha }}"
+        run: |
+          docker buildx bake -f ci/docker-bake.hcl remote-bootstrap --push \
+            --metadata-file /tmp/remote-bootstrap-metadata.json
+          digest=$(jq -r '.["remote-bootstrap"]."containerimage.digest"' /tmp/remote-bootstrap-metadata.json)
+          echo "digest=${digest}" >> "$GITHUB_OUTPUT"
+
+      - name: Attest remote bootstrap build provenance (test)
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4
+        with:
+          subject-name: ghcr.io/metalbear-co/mirrord-remote-bootstrap-staging
+          subject-digest: ${{ steps.build_remote_bootstrap_test.outputs.digest }}
+          push-to-registry: true
+
+      - name: Build and push remote bootstrap (final/release)
+        id: build_remote_bootstrap_release
+        if: needs.validate_release_request.outputs.should_release == 'true'
+        env:
+          REMOTE_BOOTSTRAP_TAGS: "ghcr.io/metalbear-co/mirrord-remote-bootstrap:${{ steps.version.outputs.version }}"
+          PRODUCT_CACHE_FROM: ""
+          PRODUCT_CACHE_TO: ""
+        run: |
+          docker buildx bake -f ci/docker-bake.hcl remote-bootstrap --push --no-cache \
+            --metadata-file /tmp/remote-bootstrap-metadata.json
+          digest=$(jq -r '.["remote-bootstrap"]."containerimage.digest"' /tmp/remote-bootstrap-metadata.json)
+          echo "digest=${digest}" >> "$GITHUB_OUTPUT"
+
+      - name: Attest remote bootstrap build provenance
+        if: needs.validate_release_request.outputs.should_release == 'true'
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4
+        with:
+          subject-name: ghcr.io/metalbear-co/mirrord-remote-bootstrap
+          subject-digest: ${{ steps.build_remote_bootstrap_release.outputs.digest }}
+          push-to-registry: true
+
+      - name: Promote remote bootstrap latest
+        if: needs.validate_release_request.outputs.should_release == 'true'
+        run: |
+          docker buildx imagetools create \
+            -t ghcr.io/metalbear-co/mirrord-remote-bootstrap:latest \
+            ghcr.io/metalbear-co/mirrord-remote-bootstrap@${{ steps.build_remote_bootstrap_release.outputs.digest }}
+
   release_cli_docker_image:
     needs: [validate_release_request]
     if: github.event_name == 'workflow_dispatch' || needs.validate_release_request.outputs.should_release == 'true'

--- a/ci/docker-bake.hcl
+++ b/ci/docker-bake.hcl
@@ -13,6 +13,11 @@ variable "AGENT_TAGS" {
   default = "${REGISTRY}/mirrord:dev"
 }
 
+# Comma-separated tags for the remote bootstrap image.
+variable "REMOTE_BOOTSTRAP_TAGS" {
+  default = "${REGISTRY}/mirrord-remote-bootstrap:dev"
+}
+
 # Comma-separated tags for the CLI image.
 variable "CLI_TAGS" {
   default = "${REGISTRY}/mirrord-cli:dev"
@@ -41,7 +46,7 @@ variable "PRODUCT_CACHE_TO" {
 
 # Product images built from this repo.
 group "default" {
-  targets = ["agent", "cli"]
+  targets = ["agent", "remote-bootstrap", "cli"]
 }
 
 # Test helper images.
@@ -63,10 +68,32 @@ group "ci-images" {
 target "agent" {
   context    = "."
   dockerfile = "mirrord/agent/Dockerfile"
+  target     = "agent"
   platforms  = split(",", PLATFORMS)
   tags       = split(",", AGENT_TAGS)
   cache-from = compact([PRODUCT_CACHE_FROM])
   cache-to   = compact([PRODUCT_CACHE_TO])
+  contexts = {
+    "ghcr.io/metalbear-co/ci-agent-build:54901618bd7bdc9b4975fb7e5439e519f6469ac0"  = "target:ci-agent-builder"
+    "ghcr.io/metalbear-co/ci-agent-runtime:54901618bd7bdc9b4975fb7e5439e519f6469ac0" = "target:ci-agent-runtime"
+  }
+}
+
+target "remote-bootstrap" {
+  context    = "."
+  dockerfile = "mirrord/agent/Dockerfile"
+  target     = "remote-bootstrap"
+  platforms  = split(",", PLATFORMS)
+  tags       = split(",", REMOTE_BOOTSTRAP_TAGS)
+  cache-from = compact([PRODUCT_CACHE_FROM])
+  cache-to   = compact([PRODUCT_CACHE_TO])
+
+  # ECS Fargate's puller dereferences platform metadata on every index member.
+  # Buildx's inline attestations have no platform, so publish those separately
+  # through the release workflow rather than embedding them in this image index.
+  provenance = false
+  sbom       = false
+
   contexts = {
     "ghcr.io/metalbear-co/ci-agent-build:54901618bd7bdc9b4975fb7e5439e519f6469ac0"  = "target:ci-agent-builder"
     "ghcr.io/metalbear-co/ci-agent-runtime:54901618bd7bdc9b4975fb7e5439e519f6469ac0" = "target:ci-agent-runtime"

--- a/ci/docker-bake.hcl
+++ b/ci/docker-bake.hcl
@@ -33,6 +33,11 @@ variable "PLATFORMS" {
   default = "linux/amd64,linux/arm64"
 }
 
+# Set to 0 for debug symbols and assertions in locally built agent and bootstrap images.
+variable "RELEASE" {
+  default = "1"
+}
+
 # Shared buildx cache settings for product images. Empty by default; each caller opts in with a
 # backend it can reach. Not `type=gha`: `mode=max` there crowds the repository out of its 10 GB
 # Actions cache quota and evicts the Rust cache records.
@@ -71,6 +76,9 @@ target "agent" {
   target     = "agent"
   platforms  = split(",", PLATFORMS)
   tags       = split(",", AGENT_TAGS)
+  args = {
+    RELEASE = RELEASE
+  }
   cache-from = compact([PRODUCT_CACHE_FROM])
   cache-to   = compact([PRODUCT_CACHE_TO])
   contexts = {
@@ -85,6 +93,9 @@ target "remote-bootstrap" {
   target     = "remote-bootstrap"
   platforms  = split(",", PLATFORMS)
   tags       = split(",", REMOTE_BOOTSTRAP_TAGS)
+  args = {
+    RELEASE = RELEASE
+  }
   cache-from = compact([PRODUCT_CACHE_FROM])
   cache-to   = compact([PRODUCT_CACHE_TO])
 

--- a/mirrord/agent/Dockerfile
+++ b/mirrord/agent/Dockerfile
@@ -48,7 +48,44 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,id=cargo-registry-agent-
     # Copy binary out of cached target directory
     cp /app/target/$(cat /.platform)/release/mirrord-agent /mirrord-agent
 
-FROM ghcr.io/metalbear-co/ci-agent-runtime:54901618bd7bdc9b4975fb7e5439e519f6469ac0
+FROM ghcr.io/metalbear-co/ci-agent-runtime:54901618bd7bdc9b4975fb7e5439e519f6469ac0 AS agent
 COPY --from=builder /mirrord-agent /
 
 CMD ["./mirrord-agent"]
+
+FROM builder AS remote-bootstrap-builder
+
+COPY mirrord/layer-lib /app/mirrord/layer-lib
+COPY mirrord/layer-go /app/mirrord/layer-go
+COPY mirrord/sip /app/mirrord/sip
+COPY mirrord/layer/core /app/mirrord/layer/core
+COPY mirrord/layer/macro /app/mirrord/layer/macro
+COPY mirrord/config /app/mirrord/config
+COPY mirrord/str-win /app/mirrord/str-win
+COPY mirrord/utils-win /app/mirrord/utils-win
+COPY mirrord/analytics /app/mirrord/analytics
+COPY mirrord/jaq /app/mirrord/jaq
+COPY mirrord/test-macros /app/mirrord/test-macros
+COPY mirrord/progress /app/mirrord/progress
+COPY mirrord/console /app/mirrord/console
+COPY mirrord/remote/bootstrap /app/mirrord/remote/bootstrap
+COPY mirrord/remote/layer /app/mirrord/remote/layer
+
+RUN sed -i '/members = \[/,/\]/c\members = [\n    "mirrord/*",\n    "mirrord/sessions-manager/client",\n    "mirrord/sessions-manager/protocol",\n    "mirrord/intproxy/protocol",\n    "mirrord/layer/core",\n    "mirrord/layer/macro",\n    "mirrord/remote/bootstrap",\n    "mirrord/remote/layer",\n    "mirrord/remote/layer/protocol",\n]' /app/Cargo.toml
+
+RUN --mount=type=cache,target=/usr/local/cargo/registry,id=cargo-registry-agent-$TARGETARCH,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,id=cargo-git-agent-$TARGETARCH,sharing=locked \
+    --mount=type=cache,target=/app/target,id=target-agent-$TARGETARCH,sharing=locked \
+    cargo +nightly-2026-08-13 zigbuild --manifest-path /app/mirrord/remote/layer/Cargo.toml --target $(cat /.platform) --release && \
+    cp /app/target/$(cat /.platform)/release/libmirrord_remote_layer.so /mirrord-remote-layer.so
+
+RUN --mount=type=cache,target=/usr/local/cargo/registry,id=cargo-registry-agent-$TARGETARCH,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,id=cargo-git-agent-$TARGETARCH,sharing=locked \
+    --mount=type=cache,target=/app/target,id=target-agent-$TARGETARCH,sharing=locked \
+    MIRRORD_AGENT_BINARY=/mirrord-agent \
+    MIRRORD_REMOTE_LAYER_BINARY=/mirrord-remote-layer.so \
+    cargo +nightly-2026-08-13 zigbuild --manifest-path /app/mirrord/remote/bootstrap/Cargo.toml --target $(cat /.platform) --release && \
+    cp /app/target/$(cat /.platform)/release/libmirrord_remote_bootstrap.so /mirrord-remote-bootstrap.so
+
+FROM debian:bookworm-slim AS remote-bootstrap
+COPY --from=remote-bootstrap-builder /mirrord-remote-bootstrap.so /opt/mirrord/lib/libmirrord_remote_bootstrap.so

--- a/mirrord/agent/Dockerfile
+++ b/mirrord/agent/Dockerfile
@@ -1,5 +1,8 @@
+ARG RELEASE=1
+
 FROM --platform=$BUILDPLATFORM ghcr.io/metalbear-co/ci-agent-build:54901618bd7bdc9b4975fb7e5439e519f6469ac0 AS builder
 ARG TARGETARCH
+ARG RELEASE
 WORKDIR /app
 
 COPY ./mirrord/agent/platform.sh /app/
@@ -44,9 +47,10 @@ RUN sed -i '/^default-members = \[/,/^\]/d' /app/Cargo.toml && \
 RUN --mount=type=cache,target=/usr/local/cargo/registry,id=cargo-registry-agent-$TARGETARCH,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,id=cargo-git-agent-$TARGETARCH,sharing=locked \
     --mount=type=cache,target=/app/target,id=target-agent-$TARGETARCH,sharing=locked \
-    cargo +nightly-2026-08-13 zigbuild -Z bindeps --manifest-path /app/mirrord/agent/Cargo.toml --target $(cat /.platform) --release && \
+    if [ "$RELEASE" = "1" ]; then release_flag=--release; target_dir=release; else release_flag=; target_dir=debug; fi; \
+    cargo +nightly-2026-08-13 zigbuild -Z bindeps --manifest-path /app/mirrord/agent/Cargo.toml --target $(cat /.platform) ${release_flag:-} && \
     # Copy binary out of cached target directory
-    cp /app/target/$(cat /.platform)/release/mirrord-agent /mirrord-agent
+    cp "/app/target/$(cat /.platform)/${target_dir}/mirrord-agent" /mirrord-agent
 
 FROM ghcr.io/metalbear-co/ci-agent-runtime:54901618bd7bdc9b4975fb7e5439e519f6469ac0 AS agent
 COPY --from=builder /mirrord-agent /
@@ -76,16 +80,18 @@ RUN sed -i '/members = \[/,/\]/c\members = [\n    "mirrord/*",\n    "mirrord/ses
 RUN --mount=type=cache,target=/usr/local/cargo/registry,id=cargo-registry-agent-$TARGETARCH,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,id=cargo-git-agent-$TARGETARCH,sharing=locked \
     --mount=type=cache,target=/app/target,id=target-agent-$TARGETARCH,sharing=locked \
-    cargo +nightly-2026-08-13 zigbuild --manifest-path /app/mirrord/remote/layer/Cargo.toml --target $(cat /.platform) --release && \
-    cp /app/target/$(cat /.platform)/release/libmirrord_remote_layer.so /mirrord-remote-layer.so
+    if [ "$RELEASE" = "1" ]; then release_flag=--release; target_dir=release; else release_flag=; target_dir=debug; fi; \
+    cargo +nightly-2026-08-13 zigbuild --manifest-path /app/mirrord/remote/layer/Cargo.toml --target $(cat /.platform) ${release_flag:-} && \
+    cp "/app/target/$(cat /.platform)/${target_dir}/libmirrord_remote_layer.so" /mirrord-remote-layer.so
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry,id=cargo-registry-agent-$TARGETARCH,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,id=cargo-git-agent-$TARGETARCH,sharing=locked \
     --mount=type=cache,target=/app/target,id=target-agent-$TARGETARCH,sharing=locked \
+    if [ "$RELEASE" = "1" ]; then release_flag=--release; target_dir=release; else release_flag=; target_dir=debug; fi; \
     MIRRORD_AGENT_BINARY=/mirrord-agent \
     MIRRORD_REMOTE_LAYER_BINARY=/mirrord-remote-layer.so \
-    cargo +nightly-2026-08-13 zigbuild --manifest-path /app/mirrord/remote/bootstrap/Cargo.toml --target $(cat /.platform) --release && \
-    cp /app/target/$(cat /.platform)/release/libmirrord_remote_bootstrap.so /mirrord-remote-bootstrap.so
+    cargo +nightly-2026-08-13 zigbuild --manifest-path /app/mirrord/remote/bootstrap/Cargo.toml --target $(cat /.platform) ${release_flag:-} && \
+    cp "/app/target/$(cat /.platform)/${target_dir}/libmirrord_remote_bootstrap.so" /mirrord-remote-bootstrap.so
 
 FROM debian:bookworm-slim AS remote-bootstrap
 COPY --from=remote-bootstrap-builder /mirrord-remote-bootstrap.so /opt/mirrord/lib/libmirrord_remote_bootstrap.so


### PR DESCRIPTION
Summary

Package the remote bootstrap shared library as a standalone container image.

- Add a `remote-bootstrap` Docker Bake target, including configurable image tags.
- Build the remote layer and bootstrap `.so` files in the agent Dockerfile’s shared builder stage.
- Publish `libmirrord_remote_bootstrap.so` at `/opt/mirrord/lib/` in a minimal Debian runtime image.
- Keep Cargo’s Docker workspace limited to the crates copied into each build stage.

## Testing

Not run (Docker image build not executed locally).