### PR TITLE
fix(ci): kill the user command's process group on `mirrord ci stop`

### DIFF
--- a/changelog.d/+cor-1855-ci-stop-process-group.fixed.md
+++ b/changelog.d/+cor-1855-ci-stop-process-group.fixed.md
@@ -1,0 +1,1 @@
+`mirrord ci stop` now terminates the whole process group of the command that `mirrord ci start` spawned, instead of only that command's own process. Servers started through a wrapper such as `npm run` were left running and holding their port. The command also gets a `SIGTERM` and a few seconds to shut down before it is `SIGKILL`ed.

--- a/mirrord/cli/Cargo.toml
+++ b/mirrord/cli/Cargo.toml
@@ -50,7 +50,7 @@ which.workspace = true
 semver.workspace = true
 reqwest = { workspace = true, features = ["stream"] }
 const-random.workspace = true
-tokio = { workspace = true, features = ["rt", "net", "macros", "process"] }
+tokio = { workspace = true, features = ["rt", "net", "macros", "process", "signal", "time"] }
 tokio-retry.workspace = true
 kube.workspace = true
 k8s-openapi.workspace = true

--- a/mirrord/cli/src/ci.rs
+++ b/mirrord/cli/src/ci.rs
@@ -117,6 +117,46 @@ MIRRORD_CI_API_KEY environment variable.
     Ok(())
 }
 
+/// Waits for `child`, forwarding the terminal signals mirrord receives to its process group.
+///
+/// The child leads its own group, which takes it out of the group a terminal signals on `Ctrl-C`.
+/// Forwarding keeps `--foreground` behaving like a plain shell job, and reaches the descendants of
+/// wrappers such as `npm run` as well.
+#[cfg(not(target_os = "windows"))]
+async fn wait_forwarding_signals(
+    child: &mut tokio::process::Child,
+) -> std::io::Result<std::process::ExitStatus> {
+    use nix::{
+        sys::signal::{Signal, kill},
+        unistd::Pid,
+    };
+    use tokio::signal::unix::{SignalKind, signal};
+
+    // Without a pid there is no group to forward to, and the child is already gone.
+    let Some(pid) = child.id() else {
+        return child.wait().await;
+    };
+    let group = Pid::from_raw(-(pid as i32));
+
+    let mut interrupt = signal(SignalKind::interrupt())?;
+    let mut terminate = signal(SignalKind::terminate())?;
+    let mut hangup = signal(SignalKind::hangup())?;
+
+    let mut wait = std::pin::pin!(child.wait());
+
+    loop {
+        let forwarded = tokio::select! {
+            status = &mut wait => break status,
+            _ = interrupt.recv() => Signal::SIGINT,
+            _ = terminate.recv() => Signal::SIGTERM,
+            _ = hangup.recv() => Signal::SIGHUP,
+        };
+
+        // The group is gone when the child exits while a signal is in flight.
+        let _ = kill(group, forwarded);
+    }
+}
+
 /// Sidecar container that is started as part of `mirrord ci container`.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub(crate) struct MirrordCiManagedContainer {
@@ -310,12 +350,19 @@ impl MirrordCi {
         )
         .await?;
 
+        // The command leads its own process group, so that `mirrord ci stop` can signal the whole
+        // tree. Wrappers such as `npm run` spawn the actual server as a child of their own, and
+        // that child survives - still holding the listening port - a signal aimed at the wrapper.
+        //
+        // Safe to do with stdin closed and stdio going to files: the group never has to read from
+        // a terminal, which a background process group cannot do.
         let mut child = match tokio::process::Command::new(binary_path)
             .args(binary_args.iter().skip(1))
             .envs(env_vars)
             .stdin(Stdio::null())
             .stdout(File::create(ci_run_output_dir.join("stdout"))?)
             .stderr(File::create(ci_run_output_dir.join("stderr"))?)
+            .process_group(0)
             .kill_on_drop(false)
             .spawn()
         {
@@ -340,7 +387,7 @@ impl MirrordCi {
 
         if self.ci_common_args.foreground {
             progress.info(&format!("waiting for child with pid {child_pid}"));
-            match child.wait().await {
+            match wait_forwarding_signals(&mut child).await {
                 Ok(status) => {
                     if status.success() {
                         progress.success(None);

--- a/mirrord/cli/src/ci/stop.rs
+++ b/mirrord/cli/src/ci/stop.rs
@@ -1,11 +1,27 @@
 #![cfg_attr(windows, allow(unused))]
+use std::time::{Duration, Instant};
+
 use itertools::Itertools;
 use mirrord_progress::{Progress, ProgressTracker};
+#[cfg(not(target_os = "windows"))]
+use nix::{
+    errno::Errno,
+    sys::signal::{Signal, kill},
+    unistd::Pid,
+};
 use tokio::process::Command;
 use tracing::Level;
 
 use super::CiResult;
+#[cfg(not(target_os = "windows"))]
+use crate::ci::CiError;
 use crate::ci::MirrordCiStore;
+
+/// How long the user's process gets to shut down on `SIGTERM` before it is `SIGKILL`ed.
+const USER_PROCESS_GRACE_PERIOD: Duration = Duration::from_secs(5);
+
+/// How often we check whether the user's process is gone during [`USER_PROCESS_GRACE_PERIOD`].
+const USER_PROCESS_POLL_INTERVAL: Duration = Duration::from_millis(100);
 
 /// Kills the sidecars that were started by `mirrord ci container`.
 ///
@@ -50,6 +66,66 @@ async fn runtime_remove_container(container: crate::ci::MirrordCiManagedContaine
     }
 }
 
+/// Sends `signal` to `target`, reporting whether `target` was still around to receive it.
+///
+/// A [`None`] signal only probes for existence. A negative `target` is a process group.
+#[cfg(not(target_os = "windows"))]
+fn try_signal(target: Pid, signal: impl Into<Option<Signal>>) -> CiResult<bool> {
+    match kill(target, signal) {
+        Ok(()) => Ok(true),
+        // ESRCH means that the process has already exited.
+        Err(Errno::ESRCH) => Ok(false),
+        Err(error) => Err(CiError::from(error)),
+    }
+}
+
+/// `SIGKILL`s `pid`, used for the processes mirrord itself started.
+#[cfg(not(target_os = "windows"))]
+fn try_kill(pid: u32) -> CiResult<()> {
+    try_signal(Pid::from_raw(pid as i32), Signal::SIGKILL)?;
+
+    Ok(())
+}
+
+/// Terminates the process group led by `pid`, falling back to the process on its own.
+///
+/// `mirrord ci start` makes the user's command a process group leader, so its pid doubles as the
+/// group id. Signalling the group is what reaches the descendants of wrappers such as `npm run`,
+/// which otherwise survive - still holding the listening port - the death of the wrapper.
+///
+/// `SIGTERM` goes first so that servers get to close their listening sockets, and whatever is
+/// still alive after [`USER_PROCESS_GRACE_PERIOD`] gets `SIGKILL`ed.
+#[cfg(not(target_os = "windows"))]
+async fn try_kill_user_process(pid: u32) -> CiResult<()> {
+    let process = Pid::from_raw(pid as i32);
+    let group = Pid::from_raw(-(pid as i32));
+
+    // Commands recorded by `mirrord ci container`, or by an older mirrord, lead no group of their
+    // own, so there is nothing to signal but the process itself.
+    let target = if try_signal(group, None)? {
+        group
+    } else {
+        process
+    };
+
+    if !try_signal(target, Signal::SIGTERM)? {
+        return Ok(());
+    }
+
+    let deadline = Instant::now() + USER_PROCESS_GRACE_PERIOD;
+    while Instant::now() < deadline {
+        tokio::time::sleep(USER_PROCESS_POLL_INTERVAL).await;
+
+        if !try_signal(target, None)? {
+            return Ok(());
+        }
+    }
+
+    try_signal(target, Signal::SIGKILL)?;
+
+    Ok(())
+}
+
 /// Handles the `mirrord ci stop` command.
 ///
 /// Builds a [`MirrordCiStore`] to kill the intproxy and the user's binary that was started by
@@ -78,14 +154,7 @@ impl CiStopCommandHandler {
     #[cfg(not(target_os = "windows"))]
     #[tracing::instrument(level = Level::TRACE, skip(self), err)]
     pub(super) async fn handle(self) -> CiResult<()> {
-        use futures::{StreamExt, stream};
-        use nix::{
-            errno::Errno,
-            sys::signal::{Signal, kill},
-            unistd::Pid,
-        };
-
-        use crate::ci::CiError;
+        use futures::{StreamExt, future, stream};
 
         let Self {
             store,
@@ -103,18 +172,17 @@ impl CiStopCommandHandler {
             return Ok(());
         }
 
-        fn try_kill(pid: u32) -> CiResult<()> {
-            kill(Pid::from_raw(pid as i32), Some(Signal::SIGKILL))
-                .or_else(|error| {
-                    if error == Errno::ESRCH {
-                        // ESRCH means that the process has already exited.
-                        Ok(())
-                    } else {
-                        Err(error)
-                    }
-                })
-                .map_err(CiError::from)
-        }
+        // The user's processes go first, while the proxies are still up, so that whatever cleanup
+        // they do on `SIGTERM` can still reach the cluster. Killed concurrently, so that their
+        // grace periods overlap.
+        let users_killed = future::join_all(
+            store
+                .user_pids
+                .into_iter()
+                .flatten()
+                .map(try_kill_user_process),
+        )
+        .await;
 
         // We don't want to short-circuit on error, go to the next pid and try to `kill` it.
         let intproxies_killed = store
@@ -140,19 +208,13 @@ impl CiStopCommandHandler {
             .map(try_kill)
             .collect::<Vec<_>>();
 
-        let users_killed = store
-            .user_pids
-            .into_iter()
-            .filter_map(|user_pid| Some(try_kill(user_pid?)))
-            .collect::<Vec<_>>();
-
-        intproxies_killed
+        users_killed
             .into_iter()
             .try_collect::<_, (), _>()
+            .and(intproxies_killed.into_iter().try_collect::<_, (), _>())
             .and(sidecars_removed.into_iter().try_collect::<_, (), _>())
             .and(extproxies_killed.into_iter().try_collect::<_, (), _>())
-            .and(sidecars_killed.into_iter().try_collect::<_, (), _>())
-            .and(users_killed.into_iter().try_collect::<_, (), _>())?;
+            .and(sidecars_killed.into_iter().try_collect::<_, (), _>())?;
 
         MirrordCiStore::remove_file().await?;
         progress.success(None);
@@ -164,5 +226,66 @@ impl CiStopCommandHandler {
     #[cfg(target_os = "windows")]
     pub(super) async fn handle(self) -> CiResult<()> {
         unimplemented!("Command not supported on windows.");
+    }
+}
+
+#[cfg(all(test, not(target_os = "windows")))]
+mod test {
+    use std::process::Stdio;
+
+    use tokio::io::{AsyncBufReadExt, BufReader};
+
+    use super::*;
+
+    /// Waits for `pid` to disappear, returning `false` if it is still around after a few seconds.
+    async fn wait_for_exit(pid: Pid) -> bool {
+        for _ in 0..100 {
+            if !try_signal(pid, None).unwrap() {
+                return true;
+            }
+
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+
+        false
+    }
+
+    /// `mirrord ci stop` has to reach the descendants of the command it started, not just the
+    /// command itself.
+    ///
+    /// A wrapper that runs the real server as a child of its own - `npm run dev` and friends - used
+    /// to leave that child alive and holding its listening port.
+    #[tokio::test]
+    async fn kills_descendants_of_the_user_command() {
+        // Stands in for the wrapper: spawns a grandchild, reports its pid, and waits for it.
+        let mut wrapper = tokio::process::Command::new("sh")
+            .arg("-c")
+            .arg("sleep 100 & echo $! ; wait")
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .process_group(0)
+            .spawn()
+            .expect("failed to spawn the wrapper");
+
+        let mut stdout = BufReader::new(wrapper.stdout.take().expect("stdout was piped")).lines();
+        let grandchild = stdout
+            .next_line()
+            .await
+            .expect("failed to read the grandchild pid")
+            .expect("wrapper printed no grandchild pid")
+            .trim()
+            .parse::<i32>()
+            .expect("wrapper printed a malformed grandchild pid");
+        let grandchild = Pid::from_raw(grandchild);
+
+        let wrapper_pid = wrapper.id().expect("wrapper should still be running");
+        // Reaping the wrapper in parallel, as the caller of `mirrord ci start` would.
+        let (killed, _) = tokio::join!(try_kill_user_process(wrapper_pid), wrapper.wait());
+        killed.expect("failed to kill the user process");
+
+        assert!(
+            wait_for_exit(grandchild).await,
+            "grandchild {grandchild} survived `mirrord ci stop`"
+        );
     }
 }


### PR DESCRIPTION
`mirrord ci stop` killed only the pid it spawned directly. When that pid is a wrapper — `npm run`, `yarn`, `pnpm`, `nodemon` — the wrapper died and the server it had spawned was reparented to init, still holding its listening port. In a start/stop loop the survivors accumulate and the oldest one stays bound, so later iterations silently serve earlier iterations' code while every surface check looks healthy. A bare binary doesn't reproduce it, which is presumably why it went unnoticed.

`mirrord ci start` now spawns the user's command as a process group leader and `ci stop` signals the group. `SIGTERM` first with a 5s grace period, then `SIGKILL`, so dev servers get to close their listeners; user processes are signalled before the proxies so their shutdown can still reach the cluster. Store entries that lead no group (`ci container`, or an older mirrord) fall back to the single pid.

Worth a look: `--foreground` no longer shares mirrord's process group, so `SIGINT`/`SIGTERM`/`SIGHUP` are forwarded to the child group explicitly. The group is only set on `ci start`, whose stdio is a null stdin plus files — `ci container --foreground` inherits a possibly-TTY stdin, where a background process group would take `SIGTTIN`.

Tested with a unit test that spawns a wrapper with a grandchild and asserts the grandchild dies; it fails against the single-pid kill and passes with the group kill. Signal forwarding in `--foreground` was not automated — it needs signals delivered to the test process itself.

Closes COR-1855.

https://claude.ai/code/session_01LA8m8VZ8mfbdMreTTA1VpQ