### PR TITLE
feat(remote): route Go runtime accept syscalls into remote-layer

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-# this change will be removed - intended to make mbe-1977 run the full ci
+# this change will be removed - intended to make mbe-1979 run the full ci
 # Hello traveler!
 # This is the CI workflow for mirrord.
 # It is a bit complicated, but it is also very powerful.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5172,13 +5172,13 @@ dependencies = [
  "ctor",
  "dotenvy",
  "exec",
- "frida-gum",
  "futures",
  "libc",
  "mirrord-config",
  "mirrord-intproxy",
  "mirrord-intproxy-protocol",
  "mirrord-layer-core",
+ "mirrord-layer-go",
  "mirrord-layer-lib",
  "mirrord-layer-macro",
  "mirrord-layer-tests",
@@ -5194,7 +5194,6 @@ dependencies = [
  "rstest",
  "serde_json",
  "socket2 0.5.10",
- "syscalls",
  "tempfile",
  "test-cdylib",
  "tokio",
@@ -5209,6 +5208,18 @@ dependencies = [
  "frida-gum",
  "libc",
  "mirrord-layer-lib",
+ "tracing",
+]
+
+[[package]]
+name = "mirrord-layer-go"
+version = "3.253.1"
+dependencies = [
+ "frida-gum",
+ "libc",
+ "mirrord-layer-core",
+ "nix",
+ "syscalls",
  "tracing",
 ]
 
@@ -5464,6 +5475,7 @@ dependencies = [
  "libc",
  "mirrord-intproxy-protocol",
  "mirrord-layer-core",
+ "mirrord-layer-go",
  "mirrord-layer-lib",
  "mirrord-layer-macro",
  "mirrord-remote-layer-protocol",

--- a/changelog.d/+mbe-1979-remote-layer-go.internal.md
+++ b/changelog.d/+mbe-1979-remote-layer-go.internal.md
@@ -1,0 +1,1 @@
+Route accept, getsockname, and getpeername syscalls made by a Go runtime into the remote layer, so Go applications go through the same connection handoff as everything else. The Go syscall trampolines now live in a shared `mirrord-layer-go` crate used by both the layer and the remote layer.

--- a/mirrord/layer-go/Cargo.toml
+++ b/mirrord/layer-go/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "mirrord-layer-go"
+version.workspace = true
+authors.workspace = true
+description.workspace = true
+documentation.workspace = true
+readme.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+publish.workspace = true
+edition.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+mirrord-layer-core = { path = "../layer/core" }
+
+libc.workspace = true
+nix = { workspace = true, features = ["signal"] }
+tracing.workspace = true
+
+[target.'cfg(target_os = "linux")'.dependencies]
+frida-gum.workspace = true
+syscalls.workspace = true

--- a/mirrord/layer-go/src/lib.rs
+++ b/mirrord/layer-go/src/lib.rs
@@ -1,0 +1,234 @@
+//! Shared machinery for hooking syscalls made by a Go runtime.
+//!
+//! Go issues syscalls directly through its own runtime instead of going through libc, so libc
+//! interposition never sees them. Catching them requires replacing the Go runtime's internal
+//! syscall entry points (`syscall.Syscall6` and friends) with assembly trampolines that switch to
+//! the `g0` system stack and then call into ordinary C-ABI Rust code.
+//!
+//! That trampoline machinery is identical for every layer that wants to interpose on a Go
+//! application; only the table deciding what to do with each syscall differs. This crate owns the
+//! trampolines, the Go runtime version detection, and the symbol hooking, and lets each layer plug
+//! in its own dispatch table through [`init`].
+//!
+//! # Usage
+//!
+//! Register the dispatch table once, before hooking, then install the hooks:
+//!
+//! ```no_run
+//! # use mirrord_layer_core::hooks::HookManager;
+//! # use mirrord_layer_go::{Handlers, passthrough};
+//! # unsafe extern "C" fn syscall6(n: i64, a: i64, b: i64, c: i64, d: i64, e: i64, f: i64) -> i64 {
+//! #     unsafe { passthrough(n, a, b, c, d, e, f) }
+//! # }
+//! # unsafe extern "C" fn syscall(n: i64, a: i64, b: i64, c: i64) -> i64 {
+//! #     unsafe { passthrough(n, a, b, c, 0, 0, 0) }
+//! # }
+//! # let hook_manager = &mut HookManager::default();
+//! mirrord_layer_go::init(Handlers { syscall, syscall6 });
+//! mirrord_layer_go::enable_hooks(hook_manager, true);
+//! ```
+#![cfg(all(
+    any(target_arch = "x86_64", target_arch = "aarch64"),
+    target_os = "linux"
+))]
+
+use std::{ffi::CStr, sync::OnceLock};
+
+use frida_gum::NativePointer;
+use mirrord_layer_core::hooks::HookManager;
+use nix::errno::Errno;
+
+#[cfg_attr(target_arch = "x86_64", path = "linux_x64.rs")]
+#[cfg_attr(target_arch = "aarch64", path = "linux_aarch64.rs")]
+mod arch;
+
+pub use arch::{enable_hooks, enable_hooks_in_loaded_module};
+
+/// Dispatch table for syscalls intercepted in a Go runtime.
+///
+/// Both entries receive the raw syscall number and arguments, and must return the raw kernel
+/// result: a non-negative value on success, or `-errno` on failure. [`passthrough`] performs the
+/// syscall unchanged and is the right thing to return for anything the layer does not handle.
+#[derive(Clone, Copy)]
+pub struct Handlers {
+    /// Handles the Go runtime's 3- and 4-argument syscall entry points.
+    ///
+    /// Only reached from Go runtimes older than 1.19, which have separate entry points per
+    /// argument count. Newer runtimes route everything through [`Handlers::syscall6`].
+    pub syscall: SyscallHandler,
+    /// Handles the Go runtime's 6-argument syscall entry point.
+    pub syscall6: Syscall6Handler,
+}
+
+pub type SyscallHandler = unsafe extern "C" fn(i64, i64, i64, i64) -> i64;
+pub type Syscall6Handler = unsafe extern "C" fn(i64, i64, i64, i64, i64, i64, i64) -> i64;
+
+static HANDLERS: OnceLock<Handlers> = OnceLock::new();
+
+/// Registers the dispatch table used by the Go syscall trampolines.
+///
+/// Must be called before [`enable_hooks`], otherwise intercepted syscalls fall through to
+/// [`passthrough`]. Only the first call takes effect.
+pub fn init(handlers: Handlers) {
+    let _ = HANDLERS.set(handlers);
+}
+
+/// Performs `syscall` unchanged, mimicking what the Go runtime would have done itself.
+///
+/// [`Errno`] is set on failure, so callers that inspect `errno` after dispatching observe the same
+/// state a real syscall would have left behind.
+///
+/// # Safety
+///
+/// Issues an arbitrary syscall with arbitrary arguments. Callers must only forward a syscall the
+/// application was already making, with its arguments untouched.
+pub unsafe fn passthrough(
+    syscall: i64,
+    param1: i64,
+    param2: i64,
+    param3: i64,
+    param4: i64,
+    param5: i64,
+    param6: i64,
+) -> i64 {
+    let (Ok(result) | Err(result)) = unsafe {
+        syscalls::syscall!(
+            syscalls::Sysno::from(syscall as i32),
+            param1,
+            param2,
+            param3,
+            param4,
+            param5,
+            param6
+        )
+    }
+    .map(|success| success as i64)
+    .map_err(|fail| {
+        let raw_errno = fail.into_raw();
+        Errno::set_raw(raw_errno);
+
+        -(raw_errno as i64)
+    });
+
+    result
+}
+
+/// C-ABI entry point called by the 6-argument assembly trampolines.
+///
+/// The symbol name is referenced verbatim from the `naked_asm!` blocks in the architecture
+/// modules, so it must stay unmangled.
+#[unsafe(no_mangle)]
+unsafe extern "C" fn c_abi_syscall6_handler(
+    syscall: i64,
+    param1: i64,
+    param2: i64,
+    param3: i64,
+    param4: i64,
+    param5: i64,
+    param6: i64,
+) -> i64 {
+    match HANDLERS.get() {
+        Some(handlers) => unsafe {
+            (handlers.syscall6)(syscall, param1, param2, param3, param4, param5, param6)
+        },
+        None => unsafe { passthrough(syscall, param1, param2, param3, param4, param5, param6) },
+    }
+}
+
+/// C-ABI entry point called by the 3- and 4-argument assembly trampolines.
+///
+/// The symbol name is referenced verbatim from the `naked_asm!` blocks in the architecture
+/// modules, so it must stay unmangled.
+#[unsafe(no_mangle)]
+unsafe extern "C" fn c_abi_syscall_handler(
+    syscall: i64,
+    param1: i64,
+    param2: i64,
+    param3: i64,
+) -> i64 {
+    match HANDLERS.get() {
+        Some(handlers) => unsafe { (handlers.syscall)(syscall, param1, param2, param3) },
+        None => unsafe { passthrough(syscall, param1, param2, param3, 0, 0, 0) },
+    }
+}
+
+/// Handler for `rawVforkSyscall` calls.
+///
+/// Removes the [`libc::CLONE_VM`] flag from the clone flags.
+/// This way the child process will **not** share parent's memory,
+/// and we will be able to safely use hooks in the child.
+///
+/// The [`libc::CLONE_VFORK`] flag is left intact on purpose,
+/// as it only suspends the parent process until the child exits or execs
+/// (which is a behavior we want to preserve - the user application might depend on it).
+///
+/// See [Linux manual](https://man7.org/linux/man-pages/man2/clone.2.html) for reference.
+#[unsafe(no_mangle)]
+unsafe extern "C" fn raw_vfork_handler(
+    mut param_1: i64,
+    param_2: i64,
+    param_3: i64,
+    syscall_num: i64,
+) -> i64 {
+    if syscall_num == libc::SYS_clone {
+        param_1 &= !(libc::CLONE_VM as i64);
+    } else if syscall_num == libc::SYS_clone3 {
+        let args = param_1 as *mut libc::clone_args;
+        let args = unsafe {
+            // Safety: we don't validate pointers from the user app.
+            args.as_mut()
+        };
+        if let Some(args) = args {
+            args.flags &= !(libc::CLONE_VM as u64);
+        }
+    };
+
+    syscalls::syscall!(
+        syscalls::Sysno::from(syscall_num as i32),
+        param_1,
+        param_2,
+        param_3,
+        0,
+        0,
+        0
+    )
+    .map(|success| success as i64)
+    .unwrap_or_else(|error| {
+        let raw_errno = error.into_raw();
+        -(raw_errno as i64)
+    })
+}
+
+/// Extracts version of the Go runtime in the current process.
+fn get_go_runtime_version(hook_manager: &mut HookManager) -> Option<f32> {
+    let version_symbol = hook_manager.resolve_symbol_main_module("runtime.buildVersion.str")?;
+    get_version_from_symbol(version_symbol)
+}
+
+/// Extracts version of the Go runtime from the given module.
+fn get_go_runtime_version_in_module(
+    hook_manager: &mut HookManager,
+    module_name: &str,
+) -> Option<f32> {
+    let version_symbol =
+        hook_manager.resolve_symbol_in_module(module_name, "runtime.buildVersion.str")?;
+    get_version_from_symbol(version_symbol)
+}
+
+/// buildVersion can look a bit complex:
+/// devel go1.25-ecc06f0 Wed Apr 9 00:32:10 2025 -0700
+///
+/// We need to find the word starting with 'go', and parse the next 4 characters.
+fn get_version_from_symbol(version_symbol: NativePointer) -> Option<f32> {
+    let version = unsafe {
+        let cstr = CStr::from_ptr(version_symbol.0 as _);
+        std::str::from_utf8_unchecked(cstr.to_bytes())
+    };
+    version
+        .split_ascii_whitespace()
+        .find_map(|chunk| chunk.strip_prefix("go"))
+        .and_then(|version| version.get(..4))
+        .and_then(|version| version.parse::<f32>().ok())
+        .unwrap_or_else(|| panic!("failed to parse Go runtime version {version:?}"))
+        .into()
+}

--- a/mirrord/layer-go/src/linux_aarch64.rs
+++ b/mirrord/layer-go/src/linux_aarch64.rs
@@ -1,8 +1,9 @@
 use std::arch::naked_asm;
 
+use mirrord_layer_core::{hook_symbol, hooks::HookManager};
 use tracing::trace;
 
-use crate::{HookManager, go::c_abi_syscall6_handler, macros::hook_symbol};
+use crate::c_abi_syscall6_handler;
 
 type VoidFn = unsafe extern "C" fn() -> ();
 static mut FN_ASMCGOCALL: Option<VoidFn> = None;
@@ -164,7 +165,7 @@ fn post_go1_23(hook_manager: &mut HookManager, go_version: f32, module_name: Opt
 /// Refer:
 ///   - File zsyscall_linux_amd64.go generated using mksyscall.pl.
 ///   - <https://cs.opensource.google/go/go/+/refs/tags/go1.18.5:src/syscall/syscall_unix.go>
-pub(crate) fn enable_hooks(hook_manager: &mut HookManager, _use_asmcgocall: bool) {
+pub fn enable_hooks(hook_manager: &mut HookManager, _use_asmcgocall: bool) {
     let Some(version) = super::get_go_runtime_version(hook_manager) else {
         return;
     };
@@ -181,7 +182,7 @@ pub(crate) fn enable_hooks(hook_manager: &mut HookManager, _use_asmcgocall: bool
 }
 
 /// Same as [`enable_hooks`], but hook symbols found in the given `module_name`.
-pub(crate) fn enable_hooks_in_loaded_module(
+pub fn enable_hooks_in_loaded_module(
     hook_manager: &mut HookManager,
     module_name: String,
     _use_asmcgocall: bool,

--- a/mirrord/layer-go/src/linux_x64.rs
+++ b/mirrord/layer-go/src/linux_x64.rs
@@ -1,11 +1,6 @@
 use std::arch::naked_asm;
 
-use nix::errno::Errno;
-use tracing::trace;
-
-use crate::{
-    close_detour, file::hooks::*, hooks::HookManager, macros::hook_symbol, socket::hooks::*,
-};
+use mirrord_layer_core::{hook_symbol, hooks::HookManager};
 /*
  * Reference for which syscalls are managed by the handlers:
  * SYS_openat: Syscall6
@@ -298,105 +293,6 @@ unsafe extern "C" fn go_runtime_abort() {
     naked_asm!("int 0x3", "jmp go_runtime_abort");
 }
 
-/// Syscall & Rawsyscall handler - supports upto 4 params, used for socket,
-/// bind, listen, and accept
-/// Note: Depending on success/failure Syscall may or may not call this handler
-#[unsafe(no_mangle)]
-unsafe extern "C" fn c_abi_syscall_handler(
-    syscall: i64,
-    param1: i64,
-    param2: i64,
-    param3: i64,
-) -> i64 {
-    unsafe {
-        trace!(
-            "c_abi_syscall_handler: syscall={} param1={} param2={} param3={}",
-            syscall, param1, param2, param3
-        );
-        let syscall_result = match syscall {
-            libc::SYS_socket => socket_detour(param1 as _, param2 as _, param3 as _) as i64,
-            libc::SYS_bind => bind_detour(param1 as _, param2 as _, param3 as _) as i64,
-            libc::SYS_listen => listen_detour(param1 as _, param2 as _) as i64,
-            libc::SYS_connect => connect_detour(param1 as _, param2 as _, param3 as _) as i64,
-            libc::SYS_accept => accept_detour(param1 as _, param2 as _, param3 as _) as i64,
-            libc::SYS_close => close_detour(param1 as _) as i64,
-
-            _ if crate::setup().fs_config().is_active() => match syscall {
-                libc::SYS_read => read_detour(param1 as _, param2 as _, param3 as _) as i64,
-                libc::SYS_write => write_detour(param1 as _, param2 as _, param3 as _) as i64,
-                libc::SYS_lseek => lseek_detour(param1 as _, param2 as _, param3 as _),
-                // Note(syscall_linux.go)
-                // if flags == 0 {
-                // 	return faccessat(dirfd, path, mode)
-                // }
-                // The Linux kernel faccessat system call does not take any flags.
-                // The glibc faccessat implements the flags itself; see
-                // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/faccessat.c;hb=HEAD
-                // Because people naturally expect syscall.Faccessat to act
-                // like C faccessat, we do the same.
-                libc::SYS_faccessat => {
-                    faccessat_detour(param1 as _, param2 as _, param3 as _, 0) as i64
-                }
-                libc::SYS_fstat => fstat_detour(param1 as _, param2 as _) as i64,
-                libc::SYS_statfs => statfs64_detour(param1 as _, param2 as _) as i64,
-                libc::SYS_fstatfs => fstatfs64_detour(param1 as _, param2 as _) as i64,
-                libc::SYS_getdents64 => {
-                    getdents64_detour(param1 as _, param2 as _, param3 as _) as i64
-                }
-                #[cfg(all(target_os = "linux", not(target_arch = "aarch64")))]
-                libc::SYS_rename => rename_detour(param1 as _, param2 as _) as i64,
-                #[cfg(all(target_os = "linux", not(target_arch = "aarch64")))]
-                libc::SYS_mkdir => mkdir_detour(param1 as _, param2 as _) as i64,
-                libc::SYS_mkdirat => mkdirat_detour(param1 as _, param2 as _, param3 as _) as i64,
-                #[cfg(all(target_os = "linux", not(target_arch = "aarch64")))]
-                libc::SYS_rmdir => rmdir_detour(param1 as _) as i64,
-                #[cfg(all(target_os = "linux", not(target_arch = "aarch64")))]
-                libc::SYS_unlink => unlink_detour(param1 as _) as i64,
-                libc::SYS_unlinkat => unlinkat_detour(param1 as _, param2 as _, param3 as _) as i64,
-                _ => {
-                    let (Ok(result) | Err(result)) = syscalls::syscall!(
-                        syscalls::Sysno::from(syscall as i32),
-                        param1,
-                        param2,
-                        param3
-                    )
-                    .map(|success| success as i64)
-                    .map_err(|fail| {
-                        let raw_errno = fail.into_raw();
-                        Errno::set_raw(raw_errno);
-
-                        -(raw_errno as i64)
-                    });
-                    result
-                }
-            },
-            _ => {
-                let (Ok(result) | Err(result)) = syscalls::syscall!(
-                    syscalls::Sysno::from(syscall as i32),
-                    param1,
-                    param2,
-                    param3
-                )
-                .map(|success| success as i64)
-                .map_err(|fail| {
-                    let raw_errno = fail.into_raw();
-                    Errno::set_raw(raw_errno);
-
-                    -(raw_errno as i64)
-                });
-                result
-            }
-        };
-
-        if syscall_result.is_negative() {
-            // Might not be an exact mapping, but it should be good enough.
-            -(Errno::last_raw() as i64)
-        } else {
-            syscall_result
-        }
-    }
-}
-
 /// Detour for Go >= 1.19
 /// On Go 1.19 one hook catches all (?) syscalls and therefore we call the syscall6 handler always
 /// so syscall6 handler need to handle syscall3 detours as well.
@@ -611,7 +507,7 @@ fn post_go1_23(hook_manager: &mut HookManager, module_name: Option<&str>) {
 /// Refer:
 ///   - File zsyscall_linux_amd64.go generated using mksyscall.pl.
 ///   - <https://cs.opensource.google/go/go/+/refs/tags/go1.18.5:src/syscall/syscall_unix.go>
-pub(crate) fn enable_hooks(hook_manager: &mut HookManager, use_asmcgocall: bool) {
+pub fn enable_hooks(hook_manager: &mut HookManager, use_asmcgocall: bool) {
     let Some(version) = super::get_go_runtime_version(hook_manager) else {
         return;
     };
@@ -635,7 +531,7 @@ pub(crate) fn enable_hooks(hook_manager: &mut HookManager, use_asmcgocall: bool)
 }
 
 /// Same as [`enable_hooks`], but hook symbols found in the given `module_name`.
-pub(crate) fn enable_hooks_in_loaded_module(
+pub fn enable_hooks_in_loaded_module(
     hook_manager: &mut HookManager,
     module_name: String,
     use_asmcgocall: bool,
@@ -666,7 +562,9 @@ pub(crate) fn enable_hooks_in_loaded_module(
 mod post_go_1_25 {
     use std::{arch::naked_asm, ffi::c_void};
 
-    use crate::{go::c_abi_syscall6_handler, hooks::HookManager, macros::hook_symbol};
+    use mirrord_layer_core::{hook_symbol, hooks::HookManager};
+
+    use crate::c_abi_syscall6_handler;
 
     static mut FN_GOSAVE_SYSTEMSTACK_SWITCH: *const c_void = std::ptr::null();
 

--- a/mirrord/layer/Cargo.toml
+++ b/mirrord/layer/Cargo.toml
@@ -40,9 +40,8 @@ rand.workspace = true
 socket2.workspace = true
 tracing.workspace = true
 
-[target.'cfg(target_os = "linux")'.dependencies]
-frida-gum.workspace = true
-syscalls.workspace = true
+[target.'cfg(all(target_os = "linux", any(target_arch = "x86_64", target_arch = "aarch64")))'.dependencies]
+mirrord-layer-go = { path = "../layer-go" }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 mirrord-sip = { path = "../sip" }

--- a/mirrord/layer/core/src/macros.rs
+++ b/mirrord/layer/core/src/macros.rs
@@ -117,7 +117,7 @@ macro_rules! replace_with_fallback {
     }};
 }
 
-/// Used by `go_hooks` to hook go syscalls with
+/// Used by `mirrord-layer-go` to hook go syscalls with
 /// `HookManager::hook_symbol_main_module`.
 ///
 /// ## Parameters

--- a/mirrord/layer/src/go.rs
+++ b/mirrord/layer/src/go.rs
@@ -1,27 +1,42 @@
+//! mirrord-layer's dispatch table for syscalls made by a Go runtime.
+//!
+//! [`mirrord_layer_go`] owns the assembly trampolines that catch syscalls issued directly by the
+//! Go runtime; this module supplies the table deciding which of them get routed into the layer's
+//! detours, and which are passed through to the kernel unchanged.
 #![cfg(all(
     any(target_arch = "x86_64", target_arch = "aarch64"),
     target_os = "linux"
 ))]
-use std::ffi::CStr;
 
-use frida_gum::NativePointer;
+use mirrord_layer_go::{Handlers, passthrough};
 use nix::errno::Errno;
+use tracing::trace;
 
 use crate::{close_detour, file::hooks::*, hooks::HookManager, socket::hooks::*};
 
-#[cfg_attr(
-    all(target_os = "linux", target_arch = "x86_64"),
-    path = "linux_x64.rs"
-)]
-#[cfg_attr(
-    all(target_os = "linux", target_arch = "aarch64"),
-    path = "linux_aarch64.rs"
-)]
-pub(crate) mod go_hooks;
+const HANDLERS: Handlers = Handlers {
+    syscall: c_abi_syscall_handler,
+    syscall6: c_abi_syscall6_handler,
+};
+
+/// Installs the Go syscall hooks, routing intercepted syscalls into the layer's detours.
+pub(crate) fn enable_hooks(hook_manager: &mut HookManager, use_asmcgocall: bool) {
+    mirrord_layer_go::init(HANDLERS);
+    mirrord_layer_go::enable_hooks(hook_manager, use_asmcgocall);
+}
+
+/// Same as [`enable_hooks`], but hooks symbols found in the given `module_name`.
+pub(crate) fn enable_hooks_in_loaded_module(
+    hook_manager: &mut HookManager,
+    module_name: String,
+    use_asmcgocall: bool,
+) {
+    mirrord_layer_go::init(HANDLERS);
+    mirrord_layer_go::enable_hooks_in_loaded_module(hook_manager, module_name, use_asmcgocall);
+}
 
 /// Syscall & Syscall6 handler - supports upto 6 params, mainly used for
 /// accept4 Note: Depending on success/failure Syscall may or may not call this handler
-#[unsafe(no_mangle)]
 unsafe extern "C" fn c_abi_syscall6_handler(
     syscall: i64,
     param1: i64,
@@ -89,23 +104,8 @@ unsafe extern "C" fn c_abi_syscall6_handler(
                     libc::SYS_newfstatat => {
                         fstatat_logic(param1 as _, param2 as _, param3 as _, param4 as _)
                             .unwrap_or_bypass_with(|_| {
-                                let (Ok(result) | Err(result)) = syscalls::syscall!(
-                                    syscalls::Sysno::from(syscall as i32),
-                                    param1,
-                                    param2,
-                                    param3,
-                                    param4,
-                                    param5,
-                                    param6
-                                )
-                                .map(|success| success as i64)
-                                .map_err(|fail| {
-                                    let raw_errno = fail.into_raw();
-                                    Errno::set_raw(raw_errno);
-
-                                    -(raw_errno as i64)
-                                });
-                                result as i32
+                                passthrough(syscall, param1, param2, param3, param4, param5, param6)
+                                    as i32
                             })
                             .into()
                     }
@@ -136,46 +136,10 @@ unsafe extern "C" fn c_abi_syscall6_handler(
                     libc::SYS_unlinkat => {
                         unlinkat_detour(param1 as _, param2 as _, param3 as _) as i64
                     }
-                    _ => {
-                        let (Ok(result) | Err(result)) = syscalls::syscall!(
-                            syscalls::Sysno::from(syscall as i32),
-                            param1,
-                            param2,
-                            param3,
-                            param4,
-                            param5,
-                            param6
-                        )
-                        .map(|success| success as i64)
-                        .map_err(|fail| {
-                            let raw_errno = fail.into_raw();
-                            Errno::set_raw(raw_errno);
-
-                            -(raw_errno as i64)
-                        });
-                        result
-                    }
+                    _ => passthrough(syscall, param1, param2, param3, param4, param5, param6),
                 }
             }
-            _ => {
-                let (Ok(result) | Err(result)) = syscalls::syscall!(
-                    syscalls::Sysno::from(syscall as i32),
-                    param1,
-                    param2,
-                    param3,
-                    param4,
-                    param5,
-                    param6
-                )
-                .map(|success| success as i64)
-                .map_err(|fail| {
-                    let raw_errno = fail.into_raw();
-                    Errno::set_raw(raw_errno);
-
-                    -(raw_errno as i64)
-                });
-                result
-            }
+            _ => passthrough(syscall, param1, param2, param3, param4, param5, param6),
         };
 
         if syscall_result.is_negative() {
@@ -187,83 +151,70 @@ unsafe extern "C" fn c_abi_syscall6_handler(
     }
 }
 
-/// Handler for `rawVforkSyscall` calls.
-///
-/// Removes the [`libc::CLONE_VM`] flag from the clone flags.
-/// This way the child process will **not** share parent's memory,
-/// and we will be able to safely use hooks in the child.
-///
-/// The [`libc::CLONE_VFORK`] flag is left intact on purpose,
-/// as it only suspends the parent process until the child exits or execs
-/// (which is a behavior we want to preserve - the user application might depend on it).
-///
-/// See [Linux manual](https://man7.org/linux/man-pages/man2/clone.2.html) for reference.
-#[unsafe(no_mangle)]
-unsafe extern "C" fn raw_vfork_handler(
-    mut param_1: i64,
-    param_2: i64,
-    param_3: i64,
-    syscall_num: i64,
+/// Syscall & Rawsyscall handler - supports upto 4 params, used for socket,
+/// bind, listen, and accept
+/// Note: Depending on success/failure Syscall may or may not call this handler
+unsafe extern "C" fn c_abi_syscall_handler(
+    syscall: i64,
+    param1: i64,
+    param2: i64,
+    param3: i64,
 ) -> i64 {
-    if syscall_num == libc::SYS_clone {
-        param_1 &= !(libc::CLONE_VM as i64);
-    } else if syscall_num == libc::SYS_clone3 {
-        let args = param_1 as *mut libc::clone_args;
-        let args = unsafe {
-            // Safety: we don't validate pointers from the user app.
-            args.as_mut()
+    unsafe {
+        trace!(
+            "c_abi_syscall_handler: syscall={} param1={} param2={} param3={}",
+            syscall, param1, param2, param3
+        );
+        let syscall_result = match syscall {
+            libc::SYS_socket => socket_detour(param1 as _, param2 as _, param3 as _) as i64,
+            libc::SYS_bind => bind_detour(param1 as _, param2 as _, param3 as _) as i64,
+            libc::SYS_listen => listen_detour(param1 as _, param2 as _) as i64,
+            libc::SYS_connect => connect_detour(param1 as _, param2 as _, param3 as _) as i64,
+            libc::SYS_accept => accept_detour(param1 as _, param2 as _, param3 as _) as i64,
+            libc::SYS_close => close_detour(param1 as _) as i64,
+
+            _ if crate::setup().fs_config().is_active() => match syscall {
+                libc::SYS_read => read_detour(param1 as _, param2 as _, param3 as _) as i64,
+                libc::SYS_write => write_detour(param1 as _, param2 as _, param3 as _) as i64,
+                libc::SYS_lseek => lseek_detour(param1 as _, param2 as _, param3 as _),
+                // Note(syscall_linux.go)
+                // if flags == 0 {
+                // 	return faccessat(dirfd, path, mode)
+                // }
+                // The Linux kernel faccessat system call does not take any flags.
+                // The glibc faccessat implements the flags itself; see
+                // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/faccessat.c;hb=HEAD
+                // Because people naturally expect syscall.Faccessat to act
+                // like C faccessat, we do the same.
+                libc::SYS_faccessat => {
+                    faccessat_detour(param1 as _, param2 as _, param3 as _, 0) as i64
+                }
+                libc::SYS_fstat => fstat_detour(param1 as _, param2 as _) as i64,
+                libc::SYS_statfs => statfs64_detour(param1 as _, param2 as _) as i64,
+                libc::SYS_fstatfs => fstatfs64_detour(param1 as _, param2 as _) as i64,
+                libc::SYS_getdents64 => {
+                    getdents64_detour(param1 as _, param2 as _, param3 as _) as i64
+                }
+                #[cfg(all(target_os = "linux", not(target_arch = "aarch64")))]
+                libc::SYS_rename => rename_detour(param1 as _, param2 as _) as i64,
+                #[cfg(all(target_os = "linux", not(target_arch = "aarch64")))]
+                libc::SYS_mkdir => mkdir_detour(param1 as _, param2 as _) as i64,
+                libc::SYS_mkdirat => mkdirat_detour(param1 as _, param2 as _, param3 as _) as i64,
+                #[cfg(all(target_os = "linux", not(target_arch = "aarch64")))]
+                libc::SYS_rmdir => rmdir_detour(param1 as _) as i64,
+                #[cfg(all(target_os = "linux", not(target_arch = "aarch64")))]
+                libc::SYS_unlink => unlink_detour(param1 as _) as i64,
+                libc::SYS_unlinkat => unlinkat_detour(param1 as _, param2 as _, param3 as _) as i64,
+                _ => passthrough(syscall, param1, param2, param3, 0, 0, 0),
+            },
+            _ => passthrough(syscall, param1, param2, param3, 0, 0, 0),
         };
-        if let Some(args) = args {
-            args.flags &= !(libc::CLONE_VM as u64);
+
+        if syscall_result.is_negative() {
+            // Might not be an exact mapping, but it should be good enough.
+            -(Errno::last_raw() as i64)
+        } else {
+            syscall_result
         }
-    };
-
-    syscalls::syscall!(
-        syscalls::Sysno::from(syscall_num as i32),
-        param_1,
-        param_2,
-        param_3,
-        0,
-        0,
-        0
-    )
-    .map(|success| success as i64)
-    .unwrap_or_else(|error| {
-        let raw_errno = error.into_raw();
-        -(raw_errno as i64)
-    })
-}
-
-/// Extracts version of the Go runtime in the current process.
-fn get_go_runtime_version(hook_manager: &mut HookManager) -> Option<f32> {
-    let version_symbol = hook_manager.resolve_symbol_main_module("runtime.buildVersion.str")?;
-    get_version_from_symbol(version_symbol)
-}
-
-/// Extracts version of the Go runtime from the given module.
-fn get_go_runtime_version_in_module(
-    hook_manager: &mut HookManager,
-    module_name: &str,
-) -> Option<f32> {
-    let version_symbol =
-        hook_manager.resolve_symbol_in_module(module_name, "runtime.buildVersion.str")?;
-    get_version_from_symbol(version_symbol)
-}
-
-/// buildVersion can look a bit complex:
-/// devel go1.25-ecc06f0 Wed Apr 9 00:32:10 2025 -0700
-///
-/// We need to find the word starting with 'go', and parse the next 4 characters.
-fn get_version_from_symbol(version_symbol: NativePointer) -> Option<f32> {
-    let version = unsafe {
-        let cstr = CStr::from_ptr(version_symbol.0 as _);
-        std::str::from_utf8_unchecked(cstr.to_bytes())
-    };
-    version
-        .split_ascii_whitespace()
-        .find_map(|chunk| chunk.strip_prefix("go"))
-        .and_then(|version| version.get(..4))
-        .and_then(|version| version.parse::<f32>().ok())
-        .unwrap_or_else(|| panic!("failed to parse Go runtime version {version:?}"))
-        .into()
+    }
 }

--- a/mirrord/layer/src/lib.rs
+++ b/mirrord/layer/src/lib.rs
@@ -158,12 +158,6 @@ mod turbo;
 ))]
 mod go;
 
-#[cfg(all(
-    any(target_arch = "x86_64", target_arch = "aarch64"),
-    target_os = "linux"
-))]
-use crate::go::go_hooks;
-
 /// if this env var exists, we exit.
 /// This to allow a way to protect from mirrord being used in destructive tests and such.
 const FAILSAFE_ENV: &str = "MIRRORD_DONT_LOAD";
@@ -664,7 +658,7 @@ fn enable_hooks(state: &LayerSetup) {
         target_os = "linux"
     ))]
     {
-        go_hooks::enable_hooks(
+        go::enable_hooks(
             &mut hook_manager,
             state.experimental().go_asmcgocall.unwrap_or_default(),
         );
@@ -991,7 +985,7 @@ pub(crate) unsafe extern "C" fn dlopen_detour(
         .to_string_lossy()
         .into_owned();
     let go_asmcgocall = setup().experimental().go_asmcgocall.unwrap_or_default();
-    go_hooks::enable_hooks_in_loaded_module(&mut hook_manager, filename, go_asmcgocall);
+    go::enable_hooks_in_loaded_module(&mut hook_manager, filename, go_asmcgocall);
 
     handle
 }

--- a/mirrord/layer/src/macros.rs
+++ b/mirrord/layer/src/macros.rs
@@ -1,9 +1,4 @@
 // macros moved to layer-core
-#[cfg(all(
-    target_os = "linux",
-    any(target_arch = "x86_64", target_arch = "aarch64")
-))]
-pub(crate) use mirrord_layer_core::hook_symbol;
 pub(crate) use mirrord_layer_core::replace;
 #[cfg(not(all(target_os = "macos", target_arch = "x86_64")))]
 pub(crate) use mirrord_layer_core::replace_with_fallback;

--- a/mirrord/remote/layer/Cargo.toml
+++ b/mirrord/remote/layer/Cargo.toml
@@ -30,5 +30,8 @@ socket2.workspace = true
 tracing.workspace = true
 thiserror.workspace = true
 
+[target.'cfg(all(target_os = "linux", any(target_arch = "x86_64", target_arch = "aarch64")))'.dependencies]
+mirrord-layer-go = { path = "../../layer-go" }
+
 [lib]
 crate-type = ["cdylib"]

--- a/mirrord/remote/layer/src/go.rs
+++ b/mirrord/remote/layer/src/go.rs
@@ -1,0 +1,113 @@
+//! remote-layer's dispatch table for syscalls made by a Go runtime.
+//!
+//! The libc hooks in [`crate::hooks`] never fire in a Go application: the Go runtime issues
+//! syscalls directly rather than calling into libc, so an unhooked Go server would accept every
+//! connection locally and the agent would never see any incoming traffic.
+//!
+//! [`mirrord_layer_go`] owns the assembly trampolines that catch those syscalls. This module
+//! supplies the table routing them into the same detours the libc hooks use, so a Go application
+//! goes through the exact same connection handoff and claimed-socket bookkeeping as any other.
+//!
+//! Only the accept and socket-address syscalls are routed. Everything else, including the
+//! [`libc::SYS_close`] and `dup` family that maintain claimed-socket bookkeeping, is still passed
+//! through unchanged, so a claimed placeholder fd that Go closes stays in
+//! [`crate::claimed_sockets`] until its number is reused.
+#![cfg(all(
+    any(target_arch = "x86_64", target_arch = "aarch64"),
+    target_os = "linux"
+))]
+
+use mirrord_layer_core::hooks::HookManager;
+use mirrord_layer_go::{Handlers, passthrough};
+use nix::errno::Errno;
+
+use crate::hooks::{accept_detour, accept4_detour, getpeername_detour, getsockname_detour};
+
+/// Installs the Go syscall hooks, routing intercepted syscalls into the remote layer's detours.
+///
+/// A no-op when the process has no Go runtime in it.
+pub(crate) fn enable_hooks(hook_manager: &mut HookManager) {
+    mirrord_layer_go::init(Handlers {
+        syscall: c_abi_syscall_handler,
+        syscall6: c_abi_syscall6_handler,
+    });
+
+    // `runtime.asmcgocall` is the Go runtime's own way of running foreign C-ABI code on the `g0`
+    // stack, and preserves the `g.sched` that `entersyscall` owns. The hand-rolled stack switch it
+    // replaces can zero `g.sched.sp`/`bp` for goroutines that reached us mid-syscall.
+    mirrord_layer_go::enable_hooks(hook_manager, true);
+}
+
+/// Entry point for the Go runtime's 6-argument syscall entry point.
+unsafe extern "C" fn c_abi_syscall6_handler(
+    syscall: i64,
+    param1: i64,
+    param2: i64,
+    param3: i64,
+    param4: i64,
+    param5: i64,
+    param6: i64,
+) -> i64 {
+    unsafe { dispatch(syscall, param1, param2, param3, param4, param5, param6) }
+}
+
+/// Entry point for the Go runtime's 3- and 4-argument syscall entry points.
+///
+/// Only Go runtimes older than 1.19 reach this; newer ones route everything through
+/// [`c_abi_syscall6_handler`].
+unsafe extern "C" fn c_abi_syscall_handler(
+    syscall: i64,
+    param1: i64,
+    param2: i64,
+    param3: i64,
+) -> i64 {
+    unsafe { dispatch(syscall, param1, param2, param3, 0, 0, 0) }
+}
+
+/// Routes a syscall caught in the Go runtime to the matching detour.
+///
+/// Detours report failure the way libc does, by returning `-1` and setting `errno`, while the Go
+/// runtime expects the raw kernel convention of `-errno`. Failures are translated back here.
+unsafe fn dispatch(
+    syscall: i64,
+    param1: i64,
+    param2: i64,
+    param3: i64,
+    param4: i64,
+    param5: i64,
+    param6: i64,
+) -> i64 {
+    tracing::trace!(
+        syscall,
+        param1,
+        param2,
+        param3,
+        param4,
+        param5,
+        param6,
+        "remote-layer dispatching go syscall"
+    );
+
+    let result = unsafe {
+        match syscall {
+            libc::SYS_accept4 => {
+                accept4_detour(param1 as _, param2 as _, param3 as _, param4 as _) as i64
+            }
+            libc::SYS_accept => accept_detour(param1 as _, param2 as _, param3 as _) as i64,
+            libc::SYS_getsockname => {
+                getsockname_detour(param1 as _, param2 as _, param3 as _) as i64
+            }
+            libc::SYS_getpeername => {
+                getpeername_detour(param1 as _, param2 as _, param3 as _) as i64
+            }
+            _ => return passthrough(syscall, param1, param2, param3, param4, param5, param6),
+        }
+    };
+
+    if result.is_negative() {
+        // Might not be an exact mapping, but it should be good enough.
+        -(Errno::last_raw() as i64)
+    } else {
+        result
+    }
+}

--- a/mirrord/remote/layer/src/lib.rs
+++ b/mirrord/remote/layer/src/lib.rs
@@ -15,6 +15,11 @@ use crate::{claimed_sockets::claimed_sockets, hooks::enable_socket_hooks};
 
 mod claimed_sockets;
 mod error;
+#[cfg(all(
+    any(target_arch = "x86_64", target_arch = "aarch64"),
+    target_os = "linux"
+))]
+mod go;
 mod handoff;
 mod hooks;
 
@@ -37,6 +42,14 @@ unsafe fn enable_hooks(hook_manager: &mut HookManager) {
     }
 
     unsafe { enable_socket_hooks(hook_manager) };
+
+    // The libc hooks above are invisible to a Go application, which issues its syscalls without
+    // going through libc.
+    #[cfg(all(
+        any(target_arch = "x86_64", target_arch = "aarch64"),
+        target_os = "linux"
+    ))]
+    crate::go::enable_hooks(hook_manager);
 }
 
 /// Hooks `libc::fork` to keep claimed-socket bookkeeping usable in the child.


### PR DESCRIPTION
Go issues syscalls directly from its own runtime rather than through libc, so remote-layer's libc hooks never fire in a Go application: every connection was accepted locally and the agent saw no incoming traffic.

Extract the Go syscall trampolines, runtime version detection and symbol hooking out of mirrord-layer into a shared mirrord-layer-go crate, with each layer plugging in its own dispatch table, and give remote-layer a table routing accept, accept4, getsockname and getpeername into the same detours the libc hooks use.

close and the dup family are still passed through, so claimed-socket bookkeeping does not yet see fds a Go application closes.