### PR TITLE
Show preview pod output on failure and add a logs command

### DIFF
--- a/changelog.d/+preview-failure-logs.added.md
+++ b/changelog.d/+preview-failure-logs.added.md
@@ -1,0 +1,1 @@
+Preview environments print their pods' last output when they fail, and `mirrord preview logs` reads it back afterwards.

--- a/mirrord/cli/src/config.rs
+++ b/mirrord/cli/src/config.rs
@@ -1407,6 +1407,8 @@ pub(super) enum PreviewCommand {
     Status(PreviewStatusArgs),
     /// Delete preview environments.
     Stop(PreviewStopArgs),
+    /// Print the output of preview environments' pods.
+    Logs(PreviewLogsArgs),
 }
 
 /// Arguments shared across all `mirrord preview` subcommands.
@@ -1624,6 +1626,58 @@ pub(super) struct PreviewStopArgs {
     /// Operate on all namespaces.
     #[arg(short = 'A', long = "all-namespaces", conflicts_with = "namespace")]
     pub all_namespaces: bool,
+}
+
+/// Arguments for `mirrord preview logs`.
+#[derive(Args, Debug)]
+pub(super) struct PreviewLogsArgs {
+    /// Filter preview environments by a Unix shell-style key glob.
+    #[arg(long, value_name = "PATTERN", conflicts_with = "key")]
+    pub glob: Option<String>,
+
+    /// Only read the environment running against this target.
+    ///
+    /// Without it, every environment matching the key is read. Can also be set via
+    /// `target.path` in the mirrord config.
+    #[arg(short = 't', long)]
+    pub target: Option<String>,
+
+    /// Namespace to search. Can also be set via `target.namespace` in the mirrord config.
+    ///
+    /// Defaults to `target.namespace` from the mirrord config, then the kubeconfig default
+    /// namespace.
+    #[arg(short = 'n', long = "namespace")]
+    pub namespace: Option<String>,
+
+    /// Search all namespaces.
+    #[arg(short = 'A', long = "all-namespaces", conflicts_with = "namespace")]
+    pub all_namespaces: bool,
+}
+
+impl PreviewLogsArgs {
+    /// Convert CLI arguments to environment variable overrides for config resolution.
+    pub fn as_env_vars<'a>(
+        &'a self,
+        common: &'a PreviewCommonArgs,
+    ) -> HashMap<&'static OsStr, Cow<'a, OsStr>> {
+        let mut envs = common.as_env_vars();
+
+        if let Some(target) = &self.target {
+            envs.insert(
+                "MIRRORD_IMPERSONATED_TARGET".as_ref(),
+                Cow::Borrowed(target.as_ref()),
+            );
+        }
+
+        if let Some(namespace) = &self.namespace {
+            envs.insert(
+                "MIRRORD_TARGET_NAMESPACE".as_ref(),
+                Cow::Borrowed(namespace.as_ref()),
+            );
+        }
+
+        envs
+    }
 }
 
 impl PreviewStopArgs {

--- a/mirrord/cli/src/error.rs
+++ b/mirrord/cli/src/error.rs
@@ -13,7 +13,10 @@ use mirrord_intproxy::{
     error::ProxyStartupError,
 };
 use mirrord_kube::error::KubeApiError;
-use mirrord_operator::client::error::{HttpError, OperatorApiError, OperatorOperation};
+use mirrord_operator::{
+    client::error::{HttpError, OperatorApiError, OperatorOperation},
+    crd::preview::PreviewPodLogs,
+};
 use mirrord_protocol_io::ProtocolError;
 use mirrord_tls_util::SecureChannelError;
 use mirrord_vpn::error::VpnError;
@@ -45,6 +48,33 @@ const GENERAL_HELP: &str = r#"
 >> Or email us at hi@metalbear.com
 
 "#;
+
+/// Renders captured preview pod output for the tail of an error message, empty when there is
+/// nothing to show.
+///
+/// Pods that printed nothing are dropped: a header over an empty block reads like the log was
+/// lost, when the point is that the container died before saying anything.
+pub(crate) fn format_preview_logs(logs: &[PreviewPodLogs]) -> String {
+    let rendered = logs
+        .iter()
+        .filter(|entry| !entry.logs.trim().is_empty())
+        .map(|entry| {
+            let location = match &entry.cluster {
+                Some(cluster) => format!("{cluster}/{}/{}", entry.pod, entry.container),
+                None => format!("{}/{}", entry.pod, entry.container),
+            };
+
+            format!("[{location}]\n{}", entry.logs.trim_end())
+        })
+        .collect::<Vec<_>>()
+        .join("\n\n");
+
+    if rendered.is_empty() {
+        return String::new();
+    }
+
+    format!("\n\nlast output from the preview pods:\n\n{rendered}")
+}
 
 const GENERAL_BUG: &str = r#"This is a bug. Please report it in our Slack or GitHub repository.
 
@@ -665,12 +695,16 @@ pub(crate) enum CliError {
     ))]
     PreviewSecretMountFailed(String),
 
-    #[error("Preview session failed: {0}")]
+    #[error("Preview session failed: {message}{}", format_preview_logs(logs))]
     #[diagnostic(help(
         "The operator reported a failure while setting up the preview environment. \
         Check the operator logs for more details.{GENERAL_HELP}"
     ))]
-    PreviewSessionFailed(String),
+    PreviewSessionFailed {
+        message: String,
+        /// Output of the preview's pods, when the operator managed to capture any.
+        logs: Vec<PreviewPodLogs>,
+    },
 
     #[error("Preview session was unexpectedly deleted while waiting for it to become ready")]
     #[diagnostic(help(
@@ -684,13 +718,16 @@ pub(crate) enum CliError {
     #[diagnostic(help("{GENERAL_BUG}"))]
     PreviewWatchFailed(String),
 
-    #[error("Preview environment creation timed out")]
+    #[error("Preview environment creation timed out{}", format_preview_logs(logs))]
     #[diagnostic(help(
         "The preview pod did not become ready within the configured timeout. \
         You can increase the timeout with `feature.preview.creation_timeout_secs` in your config file. \
         Check the operator logs for more details.{GENERAL_HELP}"
     ))]
-    PreviewTimeout,
+    PreviewTimeout {
+        /// Output of the preview's pods as of the moment the CLI gave up.
+        logs: Vec<PreviewPodLogs>,
+    },
 
     #[error("Failed to list preview sessions: {0}")]
     #[diagnostic(help(
@@ -698,6 +735,13 @@ pub(crate) enum CliError {
         and that the operator CRD is installed.{GENERAL_HELP}"
     ))]
     PreviewListFailed(String),
+
+    #[error("Failed to read preview pod logs: {0}")]
+    #[diagnostic(help(
+        "The operator serves preview pod output at `previews/logs`. Check that you have `get` \
+        on that subresource, and that the operator is running and healthy.{GENERAL_HELP}"
+    ))]
+    PreviewLogsFailed(String),
 
     #[error("Failed to delete preview session `{name}`: {reason}")]
     #[diagnostic(help("{GENERAL_HELP}"))]
@@ -1031,5 +1075,66 @@ mod tests {
                 .await
                 .unwrap();
         });
+    }
+}
+
+#[cfg(test)]
+mod preview_logs_tests {
+    use super::*;
+
+    fn pod_logs(pod: &str, logs: &str) -> PreviewPodLogs {
+        PreviewPodLogs {
+            cluster: None,
+            pod: pod.to_owned(),
+            container: "app".to_owned(),
+            logs: logs.to_owned(),
+        }
+    }
+
+    /// On a fleet the pod name alone does not say where it ran, and the same workload runs
+    /// under the same name in every cluster.
+    #[test]
+    fn fanned_out_logs_name_their_cluster() {
+        let mut entry = pod_logs("web-abc", "boom\n");
+        entry.cluster = Some("eu-west".to_owned());
+
+        assert!(format_preview_logs(&[entry]).ends_with("[eu-west/web-abc/app]\nboom"));
+    }
+
+    #[test]
+    fn no_logs_render_to_nothing() {
+        assert_eq!(format_preview_logs(&[]), "");
+    }
+
+    /// A pod that printed nothing must not produce a header: an empty block under a pod name
+    /// reads as a log that went missing, when the fact worth showing is that the container
+    /// died silently.
+    #[test]
+    fn silent_pods_are_dropped() {
+        assert_eq!(format_preview_logs(&[pod_logs("a", "   \n")]), "");
+
+        assert!(
+            format_preview_logs(&[pod_logs("quiet", ""), pod_logs("loud", "boom\n")])
+                .ends_with("[loud/app]\nboom")
+        );
+    }
+
+    /// Replicas are reported separately, so the rendering has to name each pod and keep them
+    /// apart - a concatenated blob would read as one container's output.
+    #[test]
+    fn each_pod_is_labelled_and_separated() {
+        assert!(
+            format_preview_logs(&[pod_logs("one", "first\n"), pod_logs("two", "second\n")])
+                .ends_with("[one/app]\nfirst\n\n[two/app]\nsecond")
+        );
+    }
+
+    /// The block only makes sense under a header saying what it is.
+    #[test]
+    fn rendered_logs_carry_a_header() {
+        assert!(
+            format_preview_logs(&[pod_logs("one", "first\n")])
+                .starts_with("\n\nlast output from the preview pods:\n\n")
+        );
     }
 }

--- a/mirrord/cli/src/preview.rs
+++ b/mirrord/cli/src/preview.rs
@@ -18,7 +18,7 @@ use glob::Pattern;
 use itertools::Itertools;
 use k8s_openapi::{ByteString, jiff::Timestamp};
 use kube::{
-    Api, Resource, ResourceExt,
+    Api, Client, Resource, ResourceExt,
     api::{DeleteParams, ListParams, ObjectMeta, PostParams},
     runtime::{
         wait::delete,
@@ -42,9 +42,9 @@ use mirrord_operator::{
         NewOperatorFeature, TARGET_NAMESPACE_ANNOTATION, TargetCrd,
         preview::{
             PreviewDbBranchingConfig, PreviewEnvVarsConfig, PreviewIdleConfig,
-            PreviewIncomingConfig, PreviewLabelFilter, PreviewQueueSplittingConfig,
+            PreviewIncomingConfig, PreviewLabelFilter, PreviewPodLogs, PreviewQueueSplittingConfig,
             PreviewSecretMountFile, PreviewSession, PreviewSessionPhase, PreviewSessionSpec,
-            view::PreviewMessageKind,
+            view::{PreviewEnv, PreviewMessageKind},
         },
         session::{KubeResourceTarget, SessionTarget},
     },
@@ -56,10 +56,10 @@ use tracing::Level;
 
 use crate::{
     config::{
-        PreviewArgs, PreviewCommand, PreviewCommonArgs, PreviewStartArgs, PreviewStatusArgs,
-        PreviewStopArgs,
+        PreviewArgs, PreviewCommand, PreviewCommonArgs, PreviewLogsArgs, PreviewStartArgs,
+        PreviewStatusArgs, PreviewStopArgs,
     },
-    error::{CliError, CliResult},
+    error::{CliError, CliResult, format_preview_logs},
     user_data::UserData,
 };
 
@@ -81,6 +81,7 @@ pub(crate) async fn preview_command(
             preview_status(&common, status_args, watch, user_data).await
         }
         PreviewCommand::Stop(stop_args) => preview_stop(&common, stop_args, watch, user_data).await,
+        PreviewCommand::Logs(logs_args) => preview_logs(&common, logs_args, watch, user_data).await,
     }
 }
 
@@ -347,6 +348,15 @@ async fn preview_start(
     loop {
         tokio::select! {
             _ = &mut timeout => {
+                // Read the pods before deleting the session: the delete tears down the
+                // deployment, and their output goes with it.
+                let logs = fetch_preview_logs_best_effort(
+                    operator_api.client(),
+                    &session_namespace,
+                    &session.name_any(),
+                )
+                .await;
+
                 if let Err(err) = delete::delete_and_finalize(api, &session.name_any(), &DeleteParams::default()).await {
                     subtask.warning(&format!(
                         "failed to delete timed out session '{}': {err}, \
@@ -356,7 +366,7 @@ async fn preview_start(
                 }
 
                 subtask.failure(None);
-                return Err(CliError::PreviewTimeout);
+                return Err(CliError::PreviewTimeout { logs });
             }
             _ = long_initialization_timer.tick() => {
                 subtask.warning(&format!(
@@ -393,8 +403,18 @@ async fn preview_start(
                                 }
                                 PreviewSessionPhase::Failed => {
                                     let failure_message = status.failure_message.clone().expect("Failed session must have failure_message");
+                                    let logs = fetch_preview_logs_best_effort(
+                                        operator_api.client(),
+                                        &session_namespace,
+                                        &session.name_any(),
+                                    )
+                                    .await;
+
                                     subtask.failure(None);
-                                    return Err(CliError::PreviewSessionFailed(failure_message));
+                                    return Err(CliError::PreviewSessionFailed {
+                                        message: failure_message,
+                                        logs,
+                                    });
                                 }
                                 PreviewSessionPhase::Paused => {
                                     last_known_phase = "preview session is paused";
@@ -448,8 +468,15 @@ async fn preview_start(
         // The preview is gone: reporting a successful start would print a key and session
         // name for something the user cannot use.
         multicluster::ReplicaOutcome::Failed(message) => {
+            let logs = fetch_preview_logs_best_effort(
+                operator_api.client(),
+                &session_namespace,
+                &session_name,
+            )
+            .await;
+
             progress.failure(None);
-            return Err(CliError::PreviewSessionFailed(message));
+            return Err(CliError::PreviewSessionFailed { message, logs });
         }
         multicluster::ReplicaOutcome::Deleted => {
             progress.failure(None);
@@ -703,6 +730,133 @@ async fn preview_status(
 
     Ok(())
 }
+
+/// Handle `mirrord preview logs` command.
+///
+/// Prints what the preview pods of every matching environment have written. Unlike
+/// `preview status`, failed environments are included: the output of one that died is the
+/// main thing worth reading, and it stays available for as long as the operator retains the
+/// failed session.
+async fn preview_logs(
+    common: &PreviewCommonArgs,
+    args: PreviewLogsArgs,
+    watch: drain::Watch,
+    user_data: &UserData,
+) -> CliResult<()> {
+    let mut progress = ProgressTracker::from_env("mirrord preview logs");
+
+    let layer_config = load_preview_config(args.as_env_vars(common), &mut progress)?;
+
+    let mut analytics = AnalyticsReporter::only_error(
+        layer_config.telemetry,
+        ExecutionKind::Preview,
+        watch.clone(),
+        user_data.machine_id(),
+        Some(layer_config.key.as_str().to_owned()),
+    );
+
+    let (operator_api, api) = create_preview_api(
+        &layer_config,
+        args.all_namespaces,
+        &progress,
+        &mut analytics,
+    )
+    .await?;
+
+    let mut subtask = progress.subtask("listing preview sessions");
+
+    let matcher = match args.glob.as_deref() {
+        Some(glob) => KeyMatcher::Glob(glob),
+        None => match layer_config.key.provided() {
+            Some(key) => KeyMatcher::Simple(key),
+            None => KeyMatcher::Any,
+        },
+    };
+
+    // Reading every environment that shares a key is rarely what someone wants; a target
+    // narrows it to the one they are actually debugging.
+    let session_target = match &layer_config.target.path {
+        Some(config_target) => Some(
+            resolve_config_target(
+                config_target,
+                operator_api.client(),
+                layer_config.target.namespace.as_deref(),
+            )
+            .await
+            .inspect_err(|_| subtask.failure(None))?,
+        ),
+        None => None,
+    };
+
+    let sessions: Vec<_> = matcher
+        .list_matching_sessions(&api)
+        .await
+        .inspect_err(|_| subtask.failure(None))?
+        .into_iter()
+        .filter(|session| {
+            session_target
+                .as_ref()
+                .is_none_or(|target| session.spec.target == *target)
+        })
+        .collect();
+
+    // Silence would be ambiguous here: this command's only output is the logs themselves, so
+    // finding nothing has to say so. `preview stop` treats an empty match the same way.
+    if sessions.is_empty() {
+        subtask.failure(None);
+        return Err(CliError::PreviewNotFound(matcher.as_str().to_owned()));
+    }
+
+    subtask.success(Some(&format!(
+        "found {} session{}",
+        sessions.len(),
+        if sessions.len() == 1 { "" } else { "s" }
+    )));
+    progress.success(None);
+
+    let sessions: Vec<&PreviewSession> = sessions.iter().collect();
+    print_session_logs(operator_api.client(), &sessions)
+        .await
+        .map_err(|error| CliError::PreviewLogsFailed(error.to_string()))?;
+
+    Ok(())
+}
+
+/// Prints each session's pod output, for the sessions that produced any.
+///
+/// A read that FAILS is reported rather than skipped: printing nothing for it would be
+/// indistinguishable from a preview whose pods stayed quiet, and this command exists to answer
+/// exactly that question. Reads run concurrently: one round trip for the whole command rather
+/// than one per session, matching how `preview status` fetches its multicluster detail.
+async fn print_session_logs(
+    client: &Client,
+    sessions: &[&PreviewSession],
+) -> Result<(), kube::Error> {
+    let reads = sessions.iter().filter_map(|session| {
+        let name = session.metadata.name.as_deref()?;
+        let namespace = session.metadata.namespace.as_deref()?;
+
+        Some(async move {
+            (
+                session.spec.key.as_str(),
+                name,
+                fetch_preview_logs(client, namespace, name).await,
+            )
+        })
+    });
+
+    for (key, name, logs) in futures::future::join_all(reads).await {
+        let rendered = format_preview_logs(&logs?);
+        if rendered.is_empty() {
+            continue;
+        }
+
+        println!("\n{key} ({name}){rendered}");
+    }
+
+    Ok(())
+}
+
 /// Handle `mirrord preview stop` command.
 ///
 /// Deletes preview environments matching the given key and, optionally, a target filter and
@@ -1063,4 +1217,42 @@ fn preview_namespace(operator_api: &OperatorApi<NoClientCert>, config: &LayerCon
         .or(config.target.namespace.as_deref())
         .unwrap_or_else(|| operator_api.client().default_namespace())
         .to_owned()
+}
+
+/// Reads the preview's pod output through the operator's `logs` subresource.
+///
+/// The single read path for every failure: the operator answers from the tail it stored when
+/// it gave up on the session, or tails the pods live when it has not stored one yet. Reading
+/// the CR's own `failureLogs` instead would race the operator, which stores that tail on a
+/// later reconcile than the one that marks the session failed.
+///
+/// Best-effort by design: this runs while a start is already failing, so an operator without
+/// the route, a lost connection, or pods that are simply gone all resolve to no logs rather
+/// than replacing the failure the user actually needs to see.
+async fn fetch_preview_logs(
+    client: &Client,
+    namespace: &str,
+    session_name: &str,
+) -> Result<Vec<PreviewPodLogs>, kube::Error> {
+    Api::<PreviewEnv>::namespaced(client.clone(), namespace)
+        .get_subresource("logs", session_name)
+        .await
+        .map(|view: PreviewEnv| view.status.map(|status| status.logs).unwrap_or_default())
+}
+
+/// The best-effort form, for the paths that are already reporting a different failure.
+///
+/// A start that is going to fail anyway must not have its own error replaced by one about
+/// reading logs, so an unreachable route, a lost connection, or pods that are simply gone all
+/// resolve to no logs here. `mirrord preview logs` does NOT use this: there, a failed read is
+/// the only thing worth saying.
+async fn fetch_preview_logs_best_effort(
+    client: &Client,
+    namespace: &str,
+    session_name: &str,
+) -> Vec<PreviewPodLogs> {
+    fetch_preview_logs(client, namespace, session_name)
+        .await
+        .inspect_err(|error| tracing::debug!(%error, "failed to read preview pod logs"))
+        .unwrap_or_default()
 }

--- a/mirrord/operator/src/crd/preview.rs
+++ b/mirrord/operator/src/crd/preview.rs
@@ -250,6 +250,15 @@ pub struct PreviewSessionStatus {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub failed_at: Option<MicroTime>,
 
+    /// What the preview's pods printed before the session failed.
+    ///
+    /// Captured by the operator at the moment it gives up on the pods, because failing a
+    /// session scales its deployment to zero and the pods - and their logs - go with it.
+    /// Empty when the pods produced nothing, when they could not be read, or when the
+    /// session failed before any pod existed.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub failure_logs: Vec<PreviewPodLogs>,
+
     /// Timestamp when the session's TTL expires.
     ///
     /// Set when the session enters the `Ready` phase for finite TTL sessions.
@@ -279,6 +288,24 @@ pub struct PreviewSessionStatus {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     #[schemars(extend("x-kubernetes-list-type" = "map", "x-kubernetes-list-map-keys" = ["type"]))]
     pub conditions: Vec<Condition>,
+}
+
+/// The tail of one preview container's output.
+///
+/// A preview may run several replicas, and a failing one is often the only pod with anything
+/// to say, so pods are reported separately rather than concatenated into a single blob.
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct PreviewPodLogs {
+    /// Which workload cluster the pod ran in. `None` on single-cluster operators, where there
+    /// is only one place it could have been.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cluster: Option<String>,
+    pub pod: String,
+    pub container: String,
+    /// Oldest line first. Whole lines are dropped from the front when the tail exceeds the
+    /// operator's size cap, so the end - where a crash lands - always survives.
+    pub logs: String,
 }
 
 /// Phase of a preview session's lifecycle.
@@ -328,6 +355,9 @@ pub struct PreviewStatusUpdate {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub failed_at: Option<MicroTime>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failure_logs: Option<Vec<PreviewPodLogs>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub expires_at: Option<MicroTime>,

--- a/mirrord/operator/src/crd/preview/view.rs
+++ b/mirrord/operator/src/crd/preview/view.rs
@@ -4,7 +4,7 @@ use kube::CustomResource;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use super::PreviewSessionPhase;
+use super::{PreviewPodLogs, PreviewSessionPhase};
 use crate::crd::session::SessionTarget;
 
 /// Read-only view of a preview environment, served by the operator's preview status API
@@ -60,6 +60,13 @@ pub struct PreviewEnvStatus {
     /// (empty on single-cluster operators).
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub clusters: BTreeMap<String, PreviewClusterStatus>,
+    /// Recent output from the preview's pods, for working out why one never became ready.
+    ///
+    /// Only the `logs` subresource fills this in; a plain `GET` and the list route always
+    /// leave it empty, because tailing every pod of every preview would make listing them
+    /// cost a log fetch per pod.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub logs: Vec<PreviewPodLogs>,
 }
 
 /// What one workload cluster reports about its copy of the preview. A struct rather than a


### PR DESCRIPTION
Resolves INT-642.