### PR TITLE
sip: skip patching only when the DYLD entitlement is granted

### DIFF
--- a/changelog.d/+sip-dyld-entitlement-value.fixed.md
+++ b/changelog.d/+sip-dyld-entitlement-value.fixed.md
@@ -1,0 +1,1 @@
+mirrord now SIP-patches a macOS binary that lists the `com.apple.security.cs.allow-dyld-environment-variables` entitlement with a `false` value, such as `/usr/bin/aa` on macOS 26. macOS strips `DYLD_INSERT_LIBRARIES` from such a binary, so the layer could not load into it.

--- a/mirrord/sip/src/lib.rs
+++ b/mirrord/sip/src/lib.rs
@@ -566,17 +566,13 @@ mod main {
         false
     }
 
-    /// Key element that names the DYLD environment variables entitlement inside an entitlements
-    /// plist.
     const DYLD_ENTITLEMENT_KEY: &str =
         "<key>com.apple.security.cs.allow-dyld-environment-variables</key>";
 
-    /// Whether an entitlements plist grants the DYLD environment variables entitlement.
-    ///
-    /// An entitlements blob is an XML plist in which every entitlement carries a value, and Apple
-    /// ships binaries that list an entitlement turned off: on macOS 26 `/usr/bin/aa` carries this
-    /// one with a `false` value, and macOS still strips its DYLD variables. The key alone
-    /// therefore decides nothing, only the value element right after it does.
+    /// An entitlements plist lists each entitlement with a value, and Apple ships binaries that
+    /// list this one turned off: macOS 26 signs `/usr/bin/aa` with a `false` value, and macOS
+    /// still strips its DYLD variables. The key alone therefore decides nothing, only the value
+    /// element right after it does.
     fn grants_dyld_entitlement(entitlements: &str) -> bool {
         entitlements
             .split(DYLD_ENTITLEMENT_KEY)

--- a/mirrord/sip/src/lib.rs
+++ b/mirrord/sip/src/lib.rs
@@ -566,8 +566,32 @@ mod main {
         false
     }
 
-    /// Checks if the binary has the `com.apple.security.cs.allow-dyld-environment-variables`
-    /// entitlement. Binaries with this entitlement allow `DYLD_INSERT_LIBRARIES` even when
+    /// Key element that names the DYLD environment variables entitlement inside an entitlements
+    /// plist.
+    const DYLD_ENTITLEMENT_KEY: &str =
+        "<key>com.apple.security.cs.allow-dyld-environment-variables</key>";
+
+    /// Whether an entitlements plist grants the DYLD environment variables entitlement.
+    ///
+    /// An entitlements blob is an XML plist in which every entitlement carries a value, and Apple
+    /// ships binaries that list an entitlement turned off: on macOS 26 `/usr/bin/aa` carries this
+    /// one with a `false` value, and macOS still strips its DYLD variables. The key alone
+    /// therefore decides nothing, only the value element right after it does.
+    fn grants_dyld_entitlement(entitlements: &str) -> bool {
+        entitlements
+            .split(DYLD_ENTITLEMENT_KEY)
+            .skip(1)
+            .any(|after_key| {
+                after_key
+                    .trim_start()
+                    .strip_prefix("<true")
+                    .and_then(|after_tag_name| after_tag_name.trim_start().chars().next())
+                    .is_some_and(|first_char| matches!(first_char, '>' | '/'))
+            })
+    }
+
+    /// Checks if the binary is granted the `com.apple.security.cs.allow-dyld-environment-variables`
+    /// entitlement. Binaries granted this entitlement allow `DYLD_INSERT_LIBRARIES` even when
     /// restricted, so they don't need SIP patching (node for example, probably for loading 3rd
     /// party dylibs).
     fn has_dyld_entitlement(data: &[u8]) -> bool {
@@ -577,9 +601,7 @@ mod main {
         for macho in mach.into_iter() {
             if let Ok(Some(signature)) = macho.code_signature()
                 && let Ok(Some(entitlements)) = signature.entitlements()
-                && entitlements
-                    .as_str()
-                    .contains("com.apple.security.cs.allow-dyld-environment-variables")
+                && grants_dyld_entitlement(entitlements.as_str())
             {
                 return true;
             }
@@ -906,6 +928,8 @@ mod main {
     mod tests {
         use std::io::Write;
 
+        use rstest::rstest;
+
         use super::*;
 
         #[test]
@@ -1001,6 +1025,97 @@ mod main {
             assert!(result.is_none(), "entitled binary should not need patching");
             // Verify DYLD_* features work on the original binary:
             run_and_verify_dyld_print(Path::new("/usr/bin/aa"));
+        }
+
+        /// Entitlements in the shape Apple ships them in, with the DYLD environment variables
+        /// entitlement listed and turned off. This is how `/usr/bin/aa` is signed on macOS 26.
+        const DISABLED_DYLD_ENTITLEMENTS: &str = r#"<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd"><plist version="1.0"><dict><key>com.apple.security.cs.allow-dyld-environment-variables</key><false/><key>com.apple.security.cs.disable-library-validation</key><false/></dict></plist>"#;
+
+        /// The same entitlements, with the DYLD environment variables entitlement granted.
+        const GRANTED_DYLD_ENTITLEMENTS: &str = r#"<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd"><plist version="1.0"><dict><key>com.apple.security.cs.allow-dyld-environment-variables</key><true/><key>com.apple.security.cs.disable-library-validation</key><false/></dict></plist>"#;
+
+        /// Copies `/bin/wait4path` into a temp file signed with the hardened runtime and the
+        /// given entitlements, the way macOS ships hardened system binaries.
+        fn sign_hardened_binary(entitlements: &str) -> tempfile::NamedTempFile {
+            let signed_temp_file = tempfile::NamedTempFile::new().unwrap();
+
+            let mut settings = apple_codesign::SigningSettings::default();
+            settings.set_code_signature_flags(
+                apple_codesign::SettingsScope::Main,
+                CodeSignatureFlags::ADHOC | CodeSignatureFlags::RUNTIME,
+            );
+            settings.set_binary_identifier(
+                apple_codesign::SettingsScope::Main,
+                signed_temp_file
+                    .path()
+                    .file_name()
+                    .unwrap()
+                    .to_string_lossy(),
+            );
+            settings
+                .set_entitlements_xml(apple_codesign::SettingsScope::Main, entitlements)
+                .unwrap();
+
+            apple_codesign::UnifiedSigner::new(settings)
+                .sign_path("/bin/wait4path", signed_temp_file.path())
+                .unwrap();
+
+            signed_temp_file
+        }
+
+        /// A hardened binary whose DYLD environment variables entitlement is turned off never
+        /// receives `DYLD_INSERT_LIBRARIES`, so it needs patching just like a hardened binary
+        /// that does not list the entitlement at all.
+        #[test]
+        fn binary_with_disabled_dyld_entitlement_is_sip() {
+            let signed_temp_file = sign_hardened_binary(DISABLED_DYLD_ENTITLEMENTS);
+
+            assert!(matches!(
+                get_sip_status(
+                    signed_temp_file.path().to_str().unwrap(),
+                    SipPatchOptions::default()
+                )
+                .unwrap(),
+                SipBinary(_),
+            ));
+        }
+
+        /// A hardened binary that is granted the DYLD environment variables entitlement keeps
+        /// `DYLD_INSERT_LIBRARIES`, so patching it would be pointless work.
+        #[test]
+        fn binary_with_granted_dyld_entitlement_is_not_sip() {
+            let signed_temp_file = sign_hardened_binary(GRANTED_DYLD_ENTITLEMENTS);
+
+            assert!(matches!(
+                get_sip_status(
+                    signed_temp_file.path().to_str().unwrap(),
+                    SipPatchOptions::default()
+                )
+                .unwrap(),
+                NoSip,
+            ));
+        }
+
+        /// Only the value element that follows the entitlement key decides whether macOS grants
+        /// the entitlement.
+        #[rstest]
+        #[case("<true/>", true)]
+        #[case("<true />", true)]
+        #[case("<true></true>", true)]
+        #[case("<false/>", false)]
+        #[case("<string>true</string>", false)]
+        #[test]
+        fn dyld_entitlement_value_decides(#[case] value: &str, #[case] granted: bool) {
+            let entitlements = format!("<plist><dict>{DYLD_ENTITLEMENT_KEY}{value}</dict></plist>");
+            assert_eq!(grants_dyld_entitlement(&entitlements), granted);
+        }
+
+        /// A plist that never mentions the entitlement does not grant it.
+        #[test]
+        fn unlisted_dyld_entitlement_is_not_granted() {
+            assert!(!grants_dyld_entitlement(
+                "<plist><dict><key>keychain-access-groups</key><true/></dict></plist>"
+            ));
         }
 
         /// Test that after patching we can Successfully use DYLD features on a binary that had


### PR DESCRIPTION
### Quality Checklist:

- [x] I have documented new code sufficiently
- [x] I have checked and updated the relevant existing docs in code, including removing outdated material
- [ ] ~I have written user-facing website docs for new features, or opened a (sub)issue to do so~
- [ ] ~I have checked and updated existing website docs for changed features~
- [x] I have tested this change and know it succeeds and fails as expected
- [x] I have written unit tests or purposefully omitted them
- [x] I have written e2e tests or purposefully omitted them
- [x] I have explained what this PR introduces and why, and linked to relevant context (e.g. linear issues, related PRs, documentation)
- [x] I have introduced a short, clear and well-formatted changelog entry

### The bug

`has_dyld_entitlement` (`mirrord/sip/src/lib.rs:573`, the `.contains(...)` on line 582) asks whether the entitlements plist *mentions* `com.apple.security.cs.allow-dyld-environment-variables`. An entitlement is a key plus a value, and it can be listed with the value `false`, so the key being present does not mean the binary keeps its `DYLD_*` variables.

`is_binary_sip` returns `is_restricted && !has_dyld_entitlement(data)` (line 607), so a hardened binary whose entitlement is turned off comes back as `NoSip`. mirrord runs it unpatched, macOS strips `DYLD_INSERT_LIBRARIES` from it, the layer never loads, and nothing in the logs says why.

macOS 26 signs `/usr/bin/aa` exactly like that:

```
$ codesign -dvvv /usr/bin/aa 2>&1 | grep flags=
CodeDirectory v=20500 size=1485 flags=0x10000(runtime) hashes=36+7 location=embedded

$ codesign -d --entitlements :- /usr/bin/aa
...<key>com.apple.security.cs.allow-dyld-environment-variables</key><false/><key>com.apple.security.cs.disable-library-validation</key><false/>...
```

`/usr/bin/aa` is the binary `entitled_binary_is_not_sip` uses. On macOS 26.2 that test fails on `main` today: `sip_patch` returns `None`, and then `DYLD_PRINT_LIBRARIES=1 /usr/bin/aa` prints nothing, because the entitlement is off. It passes on the `macos-latest` runner, whose `/usr/bin/aa` is granted the entitlement, so I left the test as it is.

### The fix

`grants_dyld_entitlement` reads the value element that follows the entitlement key and accepts only `<true>`. `has_dyld_entitlement` calls it instead of `contains`. Nothing else about the SIP decision moves: a binary that really is granted the entitlement is still left unpatched, and one that never lists it is still patched.

Three tests come with it. Two sign `/bin/wait4path` into a temp file with the hardened runtime, once with the entitlement set to `false` and once to `true`, and check `get_sip_status`. The third feeds the value forms (`<true/>`, `<true />`, `<true></true>`, `<false/>`, `<string>true</string>`) straight to the parser. None of them depend on the macOS version or on which binaries Apple happens to entitle.

### Verification

macOS 26.2, arm64, reproducing the `macos-latest` job for this crate: `rm rust-toolchain.toml`, Homebrew `protoc` on `PATH`, `cargo-nextest` 0.9.143, stable rustc 1.95.

The new regression test against the unmodified `has_dyld_entitlement`:

```
$ cargo nextest run -p mirrord-sip -E 'test(binary_with_disabled_dyld_entitlement_is_sip)'
FAIL  mirrord-sip main::tests::binary_with_disabled_dyld_entitlement_is_sip
assertion failed: matches!(get_sip_status(...).unwrap(), SipBinary(_))
```

With the fix:

```
$ cargo nextest run -p mirrord-sip -E 'not test(entitled_binary_is_not_sip)'
Summary [0.975s] 32 tests run: 32 passed, 1 skipped
```

`entitled_binary_is_not_sip` is excluded above because it fails on this machine before and after the change, for the reason described in the first section. On `main` it fails on the `DYLD_PRINT_LIBRARIES` assertion; with the fix it fails on `assert!(result.is_none())`, since `/usr/bin/aa` on macOS 26 does need patching.

Lint, exactly as `check-lint.yaml` runs it for this target:

```
$ cargo clippy -p mirrord-sip --all-targets --all-features --target aarch64-apple-darwin --keep-going --quiet -- "-Wclippy::indexing_slicing" -D warnings
$ cargo fmt --all -- --check
```

Both clean. No new dependencies, no changes to the crate's public API.
