### PR TITLE
fix(monitor): stop stacking chaos-rule requests when the local API is slow

### DIFF
--- a/changelog.d/+monitor-chaos-poll-inflight.fixed.md
+++ b/changelog.d/+monitor-chaos-poll-inflight.fixed.md
@@ -1,0 +1,1 @@
+The session monitor no longer starts a new chaos-rules request while the previous one is still outstanding, and each request now has a deadline. A slow or unresponsive local API previously accumulated one request per poll tick for as long as it stayed down.

--- a/packages/monitor/src/api.ts
+++ b/packages/monitor/src/api.ts
@@ -114,9 +114,13 @@ export const api = {
   eventStreamUrl: (sessionId: string): string =>
     withToken(`/api/v2/local/sessions/${encodeURIComponent(sessionId)}/events`),
 
-  listChaosRules: async (sessionId: string): Promise<ChaosRule[]> => {
+  listChaosRules: async (
+    sessionId: string,
+    signal?: AbortSignal,
+  ): Promise<ChaosRule[]> => {
     const r = await fetch(withToken(chaosRulesPath(sessionId)), {
       credentials: 'include',
+      ...(signal ? { signal } : {}),
     })
     if (!r.ok) {
       if (r.status === HTTP_NOT_FOUND) return []

--- a/packages/monitor/src/hooks/useChaosRules.ts
+++ b/packages/monitor/src/hooks/useChaosRules.ts
@@ -11,6 +11,7 @@ import type {
 // Hit counts arrive by refetching the rule list — `hit_count` is a plain field on
 // `ChaosRule`, there is no stats endpoint. Each poll's delta feeds one sparkline bucket.
 const POLL_INTERVAL_MS = 2500
+const POLL_TIMEOUT_MS = 10000
 const SPARK_BUCKETS = 9
 const FLASH_MS = 1600
 
@@ -106,6 +107,7 @@ export function useChaosRules(sessionId: string): UseChaosRules {
   // sequence on every mutation lets an in-flight merge detect and drop itself.
   const mutationSeq = useRef(0)
   const loadErrorRef = useRef(false)
+  const pollInFlight = useRef(false)
   const rulesRef = useRef(rules)
   rulesRef.current = rules
 
@@ -117,11 +119,19 @@ export function useChaosRules(sessionId: string): UseChaosRules {
     }, FLASH_MS)
   }, [])
 
+  // Skipping a tick while a request is outstanding, with a deadline so an API that
+  // accepts the connection but never answers cannot hold the guard shut.
   const poll = useCallback(async () => {
+    if (pollInFlight.current) return
+    pollInFlight.current = true
     const seq = mutationSeq.current
     let serverRules: ChaosRule[]
     try {
-      serverRules = await api.listChaosRules(sessionId)
+      serverRules = await api
+        .listChaosRules(sessionId, AbortSignal.timeout(POLL_TIMEOUT_MS))
+        .finally(() => {
+          pollInFlight.current = false
+        })
       setLoadError(false)
       loadErrorRef.current = false
     } catch (err) {
@@ -188,6 +198,7 @@ export function useChaosRules(sessionId: string): UseChaosRules {
     setRules([])
     setLoadError(false)
     loadErrorRef.current = false
+    pollInFlight.current = false
     void poll()
     const interval = setInterval(() => void poll(), POLL_INTERVAL_MS)
     return () => clearInterval(interval)


### PR DESCRIPTION
## Summary

The session monitor polls the chaos-rule list every 2.5s. The poll had no in-flight guard and no request deadline, so a local API that accepted the connection but never answered accumulated one outstanding request per tick for as long as it stayed unresponsive.

Two consequences, both observed in a browser against a stub API that accepts and never answers:

- The held requests exhaust the browser's per-origin connection limit. Once saturated, every other request the monitor makes to the same origin (session list, session snapshot, event stream) is queued behind them, so a single slow endpoint degrades the whole page.
- When the connection finally drops, the accumulated requests all reject at once. Each one that lands after a successful poll clears the hook's error latch, so one incident is reported as a burst of identical blocking events milliseconds apart rather than one.

A tick is now skipped while a request is outstanding, and each request carries a deadline so an API that never answers cannot hold the guard shut.

The deadline also makes the two failures distinguishable in the `error` property the event already carries: an unresponsive API now rejects with `TimeoutError: signal timed out`, where an absent one still rejects with `TypeError: Failed to fetch`. Previously both read as the latter.

Same class as the polling fixes in #4697 and the extension's bridge poller. The monitor's other pollers have the same shape and are deliberately left alone here to keep this reviewable.