### PR TITLE
Echo the session id as hex in `session stop` progress output

### DIFF
--- a/changelog.d/+session-stop-echoes-hex-id.fixed.md
+++ b/changelog.d/+session-stop-echoes-hex-id.fixed.md
@@ -1,0 +1,3 @@
+`mirrord operator session stop` now echoes the session id back as uppercase hex,
+matching the id the user passed and the `Session ID` column of
+`mirrord operator status`, instead of the decimal value it parsed into.

--- a/mirrord/cli/src/config.rs
+++ b/mirrord/cli/src/config.rs
@@ -950,7 +950,9 @@ pub(super) enum OperatorCommand {
 ///
 /// Allows the user to forcefully kill operator sessions, use with care!
 ///
-/// Implements [`core::fmt::Display`] to show the user a nice message.
+/// Implements [`core::fmt::Display`] to show the user a nice message. Session ids are rendered as
+/// uppercase hex there, matching both the `Session ID` column of `mirrord operator status` and the
+/// form [`hex_id`] accepts, so the id echoed back is the one the user typed.
 #[derive(Debug, Subcommand, Clone, Copy)]
 pub(crate) enum SessionCommand {
     /// Stops one or all operator sessions.
@@ -978,7 +980,7 @@ impl core::fmt::Display for SessionCommand {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             SessionCommand::Stop { id: Some(id), .. } => {
-                write!(f, "mirrord operator session stop --id {id}")
+                write!(f, "mirrord operator session stop --id {id:X}")
             }
             SessionCommand::Stop { id: None, .. } | SessionCommand::KillAll => {
                 write!(f, "mirrord operator session stop --all")


### PR DESCRIPTION
`mirrord operator session stop --id` parses the id from hex into a `u64`, but the progress printout rendered that `u64` with its plain `Display`. A user who copied an id out of `mirrord operator status` saw the command echoed back with a decimal id, which reads as a different session:

```
$ mirrord operator session stop --id 4BB83194051DBC5A
  executing `mirrord operator session stop --id 5457857622578071130`
```

Formats the id as uppercase hex, which is what `SessionId::display` uses for the `Session ID` column of `mirrord operator status` and the form `hex_id` accepts, so the id echoed back is the id that was typed.

The same `Display` feeds the success and failure lines, so all of them change together.

Closes COR-1083.

### Quality Checklist:

- [x] I have documented new code sufficiently
- [x] I have checked and updated the relevant existing docs in code, including removing outdated material
- ~~I have written user-facing website docs for new features, or opened a (sub)issue to do so~~
- ~~I have checked and updated existing website docs for changed features~~
- [x] I have tested this change and know it succeeds and fails as expected
- [x] I have written unit tests or purposefully omitted them (omitted: asserting on the rendered string would just restate the format string, and the id parsing it depends on is already covered by the `hex_id` cases)
- ~~I have written e2e tests or purposefully omitted them~~
- [x] I have explained what this PR introduces and why, and linked to relevant context
- [x] I have introduced a short, clear and well-formatted changelog entry

`cargo clippy -p mirrord --bins` clean, `cargo test -p mirrord --bins` passes 136.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
