### PR TITLE
Skip the cloud-sql-proxy sidecar when choosing a target container

### DIFF
--- a/changelog.d/+skip-cloud-sql-proxy-container.changed.md
+++ b/changelog.d/+skip-cloud-sql-proxy-container.changed.md
@@ -1,0 +1,2 @@
+Skip the `cloud-sql-proxy` sidecar when automatically picking a target container,
+so a pod running the Cloud SQL Auth Proxy resolves to the application container.

--- a/mirrord/kube/src/api/container.rs
+++ b/mirrord/kube/src/api/container.rs
@@ -27,7 +27,8 @@ pub static SKIP_NAMES: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
         "linkerd-init",
         "vault-agent",
         "vault-agent-init",
-        "queue-proxy", // Knative
+        "queue-proxy",     // Knative
+        "cloud-sql-proxy", // Cloud SQL Auth Proxy
         TELEPRESENCE_CONTAINER_NAME,
     ])
 });


### PR DESCRIPTION
Automatic target-container selection walks past known mesh sidecars via `SKIP_NAMES`, but the Cloud SQL Auth Proxy was not on that list. A pod running `cloud-sql-proxy` alongside the application resolves to the proxy whenever the proxy is listed first, which is never the container the user meant to target.

Adds `cloud-sql-proxy` to `SKIP_NAMES`. That static is the single source of truth for this behavior and the operator imports it (`operator-target`, `copy_target::restful_provider`), so both the CLI and the operator pick it up from the one entry.

`cloud-sql-proxy` is the container name used by Google's own sidecar example, which is the deployment pattern Google recommends and the one this addresses.


Closes COR-1289.

### Quality Checklist:

- [x] I have documented new code sufficiently
- [x] I have checked and updated the relevant existing docs in code, including removing outdated material
- ~~I have written user-facing website docs for new features, or opened a (sub)issue to do so~~
- ~~I have checked and updated existing website docs for changed features~~
- [x] I have tested this change and know it succeeds and fails as expected
- [x] I have written unit tests or purposefully omitted them (omitted: no other `SKIP_NAMES` entry is covered by tests, and this adds no new logic)
- ~~I have written e2e tests or purposefully omitted them~~
- [x] I have explained what this PR introduces and why, and linked to relevant context
- [x] I have introduced a short, clear and well-formatted changelog entry

Verified with `cargo clippy -p mirrord-kube --all-targets` (clean) and `cargo test -p mirrord-kube --lib` (27 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
