### PR TITLE
INT-698: Temporal queue-splitting proxy drops gRPC compression and error details

### DIFF
--- a/changelog.d/+temporal-test-apps-grpc-probes.internal.md
+++ b/changelog.d/+temporal-test-apps-grpc-probes.internal.md
@@ -1,0 +1,1 @@
+Temporal test workers can gzip requests and probe typed already-started errors.

--- a/changelog.d/+temporal-test-apps-grpc-probes.internal.md
+++ b/changelog.d/+temporal-test-apps-grpc-probes.internal.md
@@ -1,1 +1,1 @@
-Temporal test workers can gzip requests and probe typed already-started errors.
+Temporal test workers can send compressed requests and probe typed already-started errors.

--- a/tests/temporal-worker-py/worker.py
+++ b/tests/temporal-worker-py/worker.py
@@ -17,8 +17,11 @@ import os
 import sys
 from datetime import timedelta
 
+import temporalio.service
 from temporalio import activity, workflow
 from temporalio.client import Client
+from temporalio.exceptions import WorkflowAlreadyStartedError
+from temporalio.service import RPCError
 from temporalio.worker import Worker
 
 
@@ -50,6 +53,29 @@ class CheckoutWorkflow:
         return result
 
 
+async def probe_already_started(client: Client, task_queue: str, workflow_id: str) -> None:
+    """Starts one workflow twice with the same id through the worker's own client,
+    which under mirrord means through the operator's proxy. The duplicate must raise
+    WorkflowAlreadyStartedError. The server sends ALREADY_EXISTS plus a
+    WorkflowExecutionAlreadyStartedFailure in grpc-status-details-bin, and the SDK
+    only raises the typed error when those details arrive; a proxy that drops them
+    leaves a bare RPCError, and code that handles the expected duplicate never runs.
+    Lines starting with "1:" are asserted by operator E2E tests."""
+    await client.start_workflow(
+        "CheckoutWorkflow", workflow_id, id=workflow_id, task_queue=task_queue
+    )
+    try:
+        await client.start_workflow(
+            "CheckoutWorkflow", workflow_id, id=workflow_id, task_queue=task_queue
+        )
+    except WorkflowAlreadyStartedError:
+        print("1:already-started:typed", flush=True)
+    except RPCError as error:
+        print(f"1:already-started:untyped:{error}", flush=True)
+    else:
+        print("1:already-started:no-error", flush=True)
+
+
 async def main() -> None:
     address = os.environ.get("TEMPORAL_ADDRESS", "localhost:7233")
     namespace = os.environ.get("TEMPORAL_NAMESPACE", "default")
@@ -60,7 +86,32 @@ async def main() -> None:
     print(f"  TEMPORAL_NAMESPACE={namespace}", file=sys.stderr, flush=True)
     print(f"  TEMPORAL_TASK_QUEUE={task_queue}", file=sys.stderr, flush=True)
 
-    client = await Client.connect(address, namespace=namespace)
+    connect_kwargs = {}
+    compression = os.environ.get("TEMPORAL_GRPC_COMPRESSION")
+    if compression:
+        # Releases with GrpcCompression gzip every request by default; older ones
+        # always send uncompressed and have no knob, so asking for one is an error
+        # rather than a silent no-op.
+        modes = getattr(temporalio.service, "GrpcCompression", None)
+        if modes is None:
+            sys.exit(
+                f"TEMPORAL_GRPC_COMPRESSION={compression} needs a temporalio "
+                "release that has temporalio.service.GrpcCompression"
+            )
+        print(f"  TEMPORAL_GRPC_COMPRESSION={compression}", file=sys.stderr, flush=True)
+        connect_kwargs["grpc_compression"] = getattr(modes, compression.upper())
+
+    client = await Client.connect(address, namespace=namespace, **connect_kwargs)
+
+    probe_id = os.environ.get("TEMPORAL_PROBE_ALREADY_STARTED")
+    if probe_id:
+        # Under mirrord TEMPORAL_TASK_QUEUE is the session's virtual queue, which only
+        # the operator serves. A workflow started on it would sit on the server forever,
+        # so the probe is told the original queue separately.
+        probe_queue = os.environ.get("TEMPORAL_PROBE_TASK_QUEUE", task_queue)
+        print(f"  probe: starting {probe_id} twice on {probe_queue}", file=sys.stderr, flush=True)
+        await probe_already_started(client, probe_queue, probe_id)
+
     worker = Worker(
         client,
         task_queue=task_queue,

--- a/tests/temporal-worker-py/worker.py
+++ b/tests/temporal-worker-py/worker.py
@@ -54,13 +54,10 @@ class CheckoutWorkflow:
 
 
 async def probe_already_started(client: Client, task_queue: str, workflow_id: str) -> None:
-    """Starts one workflow twice with the same id through the worker's own client,
-    which under mirrord means through the operator's proxy. The duplicate must raise
-    WorkflowAlreadyStartedError. The server sends ALREADY_EXISTS plus a
-    WorkflowExecutionAlreadyStartedFailure in grpc-status-details-bin, and the SDK
-    only raises the typed error when those details arrive; a proxy that drops them
-    leaves a bare RPCError, and code that handles the expected duplicate never runs.
-    Lines starting with "1:" are asserted by operator E2E tests."""
+    """Starts one workflow twice with the same id through the worker's own client.
+    The SDK only raises the typed WorkflowAlreadyStartedError when the proxy in
+    between forwards grpc-status-details-bin, so the printed "1:" line tells
+    operator E2E tests whether that happened."""
     await client.start_workflow(
         "CheckoutWorkflow", workflow_id, id=workflow_id, task_queue=task_queue
     )

--- a/tests/temporal-worker/main.go
+++ b/tests/temporal-worker/main.go
@@ -182,12 +182,9 @@ func main() {
 }
 
 // probeAlreadyStarted starts one workflow twice with the same id through the worker's
-// own client, which under mirrord means through the operator's proxy. The duplicate
-// must come back as the typed WorkflowExecutionAlreadyStarted error. The server sends
-// it as ALREADY_EXISTS plus a WorkflowExecutionAlreadyStartedFailure in
-// grpc-status-details-bin; a proxy that drops the details leaves the SDK with a plain
-// AlreadyExists, and code that handles the expected duplicate never runs. Lines
-// starting with "1:" are asserted by operator E2E tests.
+// own client. The SDK only produces the typed WorkflowExecutionAlreadyStarted error when
+// the proxy in between forwards grpc-status-details-bin, so the printed "1:" line tells
+// operator E2E tests whether that happened.
 func probeAlreadyStarted(c client.Client, taskQueue, workflowID string) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()

--- a/tests/temporal-worker/main.go
+++ b/tests/temporal-worker/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -10,11 +11,15 @@ import (
 	"time"
 
 	commonpb "go.temporal.io/api/common/v1"
+	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/sdk/activity"
 	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/converter"
 	"go.temporal.io/sdk/worker"
 	"go.temporal.io/sdk/workflow"
+	"google.golang.org/grpc"
+	// Registers the gzip compressor that TEMPORAL_GRPC_COMPRESSION=gzip selects.
+	_ "google.golang.org/grpc/encoding/gzip"
 )
 
 const (
@@ -123,15 +128,35 @@ func main() {
 	fmt.Fprintf(os.Stderr, "  TEMPORAL_NAMESPACE=%s\n", namespace)
 	fmt.Fprintf(os.Stderr, "  TEMPORAL_TASK_QUEUE=%s\n", taskQueue)
 
-	c, err := client.Dial(client.Options{
+	options := client.Options{
 		HostPort:           address,
 		Namespace:          namespace,
 		ContextPropagators: []workflow.ContextPropagator{userHeaderPropagator{}},
-	})
+	}
+	// Compresses every request the way the Python SDK does by default (gzip), so a
+	// proxy between the worker and the frontend has to inflate intercepted RPCs and
+	// relay passthrough ones together with their grpc-encoding header.
+	if compression := os.Getenv("TEMPORAL_GRPC_COMPRESSION"); compression != "" {
+		fmt.Fprintf(os.Stderr, "  TEMPORAL_GRPC_COMPRESSION=%s\n", compression)
+		options.ConnectionOptions.DialOptions = []grpc.DialOption{
+			grpc.WithDefaultCallOptions(grpc.UseCompressor(compression)),
+		}
+	}
+
+	c, err := client.Dial(options)
 	if err != nil {
 		log.Fatalf("failed to create Temporal client: %v", err)
 	}
 	defer c.Close()
+
+	if probeID := os.Getenv("TEMPORAL_PROBE_ALREADY_STARTED"); probeID != "" {
+		// Under mirrord TEMPORAL_TASK_QUEUE is the session's virtual queue, which only the
+		// operator serves. A workflow started on it would sit on the server forever, so the
+		// probe is told the original queue separately.
+		probeQueue := envOr("TEMPORAL_PROBE_TASK_QUEUE", taskQueue)
+		fmt.Fprintf(os.Stderr, "  probe: starting %s twice on %s\n", probeID, probeQueue)
+		probeAlreadyStarted(c, probeQueue, probeID)
+	}
 
 	w := worker.New(c, taskQueue, worker.Options{})
 	w.RegisterWorkflowWithOptions(CheckoutWorkflow, workflow.RegisterOptions{Name: workflowType})
@@ -153,6 +178,40 @@ func main() {
 		if err != nil {
 			log.Fatalf("worker failed: %v", err)
 		}
+	}
+}
+
+// probeAlreadyStarted starts one workflow twice with the same id through the worker's
+// own client, which under mirrord means through the operator's proxy. The duplicate
+// must come back as the typed WorkflowExecutionAlreadyStarted error. The server sends
+// it as ALREADY_EXISTS plus a WorkflowExecutionAlreadyStartedFailure in
+// grpc-status-details-bin; a proxy that drops the details leaves the SDK with a plain
+// AlreadyExists, and code that handles the expected duplicate never runs. Lines
+// starting with "1:" are asserted by operator E2E tests.
+func probeAlreadyStarted(c client.Client, taskQueue, workflowID string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	options := client.StartWorkflowOptions{
+		ID:        workflowID,
+		TaskQueue: taskQueue,
+		// The SDK otherwise swallows the typed error and returns the running execution,
+		// which would hide whether the details made it through.
+		WorkflowExecutionErrorWhenAlreadyStarted: true,
+	}
+	if _, err := c.ExecuteWorkflow(ctx, options, workflowType, workflowID); err != nil {
+		log.Fatalf("failed to start probe workflow %s: %v", workflowID, err)
+	}
+
+	_, err := c.ExecuteWorkflow(ctx, options, workflowType, workflowID)
+	var alreadyStarted *serviceerror.WorkflowExecutionAlreadyStarted
+	switch {
+	case errors.As(err, &alreadyStarted):
+		fmt.Printf("1:already-started:typed\n")
+	case err != nil:
+		fmt.Printf("1:already-started:untyped:%T %v\n", err, err)
+	default:
+		fmt.Printf("1:already-started:no-error\n")
 	}
 }
 


### PR DESCRIPTION
…est workers

<!-- Thank you for contributing to mirrord! -->
<!-- Please use the checklist below as a guide for docs, tests and admin tasks for your PR -->
<!-- Feel free to ~strikethrough~ any items that you don't think apply -->

### Quality Checklist:

- [ ] I have documented new code sufficiently
- [ ] I have checked and updated the relevant existing docs in code, including removing outdated material
- [ ] I have written user-facing website docs for new features, or opened a (sub)issue to do so
- [ ] I have checked and updated existing website docs for changed features
- [ ] I have tested this change and know it succeeds and fails as expected
- [ ] I have written unit tests or purposefully omitted them
- [ ] I have written e2e tests or purposefully omitted them
- [ ] I have explained what this PR introduces and why, and linked to relevant context (e.g. linear issues, related PRs,
  documentation)
- [ ] I have introduced a short, clear and well-formatted changelog entry

<!-- need help with the changelog? see ../CONTRIBUTING.md#submitting-a-pull-request -->
<!-- Add more details of your changes below if needed -->