### PR TITLE
Improve platform-test failure output

### DIFF
--- a/.github/actions/collect-nextest-results/action.yml
+++ b/.github/actions/collect-nextest-results/action.yml
@@ -27,7 +27,7 @@ runs:
         NEXTEST_FAILURES_SCRIPT: ${{ github.action_path }}/../../scripts/nextest-failures
         TEST_GROUP: ${{ inputs.test-group }}
       run: |
-        timestamp="$(date --utc +%Y%m%dT%H%M%S%NZ)"
+        timestamp="$(date -u +%Y%m%dT%H%M%S%NZ)"
         suffix="$TEST_GROUP-$ARTIFACT_KEY-attempt-$timestamp"
         report="nextest-junit-$suffix"
         report_dir="$RUNNER_TEMP/$report/nextest-junit-$TEST_GROUP-xml"

--- a/.github/workflows/test-macos.yaml
+++ b/.github/workflows/test-macos.yaml
@@ -53,14 +53,35 @@ jobs:
         with:
           tool: cargo-nextest
       - name: mirrord-sip UT
-        run: cargo nextest run -p mirrord-sip
+        run: cargo nextest run --profile ci --cargo-quiet -p mirrord-sip
+      - name: Collect mirrord-sip UT results
+        if: ${{ always() }}
+        uses: ./.github/actions/collect-nextest-results
+        with:
+          artifact-key: test-macos-mirrord-sip
+          capture-nextest-failures: true
+          test-group: ut
       - name: mirrord-intproxy UT
-        run: cargo nextest run -p mirrord-intproxy
+        run: cargo nextest run --profile ci --cargo-quiet -p mirrord-intproxy
+      - name: Collect mirrord-intproxy UT results
+        if: ${{ always() }}
+        uses: ./.github/actions/collect-nextest-results
+        with:
+          artifact-key: test-macos-mirrord-intproxy
+          capture-nextest-failures: true
+          test-group: ut
       # The only place the interface's tests run on macOS, and so the only place its macOS-specific
       # process lookup (`proc_pidinfo`, where Linux reads `/proc`) is executed rather than merely
       # compiled. The pty tests need a real terminal-capable `/bin/sh`, which the runner has.
       - name: mirrord-tui UT
-        run: cargo nextest run -p mirrord-tui
+        run: cargo nextest run --profile ci --cargo-quiet -p mirrord-tui
+      - name: Collect mirrord-tui UT results
+        if: ${{ always() }}
+        uses: ./.github/actions/collect-nextest-results
+        with:
+          artifact-key: test-macos-mirrord-tui
+          capture-nextest-failures: true
+          test-group: ut
       - run: |
           cd mirrord/layer-tests/tests/apps/issue1123
           rustc issue1123.rs --out-dir target
@@ -154,9 +175,23 @@ jobs:
         with:
           tool: cargo-nextest
       - name: mirrord layer integration tests
-        run: cargo nextest run -p mirrord-layer-tests --no-default-features
+        run: cargo nextest run --profile ci --cargo-quiet -p mirrord-layer-tests --no-default-features
+      - name: Collect mirrord layer integration test results
+        if: ${{ always() }}
+        uses: ./.github/actions/collect-nextest-results
+        with:
+          artifact-key: test-macos-mirrord-layer-tests
+          capture-nextest-failures: true
+          test-group: integration
       - name: mirrord layer unit tests
-        run: cargo nextest run -p mirrord-layer
+        run: cargo nextest run --profile ci --cargo-quiet -p mirrord-layer
+      - name: Collect mirrord layer unit test results
+        if: ${{ always() }}
+        uses: ./.github/actions/collect-nextest-results
+        with:
+          artifact-key: test-macos-mirrord-layer
+          capture-nextest-failures: true
+          test-group: ut
       - name: save intproxy logs
         continue-on-error: true
         if: ${{ always() }}

--- a/.github/workflows/test-windows.yaml
+++ b/.github/workflows/test-windows.yaml
@@ -97,12 +97,33 @@ jobs:
       - name: mirrord layer integration tests
         run: |
           $ErrorActionPreference = "Stop"
-          cargo nextest run -p mirrord-layer-tests --no-default-features
+          cargo nextest run --profile ci --cargo-quiet -p mirrord-layer-tests --no-default-features
+      - name: Collect mirrord layer integration test results
+        if: ${{ always() }}
+        uses: ./.github/actions/collect-nextest-results
+        with:
+          artifact-key: test-windows-mirrord-layer-tests
+          capture-nextest-failures: true
+          test-group: integration
       - name: run UT
         run: |
           $ErrorActionPreference = "Stop"
-          cargo nextest run -p mirrord -p mirrord-layer-win
+          cargo nextest run --profile ci --cargo-quiet -p mirrord -p mirrord-layer-win
+      - name: Collect mirrord and mirrord-layer-win UT results
+        if: ${{ always() }}
+        uses: ./.github/actions/collect-nextest-results
+        with:
+          artifact-key: test-windows-mirrord-and-layer-win
+          capture-nextest-failures: true
+          test-group: ut
       - name: mirrord intproxy UT
         run: |
           $ErrorActionPreference = "Stop"
-          cargo nextest run -p mirrord-intproxy
+          cargo nextest run --profile ci --cargo-quiet -p mirrord-intproxy
+      - name: Collect mirrord intproxy UT results
+        if: ${{ always() }}
+        uses: ./.github/actions/collect-nextest-results
+        with:
+          artifact-key: test-windows-mirrord-intproxy
+          capture-nextest-failures: true
+          test-group: ut

--- a/changelog.d/+nextest-platform-output.internal.md
+++ b/changelog.d/+nextest-platform-output.internal.md
@@ -1,0 +1,1 @@
+Keep macOS and Windows test output concise and upload per-test nextest failure logs as artifacts.


### PR DESCRIPTION
## Summary

- use the concise nextest CI profile for macOS and Windows tests
- upload JUnit reports and per-test failure logs after every platform suite
- use the workflow run attempt in artifact suffixes so collection is portable across runner operating systems

This is PR 3 of 5 and depends on the agent-output PR directly below it.

## Validation

- modified workflow YAML parses successfully
- `cargo fmt --check` passes

### Quality Checklist:

- [x] I have documented new code sufficiently
- [x] I have checked and updated the relevant existing docs in code, including removing outdated material
- [x] I have tested this change and know it succeeds and fails as expected
- [x] I have written unit tests or purposefully omitted them
- [x] I have written e2e tests or purposefully omitted them
- [x] I have explained what this PR introduces and why, and linked to relevant context
- [x] I have introduced a short, clear and well-formatted changelog entry
