### PR TITLE
Pick the local HTTP protocol from the request, not from the connection pool

### DIFF
--- a/changelog.d/+local-http-client-protocol-match.fixed.md
+++ b/changelog.d/+local-http-client-protocol-match.fixed.md
@@ -1,1 +1,1 @@
-Fixed a stolen HTTP/2 request being sent to the local application over a pooled HTTP/1 connection, which made the protocol the application saw depend on what was in the connection pool. A local server that rejects cleartext HTTP/2 is now talked to over HTTP/1 for the rest of the session instead.
+Fixed a stolen HTTP/2 request being sent to the local application over a pooled HTTP/1 connection, which made the protocol the application saw depend on what was in the connection pool.

--- a/changelog.d/+local-http-client-protocol-match.fixed.md
+++ b/changelog.d/+local-http-client-protocol-match.fixed.md
@@ -1,0 +1,1 @@
+Fixed a stolen HTTP/2 request being sent to the local application over a pooled HTTP/1 connection, which made the protocol the application saw depend on what was in the connection pool. A local server that rejects cleartext HTTP/2 is now talked to over HTTP/1 for the rest of the session instead.

--- a/mirrord/intproxy/src/proxies/incoming/http.rs
+++ b/mirrord/intproxy/src/proxies/incoming/http.rs
@@ -36,6 +36,12 @@ pub struct LocalHttpClient {
     address: SocketAddr,
     /// Whether this client uses TLS.
     uses_tls: bool,
+    /// Whether this client has already delivered a request.
+    ///
+    /// Distinguishes a connection the user application has proven it can serve from one that has
+    /// never worked. See
+    /// [`ClientStore::note_send_failure`](client_store::ClientStore::note_send_failure).
+    handled_request: bool,
 }
 
 impl LocalHttpClient {
@@ -45,7 +51,9 @@ impl LocalHttpClient {
         &mut self,
         request: HttpRequest<StreamingBody>,
     ) -> Result<Response<Incoming>, LocalHttpError> {
-        self.sender.send_request(request).await
+        let response = self.sender.send_request(request).await?;
+        self.handled_request = true;
+        Ok(response)
     }
 
     /// Returns the address of the local server to which this client is connected.
@@ -53,17 +61,34 @@ impl LocalHttpClient {
         self.local_server_address
     }
 
+    /// Whether this client can send a request of the given [`Version`].
+    ///
+    /// A client speaks exactly the protocol it made its handshake with, so the versions must
+    /// match. An HTTP/1 client would send an HTTP/2 request over HTTP/1, which is a conversion
+    /// that the local application has not agreed to and that loses everything HTTP/2 carries in
+    /// its frames.
     pub fn handles_version(&self, version: Version) -> bool {
-        match (&self.sender, version) {
-            (_, Version::HTTP_3) => false,
-            (HttpSender::V2(..), Version::HTTP_2) => true,
-            (HttpSender::V1(..), _) => true,
-            (HttpSender::V2(..), _) => false,
-        }
+        matches!(
+            (&self.sender, version),
+            (
+                HttpSender::V1(..),
+                Version::HTTP_09 | Version::HTTP_10 | Version::HTTP_11
+            ) | (HttpSender::V2(..), Version::HTTP_2)
+        )
     }
 
     pub fn uses_tls(&self) -> bool {
         self.uses_tls
+    }
+
+    /// Whether this client speaks HTTP/2.
+    pub fn is_http_2(&self) -> bool {
+        matches!(self.sender, HttpSender::V2(..))
+    }
+
+    /// Whether this client has already delivered a request.
+    pub fn handled_request(&self) -> bool {
+        self.handled_request
     }
 
     /// Whether the connection with the user application's HTTP server is gone.
@@ -82,6 +107,7 @@ impl fmt::Debug for LocalHttpClient {
             .field("address", &self.address)
             .field("is_http_1", &matches!(self.sender, HttpSender::V1(..)))
             .field("uses_tls", &self.uses_tls)
+            .field("handled_request", &self.handled_request)
             .finish()
     }
 }

--- a/mirrord/intproxy/src/proxies/incoming/http.rs
+++ b/mirrord/intproxy/src/proxies/incoming/http.rs
@@ -36,12 +36,6 @@ pub struct LocalHttpClient {
     address: SocketAddr,
     /// Whether this client uses TLS.
     uses_tls: bool,
-    /// Whether this client has already delivered a request.
-    ///
-    /// Distinguishes a connection the user application has proven it can serve from one that has
-    /// never worked. See
-    /// [`ClientStore::note_send_failure`](client_store::ClientStore::note_send_failure).
-    handled_request: bool,
 }
 
 impl LocalHttpClient {
@@ -51,9 +45,7 @@ impl LocalHttpClient {
         &mut self,
         request: HttpRequest<StreamingBody>,
     ) -> Result<Response<Incoming>, LocalHttpError> {
-        let response = self.sender.send_request(request).await?;
-        self.handled_request = true;
-        Ok(response)
+        self.sender.send_request(request).await
     }
 
     /// Returns the address of the local server to which this client is connected.
@@ -64,9 +56,8 @@ impl LocalHttpClient {
     /// Whether this client can send a request of the given [`Version`].
     ///
     /// A client speaks exactly the protocol it made its handshake with, so the versions must
-    /// match. An HTTP/1 client would send an HTTP/2 request over HTTP/1, which is a conversion
-    /// that the local application has not agreed to and that loses everything HTTP/2 carries in
-    /// its frames.
+    /// match. An HTTP/1 client would send an HTTP/2 request over HTTP/1, a conversion that the
+    /// local application has not agreed to and that loses everything HTTP/2 carries in its frames.
     pub fn handles_version(&self, version: Version) -> bool {
         matches!(
             (&self.sender, version),
@@ -79,16 +70,6 @@ impl LocalHttpClient {
 
     pub fn uses_tls(&self) -> bool {
         self.uses_tls
-    }
-
-    /// Whether this client speaks HTTP/2.
-    pub fn is_http_2(&self) -> bool {
-        matches!(self.sender, HttpSender::V2(..))
-    }
-
-    /// Whether this client has already delivered a request.
-    pub fn handled_request(&self) -> bool {
-        self.handled_request
     }
 
     /// Whether the connection with the user application's HTTP server is gone.
@@ -107,7 +88,6 @@ impl fmt::Debug for LocalHttpClient {
             .field("address", &self.address)
             .field("is_http_1", &matches!(self.sender, HttpSender::V1(..)))
             .field("uses_tls", &self.uses_tls)
-            .field("handled_request", &self.handled_request)
             .finish()
     }
 }

--- a/mirrord/intproxy/src/proxies/incoming/http/client_store.rs
+++ b/mirrord/intproxy/src/proxies/incoming/http/client_store.rs
@@ -407,10 +407,9 @@ mod test {
     use super::{ClientStore, HttpSender};
     use crate::proxies::incoming::{http::StreamingBody, tls::LocalTlsSetup};
 
-    /// Verifies that an idle HTTP/1 client is not reused for an HTTP/2 request.
-    ///
-    /// Reusing one silently converts the request to HTTP/1, which makes the protocol that the
-    /// local application sees depend on what happens to be in the store.
+    /// Reusing an idle HTTP/1 client for an HTTP/2 request silently converts the request to
+    /// HTTP/1, which makes the protocol that the local application sees depend on what happens to
+    /// be in the store.
     #[tokio::test]
     async fn does_not_reuse_http1_client_for_http2_request() {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();

--- a/mirrord/intproxy/src/proxies/incoming/http/client_store.rs
+++ b/mirrord/intproxy/src/proxies/incoming/http/client_store.rs
@@ -1,7 +1,5 @@
 use std::{
-    cmp,
-    collections::HashSet,
-    fmt,
+    cmp, fmt,
     net::SocketAddr,
     ops::Not,
     sync::{Arc, Mutex},
@@ -18,7 +16,7 @@ use tokio::{
     sync::Notify,
     time::{self, Instant},
 };
-use tokio_rustls::{TlsConnector, TlsStream};
+use tokio_rustls::TlsStream;
 use tracing::Level;
 
 use super::{HttpSender, LocalHttpClient, LocalHttpError};
@@ -68,12 +66,6 @@ pub struct ClientStore {
     /// Make sure to only call [`Notify::notify_waiters`] and [`Notify::notified`] when holding a
     /// lock on [`Self::clients`]. Otherwise you'll have a race condition.
     notify: Arc<Notify>,
-    /// Addresses of local servers that rejected a cleartext HTTP/2 connection preface.
-    ///
-    /// Requests for these servers are sent over HTTP/1, so that only the first one pays for a
-    /// handshake that is known to fail. An entry is never removed, so a local application that
-    /// gains HTTP/2 support is only talked to over HTTP/2 in the next session.
-    http1_only_servers: Arc<Mutex<HashSet<SocketAddr>>>,
 }
 
 impl ClientStore {
@@ -85,7 +77,6 @@ impl ClientStore {
             clients: Default::default(),
             notify: Default::default(),
             tls_setup,
-            http1_only_servers: Default::default(),
         };
 
         // Only spawn cleanup task if connection pooling is enabled
@@ -120,51 +111,12 @@ impl ClientStore {
         transport: &IncomingTrafficTransportType,
         request_uri: &Uri,
     ) -> Result<LocalHttpClient, LocalHttpError> {
-        let version = self.resolve_version(server_addr, version, transport);
-
         if Self::should_enable_connection_pooling() {
             self.get_with_pooling(server_addr, version, transport, request_uri)
                 .await
         } else {
             self.get_without_pooling(server_addr, version, transport, request_uri)
                 .await
-        }
-    }
-
-    /// Whether a connection made with the given transport is wrapped in TLS.
-    fn uses_tls(&self, transport: &IncomingTrafficTransportType) -> bool {
-        matches!(transport, IncomingTrafficTransportType::Tls { .. }) && self.tls_setup.is_some()
-    }
-
-    /// Returns the HTTP [`Version`] to use when talking with the given local server.
-    ///
-    /// This is the request's own version, except for a request that is to be sent in cleartext to
-    /// a server known not to speak HTTP/2. See [`Self::http1_only_servers`].
-    fn resolve_version(
-        &self,
-        server_addr: SocketAddr,
-        version: Version,
-        transport: &IncomingTrafficTransportType,
-    ) -> Version {
-        if version != Version::HTTP_2 || self.uses_tls(transport) {
-            return version;
-        }
-
-        let known_http1_only = self
-            .http1_only_servers
-            .lock()
-            .expect("ClientStore mutex is poisoned, this is a bug")
-            .contains(&server_addr);
-
-        if known_http1_only {
-            tracing::debug!(
-                %server_addr,
-                "Local server does not speak cleartext HTTP/2, sending the request over HTTP/1",
-            );
-
-            Version::HTTP_11
-        } else {
-            version
         }
     }
 
@@ -176,7 +128,8 @@ impl ClientStore {
         transport: &IncomingTrafficTransportType,
         request_uri: &Uri,
     ) -> Result<LocalHttpClient, LocalHttpError> {
-        let uses_tls = self.uses_tls(transport);
+        let uses_tls = matches!(transport, IncomingTrafficTransportType::Tls { .. })
+            && self.tls_setup.is_some();
 
         if let Some(ready) = self
             .wait_for_ready(server_addr, version, uses_tls)
@@ -215,49 +168,6 @@ impl ClientStore {
             .await?;
         tracing::debug!(?client, "Created new HTTP client");
         Ok(client)
-    }
-
-    /// Records that a request failed on the given client.
-    ///
-    /// A cleartext HTTP/2 connection is made with prior knowledge - there is no negotiation, and a
-    /// server that speaks only HTTP/1 rejects the connection preface. [`hyper`] sends the preface
-    /// optimistically, so this shows up as the first request on the connection failing at the
-    /// protocol level, and never as a failed handshake.
-    ///
-    /// When that happens, the local server is remembered as one to talk HTTP/1 to. The request is
-    /// HTTP/2 because the remote server speaks it, which says nothing about the local application,
-    /// and an application that cannot be connected to cannot be developed against.
-    ///
-    /// A connection that has already served a request, or that failed because it was closed, tells
-    /// us nothing about the protocol - a local server is free to end a connection at any point.
-    pub fn note_send_failure(&self, client: &LocalHttpClient, error: &LocalHttpError) {
-        if client.handled_request() || client.uses_tls() || client.is_http_2().not() {
-            return;
-        }
-
-        let LocalHttpError::SendFailed(error) = error else {
-            return;
-        };
-
-        let connection_lost = error.is_closed()
-            || error.is_canceled()
-            || error.is_timeout()
-            || error.is_incomplete_message();
-        if connection_lost {
-            return;
-        }
-
-        tracing::debug!(
-            %error,
-            server_addr = %client.local_server_address(),
-            "Local server rejected an HTTP/2 request on a new connection, \
-            treating it as an HTTP/1 server",
-        );
-
-        self.http1_only_servers
-            .lock()
-            .expect("ClientStore mutex is poisoned, this is a bug")
-            .insert(client.local_server_address());
     }
 
     /// Stores an unused [`LocalHttpClient`], so that it can be reused later.
@@ -388,7 +298,29 @@ impl ClientStore {
 
         let uses_tls = connector_and_name.is_some();
 
-        let (stream, address) = connect(local_server_address, connector_and_name).await?;
+        let stream = TcpStream::connect(local_server_address)
+            .await
+            .map_err(LocalHttpError::ConnectTcpFailed)?;
+        // Stolen requests are relayed over this socket one at a time, so delaying small writes
+        // with Nagle's algorithm only adds latency to every request. Failing to set it costs
+        // latency, not correctness, so it must not fail the connection.
+        if let Err(error) = stream.set_nodelay(true) {
+            tracing::warn!(%error, %local_server_address, "Failed to set TCP_NODELAY on a local HTTP connection");
+        }
+        let address = stream
+            .local_addr()
+            .map_err(LocalHttpError::SocketSetupFailed)?;
+
+        let stream = match connector_and_name {
+            Some((connector, name)) => {
+                let stream = connector
+                    .connect(name, stream)
+                    .await
+                    .map_err(LocalHttpError::ConnectTlsFailed)?;
+                MaybeTls::Tls(Box::new(TlsStream::Client(stream)))
+            }
+            None => MaybeTls::NoTls(stream),
+        };
 
         let sender = HttpSender::handshake(version, stream).await?;
 
@@ -397,43 +329,8 @@ impl ClientStore {
             local_server_address,
             address,
             uses_tls,
-            handled_request: false,
         })
     }
-}
-
-/// Makes a TCP connection with the given server, wrapping it in TLS if a connector is given.
-///
-/// Returns the connection and the address of its local socket.
-async fn connect(
-    local_server_address: SocketAddr,
-    connector_and_name: Option<(TlsConnector, ServerName<'static>)>,
-) -> Result<(MaybeTls, SocketAddr), LocalHttpError> {
-    let stream = TcpStream::connect(local_server_address)
-        .await
-        .map_err(LocalHttpError::ConnectTcpFailed)?;
-    // Stolen requests are relayed over this socket one at a time, so delaying small writes
-    // with Nagle's algorithm only adds latency to every request. Failing to set it costs
-    // latency, not correctness, so it must not fail the connection.
-    if let Err(error) = stream.set_nodelay(true) {
-        tracing::warn!(%error, %local_server_address, "Failed to set TCP_NODELAY on a local HTTP connection");
-    }
-    let address = stream
-        .local_addr()
-        .map_err(LocalHttpError::SocketSetupFailed)?;
-
-    let stream = match connector_and_name {
-        Some((connector, name)) => {
-            let stream = connector
-                .connect(name, stream)
-                .await
-                .map_err(LocalHttpError::ConnectTlsFailed)?;
-            MaybeTls::Tls(Box::new(TlsStream::Client(stream)))
-        }
-        None => MaybeTls::NoTls(stream),
-    };
-
-    Ok((stream, address))
 }
 
 /// Cleans up stale [`LocalHttpClient`]s from the [`ClientStore`].
@@ -487,7 +384,7 @@ async fn cleanup_task(store: ClientStore, idle_client_timeout: Duration) {
 
 #[cfg(test)]
 mod test {
-    use std::{convert::Infallible, net::SocketAddr, ops::Not, sync::Arc, time::Duration};
+    use std::{convert::Infallible, net::SocketAddr, sync::Arc, time::Duration};
 
     use bytes::Bytes;
     use http_body_util::Empty;
@@ -504,37 +401,16 @@ mod test {
         KeyUsagePurpose,
     };
     use rustls::ServerConfig;
-    use tokio::{
-        io::{AsyncReadExt, AsyncWriteExt},
-        net::TcpListener,
-        time,
-    };
+    use tokio::{io::AsyncReadExt, net::TcpListener, time};
     use tokio_rustls::TlsAcceptor;
 
     use super::{ClientStore, HttpSender};
     use crate::proxies::incoming::{http::StreamingBody, tls::LocalTlsSetup};
 
-    /// Makes a request as [`ClientStore`]'s users make it out of a stolen HTTP/2 request: version
-    /// [`Version::HTTP_2`], target in absolute form, and no `Host` header.
-    fn http2_request(port: u16) -> HttpRequest<StreamingBody> {
-        HttpRequest {
-            connection_id: 0,
-            request_id: 0,
-            port,
-            internal_request: InternalHttpRequest {
-                method: Method::GET,
-                uri: "http://some.server.com/api/v1".parse().unwrap(),
-                headers: Default::default(),
-                version: Version::HTTP_2,
-                body: StreamingBody::default(),
-            },
-        }
-    }
-
     /// Verifies that an idle HTTP/1 client is not reused for an HTTP/2 request.
     ///
-    /// Reusing one silently converts the request to HTTP/1, which makes the protocol the local
-    /// application sees depend on what happens to be in the store.
+    /// Reusing one silently converts the request to HTTP/1, which makes the protocol that the
+    /// local application sees depend on what happens to be in the store.
     #[tokio::test]
     async fn does_not_reuse_http1_client_for_http2_request() {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -589,85 +465,6 @@ mod test {
             1,
             "the idle HTTP/1 client should have been left in the store",
         );
-    }
-
-    /// Verifies that a local server which rejects the cleartext HTTP/2 connection preface is
-    /// talked to over HTTP/1 from then on.
-    ///
-    /// A cleartext HTTP/2 connection is made with prior knowledge, so a local application that
-    /// speaks only HTTP/1 would otherwise be unreachable whenever the remote server speaks
-    /// HTTP/2.
-    #[tokio::test]
-    async fn remembers_servers_that_reject_http2() {
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-
-        tokio::spawn(async move {
-            // Answers the connection preface the way a server that speaks only HTTP/1 does.
-            let (mut rejected, _) = listener.accept().await.unwrap();
-            let mut preface = Vec::new();
-            rejected.read_buf(&mut preface).await.unwrap();
-            rejected
-                .write_all(b"HTTP/1.1 400 Bad Request\r\ncontent-length: 0\r\n\r\n")
-                .await
-                .unwrap();
-            std::mem::drop(rejected);
-
-            let service = service_fn(|_req: Request<Incoming>| {
-                std::future::ready(Ok::<_, Infallible>(Response::new(Empty::<Bytes>::new())))
-            });
-            let (connection, _) = listener.accept().await.unwrap();
-            tokio::spawn(http1::Builder::new().serve_connection(TokioIo::new(connection), service));
-
-            // Holds the listener, so that a third connection attempt is not refused but seen.
-            std::future::pending::<()>().await;
-        });
-
-        let client_store =
-            ClientStore::new_with_timeout(Duration::from_secs(60), Default::default());
-        let mut client = client_store
-            .get(
-                addr,
-                Version::HTTP_2,
-                &IncomingTrafficTransportType::Tcp,
-                &"http://some.server.com".parse().unwrap(),
-            )
-            .await
-            .unwrap();
-        assert!(
-            client.is_http_2(),
-            "the store should have made an HTTP/2 client for an HTTP/2 request: {client:?}",
-        );
-
-        // `hyper` sends the connection preface optimistically, so the rejection surfaces here and
-        // not in the handshake.
-        let error = client
-            .send_request(http2_request(addr.port()))
-            .await
-            .expect_err("the local server should have rejected the HTTP/2 request");
-        client_store.note_send_failure(&client, &error);
-        std::mem::drop(client);
-
-        let mut client = client_store
-            .get(
-                addr,
-                Version::HTTP_2,
-                &IncomingTrafficTransportType::Tcp,
-                &"http://some.server.com".parse().unwrap(),
-            )
-            .await
-            .unwrap();
-        assert!(
-            client.is_http_2().not(),
-            "the store should have made an HTTP/1 client for a server that rejected HTTP/2: \
-            {client:?}",
-        );
-
-        let response = client
-            .send_request(http2_request(addr.port()))
-            .await
-            .unwrap();
-        assert_eq!(response.status(), 200);
     }
 
     /// Verifies that [`ClientStore`] cleans up unused connections.

--- a/mirrord/intproxy/src/proxies/incoming/http/client_store.rs
+++ b/mirrord/intproxy/src/proxies/incoming/http/client_store.rs
@@ -1,5 +1,7 @@
 use std::{
-    cmp, fmt,
+    cmp,
+    collections::HashSet,
+    fmt,
     net::SocketAddr,
     ops::Not,
     sync::{Arc, Mutex},
@@ -16,7 +18,7 @@ use tokio::{
     sync::Notify,
     time::{self, Instant},
 };
-use tokio_rustls::TlsStream;
+use tokio_rustls::{TlsConnector, TlsStream};
 use tracing::Level;
 
 use super::{HttpSender, LocalHttpClient, LocalHttpError};
@@ -66,6 +68,12 @@ pub struct ClientStore {
     /// Make sure to only call [`Notify::notify_waiters`] and [`Notify::notified`] when holding a
     /// lock on [`Self::clients`]. Otherwise you'll have a race condition.
     notify: Arc<Notify>,
+    /// Addresses of local servers that rejected a cleartext HTTP/2 connection preface.
+    ///
+    /// Requests for these servers are sent over HTTP/1, so that only the first one pays for a
+    /// handshake that is known to fail. An entry is never removed, so a local application that
+    /// gains HTTP/2 support is only talked to over HTTP/2 in the next session.
+    http1_only_servers: Arc<Mutex<HashSet<SocketAddr>>>,
 }
 
 impl ClientStore {
@@ -77,6 +85,7 @@ impl ClientStore {
             clients: Default::default(),
             notify: Default::default(),
             tls_setup,
+            http1_only_servers: Default::default(),
         };
 
         // Only spawn cleanup task if connection pooling is enabled
@@ -111,12 +120,51 @@ impl ClientStore {
         transport: &IncomingTrafficTransportType,
         request_uri: &Uri,
     ) -> Result<LocalHttpClient, LocalHttpError> {
+        let version = self.resolve_version(server_addr, version, transport);
+
         if Self::should_enable_connection_pooling() {
             self.get_with_pooling(server_addr, version, transport, request_uri)
                 .await
         } else {
             self.get_without_pooling(server_addr, version, transport, request_uri)
                 .await
+        }
+    }
+
+    /// Whether a connection made with the given transport is wrapped in TLS.
+    fn uses_tls(&self, transport: &IncomingTrafficTransportType) -> bool {
+        matches!(transport, IncomingTrafficTransportType::Tls { .. }) && self.tls_setup.is_some()
+    }
+
+    /// Returns the HTTP [`Version`] to use when talking with the given local server.
+    ///
+    /// This is the request's own version, except for a request that is to be sent in cleartext to
+    /// a server known not to speak HTTP/2. See [`Self::http1_only_servers`].
+    fn resolve_version(
+        &self,
+        server_addr: SocketAddr,
+        version: Version,
+        transport: &IncomingTrafficTransportType,
+    ) -> Version {
+        if version != Version::HTTP_2 || self.uses_tls(transport) {
+            return version;
+        }
+
+        let known_http1_only = self
+            .http1_only_servers
+            .lock()
+            .expect("ClientStore mutex is poisoned, this is a bug")
+            .contains(&server_addr);
+
+        if known_http1_only {
+            tracing::debug!(
+                %server_addr,
+                "Local server does not speak cleartext HTTP/2, sending the request over HTTP/1",
+            );
+
+            Version::HTTP_11
+        } else {
+            version
         }
     }
 
@@ -128,8 +176,7 @@ impl ClientStore {
         transport: &IncomingTrafficTransportType,
         request_uri: &Uri,
     ) -> Result<LocalHttpClient, LocalHttpError> {
-        let uses_tls = matches!(transport, IncomingTrafficTransportType::Tls { .. })
-            && self.tls_setup.is_some();
+        let uses_tls = self.uses_tls(transport);
 
         if let Some(ready) = self
             .wait_for_ready(server_addr, version, uses_tls)
@@ -168,6 +215,49 @@ impl ClientStore {
             .await?;
         tracing::debug!(?client, "Created new HTTP client");
         Ok(client)
+    }
+
+    /// Records that a request failed on the given client.
+    ///
+    /// A cleartext HTTP/2 connection is made with prior knowledge - there is no negotiation, and a
+    /// server that speaks only HTTP/1 rejects the connection preface. [`hyper`] sends the preface
+    /// optimistically, so this shows up as the first request on the connection failing at the
+    /// protocol level, and never as a failed handshake.
+    ///
+    /// When that happens, the local server is remembered as one to talk HTTP/1 to. The request is
+    /// HTTP/2 because the remote server speaks it, which says nothing about the local application,
+    /// and an application that cannot be connected to cannot be developed against.
+    ///
+    /// A connection that has already served a request, or that failed because it was closed, tells
+    /// us nothing about the protocol - a local server is free to end a connection at any point.
+    pub fn note_send_failure(&self, client: &LocalHttpClient, error: &LocalHttpError) {
+        if client.handled_request() || client.uses_tls() || client.is_http_2().not() {
+            return;
+        }
+
+        let LocalHttpError::SendFailed(error) = error else {
+            return;
+        };
+
+        let connection_lost = error.is_closed()
+            || error.is_canceled()
+            || error.is_timeout()
+            || error.is_incomplete_message();
+        if connection_lost {
+            return;
+        }
+
+        tracing::debug!(
+            %error,
+            server_addr = %client.local_server_address(),
+            "Local server rejected an HTTP/2 request on a new connection, \
+            treating it as an HTTP/1 server",
+        );
+
+        self.http1_only_servers
+            .lock()
+            .expect("ClientStore mutex is poisoned, this is a bug")
+            .insert(client.local_server_address());
     }
 
     /// Stores an unused [`LocalHttpClient`], so that it can be reused later.
@@ -298,29 +388,7 @@ impl ClientStore {
 
         let uses_tls = connector_and_name.is_some();
 
-        let stream = TcpStream::connect(local_server_address)
-            .await
-            .map_err(LocalHttpError::ConnectTcpFailed)?;
-        // Stolen requests are relayed over this socket one at a time, so delaying small writes
-        // with Nagle's algorithm only adds latency to every request. Failing to set it costs
-        // latency, not correctness, so it must not fail the connection.
-        if let Err(error) = stream.set_nodelay(true) {
-            tracing::warn!(%error, %local_server_address, "Failed to set TCP_NODELAY on a local HTTP connection");
-        }
-        let address = stream
-            .local_addr()
-            .map_err(LocalHttpError::SocketSetupFailed)?;
-
-        let stream = match connector_and_name {
-            Some((connector, name)) => {
-                let stream = connector
-                    .connect(name, stream)
-                    .await
-                    .map_err(LocalHttpError::ConnectTlsFailed)?;
-                MaybeTls::Tls(Box::new(TlsStream::Client(stream)))
-            }
-            None => MaybeTls::NoTls(stream),
-        };
+        let (stream, address) = connect(local_server_address, connector_and_name).await?;
 
         let sender = HttpSender::handshake(version, stream).await?;
 
@@ -329,8 +397,43 @@ impl ClientStore {
             local_server_address,
             address,
             uses_tls,
+            handled_request: false,
         })
     }
+}
+
+/// Makes a TCP connection with the given server, wrapping it in TLS if a connector is given.
+///
+/// Returns the connection and the address of its local socket.
+async fn connect(
+    local_server_address: SocketAddr,
+    connector_and_name: Option<(TlsConnector, ServerName<'static>)>,
+) -> Result<(MaybeTls, SocketAddr), LocalHttpError> {
+    let stream = TcpStream::connect(local_server_address)
+        .await
+        .map_err(LocalHttpError::ConnectTcpFailed)?;
+    // Stolen requests are relayed over this socket one at a time, so delaying small writes
+    // with Nagle's algorithm only adds latency to every request. Failing to set it costs
+    // latency, not correctness, so it must not fail the connection.
+    if let Err(error) = stream.set_nodelay(true) {
+        tracing::warn!(%error, %local_server_address, "Failed to set TCP_NODELAY on a local HTTP connection");
+    }
+    let address = stream
+        .local_addr()
+        .map_err(LocalHttpError::SocketSetupFailed)?;
+
+    let stream = match connector_and_name {
+        Some((connector, name)) => {
+            let stream = connector
+                .connect(name, stream)
+                .await
+                .map_err(LocalHttpError::ConnectTlsFailed)?;
+            MaybeTls::Tls(Box::new(TlsStream::Client(stream)))
+        }
+        None => MaybeTls::NoTls(stream),
+    };
+
+    Ok((stream, address))
 }
 
 /// Cleans up stale [`LocalHttpClient`]s from the [`ClientStore`].
@@ -384,26 +487,188 @@ async fn cleanup_task(store: ClientStore, idle_client_timeout: Duration) {
 
 #[cfg(test)]
 mod test {
-    use std::{convert::Infallible, net::SocketAddr, sync::Arc, time::Duration};
+    use std::{convert::Infallible, net::SocketAddr, ops::Not, sync::Arc, time::Duration};
 
     use bytes::Bytes;
     use http_body_util::Empty;
     use hyper::{
-        Method, Request, Response, Version, body::Incoming, server::conn::http1,
+        Method, Request, Response, Version,
+        body::Incoming,
+        server::conn::{http1, http2},
         service::service_fn,
     };
-    use hyper_util::rt::TokioIo;
+    use hyper_util::rt::{TokioExecutor, TokioIo};
     use mirrord_protocol::tcp::{HttpRequest, IncomingTrafficTransportType, InternalHttpRequest};
     use rcgen::{
         BasicConstraints, CertificateParams, CertifiedKey, DnType, DnValue, IsCa, Issuer, KeyPair,
         KeyUsagePurpose,
     };
     use rustls::ServerConfig;
-    use tokio::{io::AsyncReadExt, net::TcpListener, time};
+    use tokio::{
+        io::{AsyncReadExt, AsyncWriteExt},
+        net::TcpListener,
+        time,
+    };
     use tokio_rustls::TlsAcceptor;
 
-    use super::ClientStore;
+    use super::{ClientStore, HttpSender};
     use crate::proxies::incoming::{http::StreamingBody, tls::LocalTlsSetup};
+
+    /// Makes a request as [`ClientStore`]'s users make it out of a stolen HTTP/2 request: version
+    /// [`Version::HTTP_2`], target in absolute form, and no `Host` header.
+    fn http2_request(port: u16) -> HttpRequest<StreamingBody> {
+        HttpRequest {
+            connection_id: 0,
+            request_id: 0,
+            port,
+            internal_request: InternalHttpRequest {
+                method: Method::GET,
+                uri: "http://some.server.com/api/v1".parse().unwrap(),
+                headers: Default::default(),
+                version: Version::HTTP_2,
+                body: StreamingBody::default(),
+            },
+        }
+    }
+
+    /// Verifies that an idle HTTP/1 client is not reused for an HTTP/2 request.
+    ///
+    /// Reusing one silently converts the request to HTTP/1, which makes the protocol the local
+    /// application sees depend on what happens to be in the store.
+    #[tokio::test]
+    async fn does_not_reuse_http1_client_for_http2_request() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        tokio::spawn(async move {
+            let service = service_fn(|_req: Request<Incoming>| {
+                std::future::ready(Ok::<_, Infallible>(Response::new(Empty::<Bytes>::new())))
+            });
+
+            let (http1_connection, _) = listener.accept().await.unwrap();
+            tokio::spawn(
+                http1::Builder::new().serve_connection(TokioIo::new(http1_connection), service),
+            );
+
+            let (http2_connection, _) = listener.accept().await.unwrap();
+            tokio::spawn(
+                http2::Builder::new(TokioExecutor::default())
+                    .serve_connection(TokioIo::new(http2_connection), service),
+            );
+        });
+
+        let client_store =
+            ClientStore::new_with_timeout(Duration::from_secs(60), Default::default());
+        let http1_client = client_store
+            .get(
+                addr,
+                Version::HTTP_11,
+                &IncomingTrafficTransportType::Tcp,
+                &"http://some.server.com".parse().unwrap(),
+            )
+            .await
+            .unwrap();
+        client_store.push_idle(http1_client);
+
+        let client = client_store
+            .get(
+                addr,
+                Version::HTTP_2,
+                &IncomingTrafficTransportType::Tcp,
+                &"http://some.server.com".parse().unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            matches!(client.sender, HttpSender::V2(..)),
+            "an HTTP/2 request must not be sent over an HTTP/1 connection: {client:?}",
+        );
+        assert_eq!(
+            client_store.clients.lock().unwrap().len(),
+            1,
+            "the idle HTTP/1 client should have been left in the store",
+        );
+    }
+
+    /// Verifies that a local server which rejects the cleartext HTTP/2 connection preface is
+    /// talked to over HTTP/1 from then on.
+    ///
+    /// A cleartext HTTP/2 connection is made with prior knowledge, so a local application that
+    /// speaks only HTTP/1 would otherwise be unreachable whenever the remote server speaks
+    /// HTTP/2.
+    #[tokio::test]
+    async fn remembers_servers_that_reject_http2() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        tokio::spawn(async move {
+            // Answers the connection preface the way a server that speaks only HTTP/1 does.
+            let (mut rejected, _) = listener.accept().await.unwrap();
+            let mut preface = Vec::new();
+            rejected.read_buf(&mut preface).await.unwrap();
+            rejected
+                .write_all(b"HTTP/1.1 400 Bad Request\r\ncontent-length: 0\r\n\r\n")
+                .await
+                .unwrap();
+            std::mem::drop(rejected);
+
+            let service = service_fn(|_req: Request<Incoming>| {
+                std::future::ready(Ok::<_, Infallible>(Response::new(Empty::<Bytes>::new())))
+            });
+            let (connection, _) = listener.accept().await.unwrap();
+            tokio::spawn(http1::Builder::new().serve_connection(TokioIo::new(connection), service));
+
+            // Holds the listener, so that a third connection attempt is not refused but seen.
+            std::future::pending::<()>().await;
+        });
+
+        let client_store =
+            ClientStore::new_with_timeout(Duration::from_secs(60), Default::default());
+        let mut client = client_store
+            .get(
+                addr,
+                Version::HTTP_2,
+                &IncomingTrafficTransportType::Tcp,
+                &"http://some.server.com".parse().unwrap(),
+            )
+            .await
+            .unwrap();
+        assert!(
+            client.is_http_2(),
+            "the store should have made an HTTP/2 client for an HTTP/2 request: {client:?}",
+        );
+
+        // `hyper` sends the connection preface optimistically, so the rejection surfaces here and
+        // not in the handshake.
+        let error = client
+            .send_request(http2_request(addr.port()))
+            .await
+            .expect_err("the local server should have rejected the HTTP/2 request");
+        client_store.note_send_failure(&client, &error);
+        std::mem::drop(client);
+
+        let mut client = client_store
+            .get(
+                addr,
+                Version::HTTP_2,
+                &IncomingTrafficTransportType::Tcp,
+                &"http://some.server.com".parse().unwrap(),
+            )
+            .await
+            .unwrap();
+        assert!(
+            client.is_http_2().not(),
+            "the store should have made an HTTP/1 client for a server that rejected HTTP/2: \
+            {client:?}",
+        );
+
+        let response = client
+            .send_request(http2_request(addr.port()))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), 200);
+    }
 
     /// Verifies that [`ClientStore`] cleans up unused connections.
     #[tokio::test]

--- a/mirrord/intproxy/src/proxies/incoming/http_gateway.rs
+++ b/mirrord/intproxy/src/proxies/incoming/http_gateway.rs
@@ -246,7 +246,15 @@ impl HttpGatewayTask {
                 &self.request.internal_request.uri,
             )
             .await?;
-        let mut response = client.send_request(self.request.clone()).await?;
+        let mut response = match client.send_request(self.request.clone()).await {
+            Ok(response) => response,
+            Err(error) => {
+                // Lets the store learn that this local server does not speak HTTP/2, so that the
+                // next attempt is made over HTTP/1.
+                self.client_store.note_send_failure(&client, &error);
+                return Err(error);
+            }
+        };
         let on_upgrade = (response.status() == StatusCode::SWITCHING_PROTOCOLS).then(|| {
             tracing::debug!("Detected an HTTP upgrade");
             hyper::upgrade::on(&mut response)
@@ -1138,5 +1146,92 @@ mod test {
                 }
             }
         }
+    }
+    /// Verifies that a stolen HTTP/2 request reaches a local server that speaks only HTTP/1.
+    ///
+    /// Such a server rejects the cleartext HTTP/2 connection preface, so the gateway has to make
+    /// another attempt over HTTP/1, and that attempt has to carry the `Host` header that HTTP/1.1
+    /// requires.
+    #[tokio::test]
+    async fn retries_over_http1_when_local_server_rejects_http2() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (host_tx, mut host_rx) = mpsc::channel::<Option<HeaderValue>>(1);
+
+        tokio::spawn(async move {
+            // Answers the connection preface the way a server that speaks only HTTP/1 does.
+            let (mut rejected, _) = listener.accept().await.unwrap();
+            let mut preface = Vec::new();
+            rejected.read_buf(&mut preface).await.unwrap();
+            rejected
+                .write_all(b"HTTP/1.1 400 Bad Request\r\ncontent-length: 0\r\n\r\n")
+                .await
+                .unwrap();
+            std::mem::drop(rejected);
+
+            let service = service_fn(move |req: Request<Incoming>| {
+                let host_tx = host_tx.clone();
+                async move {
+                    let host = req.headers().get(header::HOST).cloned();
+                    let _ = host_tx.send(host).await;
+                    Ok::<_, Infallible>(Response::new(Empty::<Bytes>::new()))
+                }
+            });
+            let (connection, _) = listener.accept().await.unwrap();
+            http1::Builder::new()
+                .serve_connection(TokioIo::new(connection), service)
+                .await
+                .unwrap();
+        });
+
+        // A request as it comes from a stolen HTTP/2 connection: target in absolute form, and no
+        // `Host` header.
+        let request = HttpRequest {
+            connection_id: 0,
+            request_id: 0,
+            port: 80,
+            internal_request: InternalHttpRequest {
+                method: Method::GET,
+                uri: "http://some.server.com/api/v1".parse().unwrap(),
+                headers: Default::default(),
+                version: Version::HTTP_2,
+                body: Default::default(),
+            },
+        };
+
+        let (connection, _, proxy_rx) = Connection::dummy();
+        let mut tasks: BackgroundTasks<(), InProxyTaskMessage, Infallible> =
+            BackgroundTasks::new(connection.tx_handle());
+        let client_store =
+            ClientStore::new_with_timeout(Duration::from_secs(60), Default::default());
+        let _gateway = tasks.register(
+            HttpGatewayTask::new(
+                request,
+                client_store,
+                Some(ResponseMode::Basic),
+                ListeningOn::Socket(addr),
+                IncomingTrafficTransportType::Tcp,
+            ),
+            (),
+            8,
+        );
+
+        match proxy_rx.next().await.unwrap() {
+            ClientMessage::TcpSteal(LayerTcpSteal::HttpResponse(response)) => {
+                assert_eq!(response.internal_response.status, StatusCode::OK);
+            }
+            other => panic!("unexpected message: {other:?}"),
+        }
+
+        assert_eq!(
+            host_rx
+                .recv()
+                .await
+                .unwrap()
+                .as_ref()
+                .map(HeaderValue::as_bytes),
+            Some(b"some.server.com".as_slice()),
+            "the request converted to HTTP/1 must carry a host header",
+        );
     }
 }

--- a/mirrord/intproxy/src/proxies/incoming/http_gateway.rs
+++ b/mirrord/intproxy/src/proxies/incoming/http_gateway.rs
@@ -246,15 +246,7 @@ impl HttpGatewayTask {
                 &self.request.internal_request.uri,
             )
             .await?;
-        let mut response = match client.send_request(self.request.clone()).await {
-            Ok(response) => response,
-            Err(error) => {
-                // Lets the store learn that this local server does not speak HTTP/2, so that the
-                // next attempt is made over HTTP/1.
-                self.client_store.note_send_failure(&client, &error);
-                return Err(error);
-            }
-        };
+        let mut response = client.send_request(self.request.clone()).await?;
         let on_upgrade = (response.status() == StatusCode::SWITCHING_PROTOCOLS).then(|| {
             tracing::debug!("Detected an HTTP upgrade");
             hyper::upgrade::on(&mut response)
@@ -1146,92 +1138,5 @@ mod test {
                 }
             }
         }
-    }
-    /// Verifies that a stolen HTTP/2 request reaches a local server that speaks only HTTP/1.
-    ///
-    /// Such a server rejects the cleartext HTTP/2 connection preface, so the gateway has to make
-    /// another attempt over HTTP/1, and that attempt has to carry the `Host` header that HTTP/1.1
-    /// requires.
-    #[tokio::test]
-    async fn retries_over_http1_when_local_server_rejects_http2() {
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        let (host_tx, mut host_rx) = mpsc::channel::<Option<HeaderValue>>(1);
-
-        tokio::spawn(async move {
-            // Answers the connection preface the way a server that speaks only HTTP/1 does.
-            let (mut rejected, _) = listener.accept().await.unwrap();
-            let mut preface = Vec::new();
-            rejected.read_buf(&mut preface).await.unwrap();
-            rejected
-                .write_all(b"HTTP/1.1 400 Bad Request\r\ncontent-length: 0\r\n\r\n")
-                .await
-                .unwrap();
-            std::mem::drop(rejected);
-
-            let service = service_fn(move |req: Request<Incoming>| {
-                let host_tx = host_tx.clone();
-                async move {
-                    let host = req.headers().get(header::HOST).cloned();
-                    let _ = host_tx.send(host).await;
-                    Ok::<_, Infallible>(Response::new(Empty::<Bytes>::new()))
-                }
-            });
-            let (connection, _) = listener.accept().await.unwrap();
-            http1::Builder::new()
-                .serve_connection(TokioIo::new(connection), service)
-                .await
-                .unwrap();
-        });
-
-        // A request as it comes from a stolen HTTP/2 connection: target in absolute form, and no
-        // `Host` header.
-        let request = HttpRequest {
-            connection_id: 0,
-            request_id: 0,
-            port: 80,
-            internal_request: InternalHttpRequest {
-                method: Method::GET,
-                uri: "http://some.server.com/api/v1".parse().unwrap(),
-                headers: Default::default(),
-                version: Version::HTTP_2,
-                body: Default::default(),
-            },
-        };
-
-        let (connection, _, proxy_rx) = Connection::dummy();
-        let mut tasks: BackgroundTasks<(), InProxyTaskMessage, Infallible> =
-            BackgroundTasks::new(connection.tx_handle());
-        let client_store =
-            ClientStore::new_with_timeout(Duration::from_secs(60), Default::default());
-        let _gateway = tasks.register(
-            HttpGatewayTask::new(
-                request,
-                client_store,
-                Some(ResponseMode::Basic),
-                ListeningOn::Socket(addr),
-                IncomingTrafficTransportType::Tcp,
-            ),
-            (),
-            8,
-        );
-
-        match proxy_rx.next().await.unwrap() {
-            ClientMessage::TcpSteal(LayerTcpSteal::HttpResponse(response)) => {
-                assert_eq!(response.internal_response.status, StatusCode::OK);
-            }
-            other => panic!("unexpected message: {other:?}"),
-        }
-
-        assert_eq!(
-            host_rx
-                .recv()
-                .await
-                .unwrap()
-                .as_ref()
-                .map(HeaderValue::as_bytes),
-            Some(b"some.server.com".as_slice()),
-            "the request converted to HTTP/1 must carry a host header",
-        );
     }
 }


### PR DESCRIPTION
Stacked on #4814.

An idle HTTP/1 client was reused for an HTTP/2 request, so whether the local application saw HTTP/2 or a silent conversion to HTTP/1 depended on what happened to be in the connection pool. Client reuse is keyed by version: a client serves only the protocol it made its handshake with.

A local server that speaks only HTTP/1 will now reject the cleartext HTTP/2 connection preface rather than being handed a converted request, which is the honest outcome — the protocol is the remote server's, not ours to change.

Tested with a store-level test: an idle HTTP/1 client is left alone while an HTTP/2 request gets an HTTP/2 client.

Fixes COR-1838.
