### PR TITLE
Improve integration-test failure output

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -10,3 +10,18 @@ slow-timeout = { period = "2m", terminate-after = 3 }
 
 [profile.default.junit]
 path = "junit.xml"
+
+# CI prints only nextest's final per-test status list. Test stdout and stderr are omitted from the
+# live job log and stored in JUnit so failed-test logs can be uploaded as separate artifacts.
+[profile.ci]
+inherits = "default"
+fail-fast = false
+failure-output = "never"
+success-output = "never"
+status-level = "none"
+final-status-level = "pass"
+
+[profile.ci.junit]
+path = "junit.xml"
+store-failure-output = true
+store-success-output = false

--- a/.github/actions/collect-nextest-results/action.yml
+++ b/.github/actions/collect-nextest-results/action.yml
@@ -1,0 +1,99 @@
+name: 'Collect nextest results'
+description: 'Uploads nextest JUnit reports and extracts captured output for failed tests.'
+
+inputs:
+  capture-nextest-failures:
+    description: "Extract each failed test's captured output from nextest's JUnit report."
+    required: false
+    default: 'false'
+  artifact-key:
+    description: 'Stable identifier for the workflow, test step, and matrix configuration.'
+    required: false
+    default: 'nextest'
+  test-group:
+    description: 'Semantic test category used for the JUnit directory name.'
+    required: false
+    default: 'ut'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Collect nextest reports and failure logs
+      id: collect
+      shell: bash
+      env:
+        ARTIFACT_KEY: ${{ inputs.artifact-key }}
+        CAPTURE_NEXTEST_FAILURES: ${{ inputs.capture-nextest-failures }}
+        NEXTEST_FAILURES_SCRIPT: ${{ github.action_path }}/../../scripts/nextest-failures
+        TEST_GROUP: ${{ inputs.test-group }}
+      run: |
+        timestamp="$(date --utc +%Y%m%dT%H%M%S%NZ)"
+        suffix="$TEST_GROUP-$ARTIFACT_KEY-attempt-$timestamp"
+        report="nextest-junit-$suffix"
+        report_dir="$RUNNER_TEMP/$report/nextest-junit-$TEST_GROUP-xml"
+        failures="test-failures-$suffix"
+        failure_dir="$RUNNER_TEMP/$failures/test-failure-logs"
+        mkdir -p "$report_dir"
+        index=0
+        dependencies_ready=false
+        postprocess_status=0
+        for target in "$GITHUB_WORKSPACE"/target "$GITHUB_WORKSPACE"/*/target; do
+          [ -d "$target/nextest" ] || continue
+          while read -r junit; do
+            [ -n "$junit" ] || continue
+            cp "$junit" "$report_dir/$index.xml"
+            if [ "$CAPTURE_NEXTEST_FAILURES" = "true" ]; then
+              if [ "$dependencies_ready" = "false" ]; then
+                if [ -d "$NEXTEST_FAILURES_SCRIPT/node_modules/fast-xml-parser" ]; then
+                  dependencies_ready=true
+                elif npm install --prefix "$NEXTEST_FAILURES_SCRIPT" \
+                  --omit=dev \
+                  --no-package-lock \
+                  --ignore-scripts \
+                  --no-audit \
+                  --no-fund; then
+                  dependencies_ready=true
+                else
+                  postprocess_status=1
+                fi
+              fi
+
+              if [ "$dependencies_ready" = "true" ] && ! node \
+                "$NEXTEST_FAILURES_SCRIPT/extract-nextest-failures.mjs" \
+                "$junit" \
+                "$failure_dir"; then
+                postprocess_status=1
+              fi
+            fi
+            rm -f "$junit"
+            index=$((index + 1))
+          done < <(find "$target/nextest" -name junit.xml 2>/dev/null)
+        done
+
+        if [ "$index" -gt 0 ]; then
+          echo "report=$report" >> "$GITHUB_OUTPUT"
+        else
+          echo "report=" >> "$GITHUB_OUTPUT"
+        fi
+
+        if [ -d "$failure_dir" ]; then
+          echo "failures=$failures" >> "$GITHUB_OUTPUT"
+        else
+          echo "failures=" >> "$GITHUB_OUTPUT"
+        fi
+
+        exit "$postprocess_status"
+    - name: Upload nextest JUnit XML
+      if: ${{ always() && steps.collect.outputs.report != '' }}
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v6.0.0
+      with:
+        name: ${{ steps.collect.outputs.report }}
+        path: ${{ runner.temp }}/${{ steps.collect.outputs.report }}
+        retention-days: 30
+    - name: Upload failed-test logs
+      if: ${{ always() && steps.collect.outputs.failures != '' }}
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      with:
+        name: ${{ steps.collect.outputs.failures }}
+        path: ${{ runner.temp }}/${{ steps.collect.outputs.failures }}
+        retention-days: 30

--- a/.github/actions/run-in-ci-runner/action.yml
+++ b/.github/actions/run-in-ci-runner/action.yml
@@ -5,14 +5,24 @@ inputs:
   command:
     description: "Shell command to run inside the image."
     required: true
+  capture-nextest-failures:
+    description: "Extract each failed test's captured output from nextest's JUnit report."
+    required: false
+    default: "false"
+  artifact-key:
+    description: "Stable identifier for the workflow, test step, and matrix configuration."
+    required: false
+    default: "nextest"
+  test-group:
+    description: "Semantic test category used for the JUnit directory name."
+    required: false
+    default: "ut"
 
 runs:
   using: "composite"
   steps:
-    - id: run
+    - name: Prepare CI runner directories
       shell: bash
-      env:
-        E2E_COMMAND: ${{ inputs.command }}
       run: |
         mkdir -p \
           "$HOME/.mirrord" \
@@ -22,7 +32,12 @@ runs:
           "$HOME/.cargo/git" \
           "$HOME/.cache/go-build" \
           "$HOME/go/pkg/mod"
-
+    - name: ${{ inputs.capture-nextest-failures == 'true' && 'Run nextests (with summary)' || 'Run command in CI runner' }}
+      id: run
+      shell: bash
+      env:
+        E2E_COMMAND: ${{ inputs.command }}
+      run: |
         status=0
         docker run --rm \
           --network host \
@@ -58,29 +73,11 @@ runs:
           "$HOME/.cache/go-build" \
           "$HOME/go/pkg/mod"
 
-        name="nextest-junit-$GITHUB_JOB-$(date +%s%N)-$RANDOM"
-        report_dir="$RUNNER_TEMP/$name"
-        mkdir -p "$report_dir"
-        index=0
-        for target in "$GITHUB_WORKSPACE"/target "$GITHUB_WORKSPACE"/*/target; do
-          [ -d "$target/nextest" ] || continue
-          while read -r report; do
-            [ -n "$report" ] || continue
-            cp "$report" "$report_dir/$index.xml"
-            rm -f "$report"
-            index=$((index + 1))
-          done < <(find "$target/nextest" -name junit.xml 2>/dev/null)
-        done
-        if [ "$index" -gt 0 ]; then
-          echo "report=$name" >> "$GITHUB_OUTPUT"
-        else
-          echo "report=" >> "$GITHUB_OUTPUT"
-        fi
-
-        exit $status
-    - if: ${{ always() && steps.run.outputs.report != '' }}
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        exit "$status"
+    - name: Collect nextest results
+      if: ${{ always() }}
+      uses: ./.github/actions/collect-nextest-results
       with:
-        name: ${{ steps.run.outputs.report }}
-        path: ${{ runner.temp }}/${{ steps.run.outputs.report }}
-        retention-days: 30
+        artifact-key: ${{ inputs.artifact-key }}
+        capture-nextest-failures: ${{ inputs.capture-nextest-failures }}
+        test-group: ${{ inputs.test-group }}

--- a/.github/scripts/nextest-failures/.gitignore
+++ b/.github/scripts/nextest-failures/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/.github/scripts/nextest-failures/extract-nextest-failures.mjs
+++ b/.github/scripts/nextest-failures/extract-nextest-failures.mjs
@@ -1,0 +1,191 @@
+import { createHash } from 'node:crypto'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+import { XMLParser } from 'fast-xml-parser'
+
+const ARRAY_ELEMENTS = new Set([
+  'error',
+  'failure',
+  'flakyError',
+  'flakyFailure',
+  'rerunError',
+  'rerunFailure',
+  'system-err',
+  'system-out',
+  'testcase',
+  'testsuite',
+])
+
+const parser = new XMLParser({
+  alwaysCreateTextNode: true,
+  attributeNamePrefix: '',
+  ignoreAttributes: false,
+  isArray: (tagName, _jPath, _isLeafNode, isAttribute) =>
+    isAttribute === false && ARRAY_ELEMENTS.has(tagName),
+  parseAttributeValue: false,
+  parseTagValue: false,
+  trimValues: false,
+})
+
+function asArray(value) {
+  if (value === undefined) {
+    return []
+  }
+
+  return Array.isArray(value) ? value : [value]
+}
+
+function text(node) {
+  if (node === undefined || node === null) {
+    return ''
+  }
+
+  if (typeof node === 'string') {
+    return node.trim()
+  }
+
+  return String(node['#text'] ?? '').trim()
+}
+
+function testcases(report) {
+  const cases = []
+
+  function visitSuite(suite) {
+    cases.push(...asArray(suite.testcase))
+    asArray(suite.testsuite).forEach(visitSuite)
+  }
+
+  asArray(report.testsuites?.testsuite).forEach(visitSuite)
+  asArray(report.testsuite).forEach(visitSuite)
+
+  return cases
+}
+
+function attemptOutput(attempt, stdout, stderr, index, total) {
+  const lines = [`=== Attempt ${index} of ${total}: FAIL ===`]
+
+  if (attempt.timestamp) {
+    lines.push(`Timestamp: ${attempt.timestamp}`)
+  }
+  if (attempt.time) {
+    lines.push(`Duration: ${attempt.time}s`)
+  }
+  if (attempt.type) {
+    lines.push(`Type: ${attempt.type}`)
+  }
+  if (attempt.message) {
+    lines.push(`Message: ${attempt.message}`)
+  }
+
+  const reason = text(attempt)
+  if (reason && !stdout && !stderr) {
+    lines.push('', '--- failure ---', reason)
+  }
+  if (stdout) {
+    lines.push('', '--- stdout ---', stdout)
+  }
+  if (stderr) {
+    lines.push('', '--- stderr ---', stderr)
+  }
+
+  return lines.join('\n')
+}
+
+function failureLog(testcase) {
+  const failures = [...asArray(testcase.failure), ...asArray(testcase.error)]
+  if (failures.length === 0) {
+    return undefined
+  }
+
+  const retries = [
+    ...asArray(testcase.rerunFailure),
+    ...asArray(testcase.rerunError),
+    ...asArray(testcase.flakyFailure),
+    ...asArray(testcase.flakyError),
+  ]
+  const attempts = [...failures, ...retries]
+  const directStdout = asArray(testcase['system-out'])
+    .map(text)
+    .filter(Boolean)
+    .join('\n')
+  const directStderr = asArray(testcase['system-err'])
+    .map(text)
+    .filter(Boolean)
+    .join('\n')
+  const output = attempts.map((attempt, index) => {
+    const stdout =
+      index === 0
+        ? directStdout
+        : asArray(attempt['system-out']).map(text).filter(Boolean).join('\n')
+    const stderr =
+      index === 0
+        ? directStderr
+        : asArray(attempt['system-err']).map(text).filter(Boolean).join('\n')
+
+    return attemptOutput(attempt, stdout, stderr, index + 1, attempts.length)
+  })
+  const header = [
+    `Test: ${testcase.name}`,
+    `Binary: ${testcase.classname}`,
+    `Failed attempts: ${attempts.length}`,
+  ]
+
+  return `${header.join('\n')}\n\n${output.join('\n\n')}\n`
+}
+
+function logFileName(testcase) {
+  const identity = `${testcase.classname}\0${testcase.name}`
+  const hash = createHash('sha256').update(identity).digest('hex').slice(0, 10)
+  const readable = String(testcase.name ?? testcase.classname ?? 'unknown-test')
+    .replaceAll('::', '__')
+    .replace(/[^A-Za-z0-9._-]+/g, '_')
+    .replace(/^[_\.]+|[_\.]+$/g, '')
+    .slice(0, 180)
+
+  return `${readable || 'unknown-test'}--${hash}.log`
+}
+
+export async function extractFailureLogs(reportPath, outputDirectory) {
+  const xml = await readFile(reportPath, 'utf8')
+  const report = parser.parse(xml)
+  const failures = testcases(report)
+    .map((testcase) => ({ log: failureLog(testcase), testcase }))
+    .filter(({ log }) => log !== undefined)
+
+  if (failures.length === 0) {
+    return 0
+  }
+
+  await mkdir(outputDirectory, { recursive: true })
+  await Promise.all(
+    failures.map(({ log, testcase }) =>
+      writeFile(path.join(outputDirectory, logFileName(testcase)), log, 'utf8'),
+    ),
+  )
+
+  return failures.length
+}
+
+async function main() {
+  const [reportPath, outputDirectory] = process.argv.slice(2)
+  if (!reportPath || !outputDirectory) {
+    throw new Error(
+      'usage: extract-nextest-failures.mjs <junit.xml> <output-directory>',
+    )
+  }
+
+  const count = await extractFailureLogs(reportPath, outputDirectory)
+  console.log(`Wrote logs for ${count} failed test${count === 1 ? '' : 's'}.`)
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main().catch((error) => {
+    console.error(error)
+    process.exitCode = 1
+  })
+}

--- a/.github/scripts/nextest-failures/extract-nextest-failures.test.mjs
+++ b/.github/scripts/nextest-failures/extract-nextest-failures.test.mjs
@@ -1,0 +1,85 @@
+import assert from 'node:assert/strict'
+import { mkdtemp, readFile, readdir, writeFile } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+
+import { extractFailureLogs } from './extract-nextest-failures.mjs'
+
+test('writes one readable log per ultimately failed test', async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), 'nextest-failures-'))
+  const report = path.join(directory, 'junit.xml')
+  const output = path.join(directory, 'failures')
+  await writeFile(
+    report,
+    `<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="nextest-run" tests="4" failures="1" errors="1">
+  <testsuite name="tests" tests="4" failures="1" errors="1">
+    <testcase name="mirrord::passes" classname="tests" time="1.000"></testcase>
+    <testcase name="mirrord::flaky" classname="tests" time="2.000">
+      <flakyFailure message="first attempt failed" type="test failure">flaky reason</flakyFailure>
+    </testcase>
+    <testcase name="mirrord::cannot_execute" classname="tests" time="0.000">
+      <error message="process did not start" type="exec failed">spawn error</error>
+    </testcase>
+    <testcase name="mirrord::fails/with unsafe chars" classname="tests" time="3.000">
+      <failure timestamp="2026-08-13T17:25:21Z" time="1.000" message="expected &lt;ready&gt; &amp; got pending" type="test failure">initial reason</failure>
+      <rerunFailure timestamp="2026-08-13T17:25:22Z" time="2.000" message="retry failed" type="test failure">
+        retry reason
+        <system-out>retry stdout</system-out>
+        <system-err>retry stderr</system-err>
+      </rerunFailure>
+      <system-out>initial stdout</system-out>
+      <system-err>initial stderr</system-err>
+    </testcase>
+  </testsuite>
+</testsuites>`,
+    'utf8',
+  )
+
+  assert.equal(await extractFailureLogs(report, output), 2)
+
+  const files = await readdir(output)
+  assert.equal(files.length, 2)
+  const failedTestFile = files.find((file) => file.startsWith('mirrord__fails'))
+  const execFailureFile = files.find((file) =>
+    file.startsWith('mirrord__cannot_execute'),
+  )
+  assert.match(
+    failedTestFile,
+    /^mirrord__fails_with_unsafe_chars--[a-f0-9]{10}\.log$/,
+  )
+  assert.match(execFailureFile, /^mirrord__cannot_execute--[a-f0-9]{10}\.log$/)
+
+  const log = await readFile(path.join(output, failedTestFile), 'utf8')
+  assert.match(log, /Test: mirrord::fails\/with unsafe chars/)
+  assert.match(log, /Failed attempts: 2/)
+  assert.match(log, /=== Attempt 1 of 2: FAIL ===/)
+  assert.match(log, /Message: expected <ready> & got pending/)
+  assert.match(log, /initial stdout/)
+  assert.match(log, /initial stderr/)
+  assert.match(log, /=== Attempt 2 of 2: FAIL ===/)
+  assert.match(log, /retry stdout/)
+  assert.match(log, /retry stderr/)
+
+  const execFailureLog = await readFile(
+    path.join(output, execFailureFile),
+    'utf8',
+  )
+  assert.match(execFailureLog, /Type: exec failed/)
+  assert.match(execFailureLog, /--- failure ---\nspawn error/)
+})
+
+test('does not create an output directory when every test ultimately passes', async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), 'nextest-failures-'))
+  const report = path.join(directory, 'junit.xml')
+  const output = path.join(directory, 'failures')
+  await writeFile(
+    report,
+    `<testsuites><testsuite><testcase name="passes" classname="tests" /></testsuite></testsuites>`,
+    'utf8',
+  )
+
+  assert.equal(await extractFailureLogs(report, output), 0)
+  await assert.rejects(readdir(output), { code: 'ENOENT' })
+})

--- a/.github/scripts/nextest-failures/package.json
+++ b/.github/scripts/nextest-failures/package.json
@@ -1,0 +1,9 @@
+{
+  "private": true,
+  "scripts": {
+    "test": "node extract-nextest-failures.test.mjs"
+  },
+  "dependencies": {
+    "fast-xml-parser": "5.10.1"
+  }
+}

--- a/.github/scripts/prune-artifacts.sh
+++ b/.github/scripts/prune-artifacts.sh
@@ -32,7 +32,7 @@ trap 'rm -rf "$work"' EXIT
 # reachable by anything.
 keep() {
   case "$1" in
-    nextest-junit|intproxy_logs_*) return 0 ;;
+    nextest-junit|test-failures-*|intproxy_logs_*) return 0 ;;
     *) return 1 ;;
   esac
 }

--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -66,76 +66,118 @@ jobs:
             cargo build --target x86_64-unknown-linux-gnu -p mirrord
       - uses: ./.github/actions/run-in-ci-runner
         with:
+          artifact-key: test-integration-mirrord-layer-lib
+          capture-nextest-failures: true
+          test-group: ut
           command: |
-            cargo nextest run --target x86_64-unknown-linux-gnu -p mirrord-layer-lib
+            cargo nextest run --profile ci --cargo-quiet --target x86_64-unknown-linux-gnu -p mirrord-layer-lib
       - uses: ./.github/actions/run-in-ci-runner
         with:
+          artifact-key: test-integration-mirrord-layer-tests
+          capture-nextest-failures: true
+          test-group: integration
           command: |
-            cargo nextest run --target x86_64-unknown-linux-gnu -p mirrord-layer-tests --no-default-features
+            cargo nextest run --profile ci --cargo-quiet --target x86_64-unknown-linux-gnu -p mirrord-layer-tests --no-default-features
       - uses: ./.github/actions/run-in-ci-runner
         with:
+          artifact-key: test-integration-mirrord-layer
+          capture-nextest-failures: true
+          test-group: ut
           command: |
-            cargo nextest run --target x86_64-unknown-linux-gnu -p mirrord-layer
+            cargo nextest run --profile ci --cargo-quiet --target x86_64-unknown-linux-gnu -p mirrord-layer
       - name: mirrord protocol UT
         uses: ./.github/actions/run-in-ci-runner
         with:
+          artifact-key: test-integration-mirrord-protocol
+          capture-nextest-failures: true
+          test-group: ut
           command: |
-            cargo nextest run --target x86_64-unknown-linux-gnu -p mirrord-protocol
+            cargo nextest run --profile ci --cargo-quiet --target x86_64-unknown-linux-gnu -p mirrord-protocol
       - name: mirrord config UT
         uses: ./.github/actions/run-in-ci-runner
         with:
+          artifact-key: test-integration-mirrord-config
+          capture-nextest-failures: true
+          test-group: ut
           command: |
-            cargo nextest run --target x86_64-unknown-linux-gnu -p mirrord-config
+            cargo nextest run --profile ci --cargo-quiet --target x86_64-unknown-linux-gnu -p mirrord-config
       - name: mirrord kube UT
         uses: ./.github/actions/run-in-ci-runner
         with:
+          artifact-key: test-integration-mirrord-kube
+          capture-nextest-failures: true
+          test-group: ut
           command: |
-            cargo nextest run --target x86_64-unknown-linux-gnu -p mirrord-kube --all-features
+            cargo nextest run --profile ci --cargo-quiet --target x86_64-unknown-linux-gnu -p mirrord-kube --all-features
       - name: mirrord intproxy UT
         uses: ./.github/actions/run-in-ci-runner
         with:
+          artifact-key: test-integration-mirrord-intproxy
+          capture-nextest-failures: true
+          test-group: ut
           command: |
-            cargo nextest run --target x86_64-unknown-linux-gnu -p mirrord-intproxy
+            cargo nextest run --profile ci --cargo-quiet --target x86_64-unknown-linux-gnu -p mirrord-intproxy
       - name: mirrord auth UT
         uses: ./.github/actions/run-in-ci-runner
         with:
+          artifact-key: test-integration-mirrord-auth
+          capture-nextest-failures: true
+          test-group: ut
           command: |
-            cargo nextest run --target x86_64-unknown-linux-gnu -p mirrord-auth
+            cargo nextest run --profile ci --cargo-quiet --target x86_64-unknown-linux-gnu -p mirrord-auth
       - name: mirrord operator UT
         uses: ./.github/actions/run-in-ci-runner
         with:
+          artifact-key: test-integration-mirrord-operator
+          capture-nextest-failures: true
+          test-group: ut
           command: |
-            cargo nextest run --target x86_64-unknown-linux-gnu -p mirrord-operator --features "crd, client"
+            cargo nextest run --profile ci --cargo-quiet --target x86_64-unknown-linux-gnu -p mirrord-operator --features "crd, client"
       - name: mirrord cli UT
         uses: ./.github/actions/run-in-ci-runner
         with:
+          artifact-key: test-integration-mirrord-cli
+          capture-nextest-failures: true
+          test-group: ut
           command: |
-            cargo xtask test-ut -- --target x86_64-unknown-linux-gnu
+            cargo xtask test-ut -- --profile ci --cargo-quiet --target x86_64-unknown-linux-gnu
       - name: mirrord protocol-io UT
         uses: ./.github/actions/run-in-ci-runner
         with:
+          artifact-key: test-integration-mirrord-protocol-io
+          capture-nextest-failures: true
+          test-group: ut
           command: |
-            cargo nextest run --target x86_64-unknown-linux-gnu -p mirrord-protocol-io
+            cargo nextest run --profile ci --cargo-quiet --target x86_64-unknown-linux-gnu -p mirrord-protocol-io
       - name: mirrord jaq UT
         uses: ./.github/actions/run-in-ci-runner
         with:
+          artifact-key: test-integration-mirrord-jaq
+          capture-nextest-failures: true
+          test-group: ut
           command: |
-            cargo nextest run --target x86_64-unknown-linux-gnu -p mirrord-jaq
+            cargo nextest run --profile ci --cargo-quiet --target x86_64-unknown-linux-gnu -p mirrord-jaq
       - name: mirrord vpn UT
         uses: ./.github/actions/run-in-ci-runner
         with:
+          artifact-key: test-integration-mirrord-vpn
+          capture-nextest-failures: true
+          test-group: ut
           command: |
-            cargo nextest run --target x86_64-unknown-linux-gnu -p mirrord-vpn
+            cargo nextest run --profile ci --cargo-quiet --target x86_64-unknown-linux-gnu -p mirrord-vpn
       - name: mirrord tui build and UT
         uses: ./.github/actions/run-in-ci-runner
         with:
+          artifact-key: test-integration-mirrord-tui
+          capture-nextest-failures: true
+          test-group: ut
           command: |
             set -e
             # Built from its own directory, so that the crate is checked the way someone working
             # only on it builds it, rather than with whatever features the rest of the workspace
             # happens to turn on.
             (cd mirrord/tui && cargo build --target x86_64-unknown-linux-gnu)
-            cargo nextest run --target x86_64-unknown-linux-gnu -p mirrord-tui
+            cargo nextest run --profile ci --cargo-quiet --target x86_64-unknown-linux-gnu -p mirrord-tui
       - name: save intproxy logs
         continue-on-error: true
         if: ${{ always() }}

--- a/changelog.d/+nextest-integration-output.internal.md
+++ b/changelog.d/+nextest-integration-output.internal.md
@@ -1,0 +1,1 @@
+Keep integration-test CI output concise and upload per-test nextest failure logs as artifacts.


### PR DESCRIPTION
## Summary

- add a shared CI nextest profile that prints only the final test summary
- retain JUnit reports and extract one readable artifact log per ultimately failed test
- apply the shared collector to every integration-test invocation
- preserve nextest JUnit and failure artifacts during inter-job cleanup

This is PR 1 of 5 in the concise-nextest-output stack.

## Validation

- nextest failure extractor tests pass
- modified YAML and TOML files parse successfully
- composite action shell scripts pass `bash -n`
- `cargo fmt --check` passes

### Quality Checklist:

- [x] I have documented new code sufficiently
- [x] I have checked and updated the relevant existing docs in code, including removing outdated material
- [x] I have tested this change and know it succeeds and fails as expected
- [x] I have written unit tests or purposefully omitted them
- [x] I have written e2e tests or purposefully omitted them
- [x] I have explained what this PR introduces and why, and linked to relevant context
- [x] I have introduced a short, clear and well-formatted changelog entry
