### PR TITLE
Set Host from the authority when sending a stolen HTTP/2 request over HTTP/1

### DIFF
--- a/changelog.d/+h2-downgrade-host-header.fixed.md
+++ b/changelog.d/+h2-downgrade-host-header.fixed.md
@@ -1,0 +1,1 @@
+Fixed a stolen HTTP/2 request being sent to the local application over HTTP/1 without a `Host` header, which servers that enforce the HTTP/1.1 host requirement answer with a 400 response before the application sees the request.

--- a/mirrord/intproxy/src/proxies/incoming/http.rs
+++ b/mirrord/intproxy/src/proxies/incoming/http.rs
@@ -1,9 +1,11 @@
 use std::{fmt, io, net::SocketAddr, ops::Not};
 
 use hyper::{
-    Request, Response, StatusCode, Version,
+    Method, Request, Response, StatusCode, Uri, Version,
     body::Incoming,
     client::conn::{http1, http2},
+    header::{HOST, HeaderValue},
+    http::uri::PathAndQuery,
 };
 use hyper_util::rt::{TokioExecutor, TokioIo};
 use mirrord_protocol::{
@@ -174,6 +176,60 @@ pub fn mirrord_error_response<M: fmt::Display>(
     }
 }
 
+/// Adapts a request taken from an HTTP/2 connection to be sent over HTTP/1.
+///
+/// HTTP/2 carries the target in the `:scheme`, `:authority` and `:path` pseudo-headers, which
+/// [`hyper`] exposes as a URI in absolute form, and carries no `Host` header. HTTP/1.1 requires
+/// `Host`, and [RFC 9113 section 8.3.1] makes recreating it from the authority the job of whoever
+/// converts the request. Servers that enforce the requirement (Tomcat, for one) answer a request
+/// without it with a bare 400, before the application sees anything.
+///
+/// The target is rewritten to origin form for a related reason: absolute form is meant for
+/// requests made to a proxy, and frameworks that route on the raw target do not expect it.
+///
+/// A request that already carries a `Host` header keeps it, and a target with no authority to take
+/// the host from is left as it is.
+///
+/// [RFC 9113 section 8.3.1]: https://www.rfc-editor.org/rfc/rfc9113#section-8.3.1
+fn downgrade_to_http1<B>(request: &mut Request<B>) {
+    if request.version() != Version::HTTP_2 {
+        return;
+    }
+
+    // In a CONNECT request the authority is the target itself, and there is no path to fall back
+    // on.
+    if request.method() == Method::CONNECT {
+        return;
+    }
+
+    *request.version_mut() = Version::HTTP_11;
+
+    let Some(authority) = request.uri().authority().cloned() else {
+        return;
+    };
+
+    if request.headers().contains_key(HOST).not() {
+        // An `Authority` can carry the deprecated userinfo component, which must not appear in a
+        // `Host` header.
+        let host = authority.as_str();
+        let host = host.rsplit_once('@').map_or(host, |(_, host)| host);
+
+        if let Ok(value) = HeaderValue::from_str(host) {
+            request.headers_mut().insert(HOST, value);
+        }
+    }
+
+    let mut parts = request.uri().clone().into_parts();
+    parts.scheme = None;
+    parts.authority = None;
+    parts
+        .path_and_query
+        .get_or_insert_with(|| PathAndQuery::from_static("/"));
+    if let Ok(uri) = Uri::from_parts(parts) {
+        *request.uri_mut() = uri;
+    }
+}
+
 /// Holds either [`http1::SendRequest`] or [`http2::SendRequest`] and exposes a unified interface.
 enum HttpSender {
     V1(http1::SendRequest<StreamingBody>),
@@ -245,12 +301,15 @@ impl HttpSender {
     ) -> Result<Response<Incoming>, LocalHttpError> {
         match self {
             Self::V1(sender) => {
+                let mut hyper_request: Request<_> = request.internal_request.into();
+                downgrade_to_http1(&mut hyper_request);
+
                 // Solves a "connection was not ready" client error.
                 // https://rust-lang.github.io/wg-async/vision/submitted_stories/status_quo/barbara_tries_unix_socket.html#the-single-magical-line
                 sender.ready().await.map_err(LocalHttpError::SendFailed)?;
 
                 sender
-                    .send_request(request.internal_request.into())
+                    .send_request(hyper_request)
                     .await
                     .map_err(LocalHttpError::SendFailed)
             }
@@ -281,5 +340,159 @@ impl HttpSender {
                     .map_err(LocalHttpError::SendFailed)
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::ops::Not;
+
+    use hyper::{Method, Request, Uri, Version, header::HOST};
+    use mirrord_protocol::tcp::{HttpRequest, InternalHttpRequest};
+    use rstest::rstest;
+    use tokio::{
+        io::{AsyncReadExt, AsyncWriteExt},
+        net::{TcpListener, TcpStream},
+    };
+
+    use super::{HttpSender, StreamingBody, downgrade_to_http1};
+
+    /// Builds a request as [`hyper`]'s HTTP/2 server produces it: version [`Version::HTTP_2`], the
+    /// target in absolute form, and no `Host` header.
+    fn http2_request(uri: &str) -> Request<()> {
+        let mut request = Request::new(());
+        *request.uri_mut() = uri.parse::<Uri>().unwrap();
+        *request.version_mut() = Version::HTTP_2;
+        request
+    }
+
+    /// Verifies that a request converted to HTTP/1 carries a `Host` header made from the
+    /// authority, and that the target is rewritten to origin form.
+    #[rstest]
+    #[case::with_path("http://some.server.com/api/v1?q=1", "some.server.com", "/api/v1?q=1")]
+    #[case::with_port("http://some.server.com:8080/", "some.server.com:8080", "/")]
+    #[case::empty_path("http://some.server.com", "some.server.com", "/")]
+    #[case::userinfo_stripped("http://user@some.server.com/", "some.server.com", "/")]
+    #[test]
+    fn downgrade_sets_host_and_origin_form(
+        #[case] uri: &str,
+        #[case] expected_host: &str,
+        #[case] expected_target: &str,
+    ) {
+        let mut request = http2_request(uri);
+        downgrade_to_http1(&mut request);
+
+        assert_eq!(request.headers().get(HOST).unwrap(), expected_host);
+        assert_eq!(request.uri().to_string(), expected_target);
+        assert_eq!(request.version(), Version::HTTP_11);
+    }
+
+    /// Verifies that a `Host` header the original request carried is not replaced.
+    ///
+    /// An HTTP/2 request may carry both, and [RFC 9113 section 8.3.1] states that the authority is
+    /// used only when there is no `Host` header.
+    ///
+    /// [RFC 9113 section 8.3.1]: https://www.rfc-editor.org/rfc/rfc9113#section-8.3.1
+    #[test]
+    fn downgrade_keeps_original_host_header() {
+        let mut request = http2_request("http://from.authority.com/");
+        request
+            .headers_mut()
+            .insert(HOST, "from.header.com".parse().unwrap());
+
+        downgrade_to_http1(&mut request);
+
+        assert_eq!(request.headers().get(HOST).unwrap(), "from.header.com");
+    }
+
+    /// Verifies that a request that did not come from an HTTP/2 connection is left alone.
+    ///
+    /// An HTTP/1 client is allowed to send a target in absolute form, and it sends its own `Host`
+    /// header. Neither is ours to rewrite.
+    #[test]
+    fn downgrade_does_not_touch_http1_requests() {
+        let mut request = http2_request("http://some.server.com/api/v1");
+        *request.version_mut() = Version::HTTP_11;
+        request
+            .headers_mut()
+            .insert(HOST, "other.server.com".parse().unwrap());
+
+        downgrade_to_http1(&mut request);
+
+        assert_eq!(request.uri().to_string(), "http://some.server.com/api/v1");
+        assert_eq!(request.headers().get(HOST).unwrap(), "other.server.com");
+    }
+
+    /// Verifies that the target of a CONNECT request is not rewritten.
+    ///
+    /// The authority of such a request is the target itself, and there is no path to replace it
+    /// with.
+    #[test]
+    fn downgrade_does_not_touch_connect_target() {
+        let mut request = http2_request("some.server.com:443");
+        *request.method_mut() = Method::CONNECT;
+
+        downgrade_to_http1(&mut request);
+
+        assert_eq!(request.uri().to_string(), "some.server.com:443");
+        assert!(request.headers().get(HOST).is_none());
+    }
+
+    /// Verifies end-to-end that a stolen HTTP/2 request reaches the local application's HTTP/1
+    /// server with a `Host` header.
+    ///
+    /// Servers that enforce the HTTP/1.1 `Host` requirement reject a request without it before the
+    /// application is involved, so this is checked on the bytes that go out on the wire.
+    #[tokio::test]
+    async fn sends_host_header_to_local_http1_server() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let server = tokio::spawn(async move {
+            let (mut connection, _) = listener.accept().await.unwrap();
+
+            let mut head = Vec::new();
+            while head.windows(4).any(|window| window == b"\r\n\r\n").not() {
+                let read = connection.read_buf(&mut head).await.unwrap();
+                assert_ne!(read, 0, "the client closed the connection");
+            }
+
+            connection
+                .write_all(b"HTTP/1.1 200 OK\r\ncontent-length: 0\r\n\r\n")
+                .await
+                .unwrap();
+
+            String::from_utf8(head).unwrap()
+        });
+
+        let stream = TcpStream::connect(addr).await.unwrap();
+        let mut sender = HttpSender::handshake(Version::HTTP_11, stream)
+            .await
+            .unwrap();
+        let request = HttpRequest {
+            connection_id: 0,
+            request_id: 0,
+            port: addr.port(),
+            internal_request: InternalHttpRequest {
+                method: Method::GET,
+                uri: "http://some.server.com:8080/api/v1?q=1".parse().unwrap(),
+                headers: Default::default(),
+                version: Version::HTTP_2,
+                body: StreamingBody::default(),
+            },
+        };
+
+        let response = sender.send_request(request).await.unwrap();
+        assert_eq!(response.status(), 200);
+
+        let head = server.await.unwrap();
+        let (request_line, headers) = head.split_once("\r\n").unwrap();
+        assert_eq!(request_line, "GET /api/v1?q=1 HTTP/1.1");
+        assert!(
+            headers
+                .lines()
+                .any(|line| line.eq_ignore_ascii_case("host: some.server.com:8080")),
+            "request head is missing the host header:\n{head}",
+        );
     }
 }

--- a/mirrord/intproxy/src/proxies/incoming/http.rs
+++ b/mirrord/intproxy/src/proxies/incoming/http.rs
@@ -95,6 +95,9 @@ pub enum LocalHttpError {
     #[error("{0:?} is not supported in the local HTTP proxy")]
     UnsupportedHttpVersion(Version),
 
+    #[error("an HTTP/2 CONNECT request cannot be sent to an HTTP/1 server")]
+    UnsupportedHttp2Connect,
+
     #[error("failed to send the request to the local application's HTTP server: {0}")]
     SendFailed(#[source] hyper::Error),
 
@@ -137,6 +140,7 @@ impl LocalHttpError {
         match self {
             Self::SocketSetupFailed(..)
             | Self::UnsupportedHttpVersion(..)
+            | Self::UnsupportedHttp2Connect
             | Self::TlsSetupError(..) => false,
             Self::ConnectTcpFailed(..) | Self::ConnectTlsFailed(..) => true,
             Self::HandshakeFailed(err) | Self::SendFailed(err) | Self::ReadBodyFailed(err) => (err
@@ -190,22 +194,25 @@ pub fn mirrord_error_response<M: fmt::Display>(
 /// A request that already carries a `Host` header keeps it, and a target with no authority to take
 /// the host from is left as it is.
 ///
+/// A CONNECT request is rejected instead. Its authority is the target itself rather than a host to
+/// put in a header, and the tunnel it asks for is not the same thing in both protocols - an HTTP/2
+/// CONNECT tunnels one stream, an HTTP/1 CONNECT tunnels the whole connection - so there is no
+/// conversion to make.
+///
 /// [RFC 9113 section 8.3.1]: https://www.rfc-editor.org/rfc/rfc9113#section-8.3.1
-fn downgrade_to_http1<B>(request: &mut Request<B>) {
+fn downgrade_to_http1<B>(request: &mut Request<B>) -> Result<(), LocalHttpError> {
     if request.version() != Version::HTTP_2 {
-        return;
+        return Ok(());
     }
 
-    // In a CONNECT request the authority is the target itself, and there is no path to fall back
-    // on.
     if request.method() == Method::CONNECT {
-        return;
+        return Err(LocalHttpError::UnsupportedHttp2Connect);
     }
 
     *request.version_mut() = Version::HTTP_11;
 
     let Some(authority) = request.uri().authority().cloned() else {
-        return;
+        return Ok(());
     };
 
     if request.headers().contains_key(HOST).not() {
@@ -228,6 +235,8 @@ fn downgrade_to_http1<B>(request: &mut Request<B>) {
     if let Ok(uri) = Uri::from_parts(parts) {
         *request.uri_mut() = uri;
     }
+
+    Ok(())
 }
 
 /// Holds either [`http1::SendRequest`] or [`http2::SendRequest`] and exposes a unified interface.
@@ -302,7 +311,7 @@ impl HttpSender {
         match self {
             Self::V1(sender) => {
                 let mut hyper_request: Request<_> = request.internal_request.into();
-                downgrade_to_http1(&mut hyper_request);
+                downgrade_to_http1(&mut hyper_request)?;
 
                 // Solves a "connection was not ready" client error.
                 // https://rust-lang.github.io/wg-async/vision/submitted_stories/status_quo/barbara_tries_unix_socket.html#the-single-magical-line
@@ -355,7 +364,7 @@ mod test {
         net::{TcpListener, TcpStream},
     };
 
-    use super::{HttpSender, StreamingBody, downgrade_to_http1};
+    use super::{HttpSender, LocalHttpError, StreamingBody, downgrade_to_http1};
 
     /// Builds a request as [`hyper`]'s HTTP/2 server produces it: version [`Version::HTTP_2`], the
     /// target in absolute form, and no `Host` header.
@@ -380,7 +389,7 @@ mod test {
         #[case] expected_target: &str,
     ) {
         let mut request = http2_request(uri);
-        downgrade_to_http1(&mut request);
+        downgrade_to_http1(&mut request).unwrap();
 
         assert_eq!(request.headers().get(HOST).unwrap(), expected_host);
         assert_eq!(request.uri().to_string(), expected_target);
@@ -400,7 +409,7 @@ mod test {
             .headers_mut()
             .insert(HOST, "from.header.com".parse().unwrap());
 
-        downgrade_to_http1(&mut request);
+        downgrade_to_http1(&mut request).unwrap();
 
         assert_eq!(request.headers().get(HOST).unwrap(), "from.header.com");
     }
@@ -417,25 +426,29 @@ mod test {
             .headers_mut()
             .insert(HOST, "other.server.com".parse().unwrap());
 
-        downgrade_to_http1(&mut request);
+        downgrade_to_http1(&mut request).unwrap();
 
         assert_eq!(request.uri().to_string(), "http://some.server.com/api/v1");
         assert_eq!(request.headers().get(HOST).unwrap(), "other.server.com");
     }
 
-    /// Verifies that the target of a CONNECT request is not rewritten.
+    /// Verifies that an HTTP/2 CONNECT request is rejected rather than converted.
     ///
-    /// The authority of such a request is the target itself, and there is no path to replace it
-    /// with.
+    /// The tunnel such a request asks for is not the same thing in both protocols, so sending it
+    /// to an HTTP/1 server would mean something else than the client asked for.
     #[test]
-    fn downgrade_does_not_touch_connect_target() {
+    fn downgrade_rejects_http2_connect() {
         let mut request = http2_request("some.server.com:443");
         *request.method_mut() = Method::CONNECT;
 
-        downgrade_to_http1(&mut request);
+        let error = downgrade_to_http1(&mut request)
+            .expect_err("an HTTP/2 CONNECT request has no HTTP/1 equivalent");
 
-        assert_eq!(request.uri().to_string(), "some.server.com:443");
-        assert!(request.headers().get(HOST).is_none());
+        assert!(
+            matches!(error, LocalHttpError::UnsupportedHttp2Connect),
+            "unexpected error: {error:?}",
+        );
+        assert!(error.can_retry().not(), "retrying cannot help");
     }
 
     /// Verifies end-to-end that a stolen HTTP/2 request reaches the local application's HTTP/1

--- a/mirrord/intproxy/src/proxies/incoming/http.rs
+++ b/mirrord/intproxy/src/proxies/incoming/http.rs
@@ -375,8 +375,6 @@ mod test {
         request
     }
 
-    /// Verifies that a request converted to HTTP/1 carries a `Host` header made from the
-    /// authority, and that the target is rewritten to origin form.
     #[rstest]
     #[case::with_path("http://some.server.com/api/v1?q=1", "some.server.com", "/api/v1?q=1")]
     #[case::with_port("http://some.server.com:8080/", "some.server.com:8080", "/")]
@@ -396,10 +394,8 @@ mod test {
         assert_eq!(request.version(), Version::HTTP_11);
     }
 
-    /// Verifies that a `Host` header the original request carried is not replaced.
-    ///
-    /// An HTTP/2 request may carry both, and [RFC 9113 section 8.3.1] states that the authority is
-    /// used only when there is no `Host` header.
+    /// An HTTP/2 request may carry an authority and a `Host` header both, and [RFC 9113 section
+    /// 8.3.1] states that the authority is used only when there is no `Host` header.
     ///
     /// [RFC 9113 section 8.3.1]: https://www.rfc-editor.org/rfc/rfc9113#section-8.3.1
     #[test]
@@ -414,8 +410,6 @@ mod test {
         assert_eq!(request.headers().get(HOST).unwrap(), "from.header.com");
     }
 
-    /// Verifies that a request that did not come from an HTTP/2 connection is left alone.
-    ///
     /// An HTTP/1 client is allowed to send a target in absolute form, and it sends its own `Host`
     /// header. Neither is ours to rewrite.
     #[test]
@@ -432,10 +426,8 @@ mod test {
         assert_eq!(request.headers().get(HOST).unwrap(), "other.server.com");
     }
 
-    /// Verifies that an HTTP/2 CONNECT request is rejected rather than converted.
-    ///
-    /// The tunnel such a request asks for is not the same thing in both protocols, so sending it
-    /// to an HTTP/1 server would mean something else than the client asked for.
+    /// The tunnel a CONNECT request asks for is not the same thing in both protocols, so sending
+    /// it to an HTTP/1 server would mean something else than the client asked for.
     #[test]
     fn downgrade_rejects_http2_connect() {
         let mut request = http2_request("some.server.com:443");
@@ -451,9 +443,6 @@ mod test {
         assert!(error.can_retry().not(), "retrying cannot help");
     }
 
-    /// Verifies end-to-end that a stolen HTTP/2 request reaches the local application's HTTP/1
-    /// server with a `Host` header.
-    ///
     /// Servers that enforce the HTTP/1.1 `Host` requirement reject a request without it before the
     /// application is involved, so this is checked on the bytes that go out on the wire.
     #[tokio::test]

--- a/mirrord/intproxy/src/proxies/incoming/http.rs
+++ b/mirrord/intproxy/src/proxies/incoming/http.rs
@@ -211,19 +211,20 @@ fn downgrade_to_http1<B>(request: &mut Request<B>) -> Result<(), LocalHttpError>
 
     *request.version_mut() = Version::HTTP_11;
 
-    let Some(authority) = request.uri().authority().cloned() else {
+    let Some(authority) = request.uri().authority() else {
         return Ok(());
     };
 
-    if request.headers().contains_key(HOST).not() {
-        // An `Authority` can carry the deprecated userinfo component, which must not appear in a
-        // `Host` header.
-        let host = authority.as_str();
-        let host = host.rsplit_once('@').map_or(host, |(_, host)| host);
+    // An `Authority` can carry the deprecated userinfo component, which must not appear in a
+    // `Host` header.
+    let host = authority.as_str();
+    let host = host.rsplit_once('@').map_or(host, |(_, host)| host);
+    let host = HeaderValue::from_str(host);
 
-        if let Ok(value) = HeaderValue::from_str(host) {
-            request.headers_mut().insert(HOST, value);
-        }
+    if let Ok(host) = host
+        && request.headers().contains_key(HOST).not()
+    {
+        request.headers_mut().insert(HOST, host);
     }
 
     let mut parts = request.uri().clone().into_parts();


### PR DESCRIPTION
An HTTP/2 request carries its target in pseudo-headers and has no `Host` header, so converting one to HTTP/1 means recreating `Host` from the authority, as [RFC 9113 section 8.3.1](https://www.rfc-editor.org/rfc/rfc9113#section-8.3.1) requires. We were sending neither, and a server that enforces the HTTP/1.1 host requirement (Tomcat, for one) answers such a request with a bare 400 before the application is involved.

The target is also rewritten from absolute to origin form, which is what a server that is not a proxy expects.

Tested with unit tests over the conversion, plus one that asserts the bytes that reach a local HTTP/1 server.

Part of COR-1838.
