### PR TITLE
Improve E2E failure output

### DIFF
--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -104,7 +104,10 @@ jobs:
         if: ${{ matrix.container-runtime == 'docker' }}
         uses: ./.github/actions/run-in-ci-runner
         with:
-          command: cargo xtask test-e2e --binary target/x86_64-unknown-linux-gnu/debug/mirrord --layer target/x86_64-unknown-linux-gnu/debug/libmirrord_layer.so -- --target=x86_64-unknown-linux-gnu --no-default-features --features cli --test-threads=6
+          artifact-key: test-e2e-cli-${{ matrix.container-runtime }}-${{ matrix.cluster-runtime }}
+          capture-nextest-failures: true
+          test-group: e2e
+          command: cargo xtask test-e2e --binary target/x86_64-unknown-linux-gnu/debug/mirrord --layer target/x86_64-unknown-linux-gnu/debug/libmirrord_layer.so -- --profile ci --cargo-quiet --target=x86_64-unknown-linux-gnu --no-default-features --features cli --test-threads=6
       - name: Smoke-test mirrord wizard (alias to mirrord ui)
         uses: ./.github/actions/run-in-ci-runner
         with:
@@ -115,17 +118,28 @@ jobs:
       - name: Run targetless E2E test
         uses: ./.github/actions/run-in-ci-runner
         with:
-          command: cargo xtask test-e2e --binary target/x86_64-unknown-linux-gnu/debug/mirrord --layer target/x86_64-unknown-linux-gnu/debug/libmirrord_layer.so -- --target=x86_64-unknown-linux-gnu --no-default-features --features targetless --test-threads=6 -- targetless
+          artifact-key: test-e2e-targetless-${{ matrix.container-runtime }}-${{ matrix.cluster-runtime }}
+          capture-nextest-failures: true
+          test-group: e2e
+          command: cargo xtask test-e2e --binary target/x86_64-unknown-linux-gnu/debug/mirrord --layer target/x86_64-unknown-linux-gnu/debug/libmirrord_layer.so -- --profile ci --cargo-quiet --target=x86_64-unknown-linux-gnu --no-default-features --features targetless --test-threads=6 -- targetless
       - name: Deploy ArgoCD Rollouts
         run: |
           kubectl create namespace argo-rollouts
           kubectl apply -n argo-rollouts -f https://github.com/argoproj/argo-rollouts/releases/download/v1.9.1/install.yaml
-      - name: Run all E2E tests
+      - name: Run job E2E tests
         uses: ./.github/actions/run-in-ci-runner
         with:
-          command: >-
-            cargo xtask test-e2e --binary target/x86_64-unknown-linux-gnu/debug/mirrord --layer target/x86_64-unknown-linux-gnu/debug/libmirrord_layer.so -- --target=x86_64-unknown-linux-gnu --no-default-features --features job --test-threads=6 &&
-            cargo xtask test-e2e --binary target/x86_64-unknown-linux-gnu/debug/mirrord --layer target/x86_64-unknown-linux-gnu/debug/libmirrord_layer.so -- --target=x86_64-unknown-linux-gnu --no-default-features --features ephemeral --test-threads=6
+          artifact-key: test-e2e-job-${{ matrix.container-runtime }}-${{ matrix.cluster-runtime }}
+          capture-nextest-failures: true
+          test-group: e2e
+          command: cargo xtask test-e2e --binary target/x86_64-unknown-linux-gnu/debug/mirrord --layer target/x86_64-unknown-linux-gnu/debug/libmirrord_layer.so -- --profile ci --cargo-quiet --target=x86_64-unknown-linux-gnu --no-default-features --features job --test-threads=6
+      - name: Run ephemeral-agent E2E tests
+        uses: ./.github/actions/run-in-ci-runner
+        with:
+          artifact-key: test-e2e-ephemeral-${{ matrix.container-runtime }}-${{ matrix.cluster-runtime }}
+          capture-nextest-failures: true
+          test-group: e2e
+          command: cargo xtask test-e2e --binary target/x86_64-unknown-linux-gnu/debug/mirrord --layer target/x86_64-unknown-linux-gnu/debug/libmirrord_layer.so -- --profile ci --cargo-quiet --target=x86_64-unknown-linux-gnu --no-default-features --features ephemeral --test-threads=6
       - name: Collect logs
         if: ${{ failure() }}
         run: |
@@ -209,8 +223,11 @@ jobs:
       - name: Run IPv6 E2E tests
         uses: ./.github/actions/run-in-ci-runner
         with:
+          artifact-key: test-e2e-ipv6-kind
+          capture-nextest-failures: true
+          test-group: e2e
           command: >-
-            cargo xtask test-e2e --binary target/x86_64-unknown-linux-gnu/debug/mirrord --layer target/x86_64-unknown-linux-gnu/debug/libmirrord_layer.so -- --target=x86_64-unknown-linux-gnu --no-default-features --features ipv6 --test-threads=1 -E 'test(ipv6)'
+            cargo xtask test-e2e --binary target/x86_64-unknown-linux-gnu/debug/mirrord --layer target/x86_64-unknown-linux-gnu/debug/libmirrord_layer.so -- --profile ci --cargo-quiet --target=x86_64-unknown-linux-gnu --no-default-features --features ipv6 --test-threads=1 -E 'test(ipv6)'
       - name: Collect logs
         if: ${{ failure() }}
         run: |

--- a/changelog.d/+nextest-e2e-output.internal.md
+++ b/changelog.d/+nextest-e2e-output.internal.md
@@ -1,0 +1,1 @@
+Keep E2E test output concise and upload per-test nextest failure logs as artifacts.


### PR DESCRIPTION
## Summary

- use the concise nextest CI profile for every regular and IPv6 E2E suite
- upload distinct JUnit and per-test failure artifacts for each matrix and feature group
- split job and ephemeral-agent E2E runs so one report cannot overwrite the other

This is PR 4 of 5 and depends on the platform-output PR directly below it.

## Validation

- modified workflow YAML parses successfully
- all E2E commands include the CI profile and quiet Cargo output
- `cargo fmt --check` passes

### Quality Checklist:

- [x] I have documented new code sufficiently
- [x] I have checked and updated the relevant existing docs in code, including removing outdated material
- [x] I have tested this change and know it succeeds and fails as expected
- [x] I have written unit tests or purposefully omitted them
- [x] I have written e2e tests or purposefully omitted them
- [x] I have explained what this PR introduces and why, and linked to relevant context
- [x] I have introduced a short, clear and well-formatted changelog entry
