### PR TITLE
Don't disconnect clients on iptables removal fail

### DIFF
--- a/changelog.d/+steal-iptables-teardown.fixed.md
+++ b/changelog.d/+steal-iptables-teardown.fixed.md
@@ -1,0 +1,1 @@
+Failed iptables rule removal during steal port teardown no longer disconnects all clients.

--- a/mirrord/agent/iptables/src/lib.rs
+++ b/mirrord/agent/iptables/src/lib.rs
@@ -193,6 +193,8 @@ enum Redirects<IPT: IPTables + Send + Sync> {
 /// Wrapper struct for IPTables so it flushes on drop.
 pub struct SafeIpTables<IPT: IPTables + Send + Sync> {
     redirect: Redirects<IPT>,
+    ipt: Arc<IPT>,
+    chain_names: ChainNames,
 }
 
 /// Wrapper for using iptables. This creates a new chain on creation and deletes it on drop.
@@ -249,7 +251,7 @@ where
         // Should be always the last composed redirect because it handles the order internally.
         if with_mesh_exclusion {
             redirect = Redirects::WithMeshExclusion(WithMeshExclusion::create(
-                ipt,
+                ipt.clone(),
                 &chain_names.exclude_from_mesh,
                 Box::new(redirect),
             )?)
@@ -257,7 +259,11 @@ where
 
         redirect.mount_entrypoint().await?;
 
-        Ok(Self { redirect })
+        Ok(Self {
+            redirect,
+            ipt,
+            chain_names: chain_names.clone(),
+        })
     }
 
     /// List rules from previous mirrord agent that exist on the IP table
@@ -315,13 +321,17 @@ where
         // Should be always the last composed redirect because it handles the order internally.
         if with_mesh_exclusion {
             redirect = Redirects::WithMeshExclusion(WithMeshExclusion::load(
-                ipt,
+                ipt.clone(),
                 &chain_names.exclude_from_mesh,
                 Box::new(redirect),
             )?)
         }
 
-        Ok(Self { redirect })
+        Ok(Self {
+            redirect,
+            ipt,
+            chain_names: chain_names.clone(),
+        })
     }
 
     /// Adds the redirect rule to iptables.
@@ -352,6 +362,42 @@ where
     #[tracing::instrument(level = Level::TRACE, skip(self), err)]
     pub async fn cleanup(&self) -> IPTablesResult<()> {
         self.redirect.unmount_entrypoint().await
+    }
+
+    /// Runs [`Self::cleanup`], tolerating failures when no mirrord rules are left in the
+    /// table anyway.
+    ///
+    /// `iptables -D` fails when the rule to delete does not exist, which happens when some
+    /// external actor (e.g. a CNI or mesh component rebuilding the table) has already removed
+    /// our rules. A cleanup failure is therefore verified against the actual table state:
+    /// if no mirrord rules remain, the goal state holds and the error is discarded.
+    #[tracing::instrument(level = Level::TRACE, skip(self), err)]
+    pub async fn cleanup_verified(self) -> IPTablesResult<()> {
+        let Err(error) = self.cleanup().await else {
+            return Ok(());
+        };
+
+        let Self {
+            redirect,
+            ipt,
+            chain_names,
+        } = self;
+        drop(redirect);
+
+        let no_rules_left = match Self::list_mirrord_rules(ipt.as_ref(), &chain_names).await {
+            Ok(mut leftover_rules) => leftover_rules.next().is_none(),
+            Err(..) => false,
+        };
+
+        if no_rules_left {
+            warn!(
+                %error,
+                "iptables cleanup failed, but no mirrord rules are left in the table",
+            );
+            Ok(())
+        } else {
+            Err(error)
+        }
     }
 
     pub fn exclusion(&self) -> Option<&MeshExclusion<IPT>> {

--- a/mirrord/agent/src/incoming/composed.rs
+++ b/mirrord/agent/src/incoming/composed.rs
@@ -54,13 +54,29 @@ where
 
     /// Called in order on all inner redirectors.
     ///
-    /// Stops at the first error.
+    /// All inner redirectors are attempted even if some of them fail,
+    /// so that a failure in one of them (e.g. IPv4) does not leave
+    /// a dangling redirection in another (e.g. IPv6).
+    ///
+    /// Returns the last encountered error.
+    /// All errors are logged.
     async fn remove_redirection(&mut self, from_port: u16) -> Result<(), Self::Error> {
+        let mut result = Ok(());
+
         for redirector in &mut self.redirectors {
-            redirector.remove_redirection(from_port).await?;
+            if let Err(error) = redirector.remove_redirection(from_port).await {
+                tracing::error!(
+                    %error,
+                    ?redirector,
+                    from_port,
+                    "Failed to remove a redirection on a port redirector",
+                );
+
+                result = Err(error);
+            }
         }
 
-        Ok(())
+        result
     }
 
     /// Called in order on all inner redirectors.

--- a/mirrord/agent/src/incoming/iptables.rs
+++ b/mirrord/agent/src/incoming/iptables.rs
@@ -163,7 +163,7 @@ impl PortRedirector for IpTablesRedirector {
                 )
             };
 
-            iptables.cleanup().await?;
+            iptables.cleanup_verified().await?;
         }
 
         Ok(())

--- a/mirrord/agent/src/incoming/task.rs
+++ b/mirrord/agent/src/incoming/task.rs
@@ -142,7 +142,7 @@ where
                 Some(message) = self.internal_rx.recv() => match message {
                     InternalMessage::MaybeDeadChannel(port)
                      => {
-                        self.handle_dead_channel(port).await?;
+                        self.handle_dead_channel(port).await;
                     }
                     InternalMessage::ConnInitialized(conn) => {
                         self.handle_initialized_connection(conn).await;
@@ -486,14 +486,37 @@ where
         Ok(())
     }
 
+    /// Removes the redirection from a no-longer-needed port,
+    /// running the full redirector cleanup if no redirected ports remain.
+    ///
+    /// Failures are logged and swallowed: a failed removal usually means the rule is already
+    /// gone, e.g. because some external actor flushed our iptables rules. The goal state — no
+    /// redirection — holds either way, and killing this task here would needlessly disconnect
+    /// all clients.
+    async fn remove_port_redirection(&mut self, port: u16) {
+        if let Err(error) = self.redirector.remove_redirection(port).await {
+            tracing::warn!(
+                %error,
+                port,
+                "Failed to remove a port redirection, assuming it no longer exists",
+            );
+        }
+
+        if self.ports.is_empty()
+            && let Err(error) = self.redirector.cleanup().await
+        {
+            tracing::error!(%error, "Failed to clean up the port redirector");
+        }
+    }
+
     /// Called when [`InternalMessage::MaybeDeadChannel`] is received from a helper task.
     ///
     /// One of the subscription channels may be closed. We need to
     /// check the related [`PortState`].
-    #[tracing::instrument(level = Level::TRACE, ret, err(level = Level::TRACE))]
-    async fn handle_dead_channel(&mut self, port: u16) -> Result<(), R::Error> {
+    #[tracing::instrument(level = Level::TRACE)]
+    async fn handle_dead_channel(&mut self, port: u16) {
         let Entry::Occupied(mut e) = self.ports.entry(port) else {
-            return Ok(());
+            return;
         };
 
         let state = e.get_mut();
@@ -520,16 +543,13 @@ where
         if mirror_txs.is_empty() && steal_tx.is_none() && connections.is_empty() {
             if self.config.unused_port_linger.is_zero() {
                 e.remove().graceful_shutdown().await;
-                self.redirector.remove_redirection(port).await?;
-                if self.ports.is_empty() {
-                    self.redirector.cleanup().await?;
-                }
-                return Ok(());
+                self.remove_port_redirection(port).await;
+                return;
             }
 
             match cleanup_sleep {
                 Some(sleep) if sleep.is_elapsed() => {}
-                Some(..) => return Ok(()),
+                Some(..) => return,
                 None => {
                     let linger = self.config.unused_port_linger;
                     *cleanup_sleep = Some(Box::pin(tokio::time::sleep(linger)));
@@ -541,21 +561,16 @@ where
                         let _ = tx.send(InternalMessage::MaybeDeadChannel(port)).await;
                     });
 
-                    return Ok(());
+                    return;
                 }
             }
 
             e.remove().graceful_shutdown().await;
-            self.redirector.remove_redirection(port).await?;
-            if self.ports.is_empty() {
-                self.redirector.cleanup().await?;
-            }
-            return Ok(());
+            self.remove_port_redirection(port).await;
+            return;
         }
 
         *cleanup_sleep = None;
-
-        Ok(())
     }
 
     fn spawn_tracked_connection<F>(
@@ -585,11 +600,20 @@ where
     /// Called when all handles are dropped and this task is about to exit.
     ///
     /// Cleans the redirections in [`Self::redirector`].
+    ///
+    /// Per-port removal failures are only logged, as the final [`PortRedirector::cleanup`]
+    /// removes all of the redirector's state anyway.
     #[tracing::instrument(level = Level::TRACE, ret, err(level = Level::TRACE))]
     async fn cleanup(&mut self) -> Result<(), R::Error> {
         for (port, state) in std::mem::take(&mut self.ports) {
             state.graceful_shutdown().await;
-            self.redirector.remove_redirection(port).await?;
+            if let Err(error) = self.redirector.remove_redirection(port).await {
+                tracing::warn!(
+                    %error,
+                    port,
+                    "Failed to remove a port redirection, assuming it no longer exists",
+                );
+            }
         }
 
         self.redirector.cleanup().await


### PR DESCRIPTION
<!-- Thank you for contributing to mirrord! -->
<!-- Please use the checklist below as a guide for docs, tests and admin tasks for your PR -->
<!-- Feel free to ~strikethrough~ any items that you don't think apply -->

### Quality Checklist:

- [X] I have documented new code sufficiently
- [X] I have checked and updated the relevant existing docs in code, including removing outdated material
- [X] I have written user-facing website docs for new features, or opened a (sub)issue to do so
- [X] I have checked and updated existing website docs for changed features
- [X] I have tested this change and know it succeeds and fails as expected
- [X] I have written unit tests or purposefully omitted them
- [X] I have written e2e tests or purposefully omitted them
- [X] I have explained what this PR introduces and why, and linked to relevant context (e.g. linear issues, related PRs,
  documentation)
- [X] I have introduced a short, clear and well-formatted changelog entry

<!-- need help with the changelog? see ../CONTRIBUTING.md#submitting-a-pull-request -->
<!-- Add more details of your changes below if needed -->

Sometimes other things (CNI/svcmesh/etc) remove our iptables rules before us, and that disconnects all clients when we try to remove them ourselves, because the error propagates to the toplevel. This PR makes it so that we make some effort to not disconnect all clients whenever that happens.