### PR TITLE
[DO NOT MERGE] Verify nextest failure artifacts

### DIFF
--- a/changelog.d/+nextest-failure-artifact-validation.internal.md
+++ b/changelog.d/+nextest-failure-artifact-validation.internal.md
@@ -1,0 +1,1 @@
+Add disposable failing tests for validating concise CI output and nextest failure artifacts.

--- a/mirrord/agent/tests/ci_failure_artifact_preview.rs
+++ b/mirrord/agent/tests/ci_failure_artifact_preview.rs
@@ -1,0 +1,6 @@
+#[test]
+fn agent_failure_artifact_preview() {
+    println!("agent failure artifact stdout preview");
+    eprintln!("agent failure artifact stderr preview");
+    panic!("intentional agent failure for CI artifact validation");
+}

--- a/mirrord/config/tests/ci_failure_artifact_preview.rs
+++ b/mirrord/config/tests/ci_failure_artifact_preview.rs
@@ -1,0 +1,6 @@
+#[test]
+fn integration_failure_artifact_preview() {
+    println!("integration failure artifact stdout preview");
+    eprintln!("integration failure artifact stderr preview");
+    panic!("intentional integration failure for CI artifact validation");
+}

--- a/mirrord/intproxy/tests/ci_failure_artifact_preview.rs
+++ b/mirrord/intproxy/tests/ci_failure_artifact_preview.rs
@@ -1,0 +1,15 @@
+#[cfg(target_os = "macos")]
+#[test]
+fn macos_failure_artifact_preview() {
+    println!("macOS failure artifact stdout preview");
+    eprintln!("macOS failure artifact stderr preview");
+    panic!("intentional macOS failure for CI artifact validation");
+}
+
+#[cfg(target_os = "windows")]
+#[test]
+fn windows_failure_artifact_preview() {
+    println!("Windows failure artifact stdout preview");
+    eprintln!("Windows failure artifact stderr preview");
+    panic!("intentional Windows failure for CI artifact validation");
+}

--- a/tests/src/ci_failure_artifact_preview.rs
+++ b/tests/src/ci_failure_artifact_preview.rs
@@ -1,0 +1,35 @@
+#[cfg(feature = "cli")]
+#[test]
+fn cli_failure_artifact_preview() {
+    fail("CLI");
+}
+
+#[cfg(feature = "targetless")]
+#[test]
+fn targetless_failure_artifact_preview() {
+    fail("targetless");
+}
+
+#[cfg(feature = "job")]
+#[test]
+fn job_failure_artifact_preview() {
+    fail("job");
+}
+
+#[cfg(feature = "ephemeral")]
+#[test]
+fn ephemeral_failure_artifact_preview() {
+    fail("ephemeral-agent");
+}
+
+#[cfg(feature = "ipv6")]
+#[test]
+fn ipv6_failure_artifact_preview() {
+    fail("IPv6");
+}
+
+fn fail(group: &str) {
+    println!("{group} E2E failure artifact stdout preview");
+    eprintln!("{group} E2E failure artifact stderr preview");
+    panic!("intentional {group} E2E failure for CI artifact validation");
+}

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -1,6 +1,7 @@
 #![warn(clippy::indexing_slicing)]
 
 mod argo_rollout;
+mod ci_failure_artifact_preview;
 mod cleanup;
 #[cfg(feature = "cli")]
 mod cli;


### PR DESCRIPTION
## Purpose

Disposable validation PR for the concise-nextest-output stack. It deliberately adds failing tests for each affected execution shape so CI produces concise summaries and downloadable per-test logs.

## Intentional failures

- integration tests
- agent tests
- macOS and Windows tests
- CLI, targetless, job, ephemeral-agent, and IPv6 E2E groups

This is PR 5 of 5 and depends on the E2E-output PR directly below it. Drop this PR and commit after the CI output and artifacts have been inspected.

**Do not merge.**

### Quality Checklist:

- [x] I have tested this change and know it succeeds and fails as expected
- [x] I have written unit tests or purposefully omitted them
- [x] I have written e2e tests or purposefully omitted them
- [x] I have explained what this PR introduces and why, and linked to relevant context
- [x] I have introduced a short, clear and well-formatted changelog entry
