### PR TITLE
fix(monitor): normalize the session list and make JSON rendering total

### DIFF
--- a/.github/workflows/check-lint.yaml
+++ b/.github/workflows/check-lint.yaml
@@ -96,6 +96,7 @@ jobs:
       - run: pnpm --filter session-monitor-frontend run lint
       - run: pnpm --filter session-monitor-frontend run format:check
       - run: pnpm --filter session-monitor-frontend run typecheck
+      - run: pnpm --filter session-monitor-frontend run test:run
       - run: pnpm --filter mirrord-ui run lint
       - run: pnpm --filter mirrord-ui run format:check
       - run: pnpm --filter mirrord-ui run typecheck

--- a/changelog.d/+monitor-session-shape-hardening.fixed.md
+++ b/changelog.d/+monitor-session-shape-hardening.fixed.md
@@ -1,0 +1,1 @@
+The session monitor no longer blanks the whole page when the local session list contains an entry without a session id, a session without a process list, or a config that can't be rendered as JSON.

--- a/packages/monitor/package.json
+++ b/packages/monitor/package.json
@@ -9,7 +9,8 @@
     "lint:fix": "eslint src --fix",
     "format": "prettier --write src",
     "format:check": "prettier --check src",
-    "typecheck": "tsc -b"
+    "typecheck": "tsc -b",
+    "test:run": "vitest run"
   },
   "dependencies": {
     "@metalbear/ui": "^0.4.0",
@@ -28,6 +29,7 @@
     "tailwindcss": "^3.4.16",
     "typescript": "^5.7.0",
     "typescript-eslint": "^8.53.1",
-    "vite": "^6.0.0"
+    "vite": "^6.0.0",
+    "vitest": "^2.1.8"
   }
 }

--- a/packages/monitor/src/App.tsx
+++ b/packages/monitor/src/App.tsx
@@ -269,7 +269,10 @@ export default function App({
 
   useEffect(() => {
     void refreshExtensionState()
-    const t = setInterval(refreshExtensionState, EXTENSION_POLL_INTERVAL)
+    const t = setInterval(
+      () => void refreshExtensionState(),
+      EXTENSION_POLL_INTERVAL,
+    )
     return () => clearInterval(t)
   }, [refreshExtensionState])
 

--- a/packages/monitor/src/api.ts
+++ b/packages/monitor/src/api.ts
@@ -9,6 +9,7 @@ import type {
   SessionInfo,
 } from './types'
 import { emitUserBlocked, emitUserSucceeded } from './analytics'
+import { normalizeSessions } from './utils'
 
 const HTTP_NOT_FOUND = 404
 
@@ -54,8 +55,7 @@ export const api = {
     if (!r.ok) {
       throw new Error(`Failed to fetch sessions: ${r.status} ${r.statusText}`)
     }
-    const data = (await r.json()) as SessionInfo[]
-    return data
+    return normalizeSessions(await r.json())
   },
 
   getSession: async (sessionId: string): Promise<SessionInfo | null> => {

--- a/packages/monitor/src/components/JsonHighlight.tsx
+++ b/packages/monitor/src/components/JsonHighlight.tsx
@@ -1,8 +1,10 @@
+import { formatJson } from '../utils'
+
 const JSON_TOKEN_RE =
   /("(?:\\.|[^"\\])*"\s*:)|("(?:\\.|[^"\\])*")|\b(true|false|null)\b|(-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)/g
 
 export default function JsonHighlight({ value }: { value: unknown }) {
-  const text = JSON.stringify(value ?? null, null, 2)
+  const text = formatJson(value)
   const parts: { kind: string; text: string; start: number }[] = []
   let last = 0
   for (const match of text.matchAll(JSON_TOKEN_RE)) {

--- a/packages/monitor/src/components/SidePane.tsx
+++ b/packages/monitor/src/components/SidePane.tsx
@@ -3,6 +3,7 @@ import { FileJson, Plus, FlaskConical } from 'lucide-react'
 import type { SessionInfo } from '../types'
 import type { UseChaosRules } from '../hooks/useChaosRules'
 import { strings } from '../strings'
+import { formatJson } from '../utils'
 import ConfigTab from './ConfigTab'
 import CopyButton from './CopyButton'
 import ChaosPane, { type ChaosFormRequest } from './chaos/ChaosPane'
@@ -80,7 +81,7 @@ export default function SidePane({
         <span className="ml-auto flex items-center pr-1">
           {tab === 'config' ? (
             <CopyButton
-              getText={() => JSON.stringify(session.config, null, 2)}
+              getText={() => formatJson(session.config)}
               title={strings.session.copyConfig}
             />
           ) : (

--- a/packages/monitor/src/utils.test.tsx
+++ b/packages/monitor/src/utils.test.tsx
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+import { renderToStaticMarkup } from 'react-dom/server'
+import JsonHighlight from './components/JsonHighlight'
+import { formatJson, normalizeSessions } from './utils'
+
+const circular: Record<string, unknown> = {}
+circular['self'] = circular
+
+const UNSERIALIZABLE: [string, unknown, string][] = [
+  ['undefined', undefined, 'null'],
+  ['null', null, 'null'],
+  ['function', () => 1, 'null'],
+  ['symbol', Symbol('s'), 'null'],
+  ['toJSON returning undefined', { toJSON: () => undefined }, 'null'],
+  ['bigint', 10n, '10'],
+  ['circular', circular, '[object Object]'],
+  ['false', false, 'false'],
+  ['string', 'text', '"text"'],
+  ['nested', { a: [1, null] }, '{\n  "a": [\n    1,\n    null\n  ]\n}'],
+]
+
+describe('formatJson', () => {
+  it.each(UNSERIALIZABLE)('renders %s', (_name, value, expected) => {
+    expect(formatJson(value)).toBe(expected)
+  })
+})
+
+describe('JsonHighlight', () => {
+  it.each(UNSERIALIZABLE)('does not throw for %s', (_name, value) => {
+    expect(() =>
+      renderToStaticMarkup(<JsonHighlight value={value} />),
+    ).not.toThrow()
+  })
+})
+
+describe('normalizeSessions', () => {
+  const session = (
+    session_id: unknown,
+    extra: Record<string, unknown> = {},
+  ) => ({
+    session_id,
+    target: 'deployment/app',
+    started_at: '2026-09-09T14:00:00Z',
+    mirrord_version: '3.255.0',
+    is_operator: false,
+    processes: [],
+    port_subscriptions: [],
+    ...extra,
+  })
+
+  it('drops entries that cannot be keyed and coerces missing lists', () => {
+    const normalized = normalizeSessions([
+      session('ok'),
+      session('no-lists', { processes: undefined, port_subscriptions: null }),
+      { info: session('nested-wrapper') },
+      session(123),
+      null,
+      'garbage',
+    ])
+
+    expect(normalized.map((s) => s.session_id)).toEqual(['ok', 'no-lists'])
+    expect(normalized[1]?.processes).toEqual([])
+    expect(normalized[1]?.port_subscriptions).toEqual([])
+  })
+
+  it('returns an empty list for a non-array body', () => {
+    expect(normalizeSessions({ sessions: [] })).toEqual([])
+  })
+})

--- a/packages/monitor/src/utils.ts
+++ b/packages/monitor/src/utils.ts
@@ -1,4 +1,8 @@
-import type { OperatorPreviewSession, OperatorSessionSummary } from './types'
+import type {
+  OperatorPreviewSession,
+  OperatorSessionSummary,
+  SessionInfo,
+} from './types'
 
 const MS_PER_SEC = 1000
 const SECS_PER_MIN = 60
@@ -170,4 +174,40 @@ export function extractLicenseKey(config: unknown): string | null {
 export function formatHostPort(address: string, port: number): string {
   const suffix = `:${port}`
   return address.endsWith(suffix) ? address : `${address}${suffix}`
+}
+
+// JSON.stringify yields undefined (not a string) for undefined, functions and symbols, and throws
+// on BigInt and circular values; the rendered value comes straight from the server.
+export function formatJson(value: unknown): string {
+  try {
+    const text: unknown = JSON.stringify(value, null, 2)
+    return typeof text === 'string' ? text : 'null'
+  } catch {
+    return String(value)
+  }
+}
+
+// A session without a string `session_id` can't be selected, killed or keyed, so it is dropped;
+// missing list fields are coerced so a shape drift on the server degrades to an empty list
+// instead of a render crash.
+export function normalizeSessions(value: unknown): SessionInfo[] {
+  return expectArray<Partial<SessionInfo> | null>(value, 'sessions').flatMap(
+    (session) => {
+      if (typeof session?.session_id !== 'string') {
+        console.warn('Dropping session without a session_id', session)
+        return []
+      }
+      return [
+        {
+          ...session,
+          processes: expectArray(session.processes, 'processes', session),
+          port_subscriptions: expectArray(
+            session.port_subscriptions,
+            'port_subscriptions',
+            session,
+          ),
+        } as SessionInfo,
+      ]
+    },
+  )
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
       vite:
         specifier: ^6.0.0
         version: 6.4.3(@types/node@22.19.21)(jiti@1.21.7)(yaml@2.9.0)
+      vitest:
+        specifier: ^2.1.8
+        version: 2.1.9(@types/node@22.19.21)(jsdom@25.0.1)
 
   packages/ui:
     dependencies:


### PR DESCRIPTION
## Summary

Crash telemetry for the session monitor keeps reporting `Cannot read properties of undefined (reading 'matchAll')`. Every report with that signature comes from the frontend bundle embedded in mirrord 3.229.0 and earlier, where the websocket `session_added` payload nested the session under `info` and the monitor rendered the missing `config`. That was fixed in 3.230.0 (#4463) and no release since produces it; the remaining reports are clients that never upgraded.

This removes the class of failure in the current monitor instead of guarding one call site:

- `normalizeSessions` runs once at the API boundary. Entries without a string `session_id` are dropped, and missing `processes` / `port_subscriptions` lists are coerced through the existing `expectArray`, so a malformed session list degrades to a warning instead of blanking the whole monitor. Today a single `null` entry in the list still crashes the page.
- `formatJson` is total. Values where `JSON.stringify` yields `undefined` (undefined, functions, symbols, `toJSON` returning undefined) render as `null`, and values it throws on (BigInt, circular) fall back to `String(value)`. `JsonHighlight` and the config copy button both use it.
- Adds vitest to `packages/monitor` (already in the workspace lockfile via the wizard) with one table-driven test over those inputs, wired into the ui lint job.
- `setInterval(refreshExtensionState)` in `App.tsx` gets a void wrapper: vitest's types pull in Node's `setInterval` signature, which trips `no-misused-promises`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
