### PR TITLE
Add E2E coverage for outgoing TLS handshakes from Go

### DIFF
--- a/changelog.d/+cor-1852-go-outgoing-tls-e2e.internal.md
+++ b/changelog.d/+cor-1852-go-outgoing-tls-e2e.internal.md
@@ -1,0 +1,1 @@
+Added an E2E test covering a Go application completing a TLS handshake with an external host over an outgoing connection.

--- a/tests/go-e2e-outgoing-tls/go.mod
+++ b/tests/go-e2e-outgoing-tls/go.mod
@@ -1,0 +1,6 @@
+module go-e2e-outgoing-tls
+
+// Kept at 1.25 on purpose: the `go` directive selects the GODEBUG compatibility
+// defaults, so a module declaring an older version would not exercise the same
+// runtime and crypto/tls behaviour that this app is here to cover.
+go 1.25

--- a/tests/go-e2e-outgoing-tls/main.go
+++ b/tests/go-e2e-outgoing-tls/main.go
@@ -1,0 +1,72 @@
+// Exercises outgoing traffic from Go's runtime network path: an in-cluster DNS
+// lookup and TCP dial, followed by TLS handshakes against external hosts.
+//
+// The handshakes are the interesting part - a plain HTTP request over an
+// outgoing connection is already covered by `go-e2e-outgoing`, while a TLS
+// handshake additionally depends on the connection carrying the full
+// negotiation, including ALPN and a multi-certificate chain, before any
+// application data flows.
+//
+// `CLUSTER_TARGET` ("host:port", reachable from the mirrord target) enables the
+// in-cluster probes. Without it, only the external handshakes run.
+package main
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net"
+	"os"
+	"strings"
+	"time"
+)
+
+const timeout = 10 * time.Second
+
+// Runs fn, reports how it went, and returns whether it succeeded.
+func probe(name string, fn func() error) bool {
+	start := time.Now()
+	err := fn()
+	fmt.Printf("%-12s err=%v secs=%.2f\n", name, err, time.Since(start).Seconds())
+	return err == nil
+}
+
+func tlsHandshake(address string) func() error {
+	return func() error {
+		dialer := &net.Dialer{Timeout: timeout}
+		conn, err := tls.DialWithDialer(dialer, "tcp", address, nil)
+		if err != nil {
+			return err
+		}
+		return conn.Close()
+	}
+}
+
+func main() {
+	ok := true
+
+	if cluster := os.Getenv("CLUSTER_TARGET"); cluster != "" {
+		host := strings.Split(cluster, ":")[0]
+
+		ok = probe("dns_cluster", func() error {
+			_, err := net.LookupHost(host)
+			return err
+		}) && ok
+
+		ok = probe("tcp_cluster", func() error {
+			conn, err := net.DialTimeout("tcp", cluster, timeout)
+			if err != nil {
+				return err
+			}
+			return conn.Close()
+		}) && ok
+	}
+
+	// Both hosts are probed so that a failure specific to one endpoint is
+	// distinguishable from outgoing TLS being broken altogether.
+	ok = probe("tls_spanner", tlsHandshake("spanner.googleapis.com:443")) && ok
+	ok = probe("tls_google", tlsHandshake("www.google.com:443")) && ok
+
+	if !ok {
+		os.Exit(1)
+	}
+}

--- a/tests/src/traffic.rs
+++ b/tests/src/traffic.rs
@@ -493,6 +493,37 @@ mod traffic_tests {
         assert!(res.success());
     }
 
+    /// Verifies that a Go application can complete a TLS handshake with an external host over an
+    /// outgoing connection, alongside DNS resolution and a TCP dial against the cluster.
+    ///
+    /// [`go_outgoing_traffic_single_request_enabled`] covers a plain HTTP request, which does not
+    /// reach the handshake at all. The test app's module also declares a recent `go` directive, so
+    /// it runs under the GODEBUG defaults that ship with the toolchain building it.
+    #[cfg_attr(not(feature = "job"), ignore)]
+    #[rstest]
+    #[tokio::test]
+    pub async fn go_outgoing_traffic_tls_handshake(
+        #[values(GoVersion::GO_1_25, GoVersion::GO_1_26, GoVersion::GO_1_27)] go_version: GoVersion,
+        #[future] basic_service: KubeService,
+    ) {
+        let command = vec![format!("go-e2e-outgoing-tls/{go_version}.go_test_app")];
+        let service = basic_service.await;
+        let cluster_target = format!(
+            "{}.{}.svc.cluster.local:80",
+            service.name, service.namespace
+        );
+        let mut process = run_exec_with_target(
+            command,
+            &service.pod_container_target(),
+            None,
+            None,
+            Some(vec![("CLUSTER_TARGET", cluster_target.as_str())]),
+        )
+        .await;
+        let res = process.wait().await;
+        assert!(res.success());
+    }
+
     #[cfg_attr(not(feature = "job"), ignore)]
     #[rstest]
     #[tokio::test]


### PR DESCRIPTION
COR-1852 reports that outgoing traffic fails under Go 1.25. The existing `go-e2e-outgoing` app only issues a plain HTTP request, so it never gets as far as a TLS handshake, and its module declares `go 1.19` — which also means it runs under old GODEBUG compatibility defaults rather than the toolchain's current ones.

This adds a `go-e2e-outgoing-tls` app that does an in-cluster DNS lookup and TCP dial, then TLS handshakes against two external hosts, run over Go 1.25/1.26/1.27. Two hosts so an endpoint-specific failure is distinguishable from outgoing TLS being broken outright.

Opened to see whether it reproduces in CI — not run locally.

https://claude.ai/code/session_01YP3jjSJGWYfGRBb9Ha2XES