### PR TITLE
feat(monitor): attach the mirrord version to session monitor telemetry

### DIFF
--- a/changelog.d/4817.internal.md
+++ b/changelog.d/4817.internal.md
@@ -1,0 +1,2 @@
+Session monitor telemetry now reports the mirrord version it is running under, so UI
+issues can be attributed to a release.

--- a/packages/monitor/src/App.tsx
+++ b/packages/monitor/src/App.tsx
@@ -17,6 +17,7 @@ import {
   initAnalytics,
   setTelemetryEnabled,
   setLicenseGroup,
+  setMirrordVersion,
   trackEvent,
   emitUserBlocked,
   emitUserSucceeded,
@@ -136,7 +137,9 @@ export default function App({
       (s) => s.config?.['telemetry'] !== false,
     )
     const shouldCapture = sessionAllowsTelemetry && telemetryPref
-    initAnalytics(shouldCapture)
+    const mirrordVersion = sessions[0]?.mirrord_version
+    initAnalytics(shouldCapture, mirrordVersion)
+    setMirrordVersion(mirrordVersion)
     setTelemetryEnabled(shouldCapture)
   }, [sessions, telemetryPref])
 

--- a/packages/monitor/src/App.tsx
+++ b/packages/monitor/src/App.tsx
@@ -17,7 +17,6 @@ import {
   initAnalytics,
   setTelemetryEnabled,
   setLicenseGroup,
-  setMirrordVersion,
   trackEvent,
   emitUserBlocked,
   emitUserSucceeded,
@@ -137,9 +136,7 @@ export default function App({
       (s) => s.config?.['telemetry'] !== false,
     )
     const shouldCapture = sessionAllowsTelemetry && telemetryPref
-    const mirrordVersion = sessions[0]?.mirrord_version
-    initAnalytics(shouldCapture, mirrordVersion)
-    setMirrordVersion(mirrordVersion)
+    initAnalytics(shouldCapture)
     setTelemetryEnabled(shouldCapture)
   }, [sessions, telemetryPref])
 

--- a/packages/monitor/src/analytics.ts
+++ b/packages/monitor/src/analytics.ts
@@ -62,11 +62,6 @@ export function initAnalytics(telemetryEnabled: boolean) {
   // `posthog.init` leaves the client opted in, and init only runs with telemetry enabled, so
   // capturing is already in the desired state before any `setTelemetryEnabled` call arrives.
   appliedTelemetry = true
-  // Under `identified_only` the monitor has no person profile until something asks for one,
-  // and anonymous events drop `$set` server-side. `setPersonProperties` creates the profile,
-  // so this must run before the first capture below. A build that never injected the version
-  // reports `unknown` rather than nothing, so the gap is visible as its own bucket in a
-  // version breakdown instead of looking like an absence of traffic.
   posthog.setPersonProperties({ version: MIRRORD_VERSION ?? 'unknown' })
   posthog.capture('session_monitor_opened', { source: 'session-monitor' })
 }

--- a/packages/monitor/src/analytics.ts
+++ b/packages/monitor/src/analytics.ts
@@ -11,8 +11,8 @@ declare const __MIRRORD_VERSION__: string
  * Users upgrade on their own schedule, so without it a crash fixed in a newer release is
  * indistinguishable from a live regression.
  *
- * Reported as the person properties `version` / `initial_version`, matching what the CLI
- * sets on `client_session_v1` so one breakdown key spans both surfaces.
+ * Reported as the person property `version`, matching what the CLI sets on
+ * `client_session_v1` so one breakdown key spans both surfaces.
  */
 const MIRRORD_VERSION: string | undefined =
   typeof __MIRRORD_VERSION__ === 'undefined' ? undefined : __MIRRORD_VERSION__
@@ -66,10 +66,7 @@ export function initAnalytics(telemetryEnabled: boolean) {
   // and anonymous events drop `$set` server-side. `setPersonProperties` creates the profile,
   // so this must run before the first capture below.
   if (MIRRORD_VERSION) {
-    posthog.setPersonProperties(
-      { version: MIRRORD_VERSION },
-      { initial_version: MIRRORD_VERSION },
-    )
+    posthog.setPersonProperties({ version: MIRRORD_VERSION })
   }
   posthog.capture('session_monitor_opened', { source: 'session-monitor' })
 }

--- a/packages/monitor/src/analytics.ts
+++ b/packages/monitor/src/analytics.ts
@@ -64,10 +64,10 @@ export function initAnalytics(telemetryEnabled: boolean) {
   appliedTelemetry = true
   // Under `identified_only` the monitor has no person profile until something asks for one,
   // and anonymous events drop `$set` server-side. `setPersonProperties` creates the profile,
-  // so this must run before the first capture below.
-  if (MIRRORD_VERSION) {
-    posthog.setPersonProperties({ version: MIRRORD_VERSION })
-  }
+  // so this must run before the first capture below. A build that never injected the version
+  // reports `unknown` rather than nothing, so the gap is visible as its own bucket in a
+  // version breakdown instead of looking like an absence of traffic.
+  posthog.setPersonProperties({ version: MIRRORD_VERSION ?? 'unknown' })
   posthog.capture('session_monitor_opened', { source: 'session-monitor' })
 }
 

--- a/packages/monitor/src/analytics.ts
+++ b/packages/monitor/src/analytics.ts
@@ -3,6 +3,17 @@ import posthog from 'posthog-js'
 const POSTHOG_KEY = 'phc_wIZh92nyk4vu6HidiLFUzjW6piZlZszuWZZFBS7yHHe'
 const POSTHOG_HOST = 'https://hog.metalbear.com'
 
+declare const __MIRRORD_VERSION__: string
+
+/**
+ * The mirrord version this bundle ships in, injected at build time from the workspace
+ * Cargo.toml (the bundle is embedded into the CLI binary built from the same checkout).
+ * Users upgrade on their own schedule, so without it on events a crash fixed in a newer
+ * release is indistinguishable from a live regression.
+ */
+const MIRRORD_VERSION: string | undefined =
+  typeof __MIRRORD_VERSION__ === 'undefined' ? undefined : __MIRRORD_VERSION__
+
 let initialized = false
 
 /**
@@ -14,10 +25,7 @@ let initialized = false
  */
 let appliedTelemetry = false
 
-export function initAnalytics(
-  telemetryEnabled: boolean,
-  mirrordVersion?: string,
-) {
+export function initAnalytics(telemetryEnabled: boolean) {
   if (!telemetryEnabled || initialized) return
   posthog.init(POSTHOG_KEY, {
     api_host: POSTHOG_HOST,
@@ -25,6 +33,18 @@ export function initAnalytics(
     person_profiles: 'identified_only',
     autocapture: false,
     capture_pageview: false,
+    // Stamped here rather than with `posthog.register`: registered super properties persist
+    // in localStorage on this fixed localhost origin, where a UI served later by a
+    // different CLI version would inherit them and misreport its version.
+    before_send: (event) => {
+      if (event && MIRRORD_VERSION) {
+        event.properties = {
+          ...event.properties,
+          mirrord_version: MIRRORD_VERSION,
+        }
+      }
+      return event
+    },
     // The session monitor UI renders file paths, pod names, DNS hostnames, HTTP URLs, and
     // request/response bodies — all of which can contain customer data. Mask every visible
     // text node and every input value in session replays; behavioral data (clicks, nav,
@@ -51,21 +71,7 @@ export function initAnalytics(
   // `posthog.init` leaves the client opted in, and init only runs with telemetry enabled, so
   // capturing is already in the desired state before any `setTelemetryEnabled` call arrives.
   appliedTelemetry = true
-  setMirrordVersion(mirrordVersion)
   posthog.capture('session_monitor_opened', { source: 'session-monitor' })
-}
-
-let registeredVersion: string | null = null
-
-/**
- * Registers the mirrord CLI version serving this UI as a super property, so every event
- * carries it. Users upgrade on their own schedule, so without it a crash fixed in a newer
- * release is indistinguishable from a live regression.
- */
-export function setMirrordVersion(version: string | undefined) {
-  if (!initialized || !version || registeredVersion === version) return
-  registeredVersion = version
-  posthog.register({ mirrord_version: version })
 }
 
 /**

--- a/packages/monitor/src/analytics.ts
+++ b/packages/monitor/src/analytics.ts
@@ -14,7 +14,10 @@ let initialized = false
  */
 let appliedTelemetry = false
 
-export function initAnalytics(telemetryEnabled: boolean) {
+export function initAnalytics(
+  telemetryEnabled: boolean,
+  mirrordVersion?: string,
+) {
   if (!telemetryEnabled || initialized) return
   posthog.init(POSTHOG_KEY, {
     api_host: POSTHOG_HOST,
@@ -48,7 +51,21 @@ export function initAnalytics(telemetryEnabled: boolean) {
   // `posthog.init` leaves the client opted in, and init only runs with telemetry enabled, so
   // capturing is already in the desired state before any `setTelemetryEnabled` call arrives.
   appliedTelemetry = true
+  setMirrordVersion(mirrordVersion)
   posthog.capture('session_monitor_opened', { source: 'session-monitor' })
+}
+
+let registeredVersion: string | null = null
+
+/**
+ * Registers the mirrord CLI version serving this UI as a super property, so every event
+ * carries it. Users upgrade on their own schedule, so without it a crash fixed in a newer
+ * release is indistinguishable from a live regression.
+ */
+export function setMirrordVersion(version: string | undefined) {
+  if (!initialized || !version || registeredVersion === version) return
+  registeredVersion = version
+  posthog.register({ mirrord_version: version })
 }
 
 /**

--- a/packages/monitor/src/analytics.ts
+++ b/packages/monitor/src/analytics.ts
@@ -8,8 +8,11 @@ declare const __MIRRORD_VERSION__: string
 /**
  * The mirrord version this bundle ships in, injected at build time from the workspace
  * Cargo.toml (the bundle is embedded into the CLI binary built from the same checkout).
- * Users upgrade on their own schedule, so without it on events a crash fixed in a newer
- * release is indistinguishable from a live regression.
+ * Users upgrade on their own schedule, so without it a crash fixed in a newer release is
+ * indistinguishable from a live regression.
+ *
+ * Reported as the person properties `version` / `initial_version`, matching what the CLI
+ * sets on `client_session_v1` so one breakdown key spans both surfaces.
  */
 const MIRRORD_VERSION: string | undefined =
   typeof __MIRRORD_VERSION__ === 'undefined' ? undefined : __MIRRORD_VERSION__
@@ -33,18 +36,6 @@ export function initAnalytics(telemetryEnabled: boolean) {
     person_profiles: 'identified_only',
     autocapture: false,
     capture_pageview: false,
-    // Stamped here rather than with `posthog.register`: registered super properties persist
-    // in localStorage on this fixed localhost origin, where a UI served later by a
-    // different CLI version would inherit them and misreport its version.
-    before_send: (event) => {
-      if (event && MIRRORD_VERSION) {
-        event.properties = {
-          ...event.properties,
-          mirrord_version: MIRRORD_VERSION,
-        }
-      }
-      return event
-    },
     // The session monitor UI renders file paths, pod names, DNS hostnames, HTTP URLs, and
     // request/response bodies — all of which can contain customer data. Mask every visible
     // text node and every input value in session replays; behavioral data (clicks, nav,
@@ -71,6 +62,15 @@ export function initAnalytics(telemetryEnabled: boolean) {
   // `posthog.init` leaves the client opted in, and init only runs with telemetry enabled, so
   // capturing is already in the desired state before any `setTelemetryEnabled` call arrives.
   appliedTelemetry = true
+  // Under `identified_only` the monitor has no person profile until something asks for one,
+  // and anonymous events drop `$set` server-side. `setPersonProperties` creates the profile,
+  // so this must run before the first capture below.
+  if (MIRRORD_VERSION) {
+    posthog.setPersonProperties(
+      { version: MIRRORD_VERSION },
+      { initial_version: MIRRORD_VERSION },
+    )
+  }
   posthog.capture('session_monitor_opened', { source: 'session-monitor' })
 }
 

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -1,6 +1,20 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import fs from 'fs'
 import path from 'path'
+
+// The bundle is embedded into the CLI binary built from the same checkout, so the workspace
+// version is exactly the mirrord version this UI ships in. Telemetry stamps it on every event.
+const cargoToml = fs.readFileSync(
+  path.resolve(__dirname, '../../Cargo.toml'),
+  'utf8',
+)
+const mirrordVersion = /^version = "([^"]+)"/m.exec(
+  cargoToml.slice(cargoToml.indexOf('[workspace.package]')),
+)?.[1]
+if (!mirrordVersion) {
+  throw new Error('failed to read the workspace version from Cargo.toml')
+}
 
 // `mirrord-ui` is the single built site. It composes two feature packages — the session monitor
 // (`packages/monitor`) and the config wizard (`packages/wizard`) — which are compiled straight from
@@ -8,12 +22,18 @@ import path from 'path'
 // needs, so each feature's (conflicting) CSS tokens only ever load on its own page.
 export default defineConfig({
   plugins: [react()],
+  define: {
+    __MIRRORD_VERSION__: JSON.stringify(mirrordVersion),
+  },
   resolve: {
     alias: {
       // Order matters: the more specific `/theme` subpath must precede the package root so it is
       // not shadowed. The shell imports just the theme module (no monitor component graph) to
       // apply the shared light/dark preference on both routes.
-      '@mirrord/monitor/theme': path.resolve(__dirname, '../monitor/src/theme.ts'),
+      '@mirrord/monitor/theme': path.resolve(
+        __dirname,
+        '../monitor/src/theme.ts',
+      ),
       '@mirrord/monitor': path.resolve(__dirname, '../monitor/src/index.tsx'),
       '@mirrord/wizard': path.resolve(__dirname, '../wizard/src/index.tsx'),
     },


### PR DESCRIPTION
## Summary

Stamps the mirrord version on session monitor telemetry as the person property `version`, matching what the CLI already sets on `client_session_v1` so a single breakdown key spans both surfaces.

The version is injected at build time from the workspace Cargo.toml (the bundle is embedded into the CLI binary built from the same checkout, so the bundle version is exactly the mirrord version it ships in) and applied with `setPersonProperties` before the first capture. That call is also what creates the person profile: under `person_profiles: 'identified_only'` the monitor has none, and `$set` on an anonymous event is dropped server-side. A build that never injected a version reports `unknown`, so the gap surfaces as its own bucket rather than as absent traffic.

Reading `sessions[0].mirrord_version` from the local session API was rejected: each session reports its own intproxy's version, and sessions from different CLI binaries (terminal CLI vs an IDE-bundled one) can coexist in one list, so the pick is arbitrary and can differ from the CLI actually serving the UI.

The UI ships inside the CLI and users upgrade on their own schedule; without the version, an issue already fixed in a newer release is indistinguishable from a live regression.

Breakdown: [Session monitor events by mirrord version](https://us.posthog.com/project/29024/insights/JygnMvkC)

Closes PRO-232.
