### PR TITLE
Emit warning when agent detects svcmesh using iptables backend different from the explicitly configured one

### DIFF
--- a/.vale/styles/config/vocabularies/Metalbear/accept.txt
+++ b/.vale/styles/config/vocabularies/Metalbear/accept.txt
@@ -81,6 +81,7 @@ ASCII
 crypto
 runtime
 goroutine
+plaintext
 
 # Linux syscalls and C API
 variadic

--- a/changelog.d/+mesh-backend-mismatch-warning.fixed.md
+++ b/changelog.d/+mesh-backend-mismatch-warning.fixed.md
@@ -1,0 +1,1 @@
+The agent now logs a warning when an explicitly configured iptables backend (`agent.nftables`) hides service mesh rules living in the other backend. Such a mismatch disables mesh-aware traffic redirection and can deliver still-encrypted mesh traffic directly to the application's plaintext port.

--- a/mirrord/agent/iptables/src/lib.rs
+++ b/mirrord/agent/iptables/src/lib.rs
@@ -536,6 +536,39 @@ pub fn get_iptables(nftables: Option<bool>, ip6: bool) -> IPTablesWrapper {
     wrapper
 }
 
+/// Checks whether an explicitly configured iptables backend hides service mesh rules living in the
+/// other backend, and logs a loud warning if so.
+///
+/// When no backend is explicitly configured, [`get_iptables`] picks the backend where mesh rules
+/// are found, so mesh-aware redirection kicks in automatically. An explicit setting skips that
+/// detection. If the mesh's rules live in the other backend, mesh detection silently fails and the
+/// agent falls back to the standard redirect, which races the mesh's own PREROUTING redirect and
+/// can deliver still-encrypted mesh traffic (e.g. a raw TLS ClientHello) directly to the
+/// application's plaintext port.
+pub fn warn_on_backend_mesh_mismatch(nftables: bool, ip6: bool) {
+    let selected = get_iptables(Some(nftables), ip6);
+    if matches!(MeshVendor::detect(&selected), Ok(Some(..))) {
+        return;
+    }
+
+    try_drop_cap_sys_module();
+
+    let other = get_iptables(Some(nftables.not()), ip6);
+    if let Ok(Some(mesh)) = MeshVendor::detect(&other) {
+        tracing::warn!(
+            %mesh,
+            configured_backend = selected.tables.cmd,
+            mesh_rules_found_with = other.tables.cmd,
+            "Service mesh rules were found with the iptables backend other than the explicitly \
+            configured one. Mesh-aware traffic redirection will not be used, and intercepting \
+            incoming traffic is likely to break meshed traffic to the target, e.g. deliver \
+            encrypted bytes directly to the application's port. Remove the explicit backend \
+            setting (`agent.nftables` config / `MIRRORD_AGENT_NFTABLES`) to let the agent pick \
+            the backend automatically."
+        );
+    }
+}
+
 /// Drops [`Capability::CAP_SYS_MODULE`] from the current thread.
 ///
 /// This will prevent the thread from loading kernel modules.

--- a/mirrord/agent/src/incoming/iptables.rs
+++ b/mirrord/agent/src/incoming/iptables.rs
@@ -83,13 +83,16 @@ impl IpTablesRedirector {
     }
 
     pub async fn init_iptables(&mut self) -> Result<(), IPTablesError> {
-        let ntfables = envs::NFTABLES.try_from_env().unwrap_or_default();
+        let nftables = envs::NFTABLES.try_from_env().unwrap_or_default();
+        if let Some(nftables) = nftables {
+            mirrord_agent_iptables::warn_on_backend_mesh_mismatch(nftables, self.ipv6);
+        }
         let chain_names = ChainNames::new(
             IPTABLES_IDENTIFIER
                 .get()
                 .expect("Should be set during state initialization!"),
         );
-        let iptables = mirrord_agent_iptables::get_iptables(ntfables, self.ipv6);
+        let iptables = mirrord_agent_iptables::get_iptables(nftables, self.ipv6);
         let iptables = SafeIpTables::create(
             iptables,
             &chain_names,


### PR DESCRIPTION


- [X] I have documented new code sufficiently
- [X] I have checked and updated the relevant existing docs in code, including removing outdated material
- [X] I have written user-facing website docs for new features, or opened a (sub)issue to do so
- [X] I have checked and updated existing website docs for changed features
- [X] I have tested this change and know it succeeds and fails as expected
- [X] I have written unit tests or purposefully omitted them
- [X] I have written e2e tests or purposefully omitted them
- [X] I have explained what this PR introduces and why, and linked to relevant context (e.g. linear issues, related PRs,
  documentation)
- [X] I have introduced a short, clear and well-formatted changelog entry

<!-- need help with the changelog? see ../CONTRIBUTING.md#submitting-a-pull-request -->
<!-- Add more details of your changes below if needed -->

Emits a warning for the flow suspected to cause https://linear.app/metalbear/issue/COR-1790/bug-in-linkerd-tls-traffic-with-mirrord